### PR TITLE
Workaround when parsing html color string fails

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Extensions\GuidExtensions.cs" />
     <Compile Include="Extensions\OpenXmlPartContainerExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Utils\ColorStringParser.cs" />
     <Compile Include="Utils\GraphicsUtils.cs" />
     <Compile Include="Utils\OpenXmlHelper.cs" />
     <Compile Include="Utils\XmlEncoder.cs" />

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -1,7 +1,7 @@
+using ClosedXML.Utils;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using DocumentFormat.OpenXml.Presentation;
 
 namespace ClosedXML.Excel
 {
@@ -28,25 +28,30 @@ namespace ClosedXML.Excel
         {
             return FromColor(Color.FromArgb(argb));
         }
+
         public static XLColor FromArgb(Int32 r, Int32 g, Int32 b)
         {
             return FromColor(Color.FromArgb(r, g, b));
         }
+
         public static XLColor FromArgb(Int32 a, Int32 r, Int32 g, Int32 b)
         {
             return FromColor(Color.FromArgb(a, r, g, b));
         }
+
         public static XLColor FromKnownColor(KnownColor color)
         {
             return FromColor(Color.FromKnownColor(color));
         }
+
         public static XLColor FromName(String name)
         {
             return FromColor(Color.FromName(name));
         }
+
         public static XLColor FromHtml(String htmlColor)
         {
-            return FromColor(ColorTranslator.FromHtml(htmlColor));
+            return FromColor(ColorStringParser.ParseFromHtml(htmlColor));
         }
 
         private static readonly Dictionary<Int32, XLColor> ByIndex = new Dictionary<Int32, XLColor>();
@@ -113,6 +118,7 @@ namespace ClosedXML.Excel
         }
 
         private static Dictionary<Int32, XLColor> _indexedColors;
+
         public static Dictionary<Int32, XLColor> IndexedColors
         {
             get

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2442,7 +2442,7 @@ namespace ClosedXML.Excel
                     Color thisColor;
                     if (!_colorList.ContainsKey(htmlColor))
                     {
-                        thisColor = ColorTranslator.FromHtml(htmlColor);
+                        thisColor = ColorStringParser.ParseFromHtml(htmlColor);
                         _colorList.Add(htmlColor, thisColor);
                     }
                     else

--- a/ClosedXML/Utils/ColorStringParser.cs
+++ b/ClosedXML/Utils/ColorStringParser.cs
@@ -1,0 +1,22 @@
+﻿using System.Drawing;
+using System.Globalization;
+
+namespace ClosedXML.Utils
+{
+    internal static class ColorStringParser
+    {
+        public static Color ParseFromHtml(string htmlColor)
+        {
+            try
+            {
+                return ColorTranslator.FromHtml(htmlColor);
+            }
+            catch
+            {
+                // https://github.com/ClosedXML/ClosedXML/issues/675
+                // When regional settings list separator is # , the standard ColorTranslator.FromHtml fails
+                return Color.FromArgb(int.Parse(htmlColor.Replace("#", ""), NumberStyles.AllowHexSpecifier));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #675 