### PR TITLE
Use worksheet style if range base style is empty

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -788,7 +788,6 @@ namespace ClosedXML.Excel
             if (cell != null)
                 return cell;
 
-            //var style = Style;
             Int32 styleId = GetStyleId();
             Int32 worksheetStyleId = Worksheet.GetStyleId();
 
@@ -808,7 +807,15 @@ namespace ClosedXML.Excel
                                  absColumn,
                                  cellAddressInRange.FixedRow,
                                  cellAddressInRange.FixedColumn);
-            var newCell = new XLCell(Worksheet, absoluteAddress, styleId);
+
+            Int32 newCellStyleId = styleId;
+
+            // If the default style for this range base is empty, but the worksheet 
+            // has a default style, use the worksheet's default style
+            if (styleId == 0 && worksheetStyleId != 0)
+                newCellStyleId = worksheetStyleId;
+
+            var newCell = new XLCell(Worksheet, absoluteAddress, newCellStyleId);
             Worksheet.Internals.CellsCollection.Add(absRow, absColumn, newCell);
             return newCell;
         }

--- a/ClosedXML_Tests/Excel/Misc/StylesTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/StylesTests.cs
@@ -77,5 +77,30 @@ namespace ClosedXML_Tests.Excel.Misc
                 Assert.AreEqual("FFFFFFFF", color);
             }
         }
+
+        [Test]
+        public void SetStyleViaRowReference()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Style
+                   .Font.SetFontSize(8)
+                   .Font.SetFontColor(XLColor.Green)
+                   .Font.SetBold(true);
+
+                var row = ws.Row(1);
+                ws.Cell(1, 1).Value = "Test";
+                row.Cell(2).Value = "Test";
+                row.Cells(3, 3).Value = "Test";
+
+                foreach (var cell in ws.CellsUsed())
+                {
+                    Assert.AreEqual(8, ws.Cell("A1").Style.Font.FontSize);
+                    Assert.AreEqual(XLColor.Green, ws.Cell("B1").Style.Font.FontColor);
+                    Assert.AreEqual(true, ws.Cell("C1").Style.Font.Bold);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #376 