### PR TITLE
Breaking change: Change XLCellValues to XLDataType

### DIFF
--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -128,7 +128,7 @@ namespace ClosedXML.Excel
                             {
                                 Boolean match = isText
                                                     ? filter.Condition(row.Cell(kp.Key).GetString())
-                                                    : row.Cell(kp.Key).DataType == XLCellValues.Number &&
+                                                    : row.Cell(kp.Key).DataType == XLDataType.Number &&
                                                       filter.Condition(row.Cell(kp.Key).GetDouble());
                                 if (firstFilter)
                                 {

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -206,7 +206,7 @@ namespace ClosedXML.Excel
                         }
 
                         var cell = row.Cell(_column);
-                        if (cell.DataType != XLCellValues.Number || !condition(cell.GetDouble())) continue;
+                        if (cell.DataType != XLDataType.Number || !condition(cell.GetDouble())) continue;
                         row.WorksheetRow().Unhide();
                         foundOne = true;
                     }
@@ -224,7 +224,7 @@ namespace ClosedXML.Excel
             {
                 using (var subColumn = column.Column(2, column.CellCount()))
                 {
-                    var cellsUsed = subColumn.CellsUsed(c => c.DataType == XLCellValues.Number);
+                    var cellsUsed = subColumn.CellsUsed(c => c.DataType == XLDataType.Number);
                     if (takeTop)
                     {
                         if (type == XLTopBottomType.Items)
@@ -284,7 +284,7 @@ namespace ClosedXML.Excel
                         }
 
                         var cell = row.Cell(_column);
-                        if (cell.DataType != XLCellValues.Number || !condition(cell.GetDouble())) continue;
+                        if (cell.DataType != XLDataType.Number || !condition(cell.GetDouble())) continue;
                         row.WorksheetRow().Unhide();
                         foundOne = true;
                     }
@@ -304,17 +304,17 @@ namespace ClosedXML.Excel
             {
                 using (var subColumn = column.Column(2, column.CellCount()))
                 {
-                    Double average = subColumn.CellsUsed(c => c.DataType == XLCellValues.Number).Select(c => c.GetDouble()).Average();
+                    Double average = subColumn.CellsUsed(c => c.DataType == XLDataType.Number).Select(c => c.GetDouble()).Average();
 
                     if (aboveAverage)
                     {
                         return
-                            subColumn.CellsUsed(c => c.DataType == XLCellValues.Number).
+                            subColumn.CellsUsed(c => c.DataType == XLDataType.Number).
                                 Select(c => c.GetDouble()).Where(c => c > average).Distinct();
                     }
 
                     return
-                        subColumn.CellsUsed(c => c.DataType == XLCellValues.Number).
+                        subColumn.CellsUsed(c => c.DataType == XLDataType.Number).
                             Select(c => c.GetDouble()).Where(c => c < average).Distinct();
 
                 }
@@ -371,7 +371,7 @@ namespace ClosedXML.Excel
             {
                 Boolean match = isText
                                     ? condition(row.Cell(_column).GetString())
-                                    : row.Cell(_column).DataType == XLCellValues.Number &&
+                                    : row.Cell(_column).DataType == XLDataType.Number &&
                                         condition(row.Cell(_column).GetDouble());
                 if (match)
                     row.WorksheetRow().Unhide();

--- a/ClosedXML/Excel/AutoFilters/XLFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilteredColumn.cs
@@ -46,7 +46,7 @@ namespace ClosedXML.Excel
                     if ((isText && condition(row.Cell(_column).GetString())) || (
                                                                                     !isText &&
                                                                                     row.Cell(_column).DataType ==
-                                                                                    XLCellValues.Number &&
+                                                                                    XLDataType.Number &&
                                                                                     condition(
                                                                                         row.Cell(_column).GetValue<T>()))
                         )

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -5,7 +5,7 @@ using System.Data;
 
 namespace ClosedXML.Excel
 {
-    public enum XLCellValues { Text, Number, Boolean, DateTime, TimeSpan }
+    public enum XLDataType { Text, Number, Boolean, DateTime, TimeSpan }
 
     public enum XLTableCellType { None, Header, Data, Total }
 
@@ -51,7 +51,7 @@ namespace ClosedXML.Excel
         /// The type of the cell's data.
         /// </value>
         /// <exception cref="ArgumentException"></exception>
-        XLCellValues DataType { get; set; }
+        XLDataType DataType { get; set; }
 
         /// <summary>
         /// Sets the type of this cell's data.
@@ -60,7 +60,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="dataType">Type of the data.</param>
         /// <returns></returns>
-        IXLCell SetDataType(XLCellValues dataType);
+        IXLCell SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Sets the cell's value.

--- a/ClosedXML/Excel/Cells/IXLCells.cs
+++ b/ClosedXML/Excel/Cells/IXLCells.cs
@@ -26,9 +26,9 @@ namespace ClosedXML.Excel
         /// The type of the cell's data.
         /// </value>
         /// <exception cref="ArgumentException"></exception>
-        XLCellValues DataType { set; }
+        XLDataType DataType { set; }
 
-        IXLCells SetDataType(XLCellValues dataType);
+        IXLCells SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these cells.

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -70,7 +70,7 @@ namespace ClosedXML.Excel
         internal string _cellValue = String.Empty;
 
         private XLComment _comment;
-        internal XLCellValues _dataType;
+        internal XLDataType _dataType;
         private XLHyperlink _hyperlink;
         private XLRichText _richText;
         private Int32? _styleCacheId;
@@ -219,20 +219,20 @@ namespace ClosedXML.Excel
             if (value is String || value is char)
             {
                 _cellValue = value.ToString();
-                _dataType = XLCellValues.Text;
+                _dataType = XLDataType.Text;
                 if (_cellValue.Contains(Environment.NewLine) && !GetStyleForRead().Alignment.WrapText)
                     Style.Alignment.WrapText = true;
             }
             else if (value is TimeSpan)
             {
                 _cellValue = value.ToString();
-                _dataType = XLCellValues.TimeSpan;
+                _dataType = XLDataType.TimeSpan;
                 if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
                     Style.NumberFormat.NumberFormatId = 46;
             }
             else if (value is DateTime)
             {
-                _dataType = XLCellValues.DateTime;
+                _dataType = XLDataType.DateTime;
                 var dtTest = (DateTime)Convert.ChangeType(value, typeof(DateTime));
                 if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
                     Style.NumberFormat.NumberFormatId = dtTest.Date == dtTest ? 14 : 22;
@@ -245,23 +245,23 @@ namespace ClosedXML.Excel
                     || Double.IsInfinity((Double)Convert.ChangeType(value, typeof(Double)))))
                 {
                     _cellValue = value.ToString();
-                    _dataType = XLCellValues.Text;
+                    _dataType = XLDataType.Text;
                 }
                 else
                 {
-                    _dataType = XLCellValues.Number;
+                    _dataType = XLDataType.Number;
                     _cellValue = ((Double)Convert.ChangeType(value, typeof(Double))).ToInvariantString();
                 }
             }
             else if (value is Boolean)
             {
-                _dataType = XLCellValues.Boolean;
+                _dataType = XLDataType.Boolean;
                 _cellValue = (Boolean)Convert.ChangeType(value, typeof(Boolean)) ? "1" : "0";
             }
             else
             {
                 _cellValue = Convert.ToString(value);
-                _dataType = XLCellValues.Text;
+                _dataType = XLDataType.Text;
             }
 
             return this;
@@ -320,11 +320,11 @@ namespace ClosedXML.Excel
                 cValue = _cellValue;
             }
 
-            if (_dataType == XLCellValues.Boolean)
+            if (_dataType == XLDataType.Boolean)
                 return (cValue != "0").ToString();
-            if (_dataType == XLCellValues.TimeSpan)
+            if (_dataType == XLDataType.TimeSpan)
                 return cValue;
-            if (_dataType == XLCellValues.DateTime || IsDateFormat())
+            if (_dataType == XLDataType.DateTime || IsDateFormat())
             {
                 double dTest;
                 if (Double.TryParse(cValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out dTest)
@@ -337,7 +337,7 @@ namespace ClosedXML.Excel
                 return cValue;
             }
 
-            if (_dataType == XLCellValues.Number)
+            if (_dataType == XLDataType.Number)
             {
                 double dTest;
                 if (Double.TryParse(cValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out dTest))
@@ -395,10 +395,10 @@ namespace ClosedXML.Excel
 
                 var cellValue = HasRichText ? _richText.ToString() : _cellValue;
 
-                if (_dataType == XLCellValues.Boolean)
+                if (_dataType == XLDataType.Boolean)
                     return cellValue != "0";
 
-                if (_dataType == XLCellValues.DateTime)
+                if (_dataType == XLDataType.DateTime)
                 {
                     Double d;
                     if (Double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d)
@@ -406,14 +406,14 @@ namespace ClosedXML.Excel
                         return DateTime.FromOADate(d);
                 }
 
-                if (_dataType == XLCellValues.Number)
+                if (_dataType == XLDataType.Number)
                 {
                     Double d;
                     if (double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d))
                         return d;
                 }
 
-                if (_dataType == XLCellValues.TimeSpan)
+                if (_dataType == XLDataType.TimeSpan)
                 {
                     TimeSpan t;
                     if (TimeSpan.TryParse(cellValue, out t))
@@ -884,13 +884,13 @@ namespace ClosedXML.Excel
             set { SetStyle(value); }
         }
 
-        public IXLCell SetDataType(XLCellValues dataType)
+        public IXLCell SetDataType(XLDataType dataType)
         {
             DataType = dataType;
             return this;
         }
 
-        public XLCellValues DataType
+        public XLDataType DataType
         {
             get { return _dataType; }
             set
@@ -905,7 +905,7 @@ namespace ClosedXML.Excel
 
                 if (_cellValue.Length > 0)
                 {
-                    if (value == XLCellValues.Boolean)
+                    if (value == XLDataType.Boolean)
                     {
                         bool bTest;
                         if (Boolean.TryParse(_cellValue, out bTest))
@@ -913,7 +913,7 @@ namespace ClosedXML.Excel
                         else
                             _cellValue = _cellValue == "0" || String.IsNullOrEmpty(_cellValue) ? "0" : "1";
                     }
-                    else if (value == XLCellValues.DateTime)
+                    else if (value == XLDataType.DateTime)
                     {
                         DateTime dtTest;
                         double dblTest;
@@ -932,7 +932,7 @@ namespace ClosedXML.Excel
                         if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
                             Style.NumberFormat.NumberFormatId = _cellValue.Contains('.') ? 22 : 14;
                     }
-                    else if (value == XLCellValues.TimeSpan)
+                    else if (value == XLDataType.TimeSpan)
                     {
                         TimeSpan tsTest;
                         if (TimeSpan.TryParse(_cellValue, out tsTest))
@@ -957,7 +957,7 @@ namespace ClosedXML.Excel
                             }
                         }
                     }
-                    else if (value == XLCellValues.Number)
+                    else if (value == XLDataType.Number)
                     {
                         double dTest;
                         if (Double.TryParse(_cellValue, XLHelper.NumberStyle, CultureInfo.InvariantCulture, out dTest))
@@ -972,9 +972,9 @@ namespace ClosedXML.Excel
                     }
                     else
                     {
-                        if (_dataType == XLCellValues.Boolean)
+                        if (_dataType == XLDataType.Boolean)
                             _cellValue = (_cellValue != "0").ToString();
-                        else if (_dataType == XLCellValues.TimeSpan)
+                        else if (_dataType == XLDataType.TimeSpan)
                             _cellValue = BaseDate.Add(GetTimeSpan()).ToOADate().ToInvariantString();
                     }
                 }
@@ -1554,7 +1554,7 @@ namespace ClosedXML.Excel
                     field.TotalsRowFunction = XLTotalsRowFunction.None;
                     field.TotalsRowLabel = value.ToString();
                     this._cellValue = value.ToString();
-                    this.DataType = XLCellValues.Text;
+                    this.DataType = XLDataType.Text;
                     return true;
                 }
             }
@@ -1686,7 +1686,7 @@ namespace ClosedXML.Excel
         private bool IsDateFormat()
         {
             var style = GetStyleForRead();
-            return _dataType == XLCellValues.Number
+            return _dataType == XLDataType.Number
                    && String.IsNullOrWhiteSpace(style.NumberFormat.Format)
                    && ((style.NumberFormat.NumberFormatId >= 14
                         && style.NumberFormat.NumberFormatId <= 22)
@@ -1717,7 +1717,7 @@ namespace ClosedXML.Excel
                 return false;
 
             _richText = asRichString;
-            _dataType = XLCellValues.Text;
+            _dataType = XLDataType.Text;
             return true;
         }
 
@@ -1812,7 +1812,7 @@ namespace ClosedXML.Excel
                 val = value.ToString();
             _richText = null;
             if (val.Length == 0)
-                _dataType = XLCellValues.Text;
+                _dataType = XLDataType.Text;
             else
             {
                 double dTest;
@@ -1822,14 +1822,14 @@ namespace ClosedXML.Excel
                 var style = GetStyleForRead();
                 if (style.NumberFormat.Format == "@")
                 {
-                    _dataType = XLCellValues.Text;
+                    _dataType = XLDataType.Text;
                     if (val.Contains(Environment.NewLine) && !style.Alignment.WrapText)
                         Style.Alignment.WrapText = true;
                 }
                 else if (val[0] == '\'')
                 {
                     val = val.Substring(1, val.Length - 1);
-                    _dataType = XLCellValues.Text;
+                    _dataType = XLDataType.Text;
                     if (val.Contains(Environment.NewLine) && !style.Alignment.WrapText)
                         Style.Alignment.WrapText = true;
                 }
@@ -1838,15 +1838,15 @@ namespace ClosedXML.Excel
                     if (!(value is TimeSpan) && TimeSpan.TryParse(val, out tsTest))
                         val = tsTest.ToString();
 
-                    _dataType = XLCellValues.TimeSpan;
+                    _dataType = XLDataType.TimeSpan;
                     if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
                         Style.NumberFormat.NumberFormatId = 46;
                 }
                 else if (val.Trim() != "NaN" && Double.TryParse(val, XLHelper.NumberStyle, XLHelper.ParseCulture, out dTest))
-                    _dataType = XLCellValues.Number;
+                    _dataType = XLDataType.Number;
                 else if (DateTime.TryParse(val, out dtTest) && dtTest >= BaseDate)
                 {
-                    _dataType = XLCellValues.DateTime;
+                    _dataType = XLDataType.DateTime;
 
                     if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
                         Style.NumberFormat.NumberFormatId = dtTest.Date == dtTest ? 14 : 22;
@@ -1864,12 +1864,12 @@ namespace ClosedXML.Excel
                 }
                 else if (Boolean.TryParse(val, out bTest))
                 {
-                    _dataType = XLCellValues.Boolean;
+                    _dataType = XLDataType.Boolean;
                     val = bTest ? "1" : "0";
                 }
                 else
                 {
-                    _dataType = XLCellValues.Text;
+                    _dataType = XLDataType.Text;
                     if (val.Contains(Environment.NewLine) && !style.Alignment.WrapText)
                         Style.Alignment.WrapText = true;
                 }

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -184,13 +184,13 @@ namespace ClosedXML.Excel
             set { this.ForEach<XLCell>(c => c.Value = value); }
         }
 
-        public IXLCells SetDataType(XLCellValues dataType)
+        public IXLCells SetDataType(XLDataType dataType)
         {
             this.ForEach<XLCell>(c => c.DataType = dataType);
             return this;
         }
 
-        public XLCellValues DataType
+        public XLDataType DataType
         {
             set { this.ForEach<XLCell>(c => c.DataType = value); }
         }

--- a/ClosedXML/Excel/Columns/IXLColumn.cs
+++ b/ClosedXML/Excel/Columns/IXLColumn.cs
@@ -166,7 +166,7 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLColumn AddVerticalPageBreak();
 
-        IXLColumn SetDataType(XLCellValues dataType);
+        IXLColumn SetDataType(XLDataType dataType);
 
         IXLColumn ColumnLeft();
         IXLColumn ColumnLeft(Int32 step);

--- a/ClosedXML/Excel/Columns/IXLColumns.cs
+++ b/ClosedXML/Excel/Columns/IXLColumns.cs
@@ -112,7 +112,7 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLColumns AddVerticalPageBreaks();
 
-        IXLColumns SetDataType(XLCellValues dataType);
+        IXLColumns SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these columns.

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -647,7 +647,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public IXLColumn SetDataType(XLCellValues dataType)
+        public IXLColumn SetDataType(XLDataType dataType)
         {
             DataType = dataType;
             return this;

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -207,7 +207,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public IXLColumns SetDataType(XLCellValues dataType)
+        public IXLColumns SetDataType(XLDataType dataType)
         {
             _columns.ForEach(c => c.DataType = dataType);
             return this;

--- a/ClosedXML/Excel/Ranges/IXLBaseCollection.cs
+++ b/ClosedXML/Excel/Ranges/IXLBaseCollection.cs
@@ -66,7 +66,7 @@ namespace ClosedXML.Excel
         /// <param name="includeFormats">if set to <c>true</c> will return all cells with a value or a style different than the default.</param>
         IXLCells CellsUsed(Boolean includeFormats);
 
-        TMultiple SetDataType(XLCellValues dataType);
+        TMultiple SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these ranges.

--- a/ClosedXML/Excel/Ranges/IXLRange.cs
+++ b/ClosedXML/Excel/Ranges/IXLRange.cs
@@ -274,7 +274,7 @@ namespace ClosedXML.Excel
 
         IXLRange SortLeftToRight(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
 
-        IXLRange SetDataType(XLCellValues dataType);
+        IXLRange SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of this range.

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -39,7 +39,7 @@ namespace ClosedXML.Excel
         ///   The type of the cell's data.
         /// </value>
         /// <exception cref = "ArgumentException"></exception>
-        XLCellValues DataType { set; }
+        XLDataType DataType { set; }
 
         /// <summary>
         ///   Sets the cells' formula with A1 references.

--- a/ClosedXML/Excel/Ranges/IXLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeColumn.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel
         IXLRangeColumn Column(IXLCell start, IXLCell end);
         IXLRangeColumns Columns(String columns);
 
-        IXLRangeColumn SetDataType(XLCellValues dataType);
+        IXLRangeColumn SetDataType(XLDataType dataType);
 
         IXLRangeColumn ColumnLeft();
         IXLRangeColumn ColumnLeft(Int32 step);

--- a/ClosedXML/Excel/Ranges/IXLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeColumns.cs
@@ -35,7 +35,7 @@ namespace ClosedXML.Excel
 
         IXLStyle Style { get; set; }
 
-        IXLRangeColumns SetDataType(XLCellValues dataType);
+        IXLRangeColumns SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these columns.

--- a/ClosedXML/Excel/Ranges/IXLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeRow.cs
@@ -92,7 +92,7 @@ namespace ClosedXML.Excel
         IXLRangeRow Row(IXLCell start, IXLCell end);
         IXLRangeRows Rows(String rows);
 
-        IXLRangeRow SetDataType(XLCellValues dataType);
+        IXLRangeRow SetDataType(XLDataType dataType);
 
         IXLRangeRow RowAbove();
         IXLRangeRow RowAbove(Int32 step);

--- a/ClosedXML/Excel/Ranges/IXLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeRows.cs
@@ -34,7 +34,7 @@ namespace ClosedXML.Excel
 
         IXLStyle Style { get; set; }
 
-        IXLRangeRows SetDataType(XLCellValues dataType);
+        IXLRangeRows SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these rows.

--- a/ClosedXML/Excel/Ranges/IXLRanges.cs
+++ b/ClosedXML/Excel/Ranges/IXLRanges.cs
@@ -82,7 +82,7 @@ namespace ClosedXML.Excel
         /// <param name="includeFormats">if set to <c>true</c> will return all cells with a value or a style different than the default.</param>
         IXLCells CellsUsed(Boolean includeFormats);
 
-        IXLRanges SetDataType(XLCellValues dataType);
+        IXLRanges SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these ranges.

--- a/ClosedXML/Excel/Ranges/XLRange.cs
+++ b/ClosedXML/Excel/Ranges/XLRange.cs
@@ -327,7 +327,7 @@ namespace ClosedXML.Excel
                                           lastColumnNumber);
         }
 
-        public IXLRange SetDataType(XLCellValues dataType)
+        public IXLRange SetDataType(XLDataType dataType)
         {
             DataType = dataType;
             return this;

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -251,7 +251,7 @@ namespace ClosedXML.Excel
             set { Cells().ForEach(c => c.Value = value); }
         }
 
-        public XLCellValues DataType
+        public XLDataType DataType
         {
             set { Cells().ForEach(c => c.DataType = value); }
         }

--- a/ClosedXML/Excel/Ranges/XLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumn.cs
@@ -175,7 +175,7 @@ namespace ClosedXML.Excel
             return retVal;
         }
 
-        public IXLRangeColumn SetDataType(XLCellValues dataType)
+        public IXLRangeColumn SetDataType(XLDataType dataType)
         {
             DataType = dataType;
             return this;
@@ -253,13 +253,13 @@ namespace ClosedXML.Excel
                 {
                     if (thisCell.DataType == otherCell.DataType)
                     {
-                        if (thisCell.DataType == XLCellValues.Text)
+                        if (thisCell.DataType == XLDataType.Text)
                         {
                             comparison = e.MatchCase
                                              ? thisCell.InnerText.CompareTo(otherCell.InnerText)
                                              : String.Compare(thisCell.InnerText, otherCell.InnerText, true);
                         }
-                        else if (thisCell.DataType == XLCellValues.TimeSpan)
+                        else if (thisCell.DataType == XLDataType.TimeSpan)
                             comparison = thisCell.GetTimeSpan().CompareTo(otherCell.GetTimeSpan());
                         else
                             comparison = Double.Parse(thisCell.InnerText, XLHelper.NumberStyle, XLHelper.ParseCulture).CompareTo(Double.Parse(otherCell.InnerText, XLHelper.NumberStyle, XLHelper.ParseCulture));

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -83,7 +83,7 @@ namespace ClosedXML.Excel
             return cells;
         }
 
-        public IXLRangeColumns SetDataType(XLCellValues dataType)
+        public IXLRangeColumns SetDataType(XLDataType dataType)
         {
             _ranges.ForEach(c => c.DataType = dataType);
             return this;

--- a/ClosedXML/Excel/Ranges/XLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRow.cs
@@ -174,7 +174,7 @@ namespace ClosedXML.Excel
             return retVal;
         }
 
-        public IXLRangeRow SetDataType(XLCellValues dataType)
+        public IXLRangeRow SetDataType(XLDataType dataType)
         {
             DataType = dataType;
             return this;
@@ -247,13 +247,13 @@ namespace ClosedXML.Excel
                 {
                     if (thisCell.DataType == otherCell.DataType)
                     {
-                        if (thisCell.DataType == XLCellValues.Text)
+                        if (thisCell.DataType == XLDataType.Text)
                         {
                             comparison = e.MatchCase
                                              ? thisCell.InnerText.CompareTo(otherCell.InnerText)
                                              : String.Compare(thisCell.InnerText, otherCell.InnerText, true);
                         }
-                        else if (thisCell.DataType == XLCellValues.TimeSpan)
+                        else if (thisCell.DataType == XLDataType.TimeSpan)
                             comparison = thisCell.GetTimeSpan().CompareTo(otherCell.GetTimeSpan());
                         else
                             comparison = Double.Parse(thisCell.InnerText, XLHelper.NumberStyle, XLHelper.ParseCulture).CompareTo(Double.Parse(otherCell.InnerText, XLHelper.NumberStyle, XLHelper.ParseCulture));

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -83,7 +83,7 @@ namespace ClosedXML.Excel
             return cells;
         }
 
-        public IXLRangeRows SetDataType(XLCellValues dataType)
+        public IXLRangeRows SetDataType(XLDataType dataType)
         {
             _ranges.ForEach(c => c.DataType = dataType);
             return this;

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -160,7 +160,7 @@ namespace ClosedXML.Excel
             return cells;
         }
 
-        public IXLRanges SetDataType(XLCellValues dataType)
+        public IXLRanges SetDataType(XLDataType dataType)
         {
             _ranges.ForEach(c => c.DataType = dataType);
             return this;

--- a/ClosedXML/Excel/Rows/IXLRow.cs
+++ b/ClosedXML/Excel/Rows/IXLRow.cs
@@ -177,7 +177,7 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLRow AddHorizontalPageBreak();
 
-        IXLRow SetDataType(XLCellValues dataType);
+        IXLRow SetDataType(XLDataType dataType);
 
         IXLRow RowAbove();
         IXLRow RowAbove(Int32 step);

--- a/ClosedXML/Excel/Rows/IXLRows.cs
+++ b/ClosedXML/Excel/Rows/IXLRows.cs
@@ -112,7 +112,7 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLRows AddHorizontalPageBreaks();
 
-        IXLRows SetDataType(XLCellValues dataType);
+        IXLRows SetDataType(XLDataType dataType);
 
         /// <summary>
         /// Clears the contents of these rows.

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -577,7 +577,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public IXLRow SetDataType(XLCellValues dataType)
+        public IXLRow SetDataType(XLDataType dataType)
         {
             DataType = dataType;
             return this;

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -203,7 +203,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public IXLRows SetDataType(XLCellValues dataType)
+        public IXLRows SetDataType(XLDataType dataType)
         {
             _rows.ForEach(c => c.DataType = dataType);
             return this;

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -100,7 +100,7 @@ namespace ClosedXML.Excel
                     {
                         name = GetUniqueName("Column", cellPos + 1, true);
                         cell.SetValue(name);
-                        cell.DataType = XLCellValues.Text;
+                        cell.DataType = XLDataType.Text;
                     }
                     if (_fieldNames.ContainsKey(name))
                         throw new ArgumentException("The header row contains more than one field name '" + name + "'.");
@@ -383,7 +383,7 @@ namespace ClosedXML.Excel
                     if (!c.IsEmpty() && newHeaders.Contains(f.Name))
                     {
                         f.TotalsRowLabel = c.GetFormattedString();
-                        c.DataType = XLCellValues.Text;
+                        c.DataType = XLDataType.Text;
                     }
                 }
 
@@ -395,7 +395,7 @@ namespace ClosedXML.Excel
                         var c = this.TotalsRow().Cell(f.Index + 1);
                         if (!String.IsNullOrWhiteSpace(f.TotalsRowLabel))
                         {
-                            c.DataType = XLCellValues.Text;
+                            c.DataType = XLDataType.Text;
 
                             //Remove previous row's label
                             var oldTotalsCell = this.Worksheet.Cell(oldTotalsRowNumber, f.Column.ColumnNumber());
@@ -404,7 +404,7 @@ namespace ClosedXML.Excel
                         }
 
                         if (f.TotalsRowFunction != XLTotalsRowFunction.None)
-                            c.DataType = XLCellValues.Number;
+                            c.DataType = XLDataType.Number;
                     }
                 }
             }
@@ -545,7 +545,7 @@ namespace ClosedXML.Excel
             if (setAutofilter)
                 InitializeAutoFilter();
 
-            AsRange().Row(1).DataType = XLCellValues.Text;
+            AsRange().Row(1).DataType = XLDataType.Text;
 
             if (RowCount() == 1)
                 InsertRowsBelow(1);
@@ -678,7 +678,7 @@ namespace ClosedXML.Excel
                 _showHeaderRow = value;
 
                 if (_showHeaderRow)
-                    HeadersRow().DataType = XLCellValues.Text;
+                    HeadersRow().DataType = XLDataType.Text;
             }
         }
 
@@ -789,23 +789,23 @@ namespace ClosedXML.Excel
                     var c = f.Column.Cells().Skip(this.ShowHeaderRow ? 1 : 0).First();
                     switch (c.DataType)
                     {
-                        case XLCellValues.Text:
+                        case XLDataType.Text:
                             type = typeof(String);
                             break;
 
-                        case XLCellValues.Boolean:
+                        case XLDataType.Boolean:
                             type = typeof(Boolean);
                             break;
 
-                        case XLCellValues.DateTime:
+                        case XLDataType.DateTime:
                             type = typeof(DateTime);
                             break;
 
-                        case XLCellValues.TimeSpan:
+                        case XLDataType.TimeSpan:
                             type = typeof(TimeSpan);
                             break;
 
-                        case XLCellValues.Number:
+                        case XLDataType.Number:
                             type = typeof(Double);
                             break;
                     }

--- a/ClosedXML/Excel/Tables/XLTableField.cs
+++ b/ClosedXML/Excel/Tables/XLTableField.cs
@@ -194,7 +194,7 @@ namespace ClosedXML.Excel
 
                 cell.FormulaA1 = "SUBTOTAL(" + formula + ",[" + Name + "])";
                 var lastCell = table.LastRow().Cell(Index + 1);
-                if (lastCell.DataType != XLCellValues.Text)
+                if (lastCell.DataType != XLDataType.Text)
                 {
                     cell.DataType = lastCell.DataType;
                     cell.Style.NumberFormat = lastCell.Style.NumberFormat;

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1327,7 +1327,7 @@ namespace ClosedXML.Excel
                     else
                         xlCell._cellValue = String.Empty;
 
-                    xlCell._dataType = XLCellValues.Text;
+                    xlCell._dataType = XLDataType.Text;
                     xlCell.ShareString = false;
                 }
                 else if (cell.DataType == CellValues.SharedString)
@@ -1340,19 +1340,19 @@ namespace ClosedXML.Excel
                     else
                         xlCell._cellValue = String.Empty;
 
-                    xlCell._dataType = XLCellValues.Text;
+                    xlCell._dataType = XLDataType.Text;
                 }
                 else if (cell.DataType == CellValues.Date)
                 {
                     if (cell.CellValue != null && !String.IsNullOrWhiteSpace(cell.CellValue.Text))
                         xlCell._cellValue = Double.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture).ToInvariantString();
-                    xlCell._dataType = XLCellValues.DateTime;
+                    xlCell._dataType = XLDataType.DateTime;
                 }
                 else if (cell.DataType == CellValues.Boolean)
                 {
                     if (cell.CellValue != null)
                         xlCell._cellValue = cell.CellValue.Text;
-                    xlCell._dataType = XLCellValues.Boolean;
+                    xlCell._dataType = XLDataType.Boolean;
                 }
                 else if (cell.DataType == CellValues.Number)
                 {
@@ -1360,7 +1360,7 @@ namespace ClosedXML.Excel
                         xlCell._cellValue = Double.Parse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture).ToInvariantString();
 
                     if (s == null)
-                        xlCell._dataType = XLCellValues.Number;
+                        xlCell._dataType = XLDataType.Number;
                     else
                         xlCell.DataType = GetDataTypeFromCell(xlCell.Style.NumberFormat);
                 }
@@ -1369,7 +1369,7 @@ namespace ClosedXML.Excel
             {
                 if (s == null)
                 {
-                    xlCell._dataType = XLCellValues.Number;
+                    xlCell._dataType = XLDataType.Number;
                 }
                 else
                 {
@@ -1678,29 +1678,29 @@ namespace ClosedXML.Excel
             }
         }
 
-        private static XLCellValues GetDataTypeFromCell(IXLNumberFormat numberFormat)
+        private static XLDataType GetDataTypeFromCell(IXLNumberFormat numberFormat)
         {
             var numberFormatId = numberFormat.NumberFormatId;
             if (numberFormatId == 46U)
-                return XLCellValues.TimeSpan;
+                return XLDataType.TimeSpan;
             else if ((numberFormatId >= 14 && numberFormatId <= 22) ||
                      (numberFormatId >= 45 && numberFormatId <= 47))
-                return XLCellValues.DateTime;
+                return XLDataType.DateTime;
             else if (numberFormatId == 49)
-                return XLCellValues.Text;
+                return XLDataType.Text;
             else
             {
                 if (!String.IsNullOrWhiteSpace(numberFormat.Format))
                 {
                     var dataType = GetDataTypeFromFormat(numberFormat.Format);
-                    return dataType.HasValue ? dataType.Value : XLCellValues.Number;
+                    return dataType.HasValue ? dataType.Value : XLDataType.Number;
                 }
                 else
-                    return XLCellValues.Number;
+                    return XLDataType.Number;
             }
         }
 
-        private static XLCellValues? GetDataTypeFromFormat(String format)
+        private static XLDataType? GetDataTypeFromFormat(String format)
         {
             int length = format.Length;
             String f = format.ToLower();
@@ -1710,9 +1710,9 @@ namespace ClosedXML.Excel
                 if (c == '"')
                     i = f.IndexOf('"', i + 1);
                 else if (c == '0' || c == '#' || c == '?')
-                    return XLCellValues.Number;
+                    return XLDataType.Number;
                 else if (c == 'y' || c == 'm' || c == 'd' || c == 'h' || c == 's')
-                    return XLCellValues.DateTime;
+                    return XLDataType.DateTime;
             }
             return null;
         }

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -150,7 +150,7 @@ namespace ClosedXML.Excel
 
         internal struct PivotTableFieldInfo
         {
-            public XLCellValues DataType;
+            public XLDataType DataType;
             public Boolean MixedDataType;
             public IEnumerable<Object> DistinctValues;
         }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -65,20 +65,20 @@ namespace ClosedXML.Excel
         {
             switch (xlCell.DataType)
             {
-                case XLCellValues.Text:
+                case XLDataType.Text:
                     {
                         return xlCell.ShareString ? CvSharedString : CvInlineString;
                     }
-                case XLCellValues.Number:
+                case XLDataType.Number:
                     return CvNumber;
 
-                case XLCellValues.DateTime:
+                case XLDataType.DateTime:
                     return CvDate;
 
-                case XLCellValues.Boolean:
+                case XLDataType.Boolean:
                     return CvBoolean;
 
-                case XLCellValues.TimeSpan:
+                case XLDataType.TimeSpan:
                     return CvNumber;
 
                 default:
@@ -871,12 +871,12 @@ namespace ClosedXML.Excel
                     Worksheets.Cast<XLWorksheet>().SelectMany(
                         w =>
                             w.Internals.CellsCollection.GetCells(
-                                c => ((c.DataType == XLCellValues.Text && c.ShareString) || c.HasRichText)
+                                c => ((c.DataType == XLDataType.Text && c.ShareString) || c.HasRichText)
                                      && (c as XLCell).InnerText.Length > 0
                                      && String.IsNullOrWhiteSpace(c.FormulaA1)
                                 )))
             {
-                c.DataType = XLCellValues.Text;
+                c.DataType = XLDataType.Text;
                 if (c.HasRichText)
                 {
                     if (newRichStrings.ContainsKey(c.RichText))
@@ -2032,13 +2032,13 @@ namespace ClosedXML.Excel
                 var types = fieldValueCells.Select(cell => cell.DataType).Distinct();
 
 
-                if (types.Count() == 1 && types.Single() == XLCellValues.Number)
+                if (types.Count() == 1 && types.Single() == XLDataType.Number)
                 {
                     sharedItems.ContainsSemiMixedTypes = false;
                     sharedItems.ContainsString = false;
                     sharedItems.ContainsNumber = true;
 
-                    ptfi.DataType = XLCellValues.Number;
+                    ptfi.DataType = XLDataType.Number;
                     ptfi.MixedDataType = false;
                     ptfi.DistinctValues = fieldValueCells
                             .Select(cell => cell.GetDouble())
@@ -2059,14 +2059,14 @@ namespace ClosedXML.Excel
                     sharedItems.MinValue = (double)ptfi.DistinctValues.Min();
                     sharedItems.MaxValue = (double)ptfi.DistinctValues.Max();
                 }
-                else if (types.Count() == 1 && types.Single() == XLCellValues.DateTime)
+                else if (types.Count() == 1 && types.Single() == XLDataType.DateTime)
                 {
                     sharedItems.ContainsSemiMixedTypes = false;
                     sharedItems.ContainsString = false;
                     sharedItems.ContainsNumber = false;
                     sharedItems.ContainsDate = true;
 
-                    ptfi.DataType = XLCellValues.DateTime;
+                    ptfi.DataType = XLDataType.DateTime;
                     ptfi.MixedDataType = false;
                     ptfi.DistinctValues = fieldValueCells
                             .Select(cell => cell.GetDateTime())
@@ -2094,7 +2094,7 @@ namespace ClosedXML.Excel
                         ptfi.DataType = types.First();
                         ptfi.MixedDataType = types.Count() > 1;
 
-                        if (!ptfi.MixedDataType && ptfi.DataType == XLCellValues.Text)
+                        if (!ptfi.MixedDataType && ptfi.DataType == XLDataType.Text)
                             ptfi.DistinctValues = fieldValueCells
                                 .Select(cell => cell.Value)
                                 .Cast<String>()
@@ -2338,7 +2338,7 @@ namespace ClosedXML.Excel
 
                     if (labelOrFilterField.SelectedValues.Count == 1)
                     {
-                        if (ptfi.MixedDataType || ptfi.DataType == XLCellValues.Text)
+                        if (ptfi.MixedDataType || ptfi.DataType == XLDataType.Text)
                         {
                             var values = ptfi.DistinctValues
                                 .Select(v => v.ToString().ToLower())
@@ -2347,7 +2347,7 @@ namespace ClosedXML.Excel
                             if (values.Contains(selectedValue))
                                 pageField.Item = Convert.ToUInt32(values.IndexOf(selectedValue));
                         }
-                        else if (ptfi.DataType == XLCellValues.DateTime)
+                        else if (ptfi.DataType == XLDataType.DateTime)
                         {
                             var values = ptfi.DistinctValues
                                 .Select(v => Convert.ToDateTime(v))
@@ -2356,7 +2356,7 @@ namespace ClosedXML.Excel
                             if (values.Contains(selectedValue))
                                 pageField.Item = Convert.ToUInt32(values.IndexOf(selectedValue));
                         }
-                        else if (ptfi.DataType == XLCellValues.Number)
+                        else if (ptfi.DataType == XLDataType.Number)
                         {
                             var values = ptfi.DistinctValues
                                 .Select(v => Convert.ToDouble(v))
@@ -4662,7 +4662,7 @@ namespace ClosedXML.Excel
                             else
                             {
                                 cell.CellFormula = null;
-                                cell.DataType = xlCell.DataType == XLCellValues.DateTime ? null : GetCellValueType(xlCell);
+                                cell.DataType = xlCell.DataType == XLDataType.DateTime ? null : GetCellValueType(xlCell);
                             }
 
                             if (evaluateFormulae || field != null || !xlCell.HasFormula)
@@ -5306,7 +5306,7 @@ namespace ClosedXML.Excel
             }
 
             var dataType = xlCell.DataType;
-            if (dataType == XLCellValues.Text)
+            if (dataType == XLDataType.Text)
             {
                 if (xlCell.InnerText.Length == 0)
                     openXmlCell.CellValue = null;
@@ -5329,7 +5329,7 @@ namespace ClosedXML.Excel
                     }
                 }
             }
-            else if (dataType == XLCellValues.TimeSpan)
+            else if (dataType == XLDataType.TimeSpan)
             {
                 var timeSpan = xlCell.GetTimeSpan();
                 var cellValue = new CellValue();
@@ -5337,7 +5337,7 @@ namespace ClosedXML.Excel
                     XLCell.BaseDate.Add(timeSpan).ToOADate().ToInvariantString();
                 openXmlCell.CellValue = cellValue;
             }
-            else if (dataType == XLCellValues.DateTime || dataType == XLCellValues.Number)
+            else if (dataType == XLDataType.DateTime || dataType == XLDataType.Number)
             {
                 if (!String.IsNullOrWhiteSpace(xlCell.InnerText))
                 {

--- a/ClosedXML_Examples/Loading/ChangingBasicTable.cs
+++ b/ClosedXML_Examples/Loading/ChangingBasicTable.cs
@@ -28,7 +28,7 @@ namespace ClosedXML_Examples
                 foreach (var cell in rngNumbers.Cells())
                 {
                     string formattedString = cell.GetFormattedString();
-                    cell.DataType = XLCellValues.Text;
+                    cell.DataType = XLDataType.Text;
                     cell.Value = formattedString + " Dollars";
                 }
 

--- a/ClosedXML_Examples/Misc/DataTypes.cs
+++ b/ClosedXML_Examples/Misc/DataTypes.cs
@@ -113,67 +113,67 @@ namespace ClosedXML_Examples.Misc
 
             ws.Cell(++ro, co).Value = "Date to Text:";
             ws.Cell(ro, co + 1).Value = new DateTime(2010, 9, 2);
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ws.Cell(++ro, co).Value = "DateTime to Text:";
             ws.Cell(ro, co + 1).Value = new DateTime(2010, 9, 2, 13, 45, 22);
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ws.Cell(++ro, co).Value = "Boolean to Text:";
             ws.Cell(ro, co + 1).Value = true;
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ws.Cell(++ro, co).Value = "Number to Text:";
             ws.Cell(ro, co + 1).Value = 123.45;
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ws.Cell(++ro, co).Value = "TimeSpan to Text:";
             ws.Cell(ro, co + 1).Value = new TimeSpan(33, 45, 22);
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ws.Cell(++ro, co).Value = "Text to Date:";
             ws.Cell(ro, co + 1).Value = "'" + new DateTime(2010, 9, 2).ToString();
-            ws.Cell(ro, co + 1).DataType = XLCellValues.DateTime;
+            ws.Cell(ro, co + 1).DataType = XLDataType.DateTime;
 
             ws.Cell(++ro, co).Value = "Text to DateTime:";
             ws.Cell(ro, co + 1).Value = "'" + new DateTime(2010, 9, 2, 13, 45, 22).ToString();
-            ws.Cell(ro, co + 1).DataType = XLCellValues.DateTime;
+            ws.Cell(ro, co + 1).DataType = XLDataType.DateTime;
 
             ws.Cell(++ro, co).Value = "Text to Boolean:";
             ws.Cell(ro, co + 1).Value = "'" + true.ToString();
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Boolean;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Boolean;
 
             ws.Cell(++ro, co).Value = "Text to Number:";
             ws.Cell(ro, co + 1).Value = "'123.45";
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Number;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Number;
 
             ws.Cell(++ro, co).Value = "@ format to Number:";
             ws.Cell(ro, co + 1).Style.NumberFormat.Format = "@";
             ws.Cell(ro, co + 1).Value = 123.45;
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Number;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Number;
 
             ws.Cell(++ro, co).Value = "Text to TimeSpan:";
             ws.Cell(ro, co + 1).Value = "'" + new TimeSpan(33, 45, 22).ToString();
-            ws.Cell(ro, co + 1).DataType = XLCellValues.TimeSpan;
+            ws.Cell(ro, co + 1).DataType = XLDataType.TimeSpan;
 
             ro++;
 
             ws.Cell(++ro, co).Value = "Formatted Date to Text:";
             ws.Cell(ro, co + 1).Value = new DateTime(2010, 9, 2);
             ws.Cell(ro, co + 1).Style.DateFormat.Format = "yyyy-MM-dd";
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ws.Cell(++ro, co).Value = "Formatted Number to Text:";
             ws.Cell(ro, co + 1).Value = 12345.6789;
             ws.Cell(ro, co + 1).Style.NumberFormat.Format = "#,##0.00";
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
 
             ro++;
 
             ws.Cell(++ro, co).Value = "Blank Text:";
             ws.Cell(ro, co + 1).Value = 12345.6789;
             ws.Cell(ro, co + 1).Style.NumberFormat.Format = "#,##0.00";
-            ws.Cell(ro, co + 1).DataType = XLCellValues.Text;
+            ws.Cell(ro, co + 1).DataType = XLDataType.Text;
             ws.Cell(ro, co + 1).Value = "";
 
             ro++;
@@ -192,17 +192,17 @@ namespace ClosedXML_Examples.Misc
             // workbook.GetSharedStrings()
 
             ws.Cell(++ro, co)
-                .SetDataType(XLCellValues.Text)
-                .SetDataType(XLCellValues.Boolean)
-                .SetDataType(XLCellValues.DateTime)
-                .SetDataType(XLCellValues.Number)
-                .SetDataType(XLCellValues.TimeSpan)
-                .SetDataType(XLCellValues.Text)
-                .SetDataType(XLCellValues.TimeSpan)
-                .SetDataType(XLCellValues.Number)
-                .SetDataType(XLCellValues.DateTime)
-                .SetDataType(XLCellValues.Boolean)
-                .SetDataType(XLCellValues.Text);
+                .SetDataType(XLDataType.Text)
+                .SetDataType(XLDataType.Boolean)
+                .SetDataType(XLDataType.DateTime)
+                .SetDataType(XLDataType.Number)
+                .SetDataType(XLDataType.TimeSpan)
+                .SetDataType(XLDataType.Text)
+                .SetDataType(XLDataType.TimeSpan)
+                .SetDataType(XLDataType.Number)
+                .SetDataType(XLDataType.DateTime)
+                .SetDataType(XLDataType.Boolean)
+                .SetDataType(XLDataType.Text);
 
             ws.Columns(2, 3).AdjustToContents();
 

--- a/ClosedXML_Examples/Misc/LambdaExpressions.cs
+++ b/ClosedXML_Examples/Misc/LambdaExpressions.cs
@@ -32,7 +32,7 @@ namespace ClosedXML_Examples
                 //        .ForEach(c => c.Style.Fill.BackgroundColor = XLColor.LightGray); // Fill with a light gray
 
                 var cells = rngData.Cells();
-                var filtered = cells.Where(c => c.DataType == XLCellValues.Text);
+                var filtered = cells.Where(c => c.DataType == XLDataType.Text);
                 var list = filtered.ToList();
                 foreach (var c in list)
                 {

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -60,7 +60,7 @@ namespace ClosedXML_Tests
             var doubleList = new List<Double> { 1.0 / 0.0 };
 
             cell.Value = doubleList;
-            Assert.AreNotEqual(XLCellValues.Number, cell.DataType);
+            Assert.AreNotEqual(XLDataType.Number, cell.DataType);
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace ClosedXML_Tests
             var doubleList = new List<Double> { 0.0 / 0.0 };
 
             cell.Value = doubleList;
-            Assert.AreNotEqual(XLCellValues.Number, cell.DataType);
+            Assert.AreNotEqual(XLDataType.Number, cell.DataType);
         }
 
         [Test]
@@ -169,7 +169,7 @@ namespace ClosedXML_Tests
             IXLCell cell = ws.Cell("A1");
             cell.Value = "NaN";
 
-            Assert.AreNotEqual(XLCellValues.Number, cell.DataType);
+            Assert.AreNotEqual(XLDataType.Number, cell.DataType);
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace ClosedXML_Tests
             IXLCell cell = ws.Cell("A1");
             cell.Value = "Nan";
 
-            Assert.AreNotEqual(XLCellValues.Number, cell.DataType);
+            Assert.AreNotEqual(XLDataType.Number, cell.DataType);
         }
 
         [Test]
@@ -241,7 +241,7 @@ namespace ClosedXML_Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             DateTime outValue;
             var date = 5545454;
-            ws.FirstCell().SetValue(date).DataType = XLCellValues.DateTime;
+            ws.FirstCell().SetValue(date).DataType = XLDataType.DateTime;
             bool success = ws.FirstCell().TryGetValue(out outValue);
             Assert.IsFalse(success);
         }
@@ -414,7 +414,7 @@ namespace ClosedXML_Tests
 
                 cell.Value = "Test";
                 Assert.AreEqual("Test", cell.Value);
-                Assert.AreEqual(XLCellValues.Text, cell.DataType);
+                Assert.AreEqual(XLDataType.Text, cell.DataType);
 
                 string s = null;
                 cell.SetValue(s);

--- a/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
@@ -125,7 +125,7 @@ namespace ClosedXML_Tests.Excel
                 var ws = wb.Worksheets.First();
                 foreach (var cell in ws.CellsUsed())
                 {
-                    Assert.AreEqual(XLCellValues.DateTime, cell.DataType);
+                    Assert.AreEqual(XLDataType.DateTime, cell.DataType);
                 }
             }
         }

--- a/ClosedXML_Tests/Excel/Misc/FormulaTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/FormulaTests.cs
@@ -112,7 +112,7 @@ namespace ClosedXML_Tests.Excel
             {
                 var ws = wb.AddWorksheet("Sheet1");
                 ws.Cell("A1").Value = new DateTime(2016, 1, 1);
-                ws.Cell("A1").DataType = XLCellValues.DateTime;
+                ws.Cell("A1").DataType = XLDataType.DateTime;
 
                 ws.Cell("A2").FormulaA1 = @"=IF(A1 = """", ""A"", ""B"")";
                 var actual = ws.Cell("A2").Value;

--- a/ClosedXML_Tests/Excel/RichText/XLRichStringTests.cs
+++ b/ClosedXML_Tests/Excel/RichText/XLRichStringTests.cs
@@ -18,7 +18,7 @@ namespace ClosedXML_Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
             cell.RichText.AddText("12");
-            cell.DataType = XLCellValues.Number;
+            cell.DataType = XLDataType.Number;
 
             Assert.AreEqual(12.0, cell.GetDouble());
 
@@ -30,7 +30,7 @@ namespace ClosedXML_Tests
 
             Assert.AreEqual("1234", cell.GetString());
 
-            Assert.AreEqual(XLCellValues.Number, cell.DataType);
+            Assert.AreEqual(XLDataType.Number, cell.DataType);
 
             Assert.AreEqual(1234.0, cell.GetDouble());
         }
@@ -147,11 +147,11 @@ namespace ClosedXML_Tests
 
             Assert.AreEqual(true, cell.HasRichText);
 
-            cell.DataType = XLCellValues.Text;
+            cell.DataType = XLDataType.Text;
 
             Assert.AreEqual(true, cell.HasRichText);
 
-            cell.DataType = XLCellValues.Number;
+            cell.DataType = XLDataType.Number;
 
             Assert.AreEqual(false, cell.HasRichText);
 


### PR DESCRIPTION
Change the `XLCellValues` enum to a more suitable name of `XLDataType`

This is a breaking change.