### PR TITLE
Fixes issue #624 Workbook.ToString() issue when default contsructor is used.

### DIFF
--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -988,7 +988,11 @@ namespace ClosedXML.Excel
 
         public override string ToString()
         {
-            return _originalFile ?? String.Format("XLWorkbook({0})", _originalStream.ToString());
+            var result = (string.IsNullOrWhiteSpace(_originalFile) && _originalStream == null)
+                ? GetType().ToString()
+                : _originalFile ?? String.Format("XLWorkbook({0})", _originalStream.ToString());
+
+            return result;
         }
     }
 }

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Excel\Misc\SearchTests.cs" />
     <Compile Include="Excel\Misc\XmlEncoderTests.cs" />
     <Compile Include="Excel\Loading\LoadingTests.cs" />
+    <Compile Include="Excel\Workbook\XLWorkbookTests.cs" />
     <Compile Include="OleDb\OleDbTests.cs" />
     <Compile Include="Excel\PageSetup\HeaderFooterTests.cs" />
     <Compile Include="Excel\PageSetup\PageBreaksTests.cs" />

--- a/ClosedXML_Tests/Excel/Workbook/XLWorkbookTests.cs
+++ b/ClosedXML_Tests/Excel/Workbook/XLWorkbookTests.cs
@@ -1,0 +1,22 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.Workbook
+{
+    [TestFixture]
+    public class XLWorkbookTests
+    {
+        [Test]
+        //When using default constructor like: new Workbook()
+        public void ReturnsDefaultToStringWhenStreamAndFileAreNull()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var result = wb.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Fixes issue #624 Workbook.ToString() issue when default contsructor is used.
#### Where should the reviewer start?
XLWorkbook.cs
#### How should this be manually tested?
Creating a new instance of XLWorkbook and calling .ToString() like: new XLWorkbook().ToString()

#### Any background context you want to provide?
This issue won't occur when a valid stream or file is used.

#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post? No
- Does the knowledge base need an update? No
- Does this add new (C#) dependencies? No

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer