### PR TITLE
Fix datetime bug with short date format

### DIFF
--- a/ClosedXML/ClosedXML/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/ClosedXML/ClosedXML/Excel/Cells/XLCell.cs
@@ -1615,7 +1615,13 @@
         private void SetValue(object value)
         {
             FormulaA1 = String.Empty;
-            var val = value == null ? String.Empty : value.ToString();
+            string val;
+            if (value == null)
+                val = string.Empty;
+            else if (value is DateTime)
+                val = ((DateTime)value).ToString("o");
+            else
+                val = value.ToString();
             _richText = null;
             if (val.Length == 0)
                 _dataType = XLCellValues.Text;

--- a/ClosedXML/ClosedXML/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML/ClosedXML/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
@@ -325,6 +326,21 @@ namespace ClosedXML_Tests
             cell.Value = null;
             string actual = cell.GetString();
             string expected = String.Empty;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ValueSetDateWithShortUserDateFormat()
+        {
+            // For this test to make sense, user's local date format should be dd/MM/yy (note without the 2 century digits)
+            // What happened previously was that the century digits got lost in .ToString() conversion and wrong century was sometimes returned.
+            CultureInfo ci = new CultureInfo(CultureInfo.InvariantCulture.LCID);
+            ci.DateTimeFormat.ShortDatePattern = "dd/MM/yy";
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            var expected = DateTime.Today.AddYears(20);
+            cell.Value = expected;
+            var actual = (DateTime)cell.Value;
             Assert.AreEqual(expected, actual);
         }
     }

--- a/ClosedXML/ClosedXML/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML/ClosedXML/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using ClosedXML.Excel;
 using NUnit.Framework;
 
@@ -334,8 +335,9 @@ namespace ClosedXML_Tests
         {
             // For this test to make sense, user's local date format should be dd/MM/yy (note without the 2 century digits)
             // What happened previously was that the century digits got lost in .ToString() conversion and wrong century was sometimes returned.
-            CultureInfo ci = new CultureInfo(CultureInfo.InvariantCulture.LCID);
+            var ci = new CultureInfo(CultureInfo.InvariantCulture.LCID);
             ci.DateTimeFormat.ShortDatePattern = "dd/MM/yy";
+            Thread.CurrentThread.CurrentCulture = ci;
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
             var expected = DateTime.Today.AddYears(20);


### PR DESCRIPTION
I have some users who have set their short date format (in Regional settings) to dd/MM/yy (note the century digits are omitted). I don't like this date format either, but they insist on using it.

This creates the odd situation that sometimes when setting a date and then retrieving it, it is out by 1 century, e.g. 11 June 2035 gets returned as 11 June 1935. 

This pull request fixes it and adds a test to the test suite.

Originally logged at https://closedxml.codeplex.com/SourceControl/network/forks/igitur/ClosedXML/contribution/8275