### PR TITLE
Fix System.InvalidOperationException: Error in implicit conversion. 

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -683,7 +683,7 @@ namespace ClosedXML.Excel
                                         else
                                             throw new NotImplementedException();
                                     }
-                                    else if (pf.MultipleItemSelectionAllowed != null && BooleanValue.ToBoolean(pf.MultipleItemSelectionAllowed))
+                                    else if (OpenXmlHelper.GetBooleanValueAsBool(pf.MultipleItemSelectionAllowed, false))
                                     {
                                         foreach (var item in pf.Items.Cast<Item>())
                                         {

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -683,7 +683,7 @@ namespace ClosedXML.Excel
                                         else
                                             throw new NotImplementedException();
                                     }
-                                    else if (BooleanValue.ToBoolean(pf.MultipleItemSelectionAllowed))
+                                    else if (pf.MultipleItemSelectionAllowed != null && BooleanValue.ToBoolean(pf.MultipleItemSelectionAllowed))
                                     {
                                         foreach (var item in pf.Items.Cast<Item>())
                                         {


### PR DESCRIPTION
Fix "System.InvalidOperationException: Error in implicit conversion. Cannot convert null object." when pf.MultipleItemSelectionAllowed is null.
