### PR TITLE
Deduce default header and footer font from worksheet

### DIFF
--- a/ClosedXML/Excel/PageSetup/XLHFItem.cs
+++ b/ClosedXML/Excel/PageSetup/XLHFItem.cs
@@ -40,7 +40,7 @@ namespace ClosedXML.Excel
 
         public IXLRichString AddText(String text, XLHFOccurrence occurrence)
         {
-            XLRichString richText = new XLRichString(text, XLWorkbook.DefaultStyle.Font, this);
+            XLRichString richText = new XLRichString(text, this.HeaderFooter.Worksheet.Style.Font, this);
 
             var hfText = new XLHFText(richText, this);
             if (occurrence == XLHFOccurrence.AllPages)


### PR DESCRIPTION
Deduce default header and footer font from worksheet, rather than workbook default style.

Fixes #174 