### PR TITLE
#548 enhance string condition capabilities of CalcEngine

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -75,7 +75,7 @@ namespace ClosedXML.Excel.CalcEngine
 
                 // if criteria is a regular expression, use regex
                 if (cs.IndexOfAny(new[] { '*', '?' }) > -1)
-                {                    
+                {
                     var pattern = Regex.Replace(
                         cs,
                         "(" + String.Join(

--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace ClosedXML.Excel.CalcEngine
@@ -25,8 +27,11 @@ namespace ClosedXML.Excel.CalcEngine
 
             // convert criteria to string
             var cs = criteria as string;
-            if (!string.IsNullOrEmpty(cs))
+            if (cs != null)
             {
+                if (cs == "")
+                    return cs.Equals(value);
+
                 // if criteria is an expression (e.g. ">20"), use calc engine
                 if (cs[0] == '=' || cs[0] == '<' || cs[0] == '>')
                 {
@@ -54,11 +59,26 @@ namespace ClosedXML.Excel.CalcEngine
                 }
 
                 // if criteria is a regular expression, use regex
-                if (cs.IndexOf('*') > -1)
+                if (cs.IndexOfAny(new[] { '*', '?' }) > -1)
                 {
-                    var pattern = cs.Replace(@"\", @"\\");
-                    pattern = pattern.Replace(".", @"\");
-                    pattern = pattern.Replace("*", ".*");
+                    var patternReplacements = new Dictionary<string, Tuple<string, string>>();
+                    // key: the literal string to match
+                    // value: a tuple: first item: the search pattern, second item: the replacement
+                    patternReplacements.Add(@"~~", new Tuple<string, string>(@"~~", "~"));
+                    patternReplacements.Add(@"~*", new Tuple<string, string>(@"~\*", @"\*"));
+                    patternReplacements.Add(@"~?", new Tuple<string, string>(@"~\?", @"\?"));
+                    patternReplacements.Add(@"?", new Tuple<string, string>(@"\?", ".?"));
+                    patternReplacements.Add(@"*", new Tuple<string, string>(@"\*", ".*"));
+                    
+                    var pattern = Regex.Replace(
+                        cs,
+                        "(" + String.Join(
+                                "|",
+                                patternReplacements.Values.Select(t => t.Item1))
+                        + ")",
+                        m => patternReplacements[m.Value].Item2);
+                    pattern = $"^{pattern}$";
+
                     return Regex.IsMatch(value.ToString(), pattern, RegexOptions.IgnoreCase);
                 }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -151,11 +151,8 @@ namespace ClosedXML.Excel.CalcEngine
                 var criteria = (string)p[1].Evaluate();
                 foreach (var value in ienum)
                 {
-                    if (!IsBlank(value))
-                    {
-                        if (CalcEngineHelpers.ValueSatisfiesCriteria(value, criteria, ce))
-                            cnt++;
-                    }
+                    if (CalcEngineHelpers.ValueSatisfiesCriteria(value, criteria, ce))
+                        cnt++;
                 }
             }
             return cnt;

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -217,6 +217,82 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.AreEqual(0.7, actual, tolerance);
         }
 
+        /// <summary>
+        /// refers to Example 1 from the Excel documentation,
+        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&rs=en-US&ad=US"/>
+        /// </summary>
+        /// <param name="expectedOutcome"></param>
+        /// <param name="formula"></param>
+        [TestCase(63000, "SUMIF(A1:A4,\">160000\", B1:B4)")]
+        [TestCase(900000, "SUMIF(A1:A4,\">160000\")")]
+        [TestCase(21000, "SUMIF(A1:A4, 300000, B1:B4)")]
+        [TestCase(28000, "SUMIF(A1:A4, \">\" &C1, B1:B4)")]
+        public void SumIf_ReturnsCorrectValues_ReferenceExample1FromMicrosoft(int expectedOutcome, string formula)
+        {
+            using(var wb = new XLWorkbook())
+            {
+                wb.ReferenceStyle = XLReferenceStyle.A1;
+
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell(1, 1).Value = 100000;
+                ws.Cell(1, 2).Value = 7000;
+                ws.Cell(2, 1).Value = 200000;
+                ws.Cell(2, 2).Value = 14000;
+                ws.Cell(3, 1).Value = 300000;
+                ws.Cell(3, 2).Value = 21000;
+                ws.Cell(4, 1).Value = 400000;
+                ws.Cell(4, 2).Value = 28000;
+
+                ws.Cell(1, 3).Value = 300000;
+
+                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
+            }
+        }
+
+        /// <summary>
+        /// refers to Example 2 from the Excel documentation,
+        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&rs=en-US&ad=US"/>
+        /// </summary>
+        /// <param name="expectedOutcome"></param>
+        /// <param name="formula"></param>
+        [TestCase( 2000, "SUMIF(A2:A7,\"Fruits\", C2:C7)")]
+        [TestCase(12000, "SUMIF(A2:A7,\"Vegetables\", C2:C7)")]
+        [TestCase( 4300, "SUMIF(B2:B7, \"*es\", C2:C7)")]
+        [TestCase(  400, "SUMIF(A2:A7, \"\", C2:C7)")]
+        public void SumIf_ReturnsCorrectValues_ReferenceExample2FromMicrosoft(int expectedOutcome, string formula)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                wb.ReferenceStyle = XLReferenceStyle.A1;
+
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell(2, 1).Value = "Vegetables";
+                ws.Cell(3, 1).Value = "Vegetables";
+                ws.Cell(4, 1).Value = "Fruits";
+                ws.Cell(5, 1).Value = "";
+                ws.Cell(6, 1).Value = "Vegetables";
+                ws.Cell(7, 1).Value = "Fruits";
+
+                ws.Cell(2, 2).Value = "Tomatoes";
+                ws.Cell(3, 2).Value = "Celery";
+                ws.Cell(4, 2).Value = "Oranges";
+                ws.Cell(5, 2).Value = "Butter";
+                ws.Cell(6, 2).Value = "Carrots";
+                ws.Cell(7, 2).Value = "Apples";
+
+                ws.Cell(2, 3).Value = 2300;
+                ws.Cell(3, 3).Value = 5500;
+                ws.Cell(4, 3).Value = 800;
+                ws.Cell(5, 3).Value = 400;
+                ws.Cell(6, 3).Value = 4200;
+                ws.Cell(7, 3).Value = 1200;
+
+                ws.Cell(1, 3).Value = 300000;
+
+                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
+            }
+        }
+
         [Test]
         public void SumProduct()
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -219,7 +219,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
 
         /// <summary>
         /// refers to Example 1 from the Excel documentation,
-        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&rs=en-US&ad=US"/>
+        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&amp;rs=en-US&amp;ad=US"/>
         /// </summary>
         /// <param name="expectedOutcome"></param>
         /// <param name="formula"></param>
@@ -229,7 +229,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase(28000, "SUMIF(A1:A4, \">\" &C1, B1:B4)")]
         public void SumIf_ReturnsCorrectValues_ReferenceExample1FromMicrosoft(int expectedOutcome, string formula)
         {
-            using(var wb = new XLWorkbook())
+            using (var wb = new XLWorkbook())
             {
                 wb.ReferenceStyle = XLReferenceStyle.A1;
 
@@ -251,14 +251,14 @@ namespace ClosedXML_Tests.Excel.CalcEngine
 
         /// <summary>
         /// refers to Example 2 from the Excel documentation,
-        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&rs=en-US&ad=US"/>
+        /// <see cref="https://support.office.com/en-us/article/SUMIF-function-169b8c99-c05c-4483-a712-1697a653039b?ui=en-US&amp;rs=en-US&amp;ad=US"/>
         /// </summary>
         /// <param name="expectedOutcome"></param>
         /// <param name="formula"></param>
-        [TestCase( 2000, "SUMIF(A2:A7,\"Fruits\", C2:C7)")]
+        [TestCase(2000, "SUMIF(A2:A7,\"Fruits\", C2:C7)")]
         [TestCase(12000, "SUMIF(A2:A7,\"Vegetables\", C2:C7)")]
-        [TestCase( 4300, "SUMIF(B2:B7, \"*es\", C2:C7)")]
-        [TestCase(  400, "SUMIF(A2:A7, \"\", C2:C7)")]
+        [TestCase(4300, "SUMIF(B2:B7, \"*es\", C2:C7)")]
+        [TestCase(400, "SUMIF(A2:A7, \"\", C2:C7)")]
         public void SumIf_ReturnsCorrectValues_ReferenceExample2FromMicrosoft(int expectedOutcome, string formula)
         {
             using (var wb = new XLWorkbook())

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -97,13 +97,41 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase(@"=COUNTIF(Data!E:E, ""*i*l"")", 9)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*i?e*"")", 9)]
         [TestCase(@"=COUNTIF(Data!E:E, ""*o??s*"")", 10)]
-        [TestCase(@"=COUNTIF(Data!E:E, """")", 0)]
+        [TestCase(@"=COUNTIF(Data!X1:X1000, """")", 1000)]
+        [TestCase(@"=COUNTIF(Data!E1:E44, """")", 1)]
         public void CountIf_ConditionWithWildcards(string formula, int expectedResult)
         {
             var ws = workbook.Worksheets.First();
 
             int value = ws.Evaluate(formula).CastTo<int>();
             Assert.AreEqual(expectedResult, value);
+        }
+
+        [TestCase("x", @"=COUNTIF(A1:A1, ""?"")", 1)]
+        [TestCase("x", @"=COUNTIF(A1:A1, ""~?"")", 0)]
+        [TestCase("?", @"=COUNTIF(A1:A1, ""~?"")", 1)]
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~?"")", 0)] 
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~~~?"")", 1)] 
+        [TestCase("?", @"=COUNTIF(A1:A1, ""~~?"")", 0)]
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~~?"")", 1)]
+        [TestCase("~x", @"=COUNTIF(A1:A1, ""~~?"")", 1)]
+        [TestCase("*", @"=COUNTIF(A1:A1, ""~*"")", 1)]
+        [TestCase("~*", @"=COUNTIF(A1:A1, ""~*"")", 0)]
+        [TestCase("~*", @"=COUNTIF(A1:A1, ""~~~*"")", 1)]
+        [TestCase("*", @"=COUNTIF(A1:A1, ""~~*"")", 0)]
+        [TestCase("~*", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
+        [TestCase("~x", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
+        [TestCase("~xyz", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
+        public void CountIf_MoreWildcards(string cellContent, string formula, int expectedResult)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+
+                ws.Cell(1, 1).Value = cellContent;
+
+                Assert.AreEqual(expectedResult, (double)ws.Evaluate(formula));
+            }
         }
 
         [OneTimeTearDown]

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -91,6 +91,21 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.AreEqual(24, value);
         }
 
+        [TestCase(@"=COUNTIF(Data!E:E, ""J*"")", 13)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*i*"")", 21)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*in*"")", 9)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*i*l"")", 9)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*i?e*"")", 9)]
+        [TestCase(@"=COUNTIF(Data!E:E, ""*o??s*"")", 10)]
+        [TestCase(@"=COUNTIF(Data!E:E, """")", 0)]
+        public void CountIf_ConditionWithWildcards(string formula, int expectedResult)
+        {
+            var ws = workbook.Worksheets.First();
+
+            int value = ws.Evaluate(formula).CastTo<int>();
+            Assert.AreEqual(expectedResult, value);
+        }
+
         [OneTimeTearDown]
         public void Dispose()
         {


### PR DESCRIPTION
#### What's this PR do?
improve wildcard pattern matching for string conditions:
- support ? wildcard
- support escaping wildcards
- support the empty string as a condition
- cover special cases with unit tests

#### Where should the reviewer start?
Splitting Pull Request #551, first part: string condition parsing.

The improvements themself are covered in the CalcEngineHelper.cs, tested by unit tests in the two test classes.

#### How should this be manually tested?
check with the behaviour of Excel ;)
#### Any background context you want to provide?
I stumbled over two more problems I couldn't yet solve, but I don't think, these should be blocker for the PR:

1. Excel can deal with really big numbers. As I know from the past (not sure about the current state) it tended to be unprecise for really big or small numbers. With that in mind it could be that Excel does most calculations in floating point arithmetics, probably in `double` values, rounding afterwards. Currently most functions in ClosedXML are implemented based on interger or long and I found some cases where the Excel crunched much higher numbers than the ClosedXML implementation.
2. For formulas with a range covering a complete column (like A:A) the results differ. I tried a unit test for COUNTIF(A:A, ""), counting all empty values in column G. ClosedXML as well as Excel itself return "very" high numbers, but the exact numbers are different. Guessing again I assume the result is the number of supported lines, which would mean, even Excel versions might not behave equally here.

#### Questions:
- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer