### PR TITLE
fix "conditional format doesn't work when range has multiple conditio…

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -4047,8 +4047,6 @@ namespace ClosedXML.Excel
                     )
                     )
                 {
-                    
-                    priority++;
                     var conditionalFormatting = new ConditionalFormatting
                     {
                         SequenceOfReferences =
@@ -4056,7 +4054,7 @@ namespace ClosedXML.Excel
                     };
                     foreach(var cf in cfGroup.CfList)
                     {
-                        conditionalFormatting.Append(XLCFConverters.Convert(cf, priority, context));
+                        conditionalFormatting.Append(XLCFConverters.Convert(cf, priority++, context));
                     }
                     worksheetPart.Worksheet.InsertAfter(conditionalFormatting, previousElement);
                     previousElement = conditionalFormatting;


### PR DESCRIPTION
I found conditional format doesn't work when a range has multiple conditional formats.

This bug seems to be caused by priority of conditional formats which are set to same value in each range.
When I checked XML data which was generated by Microsoft Excel, priority value was unique in a work sheet.

So I fixed to set unique value in each conditional formats.


