### PR TITLE
NickNack2020's fix for invalid char

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Excel\Tables\XLTableTheme.cs" />
     <Compile Include="Excel\XLConstants.cs" />
     <Compile Include="Utils\GraphicsUtils.cs" />
+    <Compile Include="Utils\XmlEncoder.cs" />
     <Compile Include="XLHelper.cs" />
     <Compile Include="Excel\AutoFilters\XLFilteredColumn.cs" />
     <Compile Include="Excel\AutoFilters\XLCustomFilteredColumn.cs" />

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using ClosedXML.Utils;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -913,7 +914,7 @@ namespace ClosedXML.Excel
                             }
 
                             if(!hasRuns)
-                                xlCell._cellValue = sharedString.Text.InnerText;
+                                xlCell._cellValue = XmlEncoder.DecodeString(sharedString.Text.InnerText);
 
                             #region Load PhoneticProperties
 

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -36,6 +36,7 @@ using Underline = DocumentFormat.OpenXml.Spreadsheet.Underline;
 using System.Xml;
 using System.Xml.Linq;
 using System.Text;
+using ClosedXML.Utils;
 using Anchor = DocumentFormat.OpenXml.Vml.Spreadsheet.Anchor;
 using Field = DocumentFormat.OpenXml.Spreadsheet.Field;
 using Run = DocumentFormat.OpenXml.Spreadsheet.Run;
@@ -823,7 +824,7 @@ namespace ClosedXML.Excel
                                     EndingBaseIndex = (UInt32)p.End
                                 };
 
-                                var text = new Text {Text = p.Text};
+                                var text = new Text { Text = p.Text };
                                 if (p.Text.PreserveSpaces())
                                     text.Space = SpaceProcessingModeValues.Preserve;
 
@@ -867,7 +868,7 @@ namespace ClosedXML.Excel
                     {
                         var s = c.Value.ToString();
                         var sharedStringItem = new SharedStringItem();
-                        var text = new Text {Text = s};
+                        var text = new Text {Text = XmlEncoder.EncodeString(s)};
                         if (!s.Trim().Equals(s))
                             text.Space = SpaceProcessingModeValues.Preserve;
                         sharedStringItem.Append(text);

--- a/ClosedXML/Utils/XmlEncoder.cs
+++ b/ClosedXML/Utils/XmlEncoder.cs
@@ -1,0 +1,47 @@
+﻿using System.Text;
+using System.Xml;
+
+namespace ClosedXML.Utils
+{
+    public static class XmlEncoder
+    {
+        /// <summary>
+        /// Checks if a character is not allowed to the XML Spec http://www.w3.org/TR/REC-xml/#charsets
+        /// </summary>
+        /// <param name="ch">Input Character</param>
+        /// <returns>Returns false if the character is invalid according to the XML specification, and will not be
+        /// escaped by an XmlWriter.</returns>
+        public static bool IsXmlChar(char ch)
+        {
+            return (((ch >= 0x0020 && ch <= 0xD7FF) ||
+                      (ch >= 0xE000 && ch <= 0xFFFD) ||
+                      ch == 0x0009 || ch == 0x000A ||
+                      ch == 0x000D));
+        }
+
+        public static string EncodeString(string encodeStr)
+        {
+            if (encodeStr == null) return null;
+
+            var newString = new StringBuilder();
+
+            foreach (var ch in encodeStr)
+            {
+                if (IsXmlChar(ch)) //this method is new in .NET 4
+                {
+                    newString.Append(ch);
+                }
+                else
+                {
+                    newString.Append(XmlConvert.EncodeName(ch.ToString()));
+                }
+            }
+            return newString.ToString();
+        }
+
+        public static string DecodeString(string decodeStr)
+        {
+            return XmlConvert.DecodeName(decodeStr);
+        }
+    }
+}

--- a/ClosedXML_Net3.5/ClosedXML_Net3.5.csproj
+++ b/ClosedXML_Net3.5/ClosedXML_Net3.5.csproj
@@ -817,6 +817,9 @@
     <Compile Include="..\ClosedXML\Utils\GraphicsUtils.cs">
       <Link>Utils\GraphicsUtils.cs</Link>
     </Compile>
+    <Compile Include="..\ClosedXML\Utils\XmlEncoder.cs">
+      <Link>Utils\XmlEncoder.cs</Link>
+    </Compile>
     <Compile Include="..\ClosedXML\XLHelper.cs">
       <Link>XLHelper.cs</Link>
     </Compile>

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Excel\CalcEngine\LogicalTests.cs" />
     <Compile Include="Excel\CalcEngine\LookupTests.cs" />
     <Compile Include="Excel\CalcEngine\TextTests.cs" />
+    <Compile Include="Excel\Misc\XmlEncoderTests.cs" />
     <Compile Include="Excel\Loading\LoadingTests.cs" />
     <Compile Include="Excel\PageSetup\HeaderFooterTests.cs" />
     <Compile Include="XLHelperTests.cs" />

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
-using ClosedXML.Excel;
-using NUnit.Framework;
 
 namespace ClosedXML_Tests
 {
@@ -56,7 +57,7 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1");
-            var doubleList = new List<Double> {1.0/0.0};
+            var doubleList = new List<Double> { 1.0 / 0.0 };
 
             cell.Value = doubleList.AsEnumerable();
             Assert.AreNotEqual(XLCellValues.Number, cell.DataType);
@@ -67,7 +68,7 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1");
-            var doubleList = new List<Double> {0.0/0.0};
+            var doubleList = new List<Double> { 0.0 / 0.0 };
 
             cell.Value = doubleList.AsEnumerable();
             Assert.AreNotEqual(XLCellValues.Number, cell.DataType);
@@ -77,7 +78,7 @@ namespace ClosedXML_Tests
         public void InsertData1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRange range = ws.Cell(2, 2).InsertData(new[] {"a", "b", "c"});
+            IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" });
             Assert.AreEqual("'Sheet1'!B2:B4", range.ToString());
         }
 
@@ -344,6 +345,26 @@ namespace ClosedXML_Tests
             cell.Value = expected;
             var actual = (DateTime)cell.Value;
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void TestInvalidXmlCharacters()
+        {
+            byte[] data;
+
+            using (var stream = new MemoryStream())
+            {
+                var wb = new XLWorkbook();
+                wb.AddWorksheet("Sheet1").FirstCell().SetValue("\u0018");
+                wb.SaveAs(stream);
+                data = stream.ToArray();
+            }
+
+            using (var stream = new MemoryStream(data))
+            {
+                var wb = new XLWorkbook(stream);
+                Assert.AreEqual("\u0018", wb.Worksheets.First().FirstCell().Value);
+            }
         }
     }
 }

--- a/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
@@ -1,0 +1,33 @@
+﻿using ClosedXML.Utils;
+using NUnit.Framework;
+
+namespace ClosedXML_Tests.Excel
+{
+    [TestFixture]
+    public class XmlEncoderTest
+    {
+        [Test]
+        public void TestControlChars()
+        {
+            Assert.AreEqual("_x0001_ _x0002_ _x0003_ _x0004_", XmlEncoder.EncodeString("\u0001 \u0002 \u0003 \u0004"));
+            Assert.AreEqual("_x0005_ _x0006_ _x0007_ _x0008_", XmlEncoder.EncodeString("\u0005 \u0006 \u0007 \u0008"));
+            Assert.AreEqual("\u0001 \u0002 \u0003 \u0004", XmlEncoder.DecodeString("_x0001_ _x0002_ _x0003_ _x0004_"));
+            Assert.AreEqual("\u0005 \u0006 \u0007 \u0008", XmlEncoder.DecodeString("_x0005_ _x0006_ _x0007_ _x0008_"));
+        }
+
+        [Test]
+        public void TestIsXmlChar()
+        {
+            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0001'));
+            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0005'));
+            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0007'));
+            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0008'));
+            Assert.AreEqual(true, XmlEncoder.IsXmlChar('J'));
+            Assert.AreEqual(true, XmlEncoder.IsXmlChar('+'));
+            Assert.AreEqual(true, XmlEncoder.IsXmlChar('S'));
+            Assert.AreEqual(true, XmlEncoder.IsXmlChar('4'));
+            Assert.AreEqual(true, XmlEncoder.IsXmlChar('!'));
+            Assert.AreEqual(true, XmlEncoder.IsXmlChar('$'));
+        }
+    }
+}


### PR DESCRIPTION
https://closedxml.codeplex.com/SourceControl/network/forks/NickNack2020/ClosedXml/contribution/8268

Possibly fixes #63

Added XML encoder util. Will encode invalid XML characters based on
XML Spec http://www.w3.org/TR/REC-xml/#charsets

-Encode shared string on save
-Decoded shared strings on load

Quick fix only applied to shared strings,
could be other problematic areas in code

Conflicts:
ClosedXML_Tests/ClosedXML_Tests.csproj
ClosedXML_Tests/Excel/Cells/XLCellTests.cs