### PR TITLE
Clearing AutoFilter shouldn't throw an exception

### DIFF
--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -85,6 +85,8 @@ namespace ClosedXML.Excel
 
         public XLAutoFilter Clear()
         {
+            if (!Enabled) return this;
+
             Enabled = false;
             Filters.Clear();
             foreach (IXLRangeRow row in Range.Rows().Where(r => r.RowNumber() > 1))
@@ -94,6 +96,9 @@ namespace ClosedXML.Excel
 
         public XLAutoFilter Sort(Int32 columnToSortBy, XLSortOrder sortOrder, Boolean matchCase, Boolean ignoreBlanks)
         {
+            if (!Enabled)
+                throw new ApplicationException("Filter has not been enabled.");
+
             var ws = Range.Worksheet as XLWorksheet;
             ws.SuspendEvents();
             Range.Range(Range.FirstCell().CellBelow(), Range.LastCell()).Sort(columnToSortBy, sortOrder, matchCase,

--- a/ClosedXML_Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML_Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -52,5 +52,25 @@ namespace ClosedXML_Tests
                 }
             }
         }
+
+        [Test]
+        public void CanClearAutoFilter()
+        {
+            var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("AutoFilter");
+            ws.Cell("A1").Value = "Names";
+            ws.Cell("A2").Value = "John";
+            ws.Cell("A3").Value = "Hank";
+            ws.Cell("A4").Value = "Dagny";
+
+            ws.AutoFilter.Clear(); // We should be able to clear a filter even if it hasn't been set.
+            Assert.That(!ws.AutoFilter.Enabled);
+
+            ws.RangeUsed().SetAutoFilter();
+            Assert.That(ws.AutoFilter.Enabled);
+
+            ws.AutoFilter.Clear();
+            Assert.That(!ws.AutoFilter.Enabled);
+        }
     }
 }


### PR DESCRIPTION
Clearing AutoFilter shouldn't throw an exception, even if no AutoFilter is enabled. It should just silently continue.

