### PR TITLE
Improve determining if the cell is of type Table.Total

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -4642,6 +4642,13 @@ namespace ClosedXML.Excel
                 xlWorksheet.Internals.CellsCollection.deleted.Remove(r.Key);
             }
 
+            var tableTotalCells = new HashSet<IXLAddress>(
+                xlWorksheet.Tables
+                .Where(table => table.ShowTotalsRow)
+                .SelectMany(table =>
+                    table.TotalsRow().CellsUsed())
+                .Select(cell => cell.Address));
+
             var distinctRows = xlWorksheet.Internals.CellsCollection.RowsCollection.Keys.Union(xlWorksheet.Internals.RowsCollection.Keys);
             var noRows = !sheetData.Elements<Row>().Any();
             foreach (var distinctRow in distinctRows.OrderBy(r => r))
@@ -4787,7 +4794,7 @@ namespace ClosedXML.Excel
 
                                 cell.CellValue = null;
                             }
-                            else if (xlCell.TableCellType() == XLTableCellType.Total)
+                            else if (tableTotalCells.Contains(xlCell.Address))
                             {
                                 var table = xlWorksheet.Tables.First(t => t.AsRange().Contains(xlCell));
                                 field = table.Fields.First(f => f.Column.ColumnNumber() == xlCell.Address.ColumnNumber) as XLTableField;


### PR DESCRIPTION
This PR fixes #714 

When the workbook is being saved each cell's type is determined only to decide if the certain cell is of type ```XLTableCellType.Total``` or not. If there are many thousands of cells this way is quite inefficient.

With this PR we prepare a complete set of those cells' addresses which are of the desired type - once per a worksheet, and then compare each cell address with this set. As a result, the saving operation performs significantly faster.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer