### PR TITLE
Delete pivotcache when deleting a sheet

### DIFF
--- a/ClosedXML/ClosedXML/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/ClosedXML/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -197,11 +197,16 @@ namespace ClosedXML.Excel
             
 
             var partsToRemove = workbookPart.Parts.Where(s => worksheets.Deleted.Contains(s.RelationshipId)).ToList();
-            var pivotCacheDefinitionsToRemove = partsToRemove.SelectMany(s => ((WorksheetPart)s.OpenXmlPart).PivotTableParts.Select(pt => pt.PivotTableCacheDefinitionPart)).Distinct().ToList();
-            var pivotCachesToRemove = workbookPart.Workbook.PivotCaches.Where(pc => pivotCacheDefinitionsToRemove.Select(pcd => workbookPart.GetIdOfPart(pcd)).ToList().Contains(((PivotCache)pc).Id)).Distinct().ToList();
 
+            var pivotCacheDefinitionsToRemove = partsToRemove.SelectMany(s => ((WorksheetPart)s.OpenXmlPart).PivotTableParts.Select(pt => pt.PivotTableCacheDefinitionPart)).Distinct().ToList();
             pivotCacheDefinitionsToRemove.ForEach(c => workbookPart.DeletePart(c));
-            pivotCachesToRemove.ForEach(c => workbookPart.Workbook.PivotCaches.RemoveChild(c));
+
+            if (workbookPart.Workbook != null && workbookPart.Workbook.PivotCaches != null)
+            {
+                var pivotCachesToRemove = workbookPart.Workbook.PivotCaches.Where(pc => pivotCacheDefinitionsToRemove.Select(pcd => workbookPart.GetIdOfPart(pcd)).ToList().Contains(((PivotCache)pc).Id)).Distinct().ToList();
+                pivotCachesToRemove.ForEach(c => workbookPart.Workbook.PivotCaches.RemoveChild(c));
+            }
+
             worksheets.Deleted.ToList().ForEach(ws => DeleteSheetAndDependencies(workbookPart, ws));
 
             context.RelIdGenerator.AddValues(workbookPart.Parts.Select(p => p.RelationshipId).ToList(), RelType.Workbook);


### PR DESCRIPTION
PR originally logged at https://closedxml.codeplex.com/SourceControl/network/forks/igitur/ClosedXML/contribution/8516

When deleting a worksheet, the pivot cache parts have to be deleted as well, else Excel complains of a corrupt file.

There are 2 cases:
When a worksheet containing a pivot table is deleted, the pivot cache has to be deleted.
When a worksheet that is the source to a pivot table on another sheet is deleted, the pivot cache also has to be deleted.

I used a snippet found at http://blogs.msdn.com/b/vsod/archive/2010/02/05/how-to-delete-a-worksheet-from-excel-using-open-xml-sdk-2-0.aspx for the latter part.