### PR TITLE
Remove obsolete XLHelper.IsNullOrWhiteSpace

### DIFF
--- a/ClosedXML/Attributes/XLColumnAttribute.cs
+++ b/ClosedXML/Attributes/XLColumnAttribute.cs
@@ -23,7 +23,7 @@ namespace ClosedXML.Attributes
         {
             var attribute = GetXLColumnAttribute(mi);
             if (attribute == null) return null;
-            return XLHelper.IsNullOrWhiteSpace(attribute.Header) ? null : attribute.Header;
+            return String.IsNullOrWhiteSpace(attribute.Header) ? null : attribute.Header;
         }
 
         internal static Int32 GetOrder(MemberInfo mi)

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -98,7 +98,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 _evaluating = true;
                 var f = cell.FormulaA1;
-                if (XLHelper.IsNullOrWhiteSpace(f))
+                if (String.IsNullOrWhiteSpace(f))
                     return cell.Value;
                 else
                     return new XLCalcEngine(cell.Worksheet).Evaluate(f);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -365,7 +365,7 @@ namespace ClosedXML.Excel
             get
             {
                 var fA1 = FormulaA1;
-                if (!XLHelper.IsNullOrWhiteSpace(fA1))
+                if (!String.IsNullOrWhiteSpace(fA1))
                 {
                     if (fA1[0] == '{')
                         fA1 = fA1.Substring(1, fA1.Length - 2);
@@ -496,7 +496,7 @@ namespace ClosedXML.Excel
                         if (!hasTitles)
                         {
                             var fieldName = XLColumnAttribute.GetHeader(itemType);
-                            if (XLHelper.IsNullOrWhiteSpace(fieldName))
+                            if (String.IsNullOrWhiteSpace(fieldName))
                                 fieldName = itemType.Name;
 
                             SetValue(fieldName, fRo, co);
@@ -574,7 +574,7 @@ namespace ClosedXML.Excel
                             if (!hasTitles)
                             {
                                 foreach (var fieldName in from DataColumn column in row.Table.Columns
-                                                          select XLHelper.IsNullOrWhiteSpace(column.Caption)
+                                                          select String.IsNullOrWhiteSpace(column.Caption)
                                                                      ? column.ColumnName
                                                                      : column.Caption)
                                 {
@@ -627,7 +627,7 @@ namespace ClosedXML.Excel
                                     if ((mi as IEnumerable) == null)
                                     {
                                         var fieldName = XLColumnAttribute.GetHeader(mi);
-                                        if (XLHelper.IsNullOrWhiteSpace(fieldName))
+                                        if (String.IsNullOrWhiteSpace(fieldName))
                                             fieldName = mi.Name;
 
                                         SetValue(fieldName, fRo, co);
@@ -968,9 +968,9 @@ namespace ClosedXML.Excel
         {
             get
             {
-                if (XLHelper.IsNullOrWhiteSpace(_formulaA1))
+                if (String.IsNullOrWhiteSpace(_formulaA1))
                 {
-                    if (!XLHelper.IsNullOrWhiteSpace(_formulaR1C1))
+                    if (!String.IsNullOrWhiteSpace(_formulaR1C1))
                     {
                         _formulaA1 = GetFormulaA1(_formulaR1C1);
                         return FormulaA1;
@@ -990,7 +990,7 @@ namespace ClosedXML.Excel
 
             set
             {
-                _formulaA1 = XLHelper.IsNullOrWhiteSpace(value) ? null : value;
+                _formulaA1 = String.IsNullOrWhiteSpace(value) ? null : value;
 
                 _formulaR1C1 = null;
             }
@@ -1000,7 +1000,7 @@ namespace ClosedXML.Excel
         {
             get
             {
-                if (XLHelper.IsNullOrWhiteSpace(_formulaR1C1))
+                if (String.IsNullOrWhiteSpace(_formulaR1C1))
                     _formulaR1C1 = GetFormulaR1C1(FormulaA1);
 
                 return _formulaR1C1;
@@ -1008,7 +1008,7 @@ namespace ClosedXML.Excel
 
             set
             {
-                _formulaR1C1 = XLHelper.IsNullOrWhiteSpace(value) ? null : value;
+                _formulaR1C1 = String.IsNullOrWhiteSpace(value) ? null : value;
             }
         }
 
@@ -1532,7 +1532,7 @@ namespace ClosedXML.Excel
         {
             var style = GetStyleForRead();
             return _dataType == XLCellValues.Number
-                   && XLHelper.IsNullOrWhiteSpace(style.NumberFormat.Format)
+                   && String.IsNullOrWhiteSpace(style.NumberFormat.Format)
                    && ((style.NumberFormat.NumberFormatId >= 14
                         && style.NumberFormat.NumberFormatId <= 22)
                        || (style.NumberFormat.NumberFormatId >= 45
@@ -1543,7 +1543,7 @@ namespace ClosedXML.Excel
         {
             var format = String.Empty;
             var style = GetStyleForRead();
-            if (XLHelper.IsNullOrWhiteSpace(style.NumberFormat.Format))
+            if (String.IsNullOrWhiteSpace(style.NumberFormat.Format))
             {
                 var formatCodes = GetFormatCodes();
                 if (formatCodes.ContainsKey(style.NumberFormat.NumberFormatId))
@@ -1783,7 +1783,7 @@ namespace ClosedXML.Excel
         private string GetFormula(string strValue, FormulaConversionType conversionType, int rowsToShift,
                                   int columnsToShift)
         {
-            if (XLHelper.IsNullOrWhiteSpace(strValue))
+            if (String.IsNullOrWhiteSpace(strValue))
                 return String.Empty;
 
             var value = ">" + strValue + "<";
@@ -2057,7 +2057,7 @@ namespace ClosedXML.Excel
         internal static String ShiftFormulaRows(String formulaA1, XLWorksheet worksheetInAction, XLRange shiftedRange,
                                                 int rowsShifted)
         {
-            if (XLHelper.IsNullOrWhiteSpace(formulaA1)) return String.Empty;
+            if (String.IsNullOrWhiteSpace(formulaA1)) return String.Empty;
 
             var value = formulaA1; // ">" + formulaA1 + "<";
 
@@ -2262,7 +2262,7 @@ namespace ClosedXML.Excel
         internal static String ShiftFormulaColumns(String formulaA1, XLWorksheet worksheetInAction, XLRange shiftedRange,
                                                    int columnsShifted)
         {
-            if (XLHelper.IsNullOrWhiteSpace(formulaA1)) return String.Empty;
+            if (String.IsNullOrWhiteSpace(formulaA1)) return String.Empty;
 
             var value = formulaA1; // ">" + formulaA1 + "<";
 
@@ -2590,7 +2590,7 @@ namespace ClosedXML.Excel
 
         #endregion XLCell Right
 
-        public Boolean HasFormula { get { return !XLHelper.IsNullOrWhiteSpace(FormulaA1); } }
+        public Boolean HasFormula { get { return !String.IsNullOrWhiteSpace(FormulaA1); } }
 
         public IXLRangeAddress FormulaReference { get; set; }
     }

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -41,9 +41,9 @@ namespace ClosedXML.Excel
             return
                 AllowedValues != XLAllowedValues.AnyValue
                 || (ShowInputMessage &&
-                  (!XLHelper.IsNullOrWhiteSpace(InputTitle) || !XLHelper.IsNullOrWhiteSpace(InputMessage)))
+                  (!String.IsNullOrWhiteSpace(InputTitle) || !String.IsNullOrWhiteSpace(InputMessage)))
                 ||(ShowErrorMessage &&
-                  (!XLHelper.IsNullOrWhiteSpace(ErrorTitle) || !XLHelper.IsNullOrWhiteSpace(ErrorMessage)));
+                  (!String.IsNullOrWhiteSpace(ErrorTitle) || !String.IsNullOrWhiteSpace(ErrorMessage)));
 
         }
 

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -159,7 +159,7 @@ namespace ClosedXML.Excel.Drawings
                 if (value.IndexOfAny(InvalidNameChars.ToCharArray()) != -1)
                     throw new ArgumentException($"Picture names cannot contain any of the following characters: {InvalidNameChars}");
 
-                if (XLHelper.IsNullOrWhiteSpace(value))
+                if (String.IsNullOrWhiteSpace(value))
                     throw new ArgumentException("Picture names cannot be empty");
 
                 if (value.Length > 31)

--- a/ClosedXML/Excel/Misc/XLFormula.cs
+++ b/ClosedXML/Excel/Misc/XLFormula.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel
                 else
                 {
                     _value = value.Trim();
-                    IsFormula = !XLHelper.IsNullOrWhiteSpace(_value) && _value.TrimStart()[0] == '=' ;
+                    IsFormula = !String.IsNullOrWhiteSpace(_value) && _value.TrimStart()[0] == '=' ;
                     if (IsFormula)
                         _value = _value.Substring(1);
                 }

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1072,7 +1072,7 @@ namespace ClosedXML.Excel
         {
             foreach (XLWorksheet ws in Worksheet.Workbook.WorksheetsInternal)
             {
-                foreach (XLCell cell in ws.Internals.CellsCollection.GetCells(c => !XLHelper.IsNullOrWhiteSpace(c.FormulaA1)))
+                foreach (XLCell cell in ws.Internals.CellsCollection.GetCells(c => !String.IsNullOrWhiteSpace(c.FormulaA1)))
                     using (var asRange = AsRange())
                         cell.ShiftFormulaColumns(asRange, numberOfColumns);
             }
@@ -1303,7 +1303,7 @@ namespace ClosedXML.Excel
             using (var asRange = AsRange())
                 foreach (XLWorksheet ws in Worksheet.Workbook.WorksheetsInternal)
                 {
-                    foreach (XLCell cell in ws.Internals.CellsCollection.GetCells(c => !XLHelper.IsNullOrWhiteSpace(c.FormulaA1)))
+                    foreach (XLCell cell in ws.Internals.CellsCollection.GetCells(c => !String.IsNullOrWhiteSpace(c.FormulaA1)))
                         cell.ShiftFormulaRows(asRange, numberOfRows);
                 }
 
@@ -1477,7 +1477,7 @@ namespace ClosedXML.Excel
                 XLCell cell in
                     Worksheet.Workbook.Worksheets.Cast<XLWorksheet>().SelectMany(
                         xlWorksheet => (xlWorksheet).Internals.CellsCollection.GetCells(
-                            c => !XLHelper.IsNullOrWhiteSpace(c.FormulaA1))))
+                            c => !String.IsNullOrWhiteSpace(c.FormulaA1))))
             {
                 if (shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp)
                     cell.ShiftFormulaRows((XLRange)shiftedRangeFormula, numberOfRows * -1);
@@ -1760,7 +1760,7 @@ namespace ClosedXML.Excel
         public IXLRangeBase Sort(String columnsToSortBy, XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true)
         {
             SortColumns.Clear();
-            if (XLHelper.IsNullOrWhiteSpace(columnsToSortBy))
+            if (String.IsNullOrWhiteSpace(columnsToSortBy))
             {
                 columnsToSortBy = String.Empty;
                 Int32 maxColumn = ColumnCount();

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel
                     foreach (var cell in headersRow.Cells())
                     {
                         var name = cell.GetString();
-                        if (XLHelper.IsNullOrWhiteSpace(name))
+                        if (String.IsNullOrWhiteSpace(name))
                         {
                             name = "Column" + (cellPos + 1);
                             cell.SetValue(name);
@@ -395,7 +395,7 @@ namespace ClosedXML.Excel
             Int32 co = 1;
             foreach (IXLCell c in range.Row(1).Cells())
             {
-                if (XLHelper.IsNullOrWhiteSpace(((XLCell)c).InnerText))
+                if (String.IsNullOrWhiteSpace(((XLCell)c).InnerText))
                     c.Value = GetUniqueName("Column" + co.ToInvariantString());
                 _uniqueNames.Add(c.GetString());
                 co++;
@@ -445,7 +445,7 @@ namespace ClosedXML.Excel
                     Int32 co = 1;
                     foreach (IXLCell c in headersRow.Cells())
                     {
-                        if (XLHelper.IsNullOrWhiteSpace(((XLCell)c).InnerText))
+                        if (String.IsNullOrWhiteSpace(((XLCell)c).InnerText))
                             c.Value = GetUniqueName("Column" + co.ToInvariantString());
                         _uniqueNames.Add(c.GetString());
                         co++;

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1223,7 +1223,7 @@ namespace ClosedXML.Excel
                 }
                 else if (cell.DataType == CellValues.SharedString)
                 {
-                    if (cell.CellValue != null && !XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
+                    if (cell.CellValue != null && !String.IsNullOrWhiteSpace(cell.CellValue.Text))
                     {
                         var sharedString = sharedStrings[Int32.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture)];
                         ParseCellValue(sharedString, xlCell);
@@ -1235,7 +1235,7 @@ namespace ClosedXML.Excel
                 }
                 else if (cell.DataType == CellValues.Date)
                 {
-                    if (cell.CellValue != null && !XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
+                    if (cell.CellValue != null && !String.IsNullOrWhiteSpace(cell.CellValue.Text))
                         xlCell._cellValue = Double.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture).ToInvariantString();
                     xlCell._dataType = XLCellValues.DateTime;
                 }
@@ -1247,7 +1247,7 @@ namespace ClosedXML.Excel
                 }
                 else if (cell.DataType == CellValues.Number)
                 {
-                    if (cell.CellValue != null && !XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
+                    if (cell.CellValue != null && !String.IsNullOrWhiteSpace(cell.CellValue.Text))
                         xlCell._cellValue = Double.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture).ToInvariantString();
 
                     if (s == null)
@@ -1265,7 +1265,7 @@ namespace ClosedXML.Excel
                 else
                 {
                     var numberFormatId = ((CellFormat)(s.CellFormats).ElementAt(styleIndex)).NumberFormatId;
-                    if (!XLHelper.IsNullOrWhiteSpace(cell.CellValue.Text))
+                    if (!String.IsNullOrWhiteSpace(cell.CellValue.Text))
                         xlCell._cellValue = Double.Parse(cell.CellValue.Text, CultureInfo.InvariantCulture).ToInvariantString();
 
                     if (s.NumberingFormats != null &&
@@ -1557,7 +1557,7 @@ namespace ClosedXML.Excel
                 return XLCellValues.Text;
             else
             {
-                if (!XLHelper.IsNullOrWhiteSpace(numberFormat.Format))
+                if (!String.IsNullOrWhiteSpace(numberFormat.Format))
                 {
                     var dataType = GetDataTypeFromFormat(numberFormat.Format);
                     return dataType.HasValue ? dataType.Value : XLCellValues.Number;
@@ -1772,7 +1772,7 @@ namespace ClosedXML.Excel
             foreach (DataValidation dvs in dataValidations.Elements<DataValidation>())
             {
                 String txt = dvs.SequenceOfReferences.InnerText;
-                if (XLHelper.IsNullOrWhiteSpace(txt)) continue;
+                if (String.IsNullOrWhiteSpace(txt)) continue;
                 foreach (var dvt in txt.Split(' ').Select(rangeAddress => ws.Range(rangeAddress).DataValidation))
                 {
                     if (dvs.AllowBlank != null) dvt.IgnoreBlanks = dvs.AllowBlank;
@@ -1820,7 +1820,7 @@ namespace ClosedXML.Excel
                     if (conditionalFormat.ConditionalFormatType == XLConditionalFormatType.CellIs && fr.Operator != null)
                         conditionalFormat.Operator = fr.Operator.Value.ToClosedXml();
 
-                    if (fr.Text != null && !XLHelper.IsNullOrWhiteSpace(fr.Text))
+                    if (fr.Text != null && !String.IsNullOrWhiteSpace(fr.Text))
                         conditionalFormat.Values.Add(GetFormula(fr.Text.Value));
 
                     if (conditionalFormat.ConditionalFormatType == XLConditionalFormatType.Top10)

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -241,12 +241,12 @@ namespace ClosedXML.Excel
 
             // Ensure all RelId's have been added to the context
             context.RelIdGenerator.AddValues(workbookPart.Parts.Select(p => p.RelationshipId), RelType.Workbook);
-            context.RelIdGenerator.AddValues(WorksheetsInternal.Cast<XLWorksheet>().Where(ws => !XLHelper.IsNullOrWhiteSpace(ws.RelId)).Select(ws => ws.RelId), RelType.Workbook);
-            context.RelIdGenerator.AddValues(WorksheetsInternal.Cast<XLWorksheet>().Where(ws => !XLHelper.IsNullOrWhiteSpace(ws.LegacyDrawingId)).Select(ws => ws.LegacyDrawingId), RelType.Workbook);
+            context.RelIdGenerator.AddValues(WorksheetsInternal.Cast<XLWorksheet>().Where(ws => !String.IsNullOrWhiteSpace(ws.RelId)).Select(ws => ws.RelId), RelType.Workbook);
+            context.RelIdGenerator.AddValues(WorksheetsInternal.Cast<XLWorksheet>().Where(ws => !String.IsNullOrWhiteSpace(ws.LegacyDrawingId)).Select(ws => ws.LegacyDrawingId), RelType.Workbook);
             context.RelIdGenerator.AddValues(WorksheetsInternal
                 .Cast<XLWorksheet>()
                 .SelectMany(ws => ws.Tables.Cast<XLTable>())
-                .Where(t => !XLHelper.IsNullOrWhiteSpace(t.RelId))
+                .Where(t => !String.IsNullOrWhiteSpace(t.RelId))
                 .Select(t => t.RelId), RelType.Workbook);
 
             var extendedFilePropertiesPart = document.ExtendedFilePropertiesPart ??
@@ -303,7 +303,7 @@ namespace ClosedXML.Excel
                     var vmlDrawingPart = worksheetPart.VmlDrawingParts.FirstOrDefault();
                     if (vmlDrawingPart == null)
                     {
-                        if (XLHelper.IsNullOrWhiteSpace(worksheet.LegacyDrawingId))
+                        if (String.IsNullOrWhiteSpace(worksheet.LegacyDrawingId))
                         {
                             worksheet.LegacyDrawingId = context.RelIdGenerator.GetNext(RelType.Workbook);
                             worksheet.LegacyDrawingIsNew = true;
@@ -473,7 +473,7 @@ namespace ClosedXML.Excel
 
             if (Properties.Manager != null)
             {
-                if (!XLHelper.IsNullOrWhiteSpace(Properties.Manager))
+                if (!String.IsNullOrWhiteSpace(Properties.Manager))
                 {
                     if (properties.Manager == null)
                         properties.Manager = new Manager();
@@ -486,7 +486,7 @@ namespace ClosedXML.Excel
 
             if (Properties.Company == null) return;
 
-            if (!XLHelper.IsNullOrWhiteSpace(Properties.Company))
+            if (!String.IsNullOrWhiteSpace(Properties.Company))
             {
                 if (properties.Company == null)
                     properties.Company = new Company();
@@ -616,7 +616,7 @@ namespace ClosedXML.Excel
             foreach (var xlSheet in WorksheetsInternal.Cast<XLWorksheet>().OrderBy(w => w.Position))
             {
                 string rId;
-                if (xlSheet.SheetId == 0 && XLHelper.IsNullOrWhiteSpace(xlSheet.RelId))
+                if (xlSheet.SheetId == 0 && String.IsNullOrWhiteSpace(xlSheet.RelId))
                 {
                     rId = context.RelIdGenerator.GetNext(RelType.Workbook);
 
@@ -628,7 +628,7 @@ namespace ClosedXML.Excel
                 }
                 else
                 {
-                    if (XLHelper.IsNullOrWhiteSpace(xlSheet.RelId))
+                    if (String.IsNullOrWhiteSpace(xlSheet.RelId))
                     {
                         rId = String.Format("rId{0}", xlSheet.SheetId);
                         context.RelIdGenerator.AddValues(new List<String> { rId }, RelType.Workbook);
@@ -773,7 +773,7 @@ namespace ClosedXML.Excel
                     if (!nr.Visible)
                         definedName.Hidden = BooleanValue.FromBoolean(true);
 
-                    if (!XLHelper.IsNullOrWhiteSpace(nr.Comment))
+                    if (!String.IsNullOrWhiteSpace(nr.Comment))
                         definedName.Comment = nr.Comment;
                     definedNames.AppendChild(definedName);
                 }
@@ -827,7 +827,7 @@ namespace ClosedXML.Excel
                 if (!nr.Visible)
                     definedName.Hidden = BooleanValue.FromBoolean(true);
 
-                if (!XLHelper.IsNullOrWhiteSpace(nr.Comment))
+                if (!String.IsNullOrWhiteSpace(nr.Comment))
                     definedName.Comment = nr.Comment;
                 definedNames.AppendChild(definedName);
             }
@@ -873,7 +873,7 @@ namespace ClosedXML.Excel
                             w.Internals.CellsCollection.GetCells(
                                 c => ((c.DataType == XLCellValues.Text && c.ShareString) || c.HasRichText)
                                      && (c as XLCell).InnerText.Length > 0
-                                     && XLHelper.IsNullOrWhiteSpace(c.FormulaA1)
+                                     && String.IsNullOrWhiteSpace(c.FormulaA1)
                                 )))
             {
                 c.DataType = XLCellValues.Text;
@@ -1019,7 +1019,7 @@ namespace ClosedXML.Excel
                 var cellsWithoutFormulas = new HashSet<String>();
                 foreach (var c in worksheet.Internals.CellsCollection.GetCells())
                 {
-                    if (XLHelper.IsNullOrWhiteSpace(c.FormulaA1))
+                    if (String.IsNullOrWhiteSpace(c.FormulaA1))
                         cellsWithoutFormulas.Add(c.Address.ToStringRelative());
                     else
                     {
@@ -1810,7 +1810,7 @@ namespace ClosedXML.Excel
                             tableColumn1.TotalsRowFormula = new TotalsRowFormula(xlField.TotalsRowFormulaA1);
                     }
 
-                    if (!XLHelper.IsNullOrWhiteSpace(xlField.TotalsRowLabel))
+                    if (!String.IsNullOrWhiteSpace(xlField.TotalsRowLabel))
                         tableColumn1.TotalsRowLabel = xlField.TotalsRowLabel;
                 }
                 tableColumns1.AppendChild(tableColumn1);
@@ -1872,7 +1872,7 @@ namespace ClosedXML.Excel
                 var workbookCacheRelId = pt.WorkbookCacheRelId;
                 PivotCache pivotCache;
                 PivotTableCacheDefinitionPart pivotTableCacheDefinitionPart;
-                if (!XLHelper.IsNullOrWhiteSpace(pt.WorkbookCacheRelId))
+                if (!String.IsNullOrWhiteSpace(pt.WorkbookCacheRelId))
                 {
                     pivotCache = pivotCaches.Cast<PivotCache>().Single(pc => pc.Id.Value == pt.WorkbookCacheRelId);
                     pivotTableCacheDefinitionPart = workbookPart.GetPartById(pt.WorkbookCacheRelId) as PivotTableCacheDefinitionPart;
@@ -1886,18 +1886,18 @@ namespace ClosedXML.Excel
 
                 GeneratePivotTableCacheDefinitionPartContent(pivotTableCacheDefinitionPart, pt);
 
-                if (XLHelper.IsNullOrWhiteSpace(pt.WorkbookCacheRelId))
+                if (String.IsNullOrWhiteSpace(pt.WorkbookCacheRelId))
                     pivotCaches.AppendChild(pivotCache);
 
                 PivotTablePart pivotTablePart;
-                if (XLHelper.IsNullOrWhiteSpace(pt.RelId))
+                if (String.IsNullOrWhiteSpace(pt.RelId))
                     pivotTablePart = worksheetPart.AddNewPart<PivotTablePart>(context.RelIdGenerator.GetNext(RelType.Workbook));
                 else
                     pivotTablePart = worksheetPart.GetPartById(pt.RelId) as PivotTablePart;
 
                 GeneratePivotTablePartContent(pivotTablePart, pt, pivotCache.CacheId, context);
 
-                if (XLHelper.IsNullOrWhiteSpace(pt.RelId))
+                if (String.IsNullOrWhiteSpace(pt.RelId))
                     pivotTablePart.AddPart(pivotTableCacheDefinitionPart, context.RelIdGenerator.GetNext(RelType.Workbook));
             }
         }
@@ -2494,7 +2494,7 @@ namespace ClosedXML.Excel
                 StrokeWeight = String.Format(CultureInfo.InvariantCulture, "{0}pt", c.Comment.Style.ColorsAndLines.LineWeight),
                 InsetMode = c.Comment.Style.Margins.Automatic ? InsetMarginValues.Auto : InsetMarginValues.Custom
             };
-            if (!XLHelper.IsNullOrWhiteSpace(c.Comment.Style.Web.AlternateText))
+            if (!String.IsNullOrWhiteSpace(c.Comment.Style.Web.AlternateText))
                 shape.Alternate = c.Comment.Style.Web.AlternateText;
 
             return shape;
@@ -3048,7 +3048,7 @@ namespace ClosedXML.Excel
         {
             var differentialFormat = new DifferentialFormat();
             differentialFormat.Append(GetNewFont(new FontInfo { Font = cf.Style.Font as XLFont }, false));
-            if (!XLHelper.IsNullOrWhiteSpace(cf.Style.NumberFormat.Format))
+            if (!String.IsNullOrWhiteSpace(cf.Style.NumberFormat.Format))
             {
                 var numberFormat = new NumberingFormat
                 {
@@ -3692,7 +3692,7 @@ namespace ClosedXML.Excel
         {
             var newXLNumberFormat = new XLNumberFormat();
 
-            if (nf.FormatCode != null && !XLHelper.IsNullOrWhiteSpace(nf.FormatCode.Value))
+            if (nf.FormatCode != null && !String.IsNullOrWhiteSpace(nf.FormatCode.Value))
                 newXLNumberFormat.Format = nf.FormatCode.Value;
             else if (nf.NumberFormatId != null)
                 newXLNumberFormat.NumberFormatId = (Int32)nf.NumberFormatId.Value;
@@ -4301,7 +4301,7 @@ namespace ClosedXML.Excel
 
                 var protection = xlWorksheet.Protection;
                 sheetProtection.Sheet = protection.Protected;
-                if (!XLHelper.IsNullOrWhiteSpace(protection.PasswordHash))
+                if (!String.IsNullOrWhiteSpace(protection.PasswordHash))
                     sheetProtection.Password = protection.PasswordHash;
                 sheetProtection.FormatCells = GetBooleanValue(!protection.FormatCells, true);
                 sheetProtection.FormatColumns = GetBooleanValue(!protection.FormatColumns, true);
@@ -4502,7 +4502,7 @@ namespace ClosedXML.Excel
                             Display = hl.Cell.GetFormattedString()
                         };
                     }
-                    if (!XLHelper.IsNullOrWhiteSpace(hl.Tooltip))
+                    if (!String.IsNullOrWhiteSpace(hl.Tooltip))
                         hyperlink.Tooltip = hl.Tooltip;
                     hyperlinks.AppendChild(hyperlink);
                 }
@@ -4759,7 +4759,7 @@ namespace ClosedXML.Excel
             {
                 worksheetPart.Worksheet.RemoveAllChildren<LegacyDrawing>();
                 {
-                    if (!XLHelper.IsNullOrWhiteSpace(xlWorksheet.LegacyDrawingId))
+                    if (!String.IsNullOrWhiteSpace(xlWorksheet.LegacyDrawingId))
                     {
                         var previousElement = cm.GetPreviousElementFor(XLWSContentManager.XLWSContents.LegacyDrawing);
                         worksheetPart.Worksheet.InsertAfter(new LegacyDrawing { Id = xlWorksheet.LegacyDrawingId },
@@ -4839,7 +4839,7 @@ namespace ClosedXML.Excel
             }
             else if (dataType == XLCellValues.DateTime || dataType == XLCellValues.Number)
             {
-                if (!XLHelper.IsNullOrWhiteSpace(xlCell.InnerText))
+                if (!String.IsNullOrWhiteSpace(xlCell.InnerText))
                 {
                     var cellValue = new CellValue();
                     cellValue.Text = Double.Parse(xlCell.InnerText, XLHelper.NumberStyle, XLHelper.ParseCulture).ToInvariantString();

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -176,7 +176,7 @@ namespace ClosedXML.Excel
                     throw new ArgumentException("Worksheet names cannot contain any of the following characters: " +
                                                 InvalidNameChars);
 
-                if (XLHelper.IsNullOrWhiteSpace(value))
+                if (String.IsNullOrWhiteSpace(value))
                     throw new ArgumentException("Worksheet names cannot be empty");
 
                 if (value.Length > 31)
@@ -651,7 +651,7 @@ namespace ClosedXML.Excel
 
         private String ReplaceRelativeSheet(string newSheetName, String value)
         {
-            if (XLHelper.IsNullOrWhiteSpace(value)) return value;
+            if (String.IsNullOrWhiteSpace(value)) return value;
 
             var newValue = new StringBuilder();
             var addresses = value.Split(',');

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -137,7 +137,7 @@ namespace ClosedXML.Excel
                     "Can't delete the worksheet because there are multiple worksheets associated with that index.");
 
             var ws = _worksheets.Values.Single(w => w.Position == position);
-            if (!XLHelper.IsNullOrWhiteSpace(ws.RelId) && !Deleted.Contains(ws.RelId))
+            if (!String.IsNullOrWhiteSpace(ws.RelId) && !Deleted.Contains(ws.RelId))
                 Deleted.Add(ws.RelId);
 
             _worksheets.RemoveAll(w => w.Position == position);
@@ -178,7 +178,7 @@ namespace ClosedXML.Excel
 
         public void Rename(String oldSheetName, String newSheetName)
         {
-            if (XLHelper.IsNullOrWhiteSpace(oldSheetName) || !_worksheets.ContainsKey(oldSheetName)) return;
+            if (String.IsNullOrWhiteSpace(oldSheetName) || !_worksheets.ContainsKey(oldSheetName)) return;
 
             if (_worksheets.Any(ws1 => ws1.Key.Equals(newSheetName, StringComparison.OrdinalIgnoreCase)))
                 throw new ArgumentException(String.Format("A worksheet with the same name ({0}) has already been added.", newSheetName), nameof(newSheetName));

--- a/ClosedXML/Extensions.cs
+++ b/ClosedXML/Extensions.cs
@@ -221,7 +221,7 @@ namespace ClosedXML.Excel
 
         public static Double GetWidth(this IXLFontBase fontBase, String text, Dictionary<IXLFontBase, Font> fontCache)
         {
-            if (XLHelper.IsNullOrWhiteSpace(text))
+            if (String.IsNullOrWhiteSpace(text))
                 return 0;
 
             var font = GetCachedFont(fontBase, fontCache);

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -117,7 +117,7 @@ namespace ClosedXML.Excel
         public static bool IsValidColumn(string column)
         {
             var length = column.Length;
-            if (IsNullOrWhiteSpace(column) || length > 3)
+            if (String.IsNullOrWhiteSpace(column) || length > 3)
                 return false;
 
             var theColumn = column.ToUpper();
@@ -153,7 +153,7 @@ namespace ClosedXML.Excel
 
         public static bool IsValidA1Address(string address)
         {
-            if (IsNullOrWhiteSpace(address))
+            if (String.IsNullOrWhiteSpace(address))
                 return false;
 
             address = address.Replace("$", "");
@@ -224,26 +224,6 @@ namespace ClosedXML.Excel
             ws.EventTrackingEnabled = tracking;
 
             return rows;
-        }
-
-        public static bool IsNullOrWhiteSpace(string value)
-        {
-#if NET4
-            return String.IsNullOrWhiteSpace(value);
-#else
-            if (value != null)
-            {
-                var length = value.Length;
-                for (int i = 0; i < length; i++)
-                {
-                    if (!char.IsWhiteSpace(value[i]))
-                    {
-                        return false;
-                    }
-                }
-            }
-            return true;
-#endif
         }
 
         private static readonly Regex A1RegexRelative = new Regex(


### PR DESCRIPTION
`XLHelper.IsNullOrWhiteSpace` was a workaround for the .NET 3.5 build.