### PR TITLE
Use existing class for handling temporary files in tests

### DIFF
--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -1,4 +1,5 @@
 using ClosedXML.Excel;
+using ClosedXML_Tests.Utils;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -13,15 +14,6 @@ namespace ClosedXML_Tests.Excel.Saving
     [TestFixture]
     public class SavingTests
     {
-        private string _tempFolder;
-        private List<string> _tempFiles;
-
-        [SetUp]
-        public void Setup()
-        {
-            _tempFolder = Path.GetTempPath();
-            _tempFiles = new List<string>();
-        }
 
         [Test]
         public void CanSuccessfullySaveFileMultipleTimes()
@@ -118,77 +110,91 @@ namespace ClosedXML_Tests.Excel.Saving
         [Test]
         public void CanSaveAsCopyReadOnlyFile()
         {
-            // Arrange
-            string id = Guid.NewGuid().ToString();
-            string original = string.Format("{0}original{1}.xlsx", _tempFolder, id);
-            string copy = string.Format("{0}copy_of_{1}.xlsx", _tempFolder, id);
-
-            using (var wb = new XLWorkbook())
+            using (var original = new TemporaryFile())
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                wb.SaveAs(original);
-                _tempFiles.Add(original);
-            }
-            System.IO.File.SetAttributes(original, FileAttributes.ReadOnly);
+                try
+                {
+                    using (var copy = new TemporaryFile())
+                    {
+                        // Arrange
+                        using (var wb = new XLWorkbook())
+                        {
+                            var sheet = wb.Worksheets.Add("TestSheet");
+                            wb.SaveAs(original.Path);
+                        }
+                        File.SetAttributes(original.Path, FileAttributes.ReadOnly);
 
-            // Act
-            using (var wb = new XLWorkbook(original))
-            {
-                wb.SaveAs(copy);
-                _tempFiles.Add(copy);
-            }
+                        // Act
+                        using (var wb = new XLWorkbook(original.Path))
+                        {
+                            wb.SaveAs(copy.Path);
+                        }
 
-            // Assert
-            Assert.IsTrue(System.IO.File.Exists(copy));
-            Assert.IsFalse(System.IO.File.GetAttributes(copy).HasFlag(FileAttributes.ReadOnly));
+                        // Assert
+                        Assert.IsTrue(File.Exists(copy.Path));
+                        Assert.IsFalse(File.GetAttributes(copy.Path).HasFlag(FileAttributes.ReadOnly));
+                    }
+                }
+                finally
+                {
+                    // Tear down
+                    File.SetAttributes(original.Path, FileAttributes.Normal);
+                }
+            }
         }
 
         [Test]
         public void CanSaveAsOverwriteExistingFile()
         {
-            // Arrange
-            string id = Guid.NewGuid().ToString();
-            string existing = string.Format("{0}existing{1}.xlsx", _tempFolder, id);
-
-            System.IO.File.WriteAllText(existing, "");
-            _tempFiles.Add(existing);
-
-            // Act
-            using (var wb = new XLWorkbook())
+            using (var existing = new TemporaryFile())
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                wb.SaveAs(existing);
-            }
+                // Arrange
+                File.WriteAllText(existing.Path, "");
 
-            // Assert
-            Assert.IsTrue(System.IO.File.Exists(existing));
-            Assert.Greater(new System.IO.FileInfo(existing).Length, 0);
+                // Act
+                using (var wb = new XLWorkbook())
+                {
+                    var sheet = wb.Worksheets.Add("TestSheet");
+                    wb.SaveAs(existing.Path);
+                }
+
+                // Assert
+                Assert.IsTrue(File.Exists(existing.Path));
+                Assert.Greater(new FileInfo(existing.Path).Length, 0);
+            }
         }
 
 
         [Test]
         public void CannotSaveAsOverwriteExistingReadOnlyFile()
         {
-            // Arrange
-            string id = Guid.NewGuid().ToString();
-            string existing = string.Format("{0}existing{1}.xlsx", _tempFolder, id);
-
-            System.IO.File.WriteAllText(existing, "");
-            _tempFiles.Add(existing);
-            System.IO.File.SetAttributes(existing, FileAttributes.ReadOnly);
-
-            // Act
-            TestDelegate saveAs = () =>
+            using (var existing = new TemporaryFile())
             {
-                using (var wb = new XLWorkbook())
+                try
                 {
-                    var sheet = wb.Worksheets.Add("TestSheet");
-                    wb.SaveAs(existing);
-                }
-            };
+                    // Arrange
+                    File.WriteAllText(existing.Path, "");
+                    File.SetAttributes(existing.Path, FileAttributes.ReadOnly);
 
-            // Assert
-            Assert.Throws(typeof(UnauthorizedAccessException), saveAs);
+                    // Act
+                    TestDelegate saveAs = () =>
+                    {
+                        using (var wb = new XLWorkbook())
+                        {
+                            var sheet = wb.Worksheets.Add("TestSheet");
+                            wb.SaveAs(existing.Path);
+                        }
+                    };
+
+                    // Assert
+                    Assert.Throws(typeof(UnauthorizedAccessException), saveAs);
+                }
+                finally
+                {
+                    // Tear down
+                    File.SetAttributes(existing.Path, FileAttributes.Normal);
+                }
+            }
         }
 
         [Test]
@@ -215,22 +221,6 @@ namespace ClosedXML_Tests.Excel.Saving
                     Assert.AreEqual(1, ws.PageSetup.RowBreaks.Count);
                 }
             }
-        }
-
-
-        [TearDown]
-        public void DeleteTempFiles()
-        {
-            foreach (var fileName in _tempFiles)
-            {
-                try
-                {
-                    System.IO.File.Delete(fileName);
-                }
-                catch
-                { }
-            }
-            _tempFiles.Clear();
         }
     }
 }


### PR DESCRIPTION
In my PR #641 I used a non-standard way of handling temporary files in unit tests. This PR fixes it.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer