### PR TITLE
Fix for Clear cell.

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1008,6 +1008,7 @@ namespace ClosedXML.Excel
                 {
                     Hyperlink = null;
                     _richText = null;
+                    _dataType = XLCellValues.Text;
                     //_comment = null;
                     _cellValue = String.Empty;
                     FormulaA1 = String.Empty;


### PR DESCRIPTION
If the cell had a DateTime value, Clear method does not reset the cell type. This leads to the fact that the cell remains unchanged when the document is saved. The SetCellValue method changes the value of the cells with the DateTime and Number types only if they are not empty. Therefore, if we clear a cell, we must also change the data type.
File XLWorkbook_Save.cs -> method SetCellValue, row 5027:
```
            if (dataType == XLCellValues.DateTime || dataType == XLCellValues.Number)
            {
                if (!String.IsNullOrWhiteSpace(xlCell.InnerText))
                {
                    ....
                    openXmlCell.CellValue = cellValue;
                }
            }
```