### PR TITLE
range copy fix for conditional formats

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -2223,7 +2223,7 @@ namespace ClosedXML.Excel
             var conditionalFormats = source.Worksheet.ConditionalFormats.Where(c => c.Range.Contains(source)).ToList();
             foreach (var cf in conditionalFormats)
             {
-                var c = new XLConditionalFormat(cf as XLConditionalFormat) { Range = AsRange() };
+                var c = new XLConditionalFormat(cf as XLConditionalFormat, AsRange());
                 var oldValues = c.Values.Values.ToList();
                 c.Values.Clear();
                 foreach (var v in oldValues)

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -116,10 +116,10 @@ namespace ClosedXML.Excel
 
         }
 
-        public XLConditionalFormat(XLConditionalFormat conditionalFormat)
+        public XLConditionalFormat(XLConditionalFormat conditionalFormat, IXLRange targetRange)
         {
+            Range = targetRange;
             Id = Guid.NewGuid();
-            Range = conditionalFormat.Range;
             Style = new XLStyle(this, conditionalFormat.Style);
             Values = new XLDictionary<XLFormula>(conditionalFormat.Values);
             Colors = new XLDictionary<XLColor>(conditionalFormat.Colors);

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Excel\CalcEngine\StatisticalTests.cs" />
     <Compile Include="Excel\CalcEngine\TextTests.cs" />
     <Compile Include="Excel\Comments\CommentsTests.cs" />
+    <Compile Include="Excel\ConditionalFormats\ConditionalFormatCopyTests.cs" />
     <Compile Include="Excel\ConditionalFormats\ConditionalFormatsConsolidateTests.cs" />
     <Compile Include="Excel\ImageHandling\PictureTests.cs" />
     <Compile Include="Excel\Misc\HyperlinkTests.cs" />

--- a/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
+++ b/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
@@ -11,19 +11,16 @@ namespace ClosedXML_Tests.Excel.ConditionalFormats
         public void StylesAreCreatedDuringCopy()
         {
             var wb = new XLWorkbook();
-            XLWorksheet ws = (XLWorksheet)wb.Worksheets.Add("Sheet");
+            var ws = wb.Worksheets.Add("Sheet");
+            var format = ws.Range("A1:A1").AddConditionalFormat();
+            format.WhenEquals("=" + format.Range.FirstCell().CellRight(4).Address.ToStringRelative()).Fill
+                  .SetBackgroundColor(XLColor.Blue);
 
-            SetFormat1(ws.Range("A1:A1").AddConditionalFormat());
             var wb2 = new XLWorkbook();
-            XLWorksheet ws2 = (XLWorksheet)wb2.Worksheets.Add("Sheet2");
+            var ws2 = wb2.Worksheets.Add("Sheet2");
             ws2.FirstCell().CopyFrom(ws.FirstCell());
             Assert.That(ws2.ConditionalFormats.First().Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Blue)); //Added blue style
 
-        }
-
-        private static void SetFormat1(IXLConditionalFormat format)
-        {
-            format.WhenEquals("=" + format.Range.FirstCell().CellRight(4).Address.ToStringRelative()).Fill.SetBackgroundColor(XLColor.Blue);
         }
     }
 }

--- a/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
+++ b/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
@@ -16,9 +16,8 @@ namespace ClosedXML_Tests.Excel.ConditionalFormats
             SetFormat1(ws.Range("A1:A1").AddConditionalFormat());
             var wb2 = new XLWorkbook();
             XLWorksheet ws2 = (XLWorksheet)wb2.Worksheets.Add("Sheet2");
-            Assert.That(ws2.Styles.Count(), Is.EqualTo(1)); //Standard style
-            ws.Range("A1:A1").CopyTo(ws2.FirstCell());
-            Assert.That(ws2.Styles.Count(), Is.EqualTo(2)); //Added blue style
+            ws2.FirstCell().CopyFrom(ws.FirstCell());
+            Assert.That(ws2.ConditionalFormats.First().Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Blue)); //Added blue style
 
         }
 

--- a/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
+++ b/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Linq;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML_Tests.Excel.ConditionalFormats
+{
+    [TestFixture]
+    public class ConditionalFormatCopyTests
+    {
+        [Test]
+        public void StylesAreCreatedDuringCopy()
+        {
+            var wb = new XLWorkbook();
+            XLWorksheet ws = (XLWorksheet)wb.Worksheets.Add("Sheet");
+
+            SetFormat1(ws.Range("A1:A1").AddConditionalFormat());
+            var wb2 = new XLWorkbook();
+            XLWorksheet ws2 = (XLWorksheet)wb2.Worksheets.Add("Sheet2");
+            Assert.That(ws2.Styles.Count(), Is.EqualTo(1)); //Standard style
+            ws.Range("A1:A1").CopyTo(ws2.FirstCell());
+            Assert.That(ws2.Styles.Count(), Is.EqualTo(2)); //Added blue style
+
+        }
+
+        private static void SetFormat1(IXLConditionalFormat format)
+        {
+            format.WhenEquals("=" + format.Range.FirstCell().CellRight(4).Address.ToStringRelative()).Fill.SetBackgroundColor(XLColor.Blue);
+        }
+    }
+}


### PR DESCRIPTION
#### What's this PR do?
Copying cells between workbooks/Worksheets with conditional formats could never really work. Since the target range of the conditonal format was only set *after* the style, it would always reference a style in the source worksheet. In the best case, this would lead to ClosedXML being unable to save the new workbook. In the worse case, a kind of randomly selected style from the target worksheet would be used for the conditional format.
#### Where should the reviewer start?
The PR is a simple change of order. Since the target range is set before, assigning the style for the conditional format correctly creates it in the target worksheet.
#### How should this be manually tested?
Copying a range with conditional formats between worksheets/workbooks.
#### Any background context you want to provide?

#### Questions:
- Is there a blog post?
Nope
- Does the knowledge base need an update?
Nope
- Does this add new (C#) dependencies?
Nope

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer