### PR TITLE
SUMPRODUCT: Blank cells and cells with text should be treated as zeros

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -380,7 +380,7 @@ namespace ClosedXML.Excel.CalcEngine
             for(int criteriaPair = 0; criteriaPair < numberOfCriteria; criteriaPair++)
             {
                 var criterion = p[criteriaPair * 2 + 1].Evaluate();
-                var criteriaRange = p[(criteriaPair + 1) * 2] as IEnumerable;   
+                var criteriaRange = p[(criteriaPair + 1) * 2] as IEnumerable;
                 var criteriaRangeValues = new List<object>();
                 foreach (var value in criteriaRange)
                 {
@@ -437,7 +437,19 @@ namespace ClosedXML.Excel.CalcEngine
 
             var values = p
                 .Cast<IEnumerable>()
-                .Select(range => range.Cast<double>().ToList());
+                .Select(range =>
+                {
+                    var results = new List<double>();
+                    foreach (var c in range)
+                    {
+                        if (c.IsNumber())
+                            results.Add(c.CastTo<double>());
+                        else
+                            results.Add(0.0);
+                    }
+                    return results;
+                })
+                .ToArray();
 
             return Enumerable.Range(0, counts.Single())
                 .Aggregate(0d, (t, i) =>
@@ -660,7 +672,7 @@ namespace ClosedXML.Excel.CalcEngine
             var num = Math.Floor((double)input);
             double fact = 1.0;
 
-            
+
             if (num < 0)
                 throw new NumberException();
 

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1270,6 +1270,13 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 Assert.AreEqual(220, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"));
 
                 Assert.Throws<NoValueAvailableException>(() => ws.Evaluate("SUMPRODUCT(A1:A10, B1:B5)"));
+
+                // Blank cells and cells with text should be treated as zeros
+                ws.Range("A1:A5").Clear();
+                Assert.AreEqual(110, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"));
+
+                ws.Range("A1:A5").SetValue("asdf");
+                Assert.AreEqual(110, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"));
             }
         }
 


### PR DESCRIPTION
Fixes #663 