### PR TITLE
Improve HasDuplicates<T>

### DIFF
--- a/ClosedXML/Extensions.cs
+++ b/ClosedXML/Extensions.cs
@@ -75,10 +75,10 @@ namespace ClosedXML.Excel
             HashSet<T> distinctItems = new HashSet<T>();
             foreach (var item in source)
             {
-                if (distinctItems.Contains(item))
-                    return true;
-                else
-                    distinctItems.Add(item);
+              if (!distinctItems.Add(item))
+              {
+                return true;
+              }
             }
             return false;
         }


### PR DESCRIPTION
There is no need for checking if the item is already
in the HashSet. Thats what a HashSet is for.
.Add() returns false if the item is alread present.
