### PR TITLE
Don't match parts of formula between single quotes (i.e. sheet names)

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -966,8 +966,6 @@ namespace ClosedXML.Excel
             set
             {
                 _formulaR1C1 = XLHelper.IsNullOrWhiteSpace(value) ? null : value;
-
-// FormulaA1 = GetFormulaA1(value);
             }
         }
 
@@ -1761,9 +1759,10 @@ namespace ClosedXML.Excel
             {
                 var matchString = match.Value;
                 var matchIndex = match.Index;
-                if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0)
+                if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0
+                    && value.Substring(0, matchIndex).CharCount('\'') % 2 == 0)
                 {
-// Check if the match is in between quotes
+                    // Check if the match is in between quotes
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
                     sb.Append(conversionType == FormulaConversionType.A1ToR1C1
                                   ? GetR1C1Address(matchString, rowsToShift, columnsToShift)

--- a/ClosedXML_Tests/Excel/Misc/FormulaTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/FormulaTests.cs
@@ -18,5 +18,25 @@ namespace ClosedXML_Tests.Excel
             ws.Cell("A1").CopyTo("A2");
             Assert.AreEqual("B2", ws.Cell("A2").FormulaA1);
         }
+
+        [Test]
+        public void CopyFormulaWithSheetNameThatResemblesFormula()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                IXLWorksheet ws = wb.Worksheets.Add("S10 Data");
+                ws.Cell("A1").Value = "Some value";
+
+                ws = wb.Worksheets.Add("Summary");
+                ws.Cell("A1").FormulaA1 = "='S10 Data'!A1";
+                Assert.AreEqual("Some value", ws.Cell("A1").Value);
+
+                ws.Cell("A1").CopyTo("A2");
+                Assert.AreEqual("'S10 Data'!A2", ws.Cell("A2").FormulaA1);
+
+                ws.Cell("A1").CopyTo("B1");
+                Assert.AreEqual("'S10 Data'!B1", ws.Cell("B1").FormulaA1);
+            }
+        }
     }
 }


### PR DESCRIPTION
Don't match parts of formula between single quotes (i.e. sheet names). Related to part of #90