### PR TITLE
#548 conditions for strings, #53 improving MULTINOMIAL function, implementing SEC

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace ClosedXML.Excel.CalcEngine
@@ -25,8 +27,11 @@ namespace ClosedXML.Excel.CalcEngine
 
             // convert criteria to string
             var cs = criteria as string;
-            if (!string.IsNullOrEmpty(cs))
+            if (cs != null)
             {
+                if (cs == "")
+                    return cs.Equals(value);
+
                 // if criteria is an expression (e.g. ">20"), use calc engine
                 if (cs[0] == '=' || cs[0] == '<' || cs[0] == '>')
                 {
@@ -54,11 +59,24 @@ namespace ClosedXML.Excel.CalcEngine
                 }
 
                 // if criteria is a regular expression, use regex
-                if (cs.IndexOf('*') > -1)
+                if (cs.IndexOfAny(new []{ '*', '?'}) > -1)
                 {
-                    var pattern = cs.Replace(@"\", @"\\");
-                    pattern = pattern.Replace(".", @"\");
-                    pattern = pattern.Replace("*", ".*");
+                    var patternReplacements = new Dictionary<string, Tuple<string, string>>();
+                    // key: the literal string to match
+                    // value: a tuple: first item: the search pattern, second item: the replacement
+                    patternReplacements.Add(@"~*", new Tuple<string, string>(@"~\*", @"\*"));
+                    patternReplacements.Add(@"~?", new Tuple<string, string>(@"~\?", @"\?"));
+                    patternReplacements.Add(@"?", new Tuple<string, string>(@"\?", ".?"));
+                    patternReplacements.Add(@"*", new Tuple<string, string>(@"\*", ".*"));
+                    
+                    var pattern = Regex.Replace(
+                        cs,
+                        "(" + String.Join(
+                                "|",
+                                patternReplacements.Values.Select(t => t.Item1))
+                        + ")",
+                        m => patternReplacements[m.Value].Item2);
+
                     return Regex.IsMatch(value.ToString(), pattern, RegexOptions.IgnoreCase);
                 }
 

--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -64,6 +64,7 @@ namespace ClosedXML.Excel.CalcEngine
                     var patternReplacements = new Dictionary<string, Tuple<string, string>>();
                     // key: the literal string to match
                     // value: a tuple: first item: the search pattern, second item: the replacement
+                    patternReplacements.Add(@"~~", new Tuple<string, string>(@"~~", "~"));
                     patternReplacements.Add(@"~*", new Tuple<string, string>(@"~\*", @"\*"));
                     patternReplacements.Add(@"~?", new Tuple<string, string>(@"~\?", @"\?"));
                     patternReplacements.Add(@"?", new Tuple<string, string>(@"\?", ".?"));
@@ -76,6 +77,7 @@ namespace ClosedXML.Excel.CalcEngine
                                 patternReplacements.Values.Select(t => t.Item1))
                         + ")",
                         m => patternReplacements[m.Value].Item2);
+                    pattern = $"^{pattern}$";
 
                     return Regex.IsMatch(value.ToString(), pattern, RegexOptions.IgnoreCase);
                 }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -494,14 +494,37 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static object Multinomial(List<Expression> p)
         {
-            return Multinomial(p.Select(v => (double)v).ToList());
+            var parsedParameters = p
+                .Select(v =>
+                    {
+                        bool isDouble = double.TryParse(
+                            (string)v,
+                            out double parsedValue);
+                        return new Tuple<bool, double>(isDouble, parsedValue);
+                    })
+                .ToList();
+
+            if (parsedParameters.Any(x => !x.Item1))
+            {
+                throw new NameNotRecognizedException();
+            }
+
+            return Multinomial(
+                parsedParameters
+                    .Select(x => x.Item2)
+                    .ToList());
         }
 
         private static double Multinomial(List<double> numbers)
         {
             double numbersSum = 0;
             foreach (var number in numbers)
+            {
+                if (number < 0)
+                    throw new NumberException();
+
                 numbersSum += number;
+            }
 
             double maxNumber = numbers.Max();
             var denomFactorPowers = new double[(uint)numbers.Max() + 1];

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -60,6 +60,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ROUND", 2, Round);
             ce.RegisterFunction("ROUNDDOWN", 2, RoundDown);
             ce.RegisterFunction("ROUNDUP", 1, 2, RoundUp);
+            ce.RegisterFunction("SEC", 1, Sec);
             ce.RegisterFunction("SERIESSUM", 4, SeriesSum);
             ce.RegisterFunction("SIGN", 1, Sign);
             ce.RegisterFunction("SIN", 1, Sin);
@@ -643,6 +644,14 @@ namespace ClosedXML.Excel.CalcEngine
                 return Math.Ceiling(value * Math.Pow(10, digits)) / Math.Pow(10, digits);
 
             return Math.Floor(value * Math.Pow(10, digits)) / Math.Pow(10, digits);
+        }
+
+        private static object Sec(List<Expression> p)
+        {
+            if (double.TryParse(p[0], out double number))
+                return 1.0 / Math.Cos(number);
+            else
+                throw new CellValueException();
         }
 
         private static object SeriesSum(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -151,11 +151,8 @@ namespace ClosedXML.Excel.CalcEngine
                 var criteria = (string)p[1].Evaluate();
                 foreach (var value in ienum)
                 {
-                    if (!IsBlank(value))
-                    {
-                        if (CalcEngineHelpers.ValueSatisfiesCriteria(value, criteria, ce))
-                            cnt++;
-                    }
+                    if (CalcEngineHelpers.ValueSatisfiesCriteria(value, criteria, ce))
+                        cnt++;
                 }
             }
             return cnt;

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -177,6 +177,77 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.AreEqual(0.7, actual, tolerance);
         }
 
+        [Theory]
+        public void Multinomial_AnySingleValue_ReturnsOne([Range(0, 10, 0.1)] double number)
+        {
+            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(
+                @"MULTINOMIAL({0})",
+                number.ToString(CultureInfo.InvariantCulture)));
+            Assert.AreEqual(1, actual);
+        }
+
+        [TestCase(1, 2, 3)]
+        [TestCase(2, 3, 10)]
+        [TestCase(3, 4, 35)]
+        [TestCase(4, 5, 126)]
+        [TestCase(5, 6, 462)]
+        [TestCase(6, 7, 1716)]
+        [TestCase(7, 8, 6435)]
+        [TestCase(8, 9, 24310)]
+        [TestCase(9, 10, 92378)]
+        [TestCase(10, 11, 352716)]
+        [TestCase(11, 12, 1352078)]
+        [TestCase(12, 13, 5200300)]
+        [TestCase(13, 14, 20058300)]
+        [TestCase(14, 15, 77558760)]
+        [TestCase(15, 16, 300540195)]
+        public void Multinomial_TwoValuesReturnCorrectValue(long first, long second, long expectedResult)
+        {
+            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(
+                @"MULTINOMIAL({0}, {1})",
+                first.ToString(CultureInfo.InvariantCulture),
+                second.ToString(CultureInfo.InvariantCulture)));
+            Assert.AreEqual(expectedResult, actual, Math.Pow(10, -5));
+        }
+
+        [TestCase(1, 1)]
+        [TestCase(2, 3)]
+        [TestCase(3, 60)]
+        [TestCase(4, 12600)]
+        [TestCase(5, 37837800)]
+        [TestCase(6, 2053230379200)]
+        public void Multinomial_Values1ToNReturnCorrectValue(int last, long expectedResult)
+        {
+            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(
+                @"MULTINOMIAL({0})",
+                string.Join(
+                    ", ",
+                    Enumerable.Range(1, last)
+                        .Select(i => i.ToString(CultureInfo.InvariantCulture)))));
+
+            Assert.AreEqual(expectedResult, actual, 0.01);
+        }
+
+        [Theory]
+        public void Multinomial_AnyNegativeValueThrowsNumberException([Range(-10, -1)] int x)
+        {
+            Assert.Throws<NumberException>(() => XLWorkbook.EvaluateExpr(
+                string.Format(
+                    @"MULTINOMIAL({0})",
+                    string.Join(
+                        ", ",
+                        Enumerable.Range(x, 2)
+                            .Reverse()
+                            .Select(i => i.ToString(CultureInfo.InvariantCulture))))));
+        }
+
+        [Test]
+        public void Multinomial_NonNumericValueThrowsNameNotRecognizedException()
+        {
+            Assert.Throws<NameNotRecognizedException>(
+                () => XLWorkbook.EvaluateExpr(@"MULTINOMIAL(x)"));
+        }
+
         [Test]
         public void SumProduct()
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -345,6 +345,50 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             }
         }
 
+        /// <summary>
+        /// refers to Example 2 from the Excel documentation,
+        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&rs=en-US&ad=US"/>
+        /// </summary>
+        /// <param name="expectedOutcome"></param>
+        /// <param name="formula"></param>
+        [TestCase( 2000, "SUMIF(A2:A7,\"Fruits\", C2:C7)")]
+        [TestCase(12000, "SUMIF(A2:A7,\"Vegetables\", C2:C7)")]
+        [TestCase( 4300, "SUMIF(A2:A7, \"*es\", C2:C7)")]
+        [TestCase(  400, "SUMIF(A2:A7, \"\", C2:C7)")]
+        public void SumIf_ReturnsCorrectValues_ReferenceExample2FromMicrosoft(int expectedOutcome, string formula)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                wb.ReferenceStyle = XLReferenceStyle.A1;
+
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell(2, 1).Value = "Vegetables";
+                ws.Cell(3, 1).Value = "Vegetables";
+                ws.Cell(4, 1).Value = "Fruits";
+                ws.Cell(5, 1).Value = "";
+                ws.Cell(6, 1).Value = "Vegetables";
+                ws.Cell(7, 1).Value = "Fruits";
+
+                ws.Cell(2, 2).Value = "Tomatoes";
+                ws.Cell(3, 2).Value = "Celery";
+                ws.Cell(4, 2).Value = "Oranges";
+                ws.Cell(5, 2).Value = "Butter";
+                ws.Cell(6, 2).Value = "Carrots";
+                ws.Cell(7, 2).Value = "Apples";
+
+                ws.Cell(2, 3).Value = 2300;
+                ws.Cell(3, 3).Value = 5500;
+                ws.Cell(4, 3).Value = 800;
+                ws.Cell(5, 3).Value = 400;
+                ws.Cell(6, 3).Value = 4200;
+                ws.Cell(7, 3).Value = 1200;
+
+                ws.Cell(1, 3).Value = 300000;
+
+                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
+            }
+        }
+
         [Test]
         public void SumProduct()
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -313,6 +313,38 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                     @"SEC(number)")));
         }
 
+        /// <summary>
+        /// refers to Example 1 from the Excel documentation,
+        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&rs=en-US&ad=US"/>
+        /// </summary>
+        /// <param name="expectedOutcome"></param>
+        /// <param name="formula"></param>
+        [TestCase(63000, "SUMIF(A1:A4,\">160000\", B1:B4)")]
+        [TestCase(900000, "SUMIF(A1:A4,\">160000\")")]
+        [TestCase(21000, "SUMIF(A1:A4, 300000, B1:B4)")]
+        [TestCase(28000, "SUMIF(A1:A4, \">\" &C1, B1:B4)")]
+        public void SumIf_ReturnsCorrectValues_ReferenceExample1FromMicrosoft(int expectedOutcome, string formula)
+        {
+            using(var wb = new XLWorkbook())
+            {
+                wb.ReferenceStyle = XLReferenceStyle.A1;
+
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell(1, 1).Value = 100000;
+                ws.Cell(1, 2).Value = 7000;
+                ws.Cell(2, 1).Value = 200000;
+                ws.Cell(2, 2).Value = 14000;
+                ws.Cell(3, 1).Value = 300000;
+                ws.Cell(3, 2).Value = 21000;
+                ws.Cell(4, 1).Value = 400000;
+                ws.Cell(4, 2).Value = 28000;
+
+                ws.Cell(1, 3).Value = 300000;
+
+                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
+            }
+        }
+
         [Test]
         public void SumProduct()
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -248,6 +248,71 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 () => XLWorkbook.EvaluateExpr(@"MULTINOMIAL(x)"));
         }
 
+        [TestCase(   0, 1)]
+        [TestCase( 0.3, 1.0467516)]
+        [TestCase( 0.6, 1.21162831)]
+        [TestCase( 0.9, 1.60872581)]
+        [TestCase( 1.2, 2.759703601)]
+        [TestCase( 1.5, 14.1368329)]
+        [TestCase( 1.8, -4.401367872)]
+        [TestCase( 2.1, -1.980801656)]
+        [TestCase( 2.4, -1.356127641)]
+        [TestCase( 2.7, -1.10610642)]
+        [TestCase( 3.0, -1.010108666)]
+        [TestCase( 3.3, -1.012678974)]
+        [TestCase( 3.6, -1.115127532)]
+        [TestCase( 3.9, -1.377538917)]
+        [TestCase( 4.2, -2.039730601)]
+        [TestCase( 4.5, -4.743927548)]
+        [TestCase( 4.8, 11.42870421)]
+        [TestCase( 5.1, 2.645658426)]
+        [TestCase( 5.4, 1.575565187)]
+        [TestCase( 5.7, 1.198016873)]
+        [TestCase( 6.0, 1.041481927)]
+        [TestCase( 6.3, 1.000141384)]
+        [TestCase( 6.6, 1.052373922)]
+        [TestCase( 6.9, 1.225903187)]
+        [TestCase( 7.2, 1.643787029)]
+        [TestCase( 7.5, 2.884876262)]
+        [TestCase( 7.8, 18.53381902)]
+        [TestCase( 8.1, -4.106031636)]
+        [TestCase( 8.4, -1.925711244)]
+        [TestCase( 8.7, -1.335743646)]
+        [TestCase( 9.0, -1.097537906)]
+        [TestCase( 9.3, -1.007835594)]
+        [TestCase( 9.6, -1.015550252)]
+        [TestCase( 9.9, -1.124617578)]
+        [TestCase(10.2, -1.400039323)]
+        [TestCase(10.5, -2.102886109)]
+        [TestCase(10.8, -5.145888341)]
+        [TestCase(11.1, 9.593612018)]
+        [TestCase(11.4, 2.541355049)]
+        [TestCase(45, 1.90359)]
+        [TestCase(30, 6.48292)]
+        public void Sec_ReturnsCorrectNumber(double input, double expectedOutput)
+        {
+            double result = (double)XLWorkbook.EvaluateExpr(
+                string.Format(
+                    @"SEC({0})",
+                    input.ToString(CultureInfo.InvariantCulture)));
+            Assert.AreEqual(expectedOutput, result, 0.00001);
+
+            // as the secant is symmetric for positive and negative numbers, let's assert twice:
+            double resultForNegative = (double)XLWorkbook.EvaluateExpr(
+                string.Format(
+                    @"SEC({0})",
+                    (-input).ToString(CultureInfo.InvariantCulture)));
+            Assert.AreEqual(expectedOutput, resultForNegative, 0.00001);
+        }
+
+        [Test]
+        public void Sec_ThrowsCellValueExceptionOnNonNumericValue()
+        {
+            Assert.Throws<CellValueException>(() => XLWorkbook.EvaluateExpr(
+                string.Format(
+                    @"SEC(number)")));
+        }
+
         [Test]
         public void SumProduct()
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -353,7 +353,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         /// <param name="formula"></param>
         [TestCase( 2000, "SUMIF(A2:A7,\"Fruits\", C2:C7)")]
         [TestCase(12000, "SUMIF(A2:A7,\"Vegetables\", C2:C7)")]
-        [TestCase( 4300, "SUMIF(A2:A7, \"*es\", C2:C7)")]
+        [TestCase( 4300, "SUMIF(B2:B7, \"*es\", C2:C7)")]
         [TestCase(  400, "SUMIF(A2:A7, \"\", C2:C7)")]
         public void SumIf_ReturnsCorrectValues_ReferenceExample2FromMicrosoft(int expectedOutcome, string formula)
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -91,19 +91,47 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.AreEqual(24, value);
         }
 
-        [TestCase(@"=COUNTIF(Data!E:E, ""J*"")", 12)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""J*"")", 13)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*i*"")", 21)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*in*"")", 9)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*i*l"")", 9)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*i?e*"")", 9)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*o??s*"")", 10)]
-        [TestCase(@"=COUNTIF(Data!E:E, """")", 0)]
+        [TestCase(@"=COUNTIF(Data!X1:X1000, """")", 1000)]
+        [TestCase(@"=COUNTIF(Data!E1:E44, """")", 1)]
         public void CountIf_ConditionWithWildcards(string formula, int expectedResult)
         {
             var ws = workbook.Worksheets.First();
 
             int value = ws.Evaluate(formula).CastTo<int>();
             Assert.AreEqual(expectedResult, value);
+        }
+
+        [TestCase("x", @"=COUNTIF(A1:A1, ""?"")", 1)]
+        [TestCase("x", @"=COUNTIF(A1:A1, ""~?"")", 0)]
+        [TestCase("?", @"=COUNTIF(A1:A1, ""~?"")", 1)]
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~?"")", 0)] 
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~~~?"")", 1)] 
+        [TestCase("?", @"=COUNTIF(A1:A1, ""~~?"")", 0)]
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~~?"")", 1)]
+        [TestCase("~x", @"=COUNTIF(A1:A1, ""~~?"")", 1)]
+        [TestCase("*", @"=COUNTIF(A1:A1, ""~*"")", 1)]
+        [TestCase("~*", @"=COUNTIF(A1:A1, ""~*"")", 0)]
+        [TestCase("~*", @"=COUNTIF(A1:A1, ""~~~*"")", 1)]
+        [TestCase("*", @"=COUNTIF(A1:A1, ""~~*"")", 0)]
+        [TestCase("~*", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
+        [TestCase("~x", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
+        [TestCase("~xyz", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
+        public void CountIf_MoreWildcards(string cellContent, string formula, int expectedResult)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+
+                ws.Cell(1, 1).Value = cellContent;
+
+                Assert.AreEqual(expectedResult, (double)ws.Evaluate(formula));
+            }
         }
 
         [OneTimeTearDown]

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -91,6 +91,21 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.AreEqual(24, value);
         }
 
+        [TestCase(@"=COUNTIF(Data!E:E, ""J*"")", 12)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*i*"")", 21)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*in*"")", 9)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*i*l"")", 9)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*i?e*"")", 9)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*o??s*"")", 10)]
+        [TestCase(@"=COUNTIF(Data!E:E, """")", 0)]
+        public void CountIf_ConditionWithWildcards(string formula, int expectedResult)
+        {
+            var ws = workbook.Worksheets.First();
+
+            int value = ws.Evaluate(formula).CastTo<int>();
+            Assert.AreEqual(expectedResult, value);
+        }
+
         [OneTimeTearDown]
         public void Dispose()
         {


### PR DESCRIPTION
#### What's this PR do?
improve wildcard pattern matching for string conditions:
- support ? wildcard
- support escaping wildcards
- support the empty string as a condition
- cover special cases with unit tests

- the MULTINOMIAL now throws the correct Exceptions as Excel does, when negative values or non-numerical values are given.
- implementing SEC function
- COUNTIF is fixed to support the empty string as a condition.

#### Where should the reviewer start?
Sorry to mix two different things in this PR, but it built on each other because I stumbled over #548 while implementing functions and unit tests.

I think, the PR should be reviewed in three parts:

1. The improvements tackling #548 are covered in the CalcEngineHelper.cs.
2. SEC as additional function and the improvements of MULTINOMIAL are implemented in MathTrig.cs, while corresponding unit tests are in MathTrigTests.cs
3. The fix for CountIf relies on the changes from (1) (CalcEngineHelper), but is completed in Statistical.cs, corresponding tests are located in StatisticalTests.cs of course.

#### How should this be manually tested?
check with the behaviour of Excel ;)
#### Any background context you want to provide?
I stumbled over two more problems I couldn't yet solve, but I don't think, these should be blocker for the PR:

1. Excel can deal with really big numbers. As I know from the past (not sure about the current state) it tended to be unprecise for really big or small numbers. With that in mind it could be that Excel does most calculations in floating point arithmetics, probably in `double` values, rounding afterwards. Currently most functions in ClosedXML are implemented based on interger or long and I found some cases where the Excel crunched much higher numbers than the ClosedXML implementation.
2. For formulas with a range covering a complete column (like A:A) the results differ. I tried a unit test for COUNTIF(A:A, ""), counting all empty values in column G. ClosedXML as well as Excel itself return "very" high numbers, but the exact numbers are different. Guessing again I assume the result is the number of supported lines, which would mean, even Excel versions might not behave equally here.

#### Questions:
- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer