### PR TITLE
Performance improvement on creation of merged cells

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -344,11 +344,15 @@ namespace ClosedXML.Excel
         {
             if (checkIntersect)
             {
-                string tAddress = RangeAddress.ToString();
-                foreach (var mergedRange in Worksheet.Internals.MergedRanges)
+                using (IXLRange range = Worksheet.Range(RangeAddress))
                 {
-                    if (mergedRange.Intersects(tAddress))
-                        Worksheet.Internals.MergedRanges.Remove(mergedRange);
+                    foreach (var mergedRange in Worksheet.Internals.MergedRanges)
+                    {
+                        if (mergedRange.Intersects(range))
+                        {
+                            Worksheet.Internals.MergedRanges.Remove(mergedRange);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Performance improvement on creation of merged cells.
#300

```c#
using (var wb = new XLWorkbook(@"template.xlsx"))
{
    var ws = wb.Worksheets.Worksheet(1);
    var firstRow = ws.FirstRow();

    var startTicks = DateTime.Now.Ticks;

    using (var range = ws.Range(1, 1, 1, 20))
    {
        for (int i = 0; i <= 500; i++)
        {
            using (var rangeTo = ws.Range(2 + i, 1, 2 + i, 20))
            {
                range.CopyTo(rangeTo);
            }
            if (i % 10 == 0)
            {
                Console.WriteLine((DateTime.Now.Ticks - startTicks) / 10000);
            }
        }
    }

    wb.SaveAs(@"template_new.xlsx");
}
```

![chart02](https://cloud.githubusercontent.com/assets/515948/25811204/6da6973a-344d-11e7-888f-5ee207fd7ef9.png)

The performance is fairly improved, but is there a possibility that this change causes side effects?
