### PR TITLE
Should not be using decimal math here as it is way slower than floating point

### DIFF
--- a/ClosedXML/Extensions.cs
+++ b/ClosedXML/Extensions.cs
@@ -229,7 +229,7 @@ namespace ClosedXML.Excel
             var textSize = GraphicsUtils.MeasureString(text, font);
 
             double width = (((textSize.Width / (double)7) * 256) - (128 / 7)) / 256;
-            width = (double)decimal.Round((decimal)width + 0.2M, 2);
+            width = Math.Round(width + 0.2, 2);
 
             return width;
         }


### PR DESCRIPTION
I mentioned this in this issue:

https://github.com/ClosedXML/ClosedXML/issues/545

Pretty simple fix but performance will suffer using decimal math here. All unit tests pass but as far as I can tell there is not actual test for this specific function.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer