### PR TITLE
FIX for Clear() for cells sets the value to "", not null #544

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -67,7 +67,7 @@ namespace ClosedXML.Excel
 
         private readonly XLWorksheet _worksheet;
 
-        internal string _cellValue = String.Empty;
+        internal string _cellValue = null;
 
         private XLComment _comment;
         internal XLDataType _dataType;

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -67,6 +67,7 @@ namespace ClosedXML.Excel
 
         private readonly XLWorksheet _worksheet;
 
+
         internal string _cellValue = null;
 
         private XLComment _comment;

--- a/ClosedXML_Sandbox/Program.cs
+++ b/ClosedXML_Sandbox/Program.cs
@@ -1,4 +1,6 @@
+using ClosedXML.Excel;
 using System;
+using System.IO;
 
 namespace ClosedXML_Sandbox
 {
@@ -6,16 +8,41 @@ namespace ClosedXML_Sandbox
     {
         private static void Main(string[] args)
         {
-            Console.WriteLine("Running {0}", nameof(PerformanceRunner.OpenTestFile));
-            PerformanceRunner.TimeAction(PerformanceRunner.OpenTestFile);
-            Console.WriteLine();
+            using (var stream = new MemoryStream())
+            {
+                // Create some test data to parse
+                using (var book = new XLWorkbook())
+                {
+                    var sheet = book.AddWorksheet("Sheet 1");
+                    sheet.Cell(1, 1).Value = "test1";
+                    // Cell(1,2) is empty
+                    sheet.Cell(1, 3).Value = null;
+                    book.SaveAs(stream);
+                }
 
-            Console.WriteLine("Running {0}", nameof(PerformanceRunner.RunInsertTable));
-            PerformanceRunner.TimeAction(PerformanceRunner.RunInsertTable);
-            Console.WriteLine();
+                // Now load it back
+                stream.Position = 0;
+                using (var book = new XLWorkbook(stream))
+                {
+                    var sheet = book.Worksheets.Worksheet(1);
+                    var result = sheet.Cell(1, 1).Value;
+                    //Assert.AreEqual("test1", result);
+                    result = sheet.Cell(1, 2).Value;
+                    /* Assert.AreEqual(null, result); */ // Should be null!
+                    result = sheet.Cell(1, 3).Value;
+                    /* Assert.AreEqual(null, result);*/  // Should be null!
+                }
+                //Console.WriteLine("Running {0}", nameof(PerformanceRunner.OpenTestFile));
+                //PerformanceRunner.TimeAction(PerformanceRunner.OpenTestFile);
+                //Console.WriteLine();
 
-            Console.WriteLine("Press any key to continue");
-            Console.ReadKey();
+                //Console.WriteLine("Running {0}", nameof(PerformanceRunner.RunInsertTable));
+                //PerformanceRunner.TimeAction(PerformanceRunner.RunInsertTable);
+                //Console.WriteLine();
+
+                //Console.WriteLine("Press any key to continue");
+                //Console.ReadKey();
+            }
         }
     }
 }


### PR DESCRIPTION
_cellValue variable was set to empty string "" rather than null in the XLCell class.

Fixes #544 