### PR TITLE
Multiple SaveAs calls causes InvalidCastException

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -99,7 +99,7 @@ namespace ClosedXML.Excel
                 {
                     _relIds.Add(relType, new List<String>());
                 }
-                _relIds[relType].AddRange(values);
+                _relIds[relType].AddRange(values.Where(v => !_relIds[relType].Contains(v)));
             }
             public void Reset(RelType relType)
             {
@@ -147,9 +147,5 @@ namespace ClosedXML.Excel
             public IXLStyle Style;
         }
         #endregion
-
-        
-        
-       
     }
 }

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Excel\Loading\LoadingTests.cs" />
     <Compile Include="Excel\PageSetup\HeaderFooterTests.cs" />
     <Compile Include="Excel\Ranges\UsedAndUnusedCellsTests.cs" />
+    <Compile Include="Excel\Saving\SavingTests.cs" />
     <Compile Include="XLHelperTests.cs" />
     <Compile Include="Excel\AutoFilters\AutoFilterTests.cs" />
     <Compile Include="Excel\CalcEngine\DateAndTimeTests.cs" />

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -1,0 +1,30 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System.IO;
+
+namespace ClosedXML_Tests.Excel.Saving
+{
+    [TestFixture]
+    public class SavingTests
+    {
+        [Test]
+        public void CanSuccessfullySaveFileMultipleTimes()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var memoryStream = new MemoryStream();
+                wb.SaveAs(memoryStream, true);
+
+                for (int i = 1; i <= 3; i++)
+                {
+                    sheet.Cell(i, 1).Value = "test" + i;
+                    wb.SaveAs(memoryStream, true);
+                }
+
+                memoryStream.Close();
+                memoryStream.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
For an existing workbook that is resaved, correctly retrieve the relId and readd it to the workbookPar.

Fixes https://closedxml.codeplex.com/workitem/9483