### PR TITLE
Force OpenXMLValidator to run under invariant culture

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -43,6 +43,7 @@ using Field = DocumentFormat.OpenXml.Spreadsheet.Field;
 using Run = DocumentFormat.OpenXml.Spreadsheet.Run;
 using RunProperties = DocumentFormat.OpenXml.Spreadsheet.RunProperties;
 using VerticalTextAlignment = DocumentFormat.OpenXml.Spreadsheet.VerticalTextAlignment;
+using System.Threading;
 
 namespace ClosedXML.Excel
 {
@@ -82,8 +83,20 @@ namespace ClosedXML.Excel
 
         private bool Validate(SpreadsheetDocument package)
         {
-            var validator = new OpenXmlValidator();
-            var errors = validator.Validate(package);
+            var backupCulture = Thread.CurrentThread.CurrentCulture;
+
+            IEnumerable<ValidationErrorInfo> errors;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                var validator = new OpenXmlValidator();
+                errors = validator.Validate(package);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = backupCulture;
+            }
+
             if (errors.Any())
             {
                 var message = string.Join("\r\n", errors.Select(e => string.Format("{0} in {1}", e.Description, e.Path.XPath)).ToArray());

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -1,6 +1,8 @@
 ﻿using ClosedXML.Excel;
 using NUnit.Framework;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 
 namespace ClosedXML_Tests.Excel.Saving
 {
@@ -24,6 +26,25 @@ namespace ClosedXML_Tests.Excel.Saving
 
                 memoryStream.Close();
                 memoryStream.Dispose();
+            }
+        }
+
+        [Test]
+        public void CanSaveAndValidateFileInAnotherCulture()
+        {
+            string[] cultures = new string[] { "it", "de-AT" };
+
+            foreach (var culture in cultures)
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+                using (var wb = new XLWorkbook())
+                {
+                    var memoryStream = new MemoryStream();
+                    var ws = wb.Worksheets.Add("Sheet1");
+
+                    wb.SaveAs(memoryStream, true);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #152 , #156

Even though the issue is fixed upstream in https://github.com/OfficeDev/Open-XML-SDK/pull/141 , we still need to enforce an invariant culture to support the .NET35 version of the library.