### PR TITLE
Add VmlDrawing Id's to context to avoid reuse.

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -225,6 +225,7 @@ namespace ClosedXML.Excel
             // Ensure all RelId's have been added to the context
             context.RelIdGenerator.AddValues(workbookPart.Parts.Select(p => p.RelationshipId), RelType.Workbook);
             context.RelIdGenerator.AddValues(WorksheetsInternal.Cast<XLWorksheet>().Where(ws => !XLHelper.IsNullOrWhiteSpace(ws.RelId)).Select(ws => ws.RelId), RelType.Workbook);
+            context.RelIdGenerator.AddValues(WorksheetsInternal.Cast<XLWorksheet>().Where(ws => !XLHelper.IsNullOrWhiteSpace(ws.LegacyDrawingId)).Select(ws => ws.LegacyDrawingId), RelType.Workbook);
             context.RelIdGenerator.AddValues(WorksheetsInternal
                 .Cast<XLWorksheet>()
                 .SelectMany(ws => ws.Tables.Cast<XLTable>())
@@ -276,8 +277,9 @@ namespace ClosedXML.Excel
 
                 if (worksheet.Internals.CellsCollection.GetCells(c => c.HasComment).Any())
                 {
+                    var id = context.RelIdGenerator.GetNext(RelType.Workbook);
                     var worksheetCommentsPart =
-                        worksheetPart.AddNewPart<WorksheetCommentsPart>(context.RelIdGenerator.GetNext(RelType.Workbook));
+                        worksheetPart.AddNewPart<WorksheetCommentsPart>(id);
 
                     GenerateWorksheetCommentsPartContent(worksheetCommentsPart, worksheet);
 

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -13,6 +13,10 @@ namespace ClosedXML_Tests.Excel.Saving
             using (var wb = new XLWorkbook())
             {
                 var sheet = wb.Worksheets.Add("TestSheet");
+
+                // Comments might cause duplicate VmlDrawing Id's - ensure it's tested:
+                sheet.Cell(1, 1).Comment.AddText("abc");
+
                 var memoryStream = new MemoryStream();
                 wb.SaveAs(memoryStream, true);
 


### PR DESCRIPTION
Fixes #221 