### PR TITLE
Add persistence of Edit objects protection setting.

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1987,6 +1987,7 @@ namespace ClosedXML.Excel
             if (sp.AutoFilter != null) ws.Protection.AutoFilter = !sp.AutoFilter.Value;
             if (sp.PivotTables != null) ws.Protection.PivotTables = !sp.PivotTables.Value;
             if (sp.Sort != null) ws.Protection.Sort = !sp.Sort.Value;
+            if (sp.Objects != null) ws.Protection.Objects = !sp.Objects.Value;
             if (sp.SelectLockedCells != null) ws.Protection.SelectLockedCells = sp.SelectLockedCells.Value;
             if (sp.SelectUnlockedCells != null) ws.Protection.SelectUnlockedCells = sp.SelectUnlockedCells.Value;
         }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -4769,6 +4769,7 @@ namespace ClosedXML.Excel
                 sheetProtection.AutoFilter = OpenXmlHelper.GetBooleanValue(!protection.AutoFilter, true);
                 sheetProtection.PivotTables = OpenXmlHelper.GetBooleanValue(!protection.PivotTables, true);
                 sheetProtection.Sort = OpenXmlHelper.GetBooleanValue(!protection.Sort, true);
+                sheetProtection.Objects = OpenXmlHelper.GetBooleanValue(!protection.Objects, true);
                 sheetProtection.SelectLockedCells = OpenXmlHelper.GetBooleanValue(!protection.SelectLockedCells, false);
                 sheetProtection.SelectUnlockedCells = OpenXmlHelper.GetBooleanValue(!protection.SelectUnlockedCells, false);
             }

--- a/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
@@ -266,5 +266,29 @@ namespace ClosedXML_Tests.Excel
                 workbook.SaveAs(tf2.Path);
             }
         }
+
+        [Test]
+        public void CanRoundTripSheetProtectionForObjects()
+        {
+            using (var book = new XLWorkbook())
+            {
+                var sheet = book.AddWorksheet("TestSheet");
+                sheet.Protect()
+                    .SetObjects(true)
+                    .SetScenarios(true);
+
+                using (var xlStream = new MemoryStream())
+                {
+                    book.SaveAs(xlStream);
+
+                    using (var persistedBook = new XLWorkbook(xlStream))
+                    {
+                        var persistedSheet = persistedBook.Worksheets.Worksheet(1);
+
+                        Assert.AreEqual(sheet.Protection.Objects, persistedSheet.Protection.Objects);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Fix issue #648  by adding support for the Protection.Objects property to the sheet load and save.
#### Where should the reviewer start?
Changed LoadSheetProtection in XLWorkbook_Load to copy the state of the Objects property from the OpenXml object tot he ClosedXml object.
Changed GenerateWorksheetPartContent in XLWorkbook_Save.cs to copy the state of the Objects property from ClosedXml to the OpenXml object.

#### How should this be manually tested?
As per the reproduction code on #648 

#### Questions:
- Is there a blog post?
- Does the knowledge base need an update?
- Does this add new (C#) dependencies?

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer