### PR TITLE
When copying a worksheet, named ranges on the source worksheet have to point to the new destination sheet

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -82,8 +82,6 @@ namespace ClosedXML.Excel
 
         #region Public properties
 
-        //public XLRangeAddress RangeAddress { get; protected set; }
-
         private XLRangeAddress _rangeAddress;
         public XLRangeAddress RangeAddress
         {
@@ -810,7 +808,7 @@ namespace ClosedXML.Excel
 
             Int32 newCellStyleId = styleId;
 
-            // If the default style for this range base is empty, but the worksheet 
+            // If the default style for this range base is empty, but the worksheet
             // has a default style, use the worksheet's default style
             if (styleId == 0 && worksheetStyleId != 0)
                 newCellStyleId = worksheetStyleId;

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -606,11 +606,18 @@ namespace ClosedXML.Excel
                 }
             }
 
-            foreach (IXLNamedRange r in NamedRanges)
+            foreach (var nr in NamedRanges)
             {
                 var ranges = new XLRanges();
-                r.Ranges.ForEach(ranges.Add);
-                targetSheet.NamedRanges.Add(r.Name, ranges);
+                foreach (var r in nr.Ranges)
+                {
+                    if (this == r.Worksheet)
+                        // Named ranges on the source worksheet have to point to the new destination sheet
+                        ranges.Add(targetSheet.Range(r.RangeAddress.FirstAddress.RowNumber, r.RangeAddress.FirstAddress.ColumnNumber, r.RangeAddress.LastAddress.RowNumber, r.RangeAddress.LastAddress.ColumnNumber));
+                    else
+                        ranges.Add(r);
+                }
+                targetSheet.NamedRanges.Add(nr.Name, ranges);
             }
 
             foreach (XLTable t in Tables.Cast<XLTable>())


### PR DESCRIPTION
Fixes #416
