### PR TITLE
Add custom attribute to specify column order of object exported.

### DIFF
--- a/ClosedXML/Attributes/ColumnOrderAttribute.cs
+++ b/ClosedXML/Attributes/ColumnOrderAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ClosedXML.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public class ColumnOrderAttribute : Attribute
+    {
+        public ColumnOrderAttribute(long order)
+        {
+            this.Order = order;
+        }
+
+        public long Order { get; private set; }
+    }
+}

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -61,6 +61,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\ColumnOrderAttribute.cs" />
     <Compile Include="Excel\CalcEngine\Functions\DateAndTime.cs" />
     <Compile Include="Excel\CalcEngine\Functions\Database.cs" />
     <Compile Include="Excel\CalcEngine\Functions\Is.cs" />

--- a/ClosedXML_Net3.5/ClosedXML_Net3.5.csproj
+++ b/ClosedXML_Net3.5/ClosedXML_Net3.5.csproj
@@ -55,6 +55,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\ClosedXML\Attributes\ColumnOrderAttribute.cs">
+      <Link>Attributes\ColumnOrderAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\ClosedXML\Excel\AutoFilters\IXLAutoFilter.cs">
       <Link>Excel\AutoFilters\IXLAutoFilter.cs</Link>
     </Compile>


### PR DESCRIPTION
Add custom attribute to specify column order of object exported.
Implement DisplayName() attribute for .NET3.5 to replicate Display() attribute for .NET4+.