### PR TITLE
Parse dates with current culture

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -25,7 +26,6 @@ namespace ClosedXML.Excel.CalcEngine
 		#region ** fields
 
 		internal Token _token;
-		static CultureInfo _ci = CultureInfo.InvariantCulture;
 
 		#endregion
 
@@ -103,6 +103,7 @@ namespace ClosedXML.Excel.CalcEngine
 			}
 
 			// handle everything else
+			CultureInfo _ci = Thread.CurrentThread.CurrentCulture;
 			return (double)Convert.ChangeType(v, typeof(double), _ci);
 		}
 		public static implicit operator bool(Expression x)
@@ -149,6 +150,7 @@ namespace ClosedXML.Excel.CalcEngine
 			}
 
 			// handle everything else
+			CultureInfo _ci = Thread.CurrentThread.CurrentCulture;
 			return (DateTime)Convert.ChangeType(v, typeof(DateTime), _ci);
 		}
 
@@ -490,7 +492,7 @@ namespace ClosedXML.Excel.CalcEngine
 		}
 		public IEnumerator GetEnumerator()
 		{
-		    return (_value as IEnumerable).GetEnumerator();
+			return (_value as IEnumerable).GetEnumerator();
 		}
 	}
 	/// <summary>

--- a/ClosedXML_Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using ClosedXML.Excel;
 using NUnit.Framework;
 
@@ -10,6 +12,12 @@ namespace ClosedXML_Tests.Excel.DataValidations
     [TestFixture]
     public class DateAndTimeTests
     {
+        [SetUp]
+        public void SetCultureInfo()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+        }
+
         [Test]
         public void Date()
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -40,6 +40,16 @@ namespace ClosedXML_Tests.Excel.DataValidations
         }
 
         [Test]
+        public void DayWithDifferentCulture()
+        {
+            CultureInfo ci = new CultureInfo(CultureInfo.InvariantCulture.LCID);
+            ci.DateTimeFormat.ShortDatePattern = "dd/MM/yyyy";
+            Thread.CurrentThread.CurrentCulture = ci;
+            Object actual = XLWorkbook.EvaluateExpr("Day(\"1/6/2008\")");
+            Assert.AreEqual(1, actual);
+        }
+
+        [Test]
         public void Days360_Default()
         {
             Object actual = XLWorkbook.EvaluateExpr("Days360(\"1/30/2008\", \"2/1/2008\")");

--- a/ClosedXML_Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -12,7 +12,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
     [TestFixture]
     public class DateAndTimeTests
     {
-        [SetUp]
+        [OneTimeSetUp]
         public void SetCultureInfo()
         {
             Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");


### PR DESCRIPTION
The expression engine currently uses an Invariant culture to parse dates. This leads to unexpected results. Rather use the culture as explicitly set in the current thread. New tests included.

Originally logged at https://closedxml.codeplex.com/SourceControl/network/forks/igitur/ClosedXML/contribution/8276