### PR TITLE
Correctly set cell's address' worksheet when copying

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1997,7 +1997,7 @@ namespace ClosedXML.Excel
         public IXLCell CopyFrom(IXLCell otherCell, Boolean copyDataValidations)
         {
             var source = otherCell as XLCell; // To expose GetFormulaR1C1, etc
-            //var source = castedOtherCell;
+
             CopyValuesFrom(source);
 
             SetStyle(source._style ?? source.Worksheet.Workbook.GetStyleById(source._styleCacheId));

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -803,7 +803,7 @@ namespace ClosedXML.Excel
                     && column.GetStyleId() != worksheetStyleId)
                     styleId = column.GetStyleId();
             }
-            var absoluteAddress = new XLAddress(cellAddressInRange.Worksheet,
+            var absoluteAddress = new XLAddress(this.Worksheet,
                                  absRow,
                                  absColumn,
                                  cellAddressInRange.FixedRow,

--- a/ClosedXML_Tests/Excel/Misc/CopyContentsTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/CopyContentsTests.cs
@@ -1,6 +1,6 @@
-using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System.Linq;
 
 namespace ClosedXML_Tests.Excel.Misc
 {
@@ -114,6 +114,21 @@ namespace ClosedXML_Tests.Excel.Misc
                 originalRow.CopyTo(destinationRow);
             }
             TestHelper.SaveWorkbook(workbook, "Misc", "CopyRowContents.xlsx");
+        }
+
+        [Test]
+        public void UpdateCellsWorksheetTest()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws1 = wb.Worksheets.Add("Sheet1");
+                ws1.Cell(1, 1).Value = "hello, world.";
+
+                var ws2 = ws1.CopyTo("Sheet2");
+
+                Assert.AreEqual("Sheet1", ws1.FirstCell().Address.Worksheet.Name);
+                Assert.AreEqual("Sheet2", ws2.FirstCell().Address.Worksheet.Name);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #371 