### PR TITLE
Disposing of operating ranges.

### DIFF
--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -25,11 +25,13 @@ namespace ClosedXML.Excel
 
         public void Remove(Predicate<IXLConditionalFormat> predicate)
         {
+            _conditionalFormats.Where(cf=>predicate(cf)).ForEach(cf=>cf.Range.Dispose());
             _conditionalFormats.RemoveAll(predicate);
         }
 
         public void RemoveAll()
         {
+            _conditionalFormats.ForEach(cf => cf.Range.Dispose());
             _conditionalFormats.Clear();
         }
     }

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1214,7 +1214,8 @@ namespace ClosedXML.Excel
                                                    - model.RangeAddress.FirstAddress.RowNumber + 1;
                             for (Int32 ro = firstRoReturned; ro <= lastRoReturned; ro++)
                             {
-                                rangeToReturn.Row(ro).Style = model.Cell(ro).Style;
+                                using (var row = rangeToReturn.Row(ro))
+                                    row.Style = model.Cell(ro).Style;
                             }
                         }
                     }
@@ -1231,13 +1232,17 @@ namespace ClosedXML.Excel
                         var styleToUse = Worksheet.Internals.RowsCollection.ContainsKey(ro)
                                              ? Worksheet.Internals.RowsCollection[ro].Style
                                              : Worksheet.Style;
-                        rangeToReturn.Row(ro).Style = styleToUse;
+                        using (var row = rangeToReturn.Row(ro))
+                            row.Style = styleToUse;
                     }
                 }
             }
 
             if (nullReturn)
+            {
+                rangeToReturn.Dispose();
                 return null;
+            }
 
             return rangeToReturn.Columns();
         }
@@ -1453,7 +1458,8 @@ namespace ClosedXML.Excel
                                                    - model.RangeAddress.FirstAddress.ColumnNumber + 1;
                             for (Int32 co = firstCoReturned; co <= lastCoReturned; co++)
                             {
-                                rangeToReturn.Column(co).Style = model.Cell(co).Style;
+                                using (var column = rangeToReturn.Column(co))
+                                    column.Style = model.Cell(co).Style;
                             }
                         }
                     }
@@ -1470,14 +1476,18 @@ namespace ClosedXML.Excel
                         var styleToUse = Worksheet.Internals.ColumnsCollection.ContainsKey(co)
                                              ? Worksheet.Internals.ColumnsCollection[co].Style
                                              : Worksheet.Style;
-                        rangeToReturn.Column(co).Style = styleToUse;
+                        using (var column = rangeToReturn.Column(co))
+                            column.Style = styleToUse;
                     }
                 }
             }
 
             // Skip calling .Rows() for performance reasons if required.
             if (nullReturn)
+            {
+                rangeToReturn.Dispose();
                 return null;
+            }
 
             return rangeToReturn.Rows();
         }


### PR DESCRIPTION
Added Dispose call where it was missed. For large documents, this is critically important. Otherwise, callback lists grow by tens and hundreds of thousands, which leads to the freezing of the application.