### PR TITLE
Preserve tables' column names when table is of type queryTable.

### DIFF
--- a/ClosedXML/ClosedXML/ClosedXML/Excel/Ranges/XLRange.cs
+++ b/ClosedXML/ClosedXML/ClosedXML/Excel/Ranges/XLRange.cs
@@ -293,6 +293,11 @@ namespace ClosedXML.Excel
             return new XLTable(this, name, true, setAutofilter);
         }
 
+        public IXLTable CreateTable(String name, Boolean setAutofilter, IEnumerable<String> columnNames)
+        {
+            return new XLTable(this, name, true, columnNames, setAutofilter);
+        }
+
         public new IXLRange CopyTo(IXLCell target)
         {
             base.CopyTo(target);

--- a/ClosedXML/ClosedXML/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/ClosedXML/ClosedXML/Excel/Tables/XLTable.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Excel
         public XLTable(XLRange range, Boolean addToTables, Boolean setAutofilter = true)
             : base(new XLRangeParameters(range.RangeAddress, range.Style ))
         {
-            InitializeValues(setAutofilter);
+            InitializeValues(setAutofilter, null);
 
             Int32 id = 1;
             while (true)
@@ -39,16 +39,25 @@ namespace ClosedXML.Excel
         public XLTable(XLRange range, String name, Boolean addToTables, Boolean setAutofilter = true)
             : base(new XLRangeParameters(range.RangeAddress, range.Style))
         {
-            InitializeValues(setAutofilter);
+            InitializeValues(setAutofilter, null);
 
             Name = name;
             AddToTables(range, addToTables);
         }
 
+        public XLTable(XLRange range, String name, Boolean addToTables, IEnumerable<String> columnNames, Boolean setAutofilter = true)
+            : base(new XLRangeParameters(range.RangeAddress, range.Style))
+        {
+            InitializeValues(setAutofilter, columnNames);
+
+            Name = name;
+            AddToTables(range, addToTables);
+        }
         #endregion
 
         private IXLRangeAddress _lastRangeAddress;
         private Dictionary<String, IXLTableField> _fieldNames = null;
+        private IList<String> _columnNames = null;
         public Dictionary<String, IXLTableField> FieldNames
         {
             get
@@ -67,7 +76,11 @@ namespace ClosedXML.Excel
                         var name = cell.GetString();
                         if (XLHelper.IsNullOrWhiteSpace(name)) 
                         {
-                            name = "Column" + (cellPos + 1);
+                            if (_columnNames != null && cellPos < _columnNames.Count)
+                                name = _columnNames[cellPos];
+                            else
+                                name = "Column" + (cellPos + 1);
+
                             cell.SetValue(name);
                         }
                         if (_fieldNames.ContainsKey(name))
@@ -368,13 +381,16 @@ namespace ClosedXML.Excel
 
 
 
-        private void InitializeValues(Boolean setAutofilter)
+        private void InitializeValues(Boolean setAutofilter, IEnumerable<String> columnNames)
         {
             ShowRowStripes = true;
             _showHeaderRow = true;
             Theme = XLTableTheme.TableStyleLight9;
             if (setAutofilter)
                 InitializeAutoFilter();
+
+            if (columnNames != null && columnNames.Any())
+                _columnNames = columnNames.ToList();
 
             HeadersRow().DataType = XLCellValues.Text;
 

--- a/ClosedXML/ClosedXML/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/ClosedXML/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -242,12 +242,13 @@ namespace ClosedXML.Excel
                 {
                     var dTable = tablePart.Table;
                     string reference = dTable.Reference.Value;
-                    XLTable xlTable = ws.Range(reference).CreateTable(dTable.Name, false) as XLTable;
+                    var columnNames = dTable.TableColumns.Cast<TableColumn>().Select(t => GetTableColumnName(t.Name.Value));
+                    XLTable xlTable = ws.Range(reference).CreateTable(dTable.Name, false, columnNames) as XLTable;
                     if (dTable.HeaderRowCount != null && dTable.HeaderRowCount == 0)
                     {
                         xlTable._showHeaderRow = false;
                         //foreach (var tableColumn in dTable.TableColumns.Cast<TableColumn>())
-                        xlTable.AddFields(dTable.TableColumns.Cast<TableColumn>().Select(t=>GetTableColumnName(t.Name.Value)));
+                        xlTable.AddFields(columnNames);
                     }
                     else
                     {


### PR DESCRIPTION
PR originally logged at https://closedxml.codeplex.com/SourceControl/network/forks/igitur/ClosedXML/contribution/8942

When opening and saving a file, tables' column names are replaced with Column1, Column2, etc. This PR fixes the issue and outputs the original column names.
