### PR TITLE
Parse inline string with rich text correctly.

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1,18 +1,16 @@
 ﻿#region
 
+using ClosedXML.Utils;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using ClosedXML.Utils;
-using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Spreadsheet;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Op = DocumentFormat.OpenXml.CustomProperties;
-using Vml = DocumentFormat.OpenXml.Vml;
-using Ss = DocumentFormat.OpenXml.Vml.Spreadsheet;
 
 #endregion
 
@@ -20,11 +18,10 @@ namespace ClosedXML.Excel
 {
     #region
 
-    using System.Drawing;
     using Ap;
     using Op;
+    using System.Drawing;
     using System.Xml.Linq;
-    using System.Text.RegularExpressions;
 
     #endregion
 
@@ -124,7 +121,6 @@ namespace ClosedXML.Excel
                 var referenceMode = calculationProperties.ReferenceMode;
                 if (referenceMode != null)
                     ReferenceStyle = referenceMode.Value.ToClosedXml();
-
             }
 
             var efp = dSpreadsheet.ExtendedFilePropertiesPart;
@@ -150,7 +146,7 @@ namespace ClosedXML.Excel
             Fonts fonts = s == null ? null : s.Fonts;
             Int32 dfCount = 0;
             Dictionary<Int32, DifferentialFormat> differentialFormats;
-            if (s != null &&s.DifferentialFormats != null)
+            if (s != null && s.DifferentialFormats != null)
                 differentialFormats = s.DifferentialFormats.Elements<DifferentialFormat>().ToDictionary(k => dfCount++);
             else
                 differentialFormats = new Dictionary<Int32, DifferentialFormat>();
@@ -166,16 +162,15 @@ namespace ClosedXML.Excel
 
                 if (wsPart == null)
                 {
-                    UnsupportedSheets.Add(new UnsupportedSheet {SheetId = dSheet.SheetId.Value, Position = position});
+                    UnsupportedSheets.Add(new UnsupportedSheet { SheetId = dSheet.SheetId.Value, Position = position });
                     continue;
                 }
 
                 var sheetName = dSheet.Name;
 
-                var ws = (XLWorksheet) WorksheetsInternal.Add(sheetName, position);
+                var ws = (XLWorksheet)WorksheetsInternal.Add(sheetName, position);
                 ws.RelId = dSheet.Id;
-                ws.SheetId = (Int32) dSheet.SheetId.Value;
-
+                ws.SheetId = (Int32)dSheet.SheetId.Value;
 
                 if (dSheet.State != null)
                     ws.Visibility = dSheet.State.Value.ToClosedXml();
@@ -249,7 +244,6 @@ namespace ClosedXML.Excel
                             LoadColumnBreaks((ColumnBreaks)reader.LoadCurrentElement(), ws);
                         else if (reader.ElementType == typeof(LegacyDrawing))
                             ws.LegacyDrawingId = (reader.LoadCurrentElement() as LegacyDrawing).Id.Value;
-
                     }
                     reader.Close();
                 }
@@ -265,7 +259,7 @@ namespace ClosedXML.Excel
                     {
                         xlTable._showHeaderRow = false;
                         //foreach (var tableColumn in dTable.TableColumns.Cast<TableColumn>())
-                        xlTable.AddFields(dTable.TableColumns.Cast<TableColumn>().Select(t=>GetTableColumnName(t.Name.Value)));
+                        xlTable.AddFields(dTable.TableColumns.Cast<TableColumn>().Select(t => GetTableColumnName(t.Name.Value)));
                     }
                     else
                     {
@@ -273,7 +267,7 @@ namespace ClosedXML.Excel
                     }
 
                     if (dTable.TotalsRowCount != null && dTable.TotalsRowCount.Value > 0)
-                        ((XLTable) xlTable)._showTotalsRow = true;
+                        ((XLTable)xlTable)._showTotalsRow = true;
 
                     if (dTable.TableStyleInfo != null)
                     {
@@ -297,15 +291,13 @@ namespace ClosedXML.Excel
                             xlTable.Theme = XLTableTheme.None;
                     }
 
-
                     if (dTable.AutoFilter != null)
                     {
                         xlTable.ShowAutoFilter = true;
-                        LoadAutoFilterColumns( dTable.AutoFilter, (xlTable as XLTable).AutoFilter);
+                        LoadAutoFilterColumns(dTable.AutoFilter, (xlTable as XLTable).AutoFilter);
                     }
                     else
                         xlTable.ShowAutoFilter = false;
-
 
                     if (xlTable.ShowTotalsRow)
                     {
@@ -329,14 +321,15 @@ namespace ClosedXML.Excel
                                                     xlTable.RangeAddress.LastAddress.RowNumber - 1, xlTable.RangeAddress.LastAddress.ColumnNumber);
                     }
                     else if (xlTable.AutoFilter != null)
-                            xlTable.AutoFilter.Range = xlTable.Worksheet.Range(xlTable.RangeAddress);
+                        xlTable.AutoFilter.Range = xlTable.Worksheet.Range(xlTable.RangeAddress);
                 }
 
                 #endregion
 
                 #region LoadComments
 
-                if (wsPart.WorksheetCommentsPart != null) {
+                if (wsPart.WorksheetCommentsPart != null)
+                {
                     var root = wsPart.WorksheetCommentsPart.Comments;
                     var authors = root.GetFirstChild<Authors>().ChildElements;
                     var comments = root.GetFirstChild<CommentList>().ChildElements;
@@ -344,7 +337,8 @@ namespace ClosedXML.Excel
                     // **** MAYBE FUTURE SHAPE SIZE SUPPORT
                     XDocument xdoc = GetCommentVmlFile(wsPart);
 
-                    foreach (Comment c in comments) {
+                    foreach (Comment c in comments)
+                    {
                         // find cell by reference
                         var cell = ws.Cell(c.Reference);
 
@@ -354,13 +348,13 @@ namespace ClosedXML.Excel
                         //ShapeIdManager.Add(xlComment.ShapeId);
 
                         var runs = c.GetFirstChild<CommentText>().Elements<Run>();
-                        foreach (Run run in runs) {
+                        foreach (Run run in runs)
+                        {
                             var runProperties = run.RunProperties;
                             String text = run.Text.InnerText.FixNewLines();
                             var rt = cell.Comment.AddText(text);
                             LoadFont(runProperties, rt);
                         }
-
 
                         XElement shape = GetCommentShape(xdoc);
 
@@ -369,7 +363,7 @@ namespace ClosedXML.Excel
                         var clientData = shape.Elements().First(e => e.Name.LocalName == "ClientData");
                         LoadClientData<IXLComment>(xlComment, clientData);
 
-                        var textBox = shape.Elements().First(e=>e.Name.LocalName == "textbox");
+                        var textBox = shape.Elements().First(e => e.Name.LocalName == "textbox");
                         LoadTextBox<IXLComment>(xlComment, textBox);
 
                         var alt = shape.Attribute("alt");
@@ -396,12 +390,12 @@ namespace ClosedXML.Excel
                 if (workbookView != null && workbookView.ActiveTab != null)
                 {
                     UnsupportedSheet unsupportedSheet =
-                        UnsupportedSheets.FirstOrDefault(us => us.Position == (Int32) (workbookView.ActiveTab.Value + 1));
+                        UnsupportedSheets.FirstOrDefault(us => us.Position == (Int32)(workbookView.ActiveTab.Value + 1));
                     if (unsupportedSheet != null)
                         unsupportedSheet.IsActive = true;
                     else
                     {
-                        Worksheet((Int32) (workbookView.ActiveTab.Value + 1)).SetTabActive();
+                        Worksheet((Int32)(workbookView.ActiveTab.Value + 1)).SetTabActive();
                     }
                 }
             }
@@ -435,18 +429,17 @@ namespace ClosedXML.Excel
             XElement shape;
             if (xml != null)
                 shape =
-                    xml.Elements().FirstOrDefault(e => (string) e.Attribute("type") == XLConstants.Comment.ShapeTypeId);
+                    xml.Elements().FirstOrDefault(e => (string)e.Attribute("type") == XLConstants.Comment.ShapeTypeId);
             else
                 shape = xdoc.Root.Elements().FirstOrDefault(e =>
-                                                            (string) e.Attribute("type") ==
+                                                            (string)e.Attribute("type") ==
                                                             XLConstants.Comment.ShapeTypeId ||
-                                                            (string) e.Attribute("type") ==
+                                                            (string)e.Attribute("type") ==
                                                             XLConstants.Comment.AlternateShapeTypeId);
             return shape;
         }
 
         #endregion
-
 
         private String GetTableColumnName(string name)
         {
@@ -467,7 +460,6 @@ namespace ClosedXML.Excel
             {
                 return XLColor.FromHtml(color);
             }
-
         }
 
         private void LoadColorsAndLines<T>(IXLDrawing<T> drawing, XElement shape)
@@ -497,7 +489,7 @@ namespace ClosedXML.Excel
                 }
             }
 
-            var stroke = shape.Elements().FirstOrDefault(e=>e.Name.LocalName == "stroke");
+            var stroke = shape.Elements().FirstOrDefault(e => e.Name.LocalName == "stroke");
             if (stroke != null)
             {
                 var opacity = stroke.Attribute("opacity");
@@ -542,7 +534,7 @@ namespace ClosedXML.Excel
                     String lineStyleVal = lineStyle.Value.ToLower();
                     switch (lineStyleVal)
                     {
-                        case "single": drawing.Style.ColorsAndLines.LineStyle = XLLineStyle.Single ; break;
+                        case "single": drawing.Style.ColorsAndLines.LineStyle = XLLineStyle.Single; break;
                         case "thickbetweenthin": drawing.Style.ColorsAndLines.LineStyle = XLLineStyle.ThickBetweenThin; break;
                         case "thickthin": drawing.Style.ColorsAndLines.LineStyle = XLLineStyle.ThickThin; break;
                         case "thinthick": drawing.Style.ColorsAndLines.LineStyle = XLLineStyle.ThinThick; break;
@@ -598,6 +590,7 @@ namespace ClosedXML.Excel
                         if (value.Equals("bottom-to-top")) xlDrawing.Style.Alignment.SetOrientation(XLDrawingTextOrientation.BottomToTop);
                         else if (value.Equals("top-to-bottom")) xlDrawing.Style.Alignment.SetOrientation(XLDrawingTextOrientation.Vertical);
                         break;
+
                     case "layout-flow": isVertical = value.Equals("vertical"); break;
                     case "mso-direction-alt": if (value == "auto") xlDrawing.Style.Alignment.Direction = XLDrawingTextDirection.Context; break;
                     case "direction": if (value == "RTL") xlDrawing.Style.Alignment.Direction = XLDrawingTextDirection.RightToLeft; break;
@@ -609,7 +602,7 @@ namespace ClosedXML.Excel
 
         private void LoadClientData<T>(IXLDrawing<T> drawing, XElement clientData)
         {
-            var anchor = clientData.Elements().FirstOrDefault(e=>e.Name.LocalName == "Anchor");
+            var anchor = clientData.Elements().FirstOrDefault(e => e.Name.LocalName == "Anchor");
             if (anchor != null) LoadClientDataAnchor<T>(drawing, anchor);
 
             LoadDrawingPositioning<T>(drawing, clientData);
@@ -644,7 +637,6 @@ namespace ClosedXML.Excel
             Boolean lockText = lockTextElement != null && lockTextElement.Value.ToLower() == "true";
             drawing.Style.Protection.Locked = locked;
             drawing.Style.Protection.LockText = lockText;
-
         }
 
         private static void LoadDrawingPositioning<T>(IXLDrawing<T> drawing, XElement clientData)
@@ -693,7 +685,6 @@ namespace ClosedXML.Excel
                     case "z-index": xlDrawing.ZOrder = Int32.Parse(value); break;
                 }
             }
-
         }
 
         private readonly Dictionary<string, double> knownUnits = new Dictionary<string, double>
@@ -712,7 +703,6 @@ namespace ClosedXML.Excel
 
             return Double.Parse(value.Replace(knownUnit.Key, String.Empty), CultureInfo.InvariantCulture) * knownUnit.Value;
         }
-
 
         private void LoadDefinedNames(Workbook workbook)
         {
@@ -817,6 +807,7 @@ namespace ClosedXML.Excel
         }
 
         private Int32 lastCell;
+
         private void LoadCells(SharedStringItem[] sharedStrings, Stylesheet s, NumberingFormats numberingFormats,
                                Fills fills, Borders borders, Fonts fonts, Dictionary<uint, string> sharedFormulasR1C1,
                                XLWorksheet ws, Dictionary<Int32, IXLStyle> styleList, Cell cell, Int32 rowIndex)
@@ -837,7 +828,6 @@ namespace ClosedXML.Excel
                 ApplyStyle(xlCell, styleIndex, s, fills, borders, fonts, numberingFormats);
                 styleList.Add(styleIndex, xlCell.Style);
             }
-
 
             if (cell.CellFormula != null && cell.CellFormula.SharedIndex != null && cell.CellFormula.Reference != null)
             {
@@ -881,71 +871,29 @@ namespace ClosedXML.Excel
             {
                 if (cell.DataType == CellValues.InlineString)
                 {
-                    xlCell._cellValue = cell.InlineString != null && cell.InlineString.Text != null ? cell.InlineString.Text.Text.FixNewLines() : String.Empty;
+                    if (cell.InlineString != null)
+                    {
+                        if (cell.InlineString.Text != null)
+                            xlCell._cellValue = cell.InlineString.Text.Text.FixNewLines();
+                        else
+                            ParseCellValue(cell.InlineString, xlCell);
+                    }
+                    else
+                        xlCell._cellValue = String.Empty;
+
                     xlCell._dataType = XLCellValues.Text;
                     xlCell.ShareString = false;
                 }
                 else if (cell.DataType == CellValues.SharedString)
                 {
-                    if (cell.CellValue != null)
+                    if (cell.CellValue != null && !XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
                     {
-                        if (!XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
-                        {
-                            var sharedString = sharedStrings[Int32.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture)];
-
-                            var runs = sharedString.Elements<Run>();
-                            var phoneticRuns = sharedString.Elements<PhoneticRun>();
-                            var phoneticProperties = sharedString.Elements<PhoneticProperties>();
-                            Boolean hasRuns = false;
-                            foreach (Run run in runs)
-                            {
-                                var runProperties = run.RunProperties;
-                                String text = run.Text.InnerText.FixNewLines();
-
-                                if (runProperties == null)
-                                    xlCell.RichText.AddText(text, xlCell.Style.Font);
-                                else
-                                {
-                                    var rt = xlCell.RichText.AddText(text);
-                                    LoadFont(runProperties, rt);
-                                }
-                                if (!hasRuns)
-                                    hasRuns = true;
-                            }
-
-                            if(!hasRuns)
-                                xlCell._cellValue = XmlEncoder.DecodeString(sharedString.Text.InnerText);
-
-                            #region Load PhoneticProperties
-
-                            var pp = phoneticProperties.FirstOrDefault();
-                            if (pp != null)
-                            {
-                                if (pp.Alignment != null)
-                                    xlCell.RichText.Phonetics.Alignment = pp.Alignment.Value.ToClosedXml();
-                                if (pp.Type != null)
-                                    xlCell.RichText.Phonetics.Type = pp.Type.Value.ToClosedXml();
-
-                                LoadFont(pp, xlCell.RichText.Phonetics);
-                            }
-
-                            #endregion
-
-                            #region Load Phonetic Runs
-
-                            foreach (PhoneticRun pr in phoneticRuns)
-                            {
-                                xlCell.RichText.Phonetics.Add(pr.Text.InnerText.FixNewLines(), (Int32)pr.BaseTextStartIndex.Value,
-                                                              (Int32) pr.EndingBaseIndex.Value);
-                            }
-
-                            #endregion
-                        }
-                        else
-                            xlCell._cellValue = cell.CellValue.Text.FixNewLines();
+                        var sharedString = sharedStrings[Int32.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture)];
+                        ParseCellValue(sharedString, xlCell);
                     }
                     else
                         xlCell._cellValue = String.Empty;
+
                     xlCell._dataType = XLCellValues.Text;
                 }
                 else if (cell.DataType == CellValues.Date)
@@ -975,7 +923,6 @@ namespace ClosedXML.Excel
                         else
                             xlCell._dataType = XLCellValues.Number;
                     }
-
                 }
             }
             else if (cell.CellValue != null)
@@ -986,21 +933,20 @@ namespace ClosedXML.Excel
                 }
                 else
                 {
-                    var numberFormatId = ((CellFormat) (s.CellFormats).ElementAt(styleIndex)).NumberFormatId;
+                    var numberFormatId = ((CellFormat)(s.CellFormats).ElementAt(styleIndex)).NumberFormatId;
                     if (!XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
                         xlCell._cellValue = Double.Parse(cell.CellValue.Text, CultureInfo.InvariantCulture).ToInvariantString();
                     if (s.NumberingFormats != null &&
-                        s.NumberingFormats.Any(nf => ((NumberingFormat) nf).NumberFormatId.Value == numberFormatId))
+                        s.NumberingFormats.Any(nf => ((NumberingFormat)nf).NumberFormatId.Value == numberFormatId))
                     {
                         xlCell.Style.NumberFormat.Format =
-                            ((NumberingFormat) s.NumberingFormats
+                            ((NumberingFormat)s.NumberingFormats
                                                 .First(
-                                                    nf => ((NumberingFormat) nf).NumberFormatId.Value == numberFormatId)
+                                                    nf => ((NumberingFormat)nf).NumberFormatId.Value == numberFormatId)
                             ).FormatCode.Value;
                     }
                     else
                         xlCell.Style.NumberFormat.NumberFormatId = Int32.Parse(numberFormatId);
-
 
                     if (!XLHelper.IsNullOrWhiteSpace(xlCell.Style.NumberFormat.Format))
                         xlCell._dataType = GetDataTypeFromFormat(xlCell.Style.NumberFormat.Format);
@@ -1013,6 +959,63 @@ namespace ClosedXML.Excel
                         xlCell._dataType = XLCellValues.Number;
                 }
             }
+        }
+
+        /// <summary>
+        /// Parses the cell value for normal or rich text
+        /// Input element should either be a shared string or inline string
+        /// </summary>
+        /// <param name="element">The element (either a shared string or inline string)</param>
+        /// <param name="xlCell">The cell.</param>
+        private void ParseCellValue(RstType element, XLCell xlCell)
+        {
+            var runs = element.Elements<Run>();
+            var phoneticRuns = element.Elements<PhoneticRun>();
+            var phoneticProperties = element.Elements<PhoneticProperties>();
+            Boolean hasRuns = false;
+            foreach (Run run in runs)
+            {
+                var runProperties = run.RunProperties;
+                String text = run.Text.InnerText.FixNewLines();
+
+                if (runProperties == null)
+                    xlCell.RichText.AddText(text, xlCell.Style.Font);
+                else
+                {
+                    var rt = xlCell.RichText.AddText(text);
+                    LoadFont(runProperties, rt);
+                }
+                if (!hasRuns)
+                    hasRuns = true;
+            }
+
+            if (!hasRuns)
+                xlCell._cellValue = XmlEncoder.DecodeString(element.Text.InnerText);
+
+            #region Load PhoneticProperties
+
+            var pp = phoneticProperties.FirstOrDefault();
+            if (pp != null)
+            {
+                if (pp.Alignment != null)
+                    xlCell.RichText.Phonetics.Alignment = pp.Alignment.Value.ToClosedXml();
+                if (pp.Type != null)
+                    xlCell.RichText.Phonetics.Type = pp.Type.Value.ToClosedXml();
+
+                LoadFont(pp, xlCell.RichText.Phonetics);
+            }
+
+            #endregion
+
+            #region Load Phonetic Runs
+
+            foreach (PhoneticRun pr in phoneticRuns)
+            {
+                xlCell.RichText.Phonetics.Add(pr.Text.InnerText.FixNewLines(), (Int32)pr.BaseTextStartIndex.Value,
+                                              (Int32)pr.EndingBaseIndex.Value);
+            }
+
+            #endregion
         }
 
         private void LoadNumberFormat(NumberingFormat nfSource, IXLNumberFormat nf)
@@ -1031,7 +1034,7 @@ namespace ClosedXML.Excel
 
             LoadBorderValues(borderSource.DiagonalBorder, border.SetDiagonalBorder, border.SetDiagonalBorderColor);
 
-            if (borderSource.DiagonalUp != null )
+            if (borderSource.DiagonalUp != null)
                 border.DiagonalUp = borderSource.DiagonalUp.Value;
             if (borderSource.DiagonalDown != null)
                 border.DiagonalDown = borderSource.DiagonalDown.Value;
@@ -1040,10 +1043,9 @@ namespace ClosedXML.Excel
             LoadBorderValues(borderSource.RightBorder, border.SetRightBorder, border.SetRightBorderColor);
             LoadBorderValues(borderSource.TopBorder, border.SetTopBorder, border.SetTopBorderColor);
             LoadBorderValues(borderSource.BottomBorder, border.SetBottomBorder, border.SetBottomBorderColor);
-
         }
 
-        private void LoadBorderValues(BorderPropertiesType source, Func<XLBorderStyleValues, IXLStyle> setBorder, Func<XLColor, IXLStyle> setColor )
+        private void LoadBorderValues(BorderPropertiesType source, Func<XLBorderStyleValues, IXLStyle> setBorder, Func<XLColor, IXLStyle> setColor)
         {
             if (source != null)
             {
@@ -1054,13 +1056,11 @@ namespace ClosedXML.Excel
             }
         }
 
-
-
         private void LoadFill(Fill fillSource, IXLFill fill)
         {
             if (fillSource == null) return;
 
-            if(fillSource.PatternFill != null)
+            if (fillSource.PatternFill != null)
             {
                 if (fillSource.PatternFill.PatternType != null)
                     fill.PatternType = fillSource.PatternFill.PatternType.Value.ToClosedXml();
@@ -1087,7 +1087,7 @@ namespace ClosedXML.Excel
                 fontSource.Elements<DocumentFormat.OpenXml.Spreadsheet.FontFamily>().FirstOrDefault();
             if (fontFamilyNumbering != null && fontFamilyNumbering.Val != null)
                 fontBase.FontFamilyNumbering =
-                    (XLFontFamilyNumberingValues) Int32.Parse(fontFamilyNumbering.Val.ToString());
+                    (XLFontFamilyNumberingValues)Int32.Parse(fontFamilyNumbering.Val.ToString());
             var runFont = fontSource.Elements<RunFont>().FirstOrDefault();
             if (runFont != null)
             {
@@ -1119,12 +1119,13 @@ namespace ClosedXML.Excel
         }
 
         private Int32 lastRow;
+
         private void LoadRows(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders, Fonts fonts,
                               XLWorksheet ws, SharedStringItem[] sharedStrings,
                               Dictionary<uint, string> sharedFormulasR1C1, Dictionary<Int32, IXLStyle> styleList,
                               Row row)
         {
-            Int32 rowIndex = row.RowIndex == null ? ++lastRow : (Int32) row.RowIndex.Value;
+            Int32 rowIndex = row.RowIndex == null ? ++lastRow : (Int32)row.RowIndex.Value;
             var xlRow = ws.Row(rowIndex, false);
 
             if (row.Height != null)
@@ -1150,7 +1151,7 @@ namespace ClosedXML.Excel
                 Int32 styleIndex = row.StyleIndex != null ? Int32.Parse(row.StyleIndex.InnerText) : -1;
                 if (styleIndex > 0)
                 {
-                        ApplyStyle(xlRow, styleIndex, s, fills, borders, fonts, numberingFormats);
+                    ApplyStyle(xlRow, styleIndex, s, fills, borders, fonts, numberingFormats);
                 }
                 else
                 {
@@ -1186,7 +1187,7 @@ namespace ClosedXML.Excel
                 //IXLStylized toApply;
                 if (col.Max == XLHelper.MaxColumnNumber) continue;
 
-                var xlColumns = (XLColumns) ws.Columns(col.Min, col.Max);
+                var xlColumns = (XLColumns)ws.Columns(col.Min, col.Max);
                 if (col.Width != null)
                 {
                     Double width = col.Width - ColumnWidthOffset;
@@ -1294,6 +1295,7 @@ namespace ClosedXML.Excel
                                 else
                                     condition = o => (o as IComparable).CompareTo(xlFilter.Value) == 0;
                                 break;
+
                             case XLFilterOperator.EqualOrGreaterThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) >= 0; break;
                             case XLFilterOperator.EqualOrLessThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) <= 0; break;
                             case XLFilterOperator.GreaterThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) > 0; break;
@@ -1347,7 +1349,6 @@ namespace ClosedXML.Excel
                         xlFilter.Condition = condition;
                         filterList.Add(xlFilter);
                     }
-
                 }
                 else if (filterColumn.Top10 != null)
                 {
@@ -1389,7 +1390,7 @@ namespace ClosedXML.Excel
                 var condition = sort.Elements<SortCondition>().FirstOrDefault();
                 if (condition != null)
                 {
-                    Int32 column = ws.Range(condition.Reference.Value).FirstCell().Address.ColumnNumber - autoFilter.Range.FirstCell().Address.ColumnNumber + 1 ;
+                    Int32 column = ws.Range(condition.Reference.Value).FirstCell().Address.ColumnNumber - autoFilter.Range.FirstCell().Address.ColumnNumber + 1;
                     autoFilter.SortColumn = column;
                     autoFilter.Sorted = true;
                     autoFilter.SortOrder = condition.Descending != null && condition.Descending.Value ? XLSortOrder.Descending : XLSortOrder.Ascending;
@@ -1456,10 +1457,10 @@ namespace ClosedXML.Excel
                     var conditionalFormat = new XLConditionalFormat(ws.Range(sor.Value));
                     if (fr.FormatId != null)
                     {
-                        LoadFont(differentialFormats[(Int32) fr.FormatId.Value].Font, conditionalFormat.Style.Font);
-                        LoadFill(differentialFormats[(Int32) fr.FormatId.Value].Fill, conditionalFormat.Style.Fill);
-                        LoadBorder(differentialFormats[(Int32) fr.FormatId.Value].Border, conditionalFormat.Style.Border);
-                        LoadNumberFormat(differentialFormats[(Int32) fr.FormatId.Value].NumberingFormat, conditionalFormat.Style.NumberFormat);
+                        LoadFont(differentialFormats[(Int32)fr.FormatId.Value].Font, conditionalFormat.Style.Font);
+                        LoadFill(differentialFormats[(Int32)fr.FormatId.Value].Fill, conditionalFormat.Style.Fill);
+                        LoadBorder(differentialFormats[(Int32)fr.FormatId.Value].Border, conditionalFormat.Style.Border);
+                        LoadNumberFormat(differentialFormats[(Int32)fr.FormatId.Value].NumberingFormat, conditionalFormat.Style.NumberFormat);
                     }
                     if (fr.Operator != null)
                         conditionalFormat.Operator = fr.Operator.Value.ToClosedXml();
@@ -1516,7 +1517,6 @@ namespace ClosedXML.Excel
                     ws.ConditionalFormats.Add(conditionalFormat);
                 }
             }
-
         }
 
         private static XLFormula GetFormula(String value)
@@ -1635,7 +1635,7 @@ namespace ClosedXML.Excel
                 ws.PageSetup.DifferentOddEvenPagesOnHF = headerFooter.DifferentOddEven;
 
             // Footers
-            var xlFooter = (XLHeaderFooter) ws.PageSetup.Footer;
+            var xlFooter = (XLHeaderFooter)ws.PageSetup.Footer;
             var evenFooter = headerFooter.EvenFooter;
             if (evenFooter != null)
                 xlFooter.SetInnerText(XLHFOccurrence.EvenPages, evenFooter.Text);
@@ -1646,7 +1646,7 @@ namespace ClosedXML.Excel
             if (firstFooter != null)
                 xlFooter.SetInnerText(XLHFOccurrence.FirstPage, firstFooter.Text);
             // Headers
-            var xlHeader = (XLHeaderFooter) ws.PageSetup.Header;
+            var xlHeader = (XLHeaderFooter)ws.PageSetup.Header;
             var evenHeader = headerFooter.EvenHeader;
             if (evenHeader != null)
                 xlHeader.SetInnerText(XLHFOccurrence.EvenPages, evenHeader.Text);
@@ -1666,7 +1666,7 @@ namespace ClosedXML.Excel
             if (pageSetup == null) return;
 
             if (pageSetup.PaperSize != null)
-                ws.PageSetup.PaperSize = (XLPaperSize) Int32.Parse(pageSetup.PaperSize.InnerText);
+                ws.PageSetup.PaperSize = (XLPaperSize)Int32.Parse(pageSetup.PaperSize.InnerText);
             if (pageSetup.Scale != null)
                 ws.PageSetup.Scale = Int32.Parse(pageSetup.Scale.InnerText);
             else
@@ -1688,8 +1688,8 @@ namespace ClosedXML.Excel
                 ws.PageSetup.ShowComments = pageSetup.CellComments.Value.ToClosedXml();
             if (pageSetup.Errors != null)
                 ws.PageSetup.PrintErrorValue = pageSetup.Errors.Value.ToClosedXml();
-            if (pageSetup.HorizontalDpi != null) ws.PageSetup.HorizontalDpi = (Int32) pageSetup.HorizontalDpi.Value;
-            if (pageSetup.VerticalDpi != null) ws.PageSetup.VerticalDpi = (Int32) pageSetup.VerticalDpi.Value;
+            if (pageSetup.HorizontalDpi != null) ws.PageSetup.HorizontalDpi = (Int32)pageSetup.HorizontalDpi.Value;
+            if (pageSetup.VerticalDpi != null) ws.PageSetup.VerticalDpi = (Int32)pageSetup.VerticalDpi.Value;
             if (pageSetup.FirstPageNumber != null)
                 ws.PageSetup.FirstPageNumber = UInt32.Parse(pageSetup.FirstPageNumber.InnerText);
         }
@@ -1763,10 +1763,9 @@ namespace ClosedXML.Excel
                 (pane.State != PaneStateValues.FrozenSplit && pane.State != PaneStateValues.Frozen)) return;
 
             if (pane.HorizontalSplit != null)
-                ws.SheetView.SplitColumn = (Int32) pane.HorizontalSplit.Value;
+                ws.SheetView.SplitColumn = (Int32)pane.HorizontalSplit.Value;
             if (pane.VerticalSplit != null)
-                ws.SheetView.SplitRow = (Int32) pane.VerticalSplit.Value;
-
+                ws.SheetView.SplitRow = (Int32)pane.VerticalSplit.Value;
         }
 
         private void SetProperties(SpreadsheetDocument dSpreadsheet)
@@ -1803,10 +1802,10 @@ namespace ClosedXML.Excel
                     retVal = XLColor.FromColor(thisColor);
                 }
                 else if (color.Indexed != null && color.Indexed < 64)
-                    retVal = XLColor.FromIndex((Int32) color.Indexed.Value);
+                    retVal = XLColor.FromIndex((Int32)color.Indexed.Value);
                 else if (color.Theme != null)
                 {
-                    retVal = color.Tint != null ? XLColor.FromTheme((XLThemeColor) color.Theme.Value, color.Tint.Value) : XLColor.FromTheme((XLThemeColor) color.Theme.Value);
+                    retVal = color.Tint != null ? XLColor.FromTheme((XLThemeColor)color.Theme.Value, color.Tint.Value) : XLColor.FromTheme((XLThemeColor)color.Theme.Value);
                 }
             }
             return retVal ?? XLColor.NoColor;
@@ -1817,7 +1816,7 @@ namespace ClosedXML.Excel
         {
             if (s == null) return; //No Stylesheet, no Styles
 
-            var cellFormat = (CellFormat) s.CellFormats.ElementAt(styleIndex);
+            var cellFormat = (CellFormat)s.CellFormats.ElementAt(styleIndex);
 
             if (cellFormat.ApplyProtection != null)
             {
@@ -1851,7 +1850,6 @@ namespace ClosedXML.Excel
                 }
             }
 
-
             var alignment = cellFormat.Alignment;
             if (alignment != null)
             {
@@ -1864,20 +1862,19 @@ namespace ClosedXML.Excel
                 if (alignment.ReadingOrder != null)
                 {
                     xlStylized.InnerStyle.Alignment.ReadingOrder =
-                        (XLAlignmentReadingOrderValues) Int32.Parse(alignment.ReadingOrder.ToString());
+                        (XLAlignmentReadingOrderValues)Int32.Parse(alignment.ReadingOrder.ToString());
                 }
                 if (alignment.RelativeIndent != null)
                     xlStylized.InnerStyle.Alignment.RelativeIndent = alignment.RelativeIndent;
                 if (alignment.ShrinkToFit != null)
                     xlStylized.InnerStyle.Alignment.ShrinkToFit = alignment.ShrinkToFit;
                 if (alignment.TextRotation != null)
-                    xlStylized.InnerStyle.Alignment.TextRotation = (Int32) alignment.TextRotation.Value;
+                    xlStylized.InnerStyle.Alignment.TextRotation = (Int32)alignment.TextRotation.Value;
                 if (alignment.Vertical != null)
                     xlStylized.InnerStyle.Alignment.Vertical = alignment.Vertical.Value.ToClosedXml();
                 if (alignment.WrapText != null)
                     xlStylized.InnerStyle.Alignment.WrapText = alignment.WrapText;
             }
-
 
             if (UInt32HasValue(cellFormat.BorderId))
             {
@@ -1987,8 +1984,6 @@ namespace ClosedXML.Excel
                 }
             }
 
-
-
             if (!UInt32HasValue(cellFormat.NumberFormatId)) return;
 
             var numberFormatId = cellFormat.NumberFormatId;
@@ -1999,8 +1994,8 @@ namespace ClosedXML.Excel
                 var numberingFormat =
                     numberingFormats.FirstOrDefault(
                         nf =>
-                        ((NumberingFormat) nf).NumberFormatId != null &&
-                        ((NumberingFormat) nf).NumberFormatId.Value == numberFormatId) as NumberingFormat;
+                        ((NumberingFormat)nf).NumberFormatId != null &&
+                        ((NumberingFormat)nf).NumberFormatId.Value == numberFormatId) as NumberingFormat;
 
                 if (numberingFormat != null && numberingFormat.FormatCode != null)
                     formatCode = numberingFormat.FormatCode.Value;
@@ -2008,7 +2003,7 @@ namespace ClosedXML.Excel
             if (formatCode.Length > 0)
                 xlStylized.InnerStyle.NumberFormat.Format = formatCode;
             else
-                xlStylized.InnerStyle.NumberFormat.NumberFormatId = (Int32) numberFormatId.Value;
+                xlStylized.InnerStyle.NumberFormat.NumberFormatId = (Int32)numberFormatId.Value;
         }
 
         private static Boolean UInt32HasValue(UInt32Value value)


### PR DESCRIPTION
Extract method to parse cell value and reuse it for inline strings too. Previously inline strings with rich text failed.
Also clean up class formatting using CodeMaid.

Fixes #91.