### PR TITLE
Clear FormulaA1 when FormulaR1C1 is set

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1080,6 +1080,8 @@ namespace ClosedXML.Excel
             set
             {
                 _formulaR1C1 = String.IsNullOrWhiteSpace(value) ? null : value;
+
+                _formulaA1 = null;
             }
         }
 

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -546,5 +546,35 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(0, c3);
             }
         }
+
+        [Test]
+        public void SetFormulaA1AffectsR1C1()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                var cell = ws.Cell(1, 1);
+                cell.FormulaR1C1 = "R[1]C";
+
+                cell.FormulaA1 = "B2";
+
+                Assert.AreEqual("R[1]C[1]", cell.FormulaR1C1);
+            }
+        }
+
+        [Test]
+        public void SetFormulaR1C1AffectsA1()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                var cell = ws.Cell(1, 1);
+                cell.FormulaA1 = "A2";
+
+                cell.FormulaR1C1 = "R[1]C[1]";
+
+                Assert.AreEqual("B2", cell.FormulaA1);
+            }
+        }
     }
 }


### PR DESCRIPTION
During #667 analysis I noticed that changing cell's R1C1 formula does not affect A1 formula if it's been set prior. This causes inconsistent state and wrong calculation as the A1 formula is used in the evaluation.
Code to reproduce the problem is in the unit test.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer