### PR TITLE
Fix error when copying sheets with certain image anchors

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -584,8 +584,9 @@ namespace ClosedXML.Excel
             foreach (var picture in Pictures)
             {
                 var newPic = targetSheet.AddPicture(picture.ImageStream, picture.Format, picture.Name)
-                    .WithPlacement(picture.Placement)
-                    .WithSize(picture.Width, picture.Height);
+                    .WithPlacement(XLPicturePlacement.FreeFloating)
+                    .WithSize(picture.Width, picture.Height)
+                    .WithPlacement(picture.Placement);
 
                 switch (picture.Placement)
                 {

--- a/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
@@ -148,6 +148,26 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
+        public void CanCopySheetsWithAllAnchorTypes()
+        {
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
+            using (var wb = new XLWorkbook(stream))
+            {
+                var ws = wb.Worksheets.First();
+                ws.CopyTo("Copy1");
+
+                var ws2 = wb.Worksheets.Skip(1).First();
+                ws2.CopyTo("Copy2");
+
+                var ws3 = wb.Worksheets.Skip(2).First();
+                ws3.CopyTo("Copy3");
+
+                var ws4 = wb.Worksheets.Skip(3).First();
+                ws3.CopyTo("Copy4");
+            }
+        }
+
+        [Test]
         public void CanLoadFileWithImagesWithCorrectImageType()
         {
             using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageFormats.xlsx")))

--- a/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
@@ -148,26 +148,6 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
-        public void CanCopySheetsWithAllAnchorTypes()
-        {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                ws.CopyTo("Copy1");
-
-                var ws2 = wb.Worksheets.Skip(1).First();
-                ws2.CopyTo("Copy2");
-
-                var ws3 = wb.Worksheets.Skip(2).First();
-                ws3.CopyTo("Copy3");
-
-                var ws4 = wb.Worksheets.Skip(3).First();
-                ws3.CopyTo("Copy4");
-            }
-        }
-
-        [Test]
         public void CanLoadFileWithImagesWithCorrectImageType()
         {
             using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageFormats.xlsx")))

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -214,5 +214,25 @@ namespace ClosedXML_Tests
                 }
             }
         }
+
+        [Test]
+        public void CanCopySheetsWithAllAnchorTypes()
+        {
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
+            using (var wb = new XLWorkbook(stream))
+            {
+                var ws = wb.Worksheets.First();
+                ws.CopyTo("Copy1");
+
+                var ws2 = wb.Worksheets.Skip(1).First();
+                ws2.CopyTo("Copy2");
+
+                var ws3 = wb.Worksheets.Skip(2).First();
+                ws3.CopyTo("Copy3");
+
+                var ws4 = wb.Worksheets.Skip(3).First();
+                ws3.CopyTo("Copy4");
+            }
+        }
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Fixes #574 
Allows a sheet to be copied that contains images with MoveAndSize placement.  It just temporarily sets the image placement to something that allows width/height to be set while copying excel sheets.

#### Where should the reviewer start?  
#### How should this be manually tested? 
#### Any background context you want to provide?
This was the easiest thing to do to fix the issue.  If you decide the width/height setters should not have that placement constraint then I'll be glad to change the PR to do that instead.

#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post? no
- Does the knowledge base need an update? no
- Does this add new (C#) dependencies? no

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer