### PR TITLE
FIX Pictures not being deleted

### DIFF
--- a/ClosedXML/Excel/Drawings/IXLPictures.cs
+++ b/ClosedXML/Excel/Drawings/IXLPictures.cs
@@ -29,6 +29,8 @@ namespace ClosedXML.Excel.Drawings
 
         void Delete(IXLPicture picture);
 
+        ICollection<String> Deleted { get; }
+
         IXLPicture Picture(String pictureName);
 
         bool TryGetPicture(string pictureName, out IXLPicture picture);

--- a/ClosedXML/Excel/Drawings/IXLPictures.cs
+++ b/ClosedXML/Excel/Drawings/IXLPictures.cs
@@ -29,8 +29,6 @@ namespace ClosedXML.Excel.Drawings
 
         void Delete(IXLPicture picture);
 
-        ICollection<String> Deleted { get; }
-
         IXLPicture Picture(String pictureName);
 
         bool TryGetPicture(string pictureName, out IXLPicture picture);

--- a/ClosedXML/Excel/Drawings/XLPictures.cs
+++ b/ClosedXML/Excel/Drawings/XLPictures.cs
@@ -12,10 +12,12 @@ namespace ClosedXML.Excel.Drawings
     {
         private readonly List<XLPicture> _pictures = new List<XLPicture>();
         private readonly XLWorksheet _worksheet;
+        public ICollection<String> Deleted { get; private set; }
 
         public XLPictures(XLWorksheet worksheet)
         {
             _worksheet = worksheet;
+             Deleted = new HashSet<String>();
         }
 
         public int Count
@@ -94,7 +96,17 @@ namespace ClosedXML.Excel.Drawings
 
         public void Delete(string pictureName)
         {
-            _pictures.RemoveAll(picture => picture.Name.Equals(pictureName, StringComparison.OrdinalIgnoreCase));
+            var picturesToDelete = _pictures
+                .Where(picture => picture.Name.Equals(pictureName, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            foreach (var picture in picturesToDelete)
+            {
+                if (!string.IsNullOrEmpty(picture.RelId))
+                    Deleted.Add(picture.RelId);
+
+                _pictures.Remove(picture);
+            }
         }
 
         IEnumerator<IXLPicture> IEnumerable<IXLPicture>.GetEnumerator()

--- a/ClosedXML/Excel/Drawings/XLPictures.cs
+++ b/ClosedXML/Excel/Drawings/XLPictures.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Excel.Drawings
     {
         private readonly List<XLPicture> _pictures = new List<XLPicture>();
         private readonly XLWorksheet _worksheet;
-        public ICollection<String> Deleted { get; private set; }
+        internal ICollection<String> Deleted { get; private set; }
 
         public XLPictures(XLWorksheet worksheet)
         {

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -5274,6 +5274,15 @@ namespace ClosedXML.Excel
 
             #region Drawings
 
+            if (worksheetPart.DrawingsPart != null)
+            {
+                foreach (var removedPicture in xlWorksheet.Pictures.Deleted)
+                {
+                    worksheetPart.DrawingsPart.DeletePart(removedPicture);
+                }
+                xlWorksheet.Pictures.Deleted.Clear();
+            }
+
             foreach (var pic in xlWorksheet.Pictures)
             {
                 AddPictureAnchor(worksheetPart, pic, context);
@@ -5288,6 +5297,14 @@ namespace ClosedXML.Excel
                 worksheetDrawing.AddNamespaceDeclaration("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
                 worksheetPart.Worksheet.InsertBefore(worksheetDrawing, tableParts);
             }
+
+            if (!xlWorksheet.Pictures.Any() && worksheetPart.DrawingsPart != null)
+            {
+                var id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart);
+                worksheetPart.Worksheet.RemoveChild<Drawing>(worksheetPart.Worksheet.OfType<Drawing>().FirstOrDefault(p => p.Id == id));
+                worksheetPart.DeletePart(worksheetPart.DrawingsPart);
+            }
+
 
             #endregion Drawings
 

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -5276,11 +5276,12 @@ namespace ClosedXML.Excel
 
             if (worksheetPart.DrawingsPart != null)
             {
-                foreach (var removedPicture in xlWorksheet.Pictures.Deleted)
+                var xlPictures = xlWorksheet.Pictures as Drawings.XLPictures;
+                foreach (var removedPicture in xlPictures.Deleted)
                 {
                     worksheetPart.DrawingsPart.DeletePart(removedPicture);
                 }
-                xlWorksheet.Pictures.Deleted.Clear();
+                xlPictures.Deleted.Clear();
             }
 
             foreach (var pic in xlWorksheet.Pictures)

--- a/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
@@ -228,15 +228,30 @@ namespace ClosedXML_Tests
         [Test]
         public void CanDeletePictures()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using (var ms = new MemoryStream())
             {
-                var ws = wb.Worksheets.First();
-                ws.Pictures.Delete(ws.Pictures.First());
+                int originalCount;
 
-                var pictureName = ws.Pictures.First().Name;
-                ws.Pictures.Delete(pictureName);
+                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
+                using (var wb = new XLWorkbook(stream))
+                {
+                    var ws = wb.Worksheets.First();
+                    originalCount = ws.Pictures.Count;
+                    ws.Pictures.Delete(ws.Pictures.First());
+
+                    var pictureName = ws.Pictures.First().Name;
+                    ws.Pictures.Delete(pictureName);
+
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws = wb.Worksheets.First();
+                    Assert.AreEqual(originalCount - 2, ws.Pictures.Count);
+                }
             }
+        
         }
 
         [Test]


### PR DESCRIPTION
This PR fixes #673, #655 

Previously, ClosedXML did not delete images from the file, only added them.
This PR
1. Puts deleted pictures into a separate collection and then removes them from a workbook as well.
2. Removes drawings that have no contents (it is not absolutely necessary, just prevents empty ```drawing``` sections from being stored in the file).
3. Original test expanded to check not only that pictures were deleted from a workbook in memory, but that they were removed from a file too.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer