### PR TITLE
Support TargetFramework with a lower version (4.0)

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClosedXML</RootNamespace>
     <AssemblyName>ClosedXML</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -647,7 +647,7 @@ namespace ClosedXML.Excel
                             foreach (var mi in members)
                             {
                                 if (mi.MemberType == MemberTypes.Property && (mi as PropertyInfo).GetGetMethod().IsStatic)
-                                    _worksheet.SetValue((mi as PropertyInfo).GetValue(null), ro, co);
+                                    _worksheet.SetValue((mi as PropertyInfo).GetValue(null, null), ro, co);
                                 else if (mi.MemberType == MemberTypes.Field && (mi as FieldInfo).IsStatic)
                                     _worksheet.SetValue((mi as FieldInfo).GetValue(null), ro, co);
                                 else
@@ -842,7 +842,7 @@ namespace ClosedXML.Excel
                         foreach (var mi in members)
                         {
                             if (mi.MemberType == MemberTypes.Property && (mi as PropertyInfo).GetGetMethod().IsStatic)
-                                _worksheet.SetValue((mi as PropertyInfo).GetValue(null), rowNumber, columnNumber);
+                                _worksheet.SetValue((mi as PropertyInfo).GetValue(null, null), rowNumber, columnNumber);
                             else if (mi.MemberType == MemberTypes.Field && (mi as FieldInfo).IsStatic)
                                 _worksheet.SetValue((mi as FieldInfo).GetValue(null), rowNumber, columnNumber);
                             else

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -498,7 +498,10 @@ namespace ClosedXML.Excel
             else if (_loadSource == XLLoadSource.File)
             {
                 if (String.Compare(_originalFile.Trim(), file.Trim(), true) != 0)
+                {
                     File.Copy(_originalFile, file, true);
+                    File.SetAttributes(file, FileAttributes.Normal);
+                }
 
                 CreatePackage(file, GetSpreadsheetDocumentType(file), options);
             }

--- a/ClosedXML_Examples/ClosedXML_Examples.csproj
+++ b/ClosedXML_Examples/ClosedXML_Examples.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClosedXML_Examples</RootNamespace>
     <AssemblyName>ClosedXML_Examples</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/ClosedXML_Examples/app.config
+++ b/ClosedXML_Examples/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
   </startup>
 </configuration>

--- a/ClosedXML_Sandbox/ClosedXML_Sandbox.csproj
+++ b/ClosedXML_Sandbox/ClosedXML_Sandbox.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClosedXML_Sandbox</RootNamespace>
     <AssemblyName>ClosedXML_Sandbox</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/ClosedXML_Sandbox/PerformanceRunner.cs
+++ b/ClosedXML_Sandbox/PerformanceRunner.cs
@@ -91,7 +91,7 @@ namespace ClosedXML_Sandbox
             }
             foreach (var str in strings)
             {
-                str.SetValue(row, tmpString.ToString());
+                str.SetValue(row, tmpString.ToString(), null);
             }
 
             // Format decimals
@@ -99,7 +99,7 @@ namespace ClosedXML_Sandbox
 
             foreach (var dec in decimals)
             {
-                dec.SetValue(row, tmpDec);
+                dec.SetValue(row, tmpDec, null);
             }
 
             // Format ints
@@ -107,7 +107,7 @@ namespace ClosedXML_Sandbox
 
             foreach (var intValue in ints)
             {
-                intValue.SetValue(row, tmpInt);
+                intValue.SetValue(row, tmpInt, null);
             }
 
             // Format dates
@@ -115,7 +115,7 @@ namespace ClosedXML_Sandbox
             tmpDate = tmpDate.AddSeconds(rnd.Next(-10000, 100000));
             foreach (var dt in dates)
             {
-                dt.SetValue(row, tmpDate);
+                dt.SetValue(row, tmpDate, null);
             }
 
             // Format timespans
@@ -123,14 +123,14 @@ namespace ClosedXML_Sandbox
 
             foreach (var ts in timeSpans)
             {
-                ts.SetValue(row, tmpTimespan);
+                ts.SetValue(row, tmpTimespan, null);
             }
 
             // Format booleans
             var tmpBool = (rnd.Next(0, 2) > 0);
             foreach (var bl in booleans)
             {
-                bl.SetValue(row, tmpBool);
+                bl.SetValue(row, tmpBool, null);
             }
 
             return row;

--- a/ClosedXML_Sandbox/app.config
+++ b/ClosedXML_Sandbox/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
   </startup>
 </configuration>

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -12,11 +12,13 @@ namespace ClosedXML_Tests.Excel.Saving
     [TestFixture]
     public class SavingTests
     {
+        private string _tempFolder;
         private List<string> _tempFiles;
 
         [SetUp]
         public void Setup()
         {
+            _tempFolder = Path.GetTempPath();
             _tempFiles = new List<string>();
         }
 
@@ -116,8 +118,9 @@ namespace ClosedXML_Tests.Excel.Saving
         public void CanSaveAsCopyReadOnlyFile()
         {
             // Arrange
-            string original = string.Format("original{0}.xlsx", Guid.NewGuid());
-            string copy = string.Format("copy_of_{0}", original);
+            string id = Guid.NewGuid().ToString();
+            string original = string.Format("{0}original{1}.xlsx", _tempFolder, id);
+            string copy = string.Format("{0}copy_of_{1}.xlsx", _tempFolder, id);
 
             using (var wb = new XLWorkbook())
             {


### PR DESCRIPTION
**Version of ClosedXML**

0.88 — 0.90

**What is the current behavior?**

Starting from version 0.88 ClosedXml requires framework version 4.5.2 or higher. Thus the library cannot be installed with the nuget package manager to projects that uses the older versions of the framework.

**What is the expected behavior or new feature?**

Support framework versions 4.0 - 4.5.1 as well.

**Did this work in previous versions of our tool?  Which versions?**

Yes, up till the version 0.87.1

## Reproducibility

I realize that framework 4.0 is something quite ancient, but don't see clear reasons why the target framework version was changed in the 0.88. Currently, we have a few solution with several hundred csproj-es in each of them - all reference target framework 4.5, and a few of them use ClosedXML. Update all these projects only to be able to install a newer version of ClosedXML would be insane, obviously. At the same time, there are only two methods used in entire ClosedXML that are not presented in the framework 4.0:

```c#
PropertyInfo.GetValue(object obj); // used twice in ClosedXML
PropertyInfo.SetValue(object obj, object value); // used in 6 places in ClosedXML_Sandbox
```

Luckily, they both have overloads with an additional argument and exactly the same functionality:
```c#
PropertyInfo.GetValue(object obj, object[] index);
PropertyInfo.SetValue(object obj, object value, object[] index);
```
Adding additional ```null``` in 8 places I was able to build the solution and pass all tests.
So, unless I missed some important considerations I ask you to change TargetFramework back to 4.0.


- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer