### PR TITLE
Refactor XLClearOptions and implement conditional formatting clearing

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Excel\SaveOptions.cs" />
     <Compile Include="Excel\Style\XLPredefinedFormat.cs" />
     <Compile Include="Excel\Tables\XLTableTheme.cs" />
+    <Compile Include="Excel\XLClearOptions.cs" />
     <Compile Include="Excel\XLConstants.cs" />
     <Compile Include="Excel\IXLWorkbook.cs" />
     <Compile Include="Excel\XLWorkbook_ImageHandling.cs" />

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -9,13 +9,6 @@ namespace ClosedXML.Excel
 
     public enum XLTableCellType { None, Header, Data, Total }
 
-    public enum XLClearOptions
-    {
-        ContentsAndFormats,
-        Contents,
-        Formats
-    }
-
     public interface IXLCell
     {
         /// <summary>
@@ -131,7 +124,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of this cell.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLCell Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLCell Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         /// <summary>
         /// Deletes the current cell and shifts the surrounding cells according to the shiftDeleteCells parameter.

--- a/ClosedXML/Excel/Cells/IXLCells.cs
+++ b/ClosedXML/Excel/Cells/IXLCells.cs
@@ -34,7 +34,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these cells.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLCells Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLCells Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         /// <summary>
         /// Delete the comments of these cells.

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace ClosedXML.Excel
 {
@@ -10,6 +9,7 @@ namespace ClosedXML.Excel
     internal class XLCells : IXLCells, IXLStylized, IEnumerable<XLCell>
     {
         public Boolean StyleChanged { get; set; }
+
         #region Fields
 
         private readonly bool _includeFormats;
@@ -17,7 +17,8 @@ namespace ClosedXML.Excel
         private readonly bool _usedCellsOnly;
         private IXLStyle _style;
         private readonly Func<IXLCell, Boolean> _predicate;
-        #endregion
+
+        #endregion Fields
 
         #region Constructor
 
@@ -29,7 +30,7 @@ namespace ClosedXML.Excel
             _predicate = predicate;
         }
 
-        #endregion
+        #endregion Constructor
 
         #region IEnumerable<XLCell> Members
 
@@ -65,7 +66,7 @@ namespace ClosedXML.Excel
                                         && (_predicate == null || _predicate(c))
                             );
 
-                        foreach(var cell in cellRange)
+                        foreach (var cell in cellRange)
                         {
                             yield return cell;
                         }
@@ -89,12 +90,12 @@ namespace ClosedXML.Excel
                 else
                 {
                     var mm = new MinMax
-                                 {
-                                     MinRow = range.FirstAddress.RowNumber,
-                                     MaxRow = range.LastAddress.RowNumber,
-                                     MinColumn = range.FirstAddress.ColumnNumber,
-                                     MaxColumn = range.LastAddress.ColumnNumber
-                                 };
+                    {
+                        MinRow = range.FirstAddress.RowNumber,
+                        MaxRow = range.LastAddress.RowNumber,
+                        MinColumn = range.FirstAddress.ColumnNumber,
+                        MaxColumn = range.LastAddress.ColumnNumber
+                    };
                     if (mm.MaxRow > 0 && mm.MaxColumn > 0)
                     {
                         for (Int32 ro = mm.MinRow; ro <= mm.MaxRow; ro++)
@@ -154,7 +155,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IEnumerable<XLCell> Members
 
         #region IXLCells Members
 
@@ -195,14 +196,14 @@ namespace ClosedXML.Excel
             set { this.ForEach<XLCell>(c => c.DataType = value); }
         }
 
-
-        public IXLCells Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLCells Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             this.ForEach<XLCell>(c => c.Clear(clearOptions));
             return this;
         }
 
-        public void DeleteComments() {
+        public void DeleteComments()
+        {
             this.ForEach<XLCell>(c => c.DeleteComment());
         }
 
@@ -216,7 +217,7 @@ namespace ClosedXML.Excel
             set { this.ForEach<XLCell>(c => c.FormulaR1C1 = value); }
         }
 
-        #endregion
+        #endregion IXLCells Members
 
         #region IXLStylized Members
 
@@ -250,7 +251,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         public void Add(XLRangeAddress rangeAddress)
         {
@@ -274,7 +275,7 @@ namespace ClosedXML.Excel
             public Int32 MinRow;
         }
 
-        #endregion
+        #endregion Nested type: MinMax
 
         public void Select()
         {

--- a/ClosedXML/Excel/Columns/IXLColumn.cs
+++ b/ClosedXML/Excel/Columns/IXLColumn.cs
@@ -4,7 +4,6 @@ namespace ClosedXML.Excel
 {
     public interface IXLColumn : IXLRangeBase
     {
-
         /// <summary>
         /// Gets or sets the width of this column.
         /// </summary>
@@ -66,11 +65,13 @@ namespace ClosedXML.Excel
         /// Adjusts the width of the column based on its contents.
         /// </summary>
         IXLColumn AdjustToContents();
+
         /// <summary>
         /// Adjusts the width of the column based on its contents, starting from the startRow.
         /// </summary>
         /// <param name="startRow">The row to start calculating the column width.</param>
         IXLColumn AdjustToContents(Int32 startRow);
+
         /// <summary>
         /// Adjusts the width of the column based on its contents, starting from the startRow and ending at endRow.
         /// </summary>
@@ -79,7 +80,9 @@ namespace ClosedXML.Excel
         IXLColumn AdjustToContents(Int32 startRow, Int32 endRow);
 
         IXLColumn AdjustToContents(Double minWidth, Double maxWidth);
+
         IXLColumn AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth);
+
         IXLColumn AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth);
 
         /// <summary>
@@ -152,13 +155,17 @@ namespace ClosedXML.Excel
         Int32 CellCount();
 
         IXLRangeColumn CopyTo(IXLCell cell);
+
         IXLRangeColumn CopyTo(IXLRangeBase range);
+
         IXLColumn CopyTo(IXLColumn column);
 
         IXLColumn Sort(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
 
         IXLRangeColumn Column(Int32 start, Int32 end);
+
         IXLRangeColumn Column(IXLCell start, IXLCell end);
+
         IXLRangeColumns Columns(String columns);
 
         /// <summary>
@@ -169,17 +176,19 @@ namespace ClosedXML.Excel
         IXLColumn SetDataType(XLDataType dataType);
 
         IXLColumn ColumnLeft();
+
         IXLColumn ColumnLeft(Int32 step);
+
         IXLColumn ColumnRight();
+
         IXLColumn ColumnRight(Int32 step);
 
         /// <summary>
         /// Clears the contents of this column.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLColumn Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLColumn Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         IXLRangeColumn ColumnUsed(Boolean includeFormats = false);
-
     }
 }

--- a/ClosedXML/Excel/Columns/IXLColumns.cs
+++ b/ClosedXML/Excel/Columns/IXLColumns.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLColumns: IEnumerable<IXLColumn>, IDisposable
+    public interface IXLColumns : IEnumerable<IXLColumn>, IDisposable
     {
         /// <summary>
         /// Sets the width of all columns.
@@ -22,11 +22,13 @@ namespace ClosedXML.Excel
         /// Adjusts the width of all columns based on its contents.
         /// </summary>
         IXLColumns AdjustToContents();
+
         /// <summary>
         /// Adjusts the width of all columns based on its contents, starting from the startRow.
         /// </summary>
         /// <param name="startRow">The row to start calculating the column width.</param>
         IXLColumns AdjustToContents(Int32 startRow);
+
         /// <summary>
         /// Adjusts the width of all columns based on its contents, starting from the startRow and ending at endRow.
         /// </summary>
@@ -35,7 +37,9 @@ namespace ClosedXML.Excel
         IXLColumns AdjustToContents(Int32 startRow, Int32 endRow);
 
         IXLColumns AdjustToContents(Double minWidth, Double maxWidth);
+
         IXLColumns AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth);
+
         IXLColumns AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth);
 
         /// <summary>
@@ -93,7 +97,7 @@ namespace ClosedXML.Excel
         /// Returns the collection of cells.
         /// </summary>
         IXLCells Cells();
-        
+
         /// <summary>
         /// Returns the collection of cells that have a value.
         /// </summary>
@@ -118,7 +122,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these columns.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLColumns Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLColumns Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Select();
     }

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Drawing;
-
+using System.Linq;
 
 namespace ClosedXML.Excel
 {
@@ -16,7 +15,7 @@ namespace ClosedXML.Excel
 
         private Double _width;
 
-        #endregion
+        #endregion Private fields
 
         #region Constructor
 
@@ -54,7 +53,7 @@ namespace ClosedXML.Excel
             SetStyle(column.GetStyleId());
         }
 
-        #endregion
+        #endregion Constructor
 
         public Boolean IsReference { get; private set; }
 
@@ -139,7 +138,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        public new IXLColumn Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLColumn Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;
@@ -327,7 +326,7 @@ namespace ClosedXML.Excel
                         foreach (IXLRichString rt in c.RichText)
                         {
                             String formattedString = rt.Text;
-                            var arr = formattedString.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+                            var arr = formattedString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
                             Int32 arrCount = arr.Count();
                             for (Int32 i = 0; i < arrCount; i++)
                             {
@@ -341,7 +340,7 @@ namespace ClosedXML.Excel
                     else
                     {
                         String formattedString = c.GetFormattedString();
-                        var arr = formattedString.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+                        var arr = formattedString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
                         Int32 arrCount = arr.Count();
                         for (Int32 i = 0; i < arrCount; i++)
                         {
@@ -352,7 +351,7 @@ namespace ClosedXML.Excel
                         }
                     }
 
-                    #endregion
+                    #endregion if (c.HasRichText)
 
                     #region foreach (var kp in kpList)
 
@@ -385,7 +384,7 @@ namespace ClosedXML.Excel
                             else
                                 runningWidth += f.GetWidth(formattedString, fontCache);
 
-                            #endregion
+                            #endregion if (newLinePosition >= 0)
                         }
                         else
                         {
@@ -424,11 +423,11 @@ namespace ClosedXML.Excel
                                     runningWidth += f.GetWidth(formattedString, fontCache);
                             }
 
-                            #endregion
+                            #endregion if (textRotation == 255)
                         }
                     }
 
-                    #endregion
+                    #endregion foreach (var kp in kpList)
 
                     if (runningWidth > thisWidthMax)
                         thisWidthMax = runningWidth;
@@ -448,14 +447,13 @@ namespace ClosedXML.Excel
                         thisWidthMax = (thisWidthMax * Math.Cos(r)) + (maxLineWidth * lineCount);
                     }
 
-                    #endregion
+                    #endregion if (rotated)
                 }
                 else
                     thisWidthMax = c.Style.Font.GetWidth(c.GetFormattedString(), fontCache);
 
                 if (autoFilterRows.Contains(c.Address.RowNumber))
                     thisWidthMax += 2.7148; // Allow room for arrow icon in autofilter
-
 
                 if (thisWidthMax >= maxWidth)
                 {
@@ -478,7 +476,6 @@ namespace ClosedXML.Excel
             }
             return this;
         }
-
 
         public IXLColumn Hide()
         {
@@ -590,19 +587,18 @@ namespace ClosedXML.Excel
             return this;
         }
 
-
         IXLRangeColumn IXLColumn.CopyTo(IXLCell target)
         {
             using (var asRange = AsRange())
-                using (var copy = asRange.CopyTo(target))
-                    return copy.Column(1);
+            using (var copy = asRange.CopyTo(target))
+                return copy.Column(1);
         }
 
         IXLRangeColumn IXLColumn.CopyTo(IXLRangeBase target)
         {
             using (var asRange = AsRange())
-                using (var copy = asRange.CopyTo(target))
-                    return copy.Column(1);
+            using (var copy = asRange.CopyTo(target))
+                return copy.Column(1);
         }
 
         public IXLColumn CopyTo(IXLColumn column)
@@ -658,7 +654,7 @@ namespace ClosedXML.Excel
             return Column(FirstCellUsed(includeFormats), LastCellUsed(includeFormats));
         }
 
-        #endregion
+        #endregion IXLColumn Members
 
         public override XLRange AsRange()
         {
@@ -720,7 +716,6 @@ namespace ClosedXML.Excel
             return Math.PI * angle / 180.0;
         }
 
-
         private XLColumn ColumnShift(Int32 columnsToShift)
         {
             return Worksheet.Column(ColumnNumber() + columnsToShift);
@@ -748,7 +743,7 @@ namespace ClosedXML.Excel
             return ColumnShift(step * -1);
         }
 
-        #endregion
+        #endregion XLColumn Left
 
         #region XLColumn Right
 
@@ -772,7 +767,7 @@ namespace ClosedXML.Excel
             return ColumnShift(step);
         }
 
-        #endregion
+        #endregion XLColumn Right
 
         public override Boolean IsEmpty()
         {

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -213,7 +213,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        #endregion
+        #endregion IXLColumns Members
 
         #region IXLStylized Members
 
@@ -254,7 +254,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         public void Add(XLColumn column)
         {
@@ -266,9 +266,9 @@ namespace ClosedXML.Excel
             _columns.ForEach(c => c.Collapsed = true);
         }
 
-        public IXLColumns Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLColumns Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
-            _columns.ForEach(c=>c.Clear(clearOptions));
+            _columns.ForEach(c => c.Clear(clearOptions));
             return this;
         }
 

--- a/ClosedXML/Excel/Ranges/IXLBaseCollection.cs
+++ b/ClosedXML/Excel/Ranges/IXLBaseCollection.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLBaseCollection<TSingle, TMultiple>: IEnumerable<TSingle>
-    { 
+    public interface IXLBaseCollection<TSingle, TMultiple> : IEnumerable<TSingle>
+    {
         Int32 Count { get; }
 
         IXLStyle Style { get; set; }
@@ -12,7 +12,7 @@ namespace ClosedXML.Excel
         IXLDataValidation SetDataValidation();
 
         /// <summary>
-        /// Creates a named range out of these ranges. 
+        /// Creates a named range out of these ranges.
         /// <para>If the named range exists, it will add these ranges to that named range.</para>
         /// <para>The default scope for the named range is Workbook.</para>
         /// </summary>
@@ -20,7 +20,7 @@ namespace ClosedXML.Excel
         TMultiple AddToNamed(String rangeName);
 
         /// <summary>
-        /// Creates a named range out of these ranges. 
+        /// Creates a named range out of these ranges.
         /// <para>If the named range exists, it will add these ranges to that named range.</para>
         /// <param name="rangeName">Name of the range.</param>
         /// <param name="scope">The scope for the named range.</param>
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel
         TMultiple AddToNamed(String rangeName, XLScope scope);
 
         /// <summary>
-        /// Creates a named range out of these ranges. 
+        /// Creates a named range out of these ranges.
         /// <para>If the named range exists, it will add these ranges to that named range.</para>
         /// <param name="rangeName">Name of the range.</param>
         /// <param name="scope">The scope for the named range.</param>
@@ -72,6 +72,6 @@ namespace ClosedXML.Excel
         /// Clears the contents of these ranges.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        TMultiple Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        TMultiple Clear(XLClearOptions clearOptions = XLClearOptions.All);
     }
 }

--- a/ClosedXML/Excel/Ranges/IXLRange.cs
+++ b/ClosedXML/Excel/Ranges/IXLRange.cs
@@ -280,7 +280,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of this range.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLRange Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLRange Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         IXLRangeRows RowsUsed(Boolean includeFormats, Func<IXLRangeRow, Boolean> predicate = null);
 

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -230,7 +230,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of this range.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLRangeBase Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLRangeBase Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         /// <summary>
         ///   Deletes the cell comments from this range.

--- a/ClosedXML/Excel/Ranges/IXLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeColumn.cs
@@ -1,6 +1,5 @@
 using System;
 
-
 namespace ClosedXML.Excel
 {
     public interface IXLRangeColumn : IXLRangeBase
@@ -17,6 +16,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="cellsInColumn">The column cells to return.</param>
         new IXLCells Cells(String cellsInColumn);
+
         /// <summary>
         /// Returns the specified group of cells.
         /// </summary>
@@ -30,33 +30,41 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="numberOfColumns">Number of columns to insert.</param>
         IXLRangeColumns InsertColumnsAfter(int numberOfColumns);
+
         IXLRangeColumns InsertColumnsAfter(int numberOfColumns, Boolean expandRange);
+
         /// <summary>
         /// Inserts X number of columns to the left of this range.
         /// <para>This range and all cells to the right of this range will be shifted X number of columns.</para>
         /// </summary>
         /// <param name="numberOfColumns">Number of columns to insert.</param>
         IXLRangeColumns InsertColumnsBefore(int numberOfColumns);
+
         IXLRangeColumns InsertColumnsBefore(int numberOfColumns, Boolean expandRange);
+
         /// <summary>
         /// Inserts X number of cells on top of this column.
         /// <para>This column and all cells below it will be shifted X number of rows.</para>
         /// </summary>
         /// <param name="numberOfRows">Number of cells to insert.</param>
         IXLCells InsertCellsAbove(int numberOfRows);
+
         IXLCells InsertCellsAbove(int numberOfRows, Boolean expandRange);
+
         /// <summary>
         /// Inserts X number of cells below this range.
         /// <para>All cells below this column will be shifted X number of rows.</para>
         /// </summary>
         /// <param name="numberOfRows">Number of cells to insert.</param>
         IXLCells InsertCellsBelow(int numberOfRows);
+
         IXLCells InsertCellsBelow(int numberOfRows, Boolean expandRange);
 
         /// <summary>
         /// Deletes this range and shifts the cells at the right.
         /// </summary>
         void Delete();
+
         /// <summary>
         /// Deletes this range and shifts the surrounding cells accordingly.
         /// </summary>
@@ -76,35 +84,43 @@ namespace ClosedXML.Excel
         Int32 CellCount();
 
         IXLRangeColumn CopyTo(IXLCell target);
+
         IXLRangeColumn CopyTo(IXLRangeBase target);
 
         IXLRangeColumn Sort(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
-        
+
         IXLRangeColumn Column(Int32 start, Int32 end);
+
         IXLRangeColumn Column(IXLCell start, IXLCell end);
+
         IXLRangeColumns Columns(String columns);
 
         IXLRangeColumn SetDataType(XLDataType dataType);
 
         IXLRangeColumn ColumnLeft();
+
         IXLRangeColumn ColumnLeft(Int32 step);
+
         IXLRangeColumn ColumnRight();
+
         IXLRangeColumn ColumnRight(Int32 step);
 
         IXLColumn WorksheetColumn();
 
         IXLTable AsTable();
+
         IXLTable AsTable(String name);
+
         IXLTable CreateTable();
+
         IXLTable CreateTable(String name);
 
         /// <summary>
         /// Clears the contents of this column.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLRangeColumn Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLRangeColumn Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         IXLRangeColumn ColumnUsed(Boolean includeFormats = false);
     }
 }
-

--- a/ClosedXML/Excel/Ranges/IXLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeColumns.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLRangeColumns: IEnumerable<IXLRangeColumn>, IDisposable
+    public interface IXLRangeColumns : IEnumerable<IXLRangeColumn>, IDisposable
     {
-
         /// <summary>
         /// Adds a column range to this group.
         /// </summary>
@@ -16,7 +15,7 @@ namespace ClosedXML.Excel
         /// Returns the collection of cells.
         /// </summary>
         IXLCells Cells();
-        
+
         /// <summary>
         /// Returns the collection of cells that have a value.
         /// </summary>
@@ -41,7 +40,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these columns.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLRangeColumns Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLRangeColumns Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Select();
     }

--- a/ClosedXML/Excel/Ranges/IXLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeRow.cs
@@ -1,9 +1,8 @@
 using System;
 
-
 namespace ClosedXML.Excel
 {
-    public interface IXLRangeRow: IXLRangeBase
+    public interface IXLRangeRow : IXLRangeBase
     {
         /// <summary>
         /// Gets the cell in the specified column.
@@ -23,12 +22,14 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="cellsInRow">The row's cells to return.</param>
         new IXLCells Cells(String cellsInRow);
+
         /// <summary>
         /// Returns the specified group of cells.
         /// </summary>
         /// <param name="firstColumn">The first column in the group of cells to return.</param>
         /// <param name="lastColumn">The last column in the group of cells to return.</param>
         IXLCells Cells(Int32 firstColumn, Int32 lastColumn);
+
         /// <summary>
         /// Returns the specified group of cells.
         /// </summary>
@@ -42,33 +43,41 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="numberOfColumns">Number of cells to insert.</param>
         IXLCells InsertCellsAfter(int numberOfColumns);
+
         IXLCells InsertCellsAfter(int numberOfColumns, Boolean expandRange);
+
         /// <summary>
         /// Inserts X number of cells to the left of this row.
         /// <para>This row and all cells to the right of it will be shifted X number of columns.</para>
         /// </summary>
         /// <param name="numberOfColumns">Number of cells to insert.</param>
         IXLCells InsertCellsBefore(int numberOfColumns);
+
         IXLCells InsertCellsBefore(int numberOfColumns, Boolean expandRange);
+
         /// <summary>
         /// Inserts X number of rows on top of this row.
         /// <para>This row and all cells below it will be shifted X number of rows.</para>
         /// </summary>
         /// <param name="numberOfRows">Number of rows to insert.</param>
         IXLRangeRows InsertRowsAbove(int numberOfRows);
+
         IXLRangeRows InsertRowsAbove(int numberOfRows, Boolean expandRange);
+
         /// <summary>
         /// Inserts X number of rows below this row.
         /// <para>All cells below this row will be shifted X number of rows.</para>
         /// </summary>
         /// <param name="numberOfRows">Number of rows to insert.</param>
         IXLRangeRows InsertRowsBelow(int numberOfRows);
+
         IXLRangeRows InsertRowsBelow(int numberOfRows, Boolean expandRange);
 
         /// <summary>
         /// Deletes this range and shifts the cells below.
         /// </summary>
         void Delete();
+
         /// <summary>
         /// Deletes this range and shifts the surrounding cells accordingly.
         /// </summary>
@@ -83,20 +92,27 @@ namespace ClosedXML.Excel
         Int32 CellCount();
 
         IXLRangeRow CopyTo(IXLCell target);
+
         IXLRangeRow CopyTo(IXLRangeBase target);
 
         IXLRangeRow Sort();
+
         IXLRangeRow SortLeftToRight(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
 
         IXLRangeRow Row(Int32 start, Int32 end);
+
         IXLRangeRow Row(IXLCell start, IXLCell end);
+
         IXLRangeRows Rows(String rows);
 
         IXLRangeRow SetDataType(XLDataType dataType);
 
         IXLRangeRow RowAbove();
+
         IXLRangeRow RowAbove(Int32 step);
+
         IXLRangeRow RowBelow();
+
         IXLRangeRow RowBelow(Int32 step);
 
         IXLRow WorksheetRow();
@@ -105,9 +121,8 @@ namespace ClosedXML.Excel
         /// Clears the contents of this row.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLRangeRow Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLRangeRow Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         IXLRangeRow RowUsed(Boolean includeFormats = false);
     }
 }
-

--- a/ClosedXML/Excel/Ranges/IXLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeRows.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel
         /// Returns the collection of cells.
         /// </summary>
         IXLCells Cells();
-        
+
         /// <summary>
         /// Returns the collection of cells that have a value.
         /// </summary>
@@ -40,7 +40,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these rows.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLRangeRows Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLRangeRows Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Select();
     }

--- a/ClosedXML/Excel/Ranges/IXLRanges.cs
+++ b/ClosedXML/Excel/Ranges/IXLRanges.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLRanges: IEnumerable<IXLRange>, IDisposable
+    public interface IXLRanges : IEnumerable<IXLRange>, IDisposable
     {
         /// <summary>
         /// Adds the specified range to this group.
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel
         IXLDataValidation SetDataValidation();
 
         /// <summary>
-        /// Creates a named range out of these ranges. 
+        /// Creates a named range out of these ranges.
         /// <para>If the named range exists, it will add these ranges to that named range.</para>
         /// <para>The default scope for the named range is Workbook.</para>
         /// </summary>
@@ -36,7 +36,7 @@ namespace ClosedXML.Excel
         IXLRanges AddToNamed(String rangeName);
 
         /// <summary>
-        /// Creates a named range out of these ranges. 
+        /// Creates a named range out of these ranges.
         /// <para>If the named range exists, it will add these ranges to that named range.</para>
         /// <param name="rangeName">Name of the range.</param>
         /// <param name="scope">The scope for the named range.</param>
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel
         IXLRanges AddToNamed(String rangeName, XLScope scope);
 
         /// <summary>
-        /// Creates a named range out of these ranges. 
+        /// Creates a named range out of these ranges.
         /// <para>If the named range exists, it will add these ranges to that named range.</para>
         /// <param name="rangeName">Name of the range.</param>
         /// <param name="scope">The scope for the named range.</param>
@@ -88,7 +88,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these ranges.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLRanges Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLRanges Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Select();
     }

--- a/ClosedXML/Excel/Ranges/XLRange.cs
+++ b/ClosedXML/Excel/Ranges/XLRange.cs
@@ -815,7 +815,7 @@ namespace ClosedXML.Excel
                    ^ Worksheet.GetHashCode();
         }
 
-        public new IXLRange Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLRange Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;

--- a/ClosedXML/Excel/Ranges/XLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumn.cs
@@ -371,7 +371,7 @@ namespace ClosedXML.Excel
                 return asRange.CreateTable(name);
         }
 
-        public new IXLRangeColumn Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLRangeColumn Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -19,7 +19,7 @@ namespace ClosedXML.Excel
 
         #region IXLRangeColumns Members
 
-        public IXLRangeColumns Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLRangeColumns Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             _ranges.ForEach(c => c.Clear(clearOptions));
             return this;
@@ -89,7 +89,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        #endregion
+        #endregion IXLRangeColumns Members
 
         #region IXLStylized Members
 
@@ -131,7 +131,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         public void Dispose()
         {

--- a/ClosedXML/Excel/Ranges/XLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRow.cs
@@ -350,7 +350,7 @@ namespace ClosedXML.Excel
 
         #endregion XLRangeRow Below
 
-        public new IXLRangeRow Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLRangeRow Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -19,7 +19,7 @@ namespace ClosedXML.Excel
 
         #region IXLRangeRows Members
 
-        public IXLRangeRows Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLRangeRows Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             _ranges.ForEach(c => c.Clear(clearOptions));
             return this;
@@ -39,7 +39,7 @@ namespace ClosedXML.Excel
         public IEnumerator<IXLRangeRow> GetEnumerator()
         {
             return _ranges.Cast<IXLRangeRow>()
-                          .OrderBy(r=>r.Worksheet.Position)
+                          .OrderBy(r => r.Worksheet.Position)
                           .ThenBy(r => r.RowNumber())
                           .GetEnumerator();
         }
@@ -89,7 +89,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        #endregion
+        #endregion IXLRangeRows Members
 
         #region IXLStylized Members
 
@@ -131,7 +131,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         public void Dispose()
         {
@@ -144,6 +144,5 @@ namespace ClosedXML.Excel
             foreach (var range in this)
                 range.Select();
         }
-
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -18,7 +18,7 @@ namespace ClosedXML.Excel
 
         #region IXLRanges Members
 
-        public IXLRanges Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLRanges Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             _ranges.ForEach(c => c.Clear(clearOptions));
             return this;
@@ -149,7 +149,7 @@ namespace ClosedXML.Excel
             _ranges.ForEach(r => r.Dispose());
         }
 
-        #endregion
+        #endregion IXLRanges Members
 
         #region IXLStylized Members
 
@@ -188,7 +188,7 @@ namespace ClosedXML.Excel
             get { return this; }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         public override string ToString()
         {

--- a/ClosedXML/Excel/Rows/IXLRow.cs
+++ b/ClosedXML/Excel/Rows/IXLRow.cs
@@ -4,8 +4,6 @@ namespace ClosedXML.Excel
 {
     public interface IXLRow : IXLRangeBase
     {
-        
-
         /// <summary>
         /// Gets or sets the height of this row.
         /// </summary>
@@ -50,6 +48,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="startColumn">The column to start calculating the row height.</param>
         IXLRow AdjustToContents(Int32 startColumn);
+
         /// <summary>
         /// Adjusts the height of the row based on its contents, starting from the startColumn and ending at endColumn.
         /// </summary>
@@ -57,9 +56,10 @@ namespace ClosedXML.Excel
         /// <param name="endColumn">The column to end calculating the row height.</param>
         IXLRow AdjustToContents(Int32 startColumn, Int32 endColumn);
 
-
         IXLRow AdjustToContents(Double minHeight, Double maxHeight);
+
         IXLRow AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight);
+
         IXLRow AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight);
 
         /// <summary>Hides this row.</summary>
@@ -113,7 +113,6 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLRow Ungroup();
 
-
         /// <summary>
         /// Adds this row to the previous outline level (decrements the outline level for this row by 1).
         /// </summary>
@@ -143,12 +142,14 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="cellsInRow">The row's cells to return.</param>
         new IXLCells Cells(String cellsInRow);
+
         /// <summary>
         /// Returns the specified group of cells.
         /// </summary>
         /// <param name="firstColumn">The first column in the group of cells to return.</param>
         /// <param name="lastColumn">The last column in the group of cells to return.</param>
         IXLCells Cells(Int32 firstColumn, Int32 lastColumn);
+
         /// <summary>
         /// Returns the specified group of cells.
         /// </summary>
@@ -162,14 +163,19 @@ namespace ClosedXML.Excel
         Int32 CellCount();
 
         IXLRangeRow CopyTo(IXLCell cell);
+
         IXLRangeRow CopyTo(IXLRangeBase range);
+
         IXLRow CopyTo(IXLRow row);
 
         IXLRow Sort();
+
         IXLRow SortLeftToRight(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
 
         IXLRangeRow Row(Int32 start, Int32 end);
+
         IXLRangeRow Row(IXLCell start, IXLCell end);
+
         IXLRangeRows Rows(String columns);
 
         /// <summary>
@@ -180,15 +186,18 @@ namespace ClosedXML.Excel
         IXLRow SetDataType(XLDataType dataType);
 
         IXLRow RowAbove();
+
         IXLRow RowAbove(Int32 step);
+
         IXLRow RowBelow();
+
         IXLRow RowBelow(Int32 step);
 
         /// <summary>
         /// Clears the contents of this row.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLRow Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLRow Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         IXLRangeRow RowUsed(Boolean includeFormats = false);
     }

--- a/ClosedXML/Excel/Rows/IXLRows.cs
+++ b/ClosedXML/Excel/Rows/IXLRows.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLRows: IEnumerable<IXLRow>, IDisposable
+    public interface IXLRows : IEnumerable<IXLRow>, IDisposable
     {
         /// <summary>
         /// Sets the height of all rows.
@@ -22,11 +22,13 @@ namespace ClosedXML.Excel
         /// Adjusts the height of all rows based on its contents.
         /// </summary>
         IXLRows AdjustToContents();
+
         /// <summary>
         /// Adjusts the height of all rows based on its contents, starting from the startColumn.
         /// </summary>
         /// <param name="startColumn">The column to start calculating the row height.</param>
         IXLRows AdjustToContents(Int32 startColumn);
+
         /// <summary>
         /// Adjusts the height of all rows based on its contents, starting from the startColumn and ending at endColumn.
         /// </summary>
@@ -35,7 +37,9 @@ namespace ClosedXML.Excel
         IXLRows AdjustToContents(Int32 startColumn, Int32 endColumn);
 
         IXLRows AdjustToContents(Double minHeight, Double maxHeight);
+
         IXLRows AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight);
+
         IXLRows AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight);
 
         /// <summary>
@@ -93,7 +97,7 @@ namespace ClosedXML.Excel
         /// Returns the collection of cells.
         /// </summary>
         IXLCells Cells();
-        
+
         /// <summary>
         /// Returns the collection of cells that have a value.
         /// </summary>
@@ -118,7 +122,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these rows.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLRows Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLRows Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Select();
     }

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -213,7 +213,7 @@ namespace ClosedXML.Excel
             return Worksheet.Rows(rowNum, rowNum + numberOfRows - 1);
         }
 
-        public new IXLRow Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLRow Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -23,7 +23,7 @@ namespace ClosedXML.Excel
 
         public IEnumerator<IXLRow> GetEnumerator()
         {
-            return _rows.Cast<IXLRow>().OrderBy(r=>r.RowNumber()).GetEnumerator();
+            return _rows.Cast<IXLRow>().OrderBy(r => r.RowNumber()).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -121,7 +121,6 @@ namespace ClosedXML.Excel
             return this;
         }
 
-
         public void Hide()
         {
             _rows.ForEach(r => r.Hide());
@@ -209,7 +208,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        #endregion
+        #endregion IXLRows Members
 
         #region IXLStylized Members
 
@@ -250,14 +249,14 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         public void Add(XLRow row)
         {
             _rows.Add(row);
         }
 
-        public IXLRows Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLRows Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             _rows.ForEach(c => c.Clear(clearOptions));
             return this;

--- a/ClosedXML/Excel/Tables/IXLTable.cs
+++ b/ClosedXML/Excel/Tables/IXLTable.cs
@@ -23,7 +23,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of this table.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLTable Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLTable Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         IXLTableField Field(string fieldName);
 

--- a/ClosedXML/Excel/Tables/IXLTableRow.cs
+++ b/ClosedXML/Excel/Tables/IXLTableRow.cs
@@ -2,26 +2,32 @@ using System;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLTableRow: IXLRangeRow
+    public interface IXLTableRow : IXLRangeRow
     {
         IXLCell Field(Int32 index);
+
         IXLCell Field(String name);
 
         new IXLTableRow Sort();
+
         new IXLTableRow SortLeftToRight(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
 
         new IXLTableRow RowAbove();
+
         new IXLTableRow RowAbove(Int32 step);
+
         new IXLTableRow RowBelow();
+
         new IXLTableRow RowBelow(Int32 step);
 
         /// <summary>
         /// Clears the contents of this row.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        new IXLTableRow Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        new IXLTableRow Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         new IXLTableRows InsertRowsAbove(int numberOfRows);
+
         new IXLTableRows InsertRowsBelow(int numberOfRows);
     }
 }

--- a/ClosedXML/Excel/Tables/IXLTableRows.cs
+++ b/ClosedXML/Excel/Tables/IXLTableRows.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLTableRows: IEnumerable<IXLTableRow>
+    public interface IXLTableRows : IEnumerable<IXLTableRow>
     {
         /// <summary>
         /// Adds a table row to this group.
@@ -33,7 +33,7 @@ namespace ClosedXML.Excel
         /// Clears the contents of these rows.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLTableRows Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLTableRows Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Select();
     }

--- a/ClosedXML/Excel/Tables/IXLTables.cs
+++ b/ClosedXML/Excel/Tables/IXLTables.cs
@@ -3,19 +3,22 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLTables: IEnumerable<IXLTable>
+    public interface IXLTables : IEnumerable<IXLTable>
     {
         void Add(IXLTable table);
+
         IXLTable Table(Int32 index);
+
         IXLTable Table(String name);
 
         /// <summary>
         /// Clears the contents of these tables.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
-        IXLTables Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats);
+        IXLTables Clear(XLClearOptions clearOptions = XLClearOptions.All);
 
         void Remove(Int32 index);
+
         void Remove(String name);
     }
 }

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -518,7 +518,7 @@ namespace ClosedXML.Excel
             return DataRange.Sort(toSortBy.ToString(), sortOrder, matchCase, ignoreBlanks);
         }
 
-        public new IXLTable Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLTable Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;

--- a/ClosedXML/Excel/Tables/XLTableRow.cs
+++ b/ClosedXML/Excel/Tables/XLTableRow.cs
@@ -36,7 +36,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        #endregion
+        #endregion IXLTableRow Members
 
         private XLTableRow RowShift(Int32 rowsToShift)
         {
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel
             return RowShift(step * -1);
         }
 
-        #endregion
+        #endregion XLTableRow Above
 
         #region XLTableRow Below
 
@@ -89,9 +89,9 @@ namespace ClosedXML.Excel
             return RowShift(step);
         }
 
-        #endregion
+        #endregion XLTableRow Below
 
-        public new IXLTableRow Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public new IXLTableRow Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             base.Clear(clearOptions);
             return this;
@@ -101,6 +101,7 @@ namespace ClosedXML.Excel
         {
             return XLHelper.InsertRowsWithoutEvents(base.InsertRowsAbove, _tableRange, numberOfRows, !_tableRange.Table.ShowTotalsRow);
         }
+
         public new IXLTableRows InsertRowsBelow(int numberOfRows)
         {
             return XLHelper.InsertRowsWithoutEvents(base.InsertRowsBelow, _tableRange, numberOfRows, !_tableRange.Table.ShowTotalsRow);

--- a/ClosedXML/Excel/Tables/XLTableRows.cs
+++ b/ClosedXML/Excel/Tables/XLTableRows.cs
@@ -10,7 +10,6 @@ namespace ClosedXML.Excel
         public Boolean StyleChanged { get; set; }
         private readonly List<XLTableRow> _ranges = new List<XLTableRow>();
         private IXLStyle _style;
-        
 
         public XLTableRows(IXLStyle defaultStyle)
         {
@@ -57,11 +56,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        #endregion
+        #endregion IXLStylized Members
 
         #region IXLTableRows Members
 
-        public IXLTableRows Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLTableRows Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             _ranges.ForEach(r => r.Clear(clearOptions));
             return this;
@@ -118,7 +117,7 @@ namespace ClosedXML.Excel
             return cells;
         }
 
-        #endregion
+        #endregion IXLTableRows Members
 
         public void Select()
         {

--- a/ClosedXML/Excel/Tables/XLTables.cs
+++ b/ClosedXML/Excel/Tables/XLTables.cs
@@ -46,7 +46,7 @@ namespace ClosedXML.Excel
 
         #endregion IXLTables Members
 
-        public IXLTables Clear(XLClearOptions clearOptions = XLClearOptions.ContentsAndFormats)
+        public IXLTables Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
             _tables.Values.ForEach(t => t.Clear(clearOptions));
             return this;

--- a/ClosedXML/Excel/XLClearOptions.cs
+++ b/ClosedXML/Excel/XLClearOptions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace ClosedXML.Excel
+{
+    [Flags]
+    public enum XLClearOptions
+    {
+        Contents                = 1 << 0,
+        DataType                = 1 << 1,
+        NormalFormats           = 1 << 2,
+        ConditionalFormats      = 1 << 3,
+        Comments                = 1 << 4,
+        DataValidation          = 1 << 5,
+
+        AllFormats = NormalFormats | ConditionalFormats,
+        All = Contents | DataType | NormalFormats | ConditionalFormats | Comments | DataValidation
+    }
+}

--- a/ClosedXML_Examples/Ranges/AddingRowToTables.cs
+++ b/ClosedXML_Examples/Ranges/AddingRowToTables.cs
@@ -1,8 +1,7 @@
+using ClosedXML.Excel;
 using System;
 using System.IO;
-using ClosedXML.Excel;
 using System.Linq;
-
 
 namespace ClosedXML_Examples.Ranges
 {
@@ -26,7 +25,7 @@ namespace ClosedXML_Examples.Ranges
                 range.FirstRow().Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
 
                 // We want to use a theme for table, not the hard coded format of the BasicTable
-                range.Clear(XLClearOptions.Formats);
+                range.Clear(XLClearOptions.AllFormats);
                 // Put back the date and number formats
                 range.Column(4).Style.NumberFormat.NumberFormatId = 15;
                 range.Column(5).Style.NumberFormat.Format = "$ #,##0";
@@ -52,7 +51,6 @@ namespace ClosedXML_Examples.Ranges
 
         // Override
 
-
-        #endregion
+        #endregion Methods
     }
 }

--- a/ClosedXML_Examples/Tables/UsingTables.cs
+++ b/ClosedXML_Examples/Tables/UsingTables.cs
@@ -25,7 +25,7 @@ namespace ClosedXML_Examples.Tables
                     range.FirstRow().Delete(); // Deleting the "Contacts" header (we don't need it for our purposes)
 
                     // We want to use a theme for table, not the hard coded format of the BasicTable
-                    range.Clear(XLClearOptions.Formats);
+                    range.Clear(XLClearOptions.AllFormats);
                     // Put back the date and number formats
                     range.Column(4).Style.NumberFormat.NumberFormatId = 15;
                     range.Column(5).Style.NumberFormat.Format = "$ #,##0";

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Excel\CalcEngine\MathTrigTests.cs" />
     <Compile Include="Excel\CalcEngine\StatisticalTests.cs" />
     <Compile Include="Excel\CalcEngine\TextTests.cs" />
+    <Compile Include="Excel\Clearing\ClearingTests.cs" />
     <Compile Include="Excel\Comments\CommentsTests.cs" />
     <Compile Include="Excel\ConditionalFormats\ConditionalFormatCopyTests.cs" />
     <Compile Include="Excel\ConditionalFormats\ConditionalFormatsConsolidateTests.cs" />

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -427,6 +427,43 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void CanClearDateTimeCellValue()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    var ws = wb.AddWorksheet("Sheet1");
+                    var c = ws.FirstCell();
+                    c.SetValue(new DateTime(2017, 10, 08));
+                    Assert.AreEqual(XLDataType.DateTime, c.DataType);
+                    Assert.AreEqual(new DateTime(2017, 10, 08), c.Value);
+
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws = wb.Worksheets.First();
+                    var c = ws.FirstCell();
+                    Assert.AreEqual(XLDataType.DateTime, c.DataType);
+                    Assert.AreEqual(new DateTime(2017, 10, 08), c.Value);
+
+                    c.Clear();
+                    wb.Save();
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws = wb.Worksheets.First();
+                    var c = ws.FirstCell();
+                    Assert.AreEqual(XLDataType.Text, c.DataType);
+                    Assert.True(c.IsEmpty());
+                }
+            }
+        }
+
+        [Test]
         public void CurrentRegion()
         {
             // Partially based on sample in https://github.com/ClosedXML/ClosedXML/issues/120

--- a/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
+++ b/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
@@ -1,0 +1,265 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace ClosedXML_Tests
+{
+    [TestFixture]
+    public class ClearingTests
+    {
+        private static XLColor backgroundColor = XLColor.LightBlue;
+        private static XLColor foregroundColor = XLColor.DarkBrown;
+
+        private IXLWorkbook SetupWorkbook()
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
+
+            var c = ws.FirstCell()
+                .SetValue("Hello world!");
+
+            c.Comment.AddText("Some comment");
+
+            c.Style.Fill.BackgroundColor = backgroundColor;
+            c.Style.Font.FontColor = foregroundColor;
+            c.SetDataValidation().Custom("B1");
+
+            ////
+
+            c = ws.FirstCell()
+                .CellBelow()
+                .SetFormulaA1("=LEFT(A1,5)");
+
+            c.Comment.AddText("Another comment");
+
+            c.Style.Fill.BackgroundColor = backgroundColor;
+            c.Style.Font.FontColor = foregroundColor;
+
+            ////
+
+            c = ws.FirstCell()
+                .CellBelow(2)
+                .SetValue(new DateTime(2018, 1, 15));
+
+            c.Comment.AddText("A date");
+
+            c.Style.Fill.BackgroundColor = backgroundColor;
+            c.Style.Font.FontColor = foregroundColor;
+
+            ws.Column(1)
+                .AddConditionalFormat().WhenStartsWith("Hell")
+                .Fill.SetBackgroundColor(XLColor.Red)
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetOutsideBorderColor(XLColor.Blue)
+                .Font.SetBold();
+
+            Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
+            Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
+            Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
+
+            Assert.AreEqual(false, ws.Cell("A1").HasFormula);
+            Assert.AreEqual(true, ws.Cell("A2").HasFormula);
+            Assert.AreEqual(false, ws.Cell("A1").HasFormula);
+
+            foreach (var cell in ws.Range("A1:A3").Cells())
+            {
+                Assert.AreEqual(backgroundColor, cell.Style.Fill.BackgroundColor);
+                Assert.AreEqual(foregroundColor, cell.Style.Font.FontColor);
+                Assert.IsTrue(ws.ConditionalFormats.Any());
+                Assert.IsTrue(cell.HasComment);
+            }
+
+            Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+
+            return wb;
+        }
+
+        [Test]
+        public void WorksheetClearAll()
+        {
+            using (var wb = SetupWorkbook())
+            {
+                var ws = wb.Worksheets.First();
+
+                ws.Clear(XLClearOptions.All);
+
+                foreach (var c in ws.Range("A1:A10").Cells())
+                {
+                    Assert.IsTrue(c.IsEmpty());
+                    Assert.AreEqual(XLDataType.Text, c.DataType);
+                    Assert.AreEqual(ws.Style.Fill.BackgroundColor, c.Style.Fill.BackgroundColor);
+                    Assert.AreEqual(ws.Style.Font.FontColor, c.Style.Font.FontColor);
+                    Assert.IsFalse(ws.ConditionalFormats.Any());
+                    Assert.IsFalse(c.HasComment);
+                    Assert.AreEqual(String.Empty, c.DataValidation.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void WorksheetClearContents()
+        {
+            {
+                using (var wb = SetupWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.Clear(XLClearOptions.Contents);
+
+                    foreach (var c in ws.Range("A1:A3").Cells())
+                    {
+                        Assert.IsTrue(c.IsEmpty());
+                        Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
+                        Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
+                        Assert.IsTrue(ws.ConditionalFormats.Any());
+                        Assert.IsTrue(c.HasComment);
+                    }
+
+                    Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
+                    Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
+                }
+            }
+        }
+
+        [Test]
+        public void WorksheetClearDataType()
+        {
+            {
+                using (var wb = SetupWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.Clear(XLClearOptions.DataType);
+
+                    foreach (var c in ws.Range("A1:A3").Cells())
+                    {
+                        Assert.IsFalse(c.IsEmpty());
+                        Assert.AreEqual(XLDataType.Text, c.DataType);
+                        Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
+                        Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
+                        Assert.IsTrue(ws.ConditionalFormats.Any());
+                        Assert.IsTrue(c.HasComment);
+                    }
+
+                    Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void WorksheetClearNormalFormats()
+        {
+            {
+                using (var wb = SetupWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.Clear(XLClearOptions.NormalFormats);
+
+                    foreach (var c in ws.Range("A1:A3").Cells())
+                    {
+                        Assert.IsFalse(c.IsEmpty());
+                        Assert.AreEqual(ws.Style.Fill.BackgroundColor, c.Style.Fill.BackgroundColor);
+                        Assert.AreEqual(ws.Style.Font.FontColor, c.Style.Font.FontColor);
+                        Assert.IsTrue(ws.ConditionalFormats.Any());
+                        Assert.IsTrue(c.HasComment);
+                    }
+
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
+                    Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
+
+                    Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void WorksheetClearConditionalFormats()
+        {
+            {
+                using (var wb = SetupWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.Clear(XLClearOptions.ConditionalFormats);
+
+                    foreach (var c in ws.Range("A1:A3").Cells())
+                    {
+                        Assert.IsFalse(c.IsEmpty());
+                        Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
+                        Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
+                        Assert.IsFalse(ws.ConditionalFormats.Any());
+                        Assert.IsTrue(c.HasComment);
+                    }
+
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
+                    Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
+
+                    Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void WorksheetClearComments()
+        {
+            {
+                using (var wb = SetupWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.Clear(XLClearOptions.Comments);
+
+                    foreach (var c in ws.Range("A1:A3").Cells())
+                    {
+                        Assert.IsFalse(c.IsEmpty());
+                        Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
+                        Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
+                        Assert.IsTrue(ws.ConditionalFormats.Any());
+                        Assert.IsFalse(c.HasComment);
+                    }
+
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
+                    Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
+
+                    Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void WorksheetClearDataValidation()
+        {
+            {
+                using (var wb = SetupWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.Clear(XLClearOptions.DataValidation);
+
+                    foreach (var c in ws.Range("A1:A3").Cells())
+                    {
+                        Assert.IsFalse(c.IsEmpty());
+                        Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
+                        Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
+                        Assert.IsTrue(ws.ConditionalFormats.Any());
+                        Assert.IsTrue(c.HasComment);
+                    }
+
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
+                    Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
+                    Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
+
+                    Assert.AreEqual(string.Empty, ws.Cell("A1").DataValidation.Value);
+                }
+            }
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML_Tests/Excel/DataValidations/DataValidationTests.cs
@@ -213,7 +213,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
                 validation.WholeNumber.Between(0, 100);
 
                 //Act
-                ws.Cell("B2").Clear(XLClearOptions.ContentsAndFormats);
+                ws.Cell("B2").Clear(XLClearOptions.DataValidation);
 
                 //Assert
                 Assert.IsFalse(ws.Cell("B2").HasDataValidation);

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -298,5 +298,94 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(0, ws.Range("C3:D6").AsRange().SurroundingCells(c => !c.IsEmpty()).Count());
             }
         }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeAbove1()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:D7").AddConditionalFormat();
+            ws.Range("B2:E3").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.AreEqual("C4:D7", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+        }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeAbove2()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:D7").AddConditionalFormat();
+            ws.Range("C3:D3").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.AreEqual("C4:D7", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+        }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeBelow1()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:D7").AddConditionalFormat();
+            ws.Range("B7:E8").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.AreEqual("C3:D6", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+        }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeBelow2()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:D7").AddConditionalFormat();
+            ws.Range("C7:D7").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.AreEqual("C3:D6", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+        }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeRowInMiddle()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:D7").AddConditionalFormat();
+            ws.Range("C5:E5").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(2, ws.ConditionalFormats.Count());
+            Assert.IsTrue(ws.ConditionalFormats.Any(x => x.Range.RangeAddress.ToStringRelative() == "C3:D4"));
+            Assert.IsTrue(ws.ConditionalFormats.Any(x => x.Range.RangeAddress.ToStringRelative() == "C6:D7"));
+        }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeColumnInMiddle()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:G4").AddConditionalFormat();
+            ws.Range("E2:E4").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(2, ws.ConditionalFormats.Count());
+            Assert.IsTrue(ws.ConditionalFormats.Any(x => x.Range.RangeAddress.ToStringRelative() == "C3:D4"));
+            Assert.IsTrue(ws.ConditionalFormats.Any(x => x.Range.RangeAddress.ToStringRelative() == "F3:G4"));
+        }
+
+        [Test]
+        public void ClearConditionalFormattingsWhenRangeContainsFormatWhole()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:G4").AddConditionalFormat();
+            ws.Range("B2:G4").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(0, ws.ConditionalFormats.Count());
+        }
+
+        [Test]
+        public void NoClearConditionalFormattingsWhenRangePartiallySuperimposed()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Range("C3:G4").AddConditionalFormat();
+            ws.Range("C2:D3").Clear(XLClearOptions.Formats);
+
+            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.AreEqual("C3:G4", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -304,7 +304,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:D7").AddConditionalFormat();
-            ws.Range("B2:E3").Clear(XLClearOptions.Formats);
+            ws.Range("B2:E3").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
             Assert.AreEqual("C4:D7", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
@@ -315,7 +315,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:D7").AddConditionalFormat();
-            ws.Range("C3:D3").Clear(XLClearOptions.Formats);
+            ws.Range("C3:D3").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
             Assert.AreEqual("C4:D7", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
@@ -326,7 +326,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:D7").AddConditionalFormat();
-            ws.Range("B7:E8").Clear(XLClearOptions.Formats);
+            ws.Range("B7:E8").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
             Assert.AreEqual("C3:D6", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
@@ -337,7 +337,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:D7").AddConditionalFormat();
-            ws.Range("C7:D7").Clear(XLClearOptions.Formats);
+            ws.Range("C7:D7").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
             Assert.AreEqual("C3:D6", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
@@ -348,7 +348,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:D7").AddConditionalFormat();
-            ws.Range("C5:E5").Clear(XLClearOptions.Formats);
+            ws.Range("C5:E5").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(2, ws.ConditionalFormats.Count());
             Assert.IsTrue(ws.ConditionalFormats.Any(x => x.Range.RangeAddress.ToStringRelative() == "C3:D4"));
@@ -360,7 +360,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:G4").AddConditionalFormat();
-            ws.Range("E2:E4").Clear(XLClearOptions.Formats);
+            ws.Range("E2:E4").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(2, ws.ConditionalFormats.Count());
             Assert.IsTrue(ws.ConditionalFormats.Any(x => x.Range.RangeAddress.ToStringRelative() == "C3:D4"));
@@ -372,7 +372,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:G4").AddConditionalFormat();
-            ws.Range("B2:G4").Clear(XLClearOptions.Formats);
+            ws.Range("B2:G4").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(0, ws.ConditionalFormats.Count());
         }
@@ -382,7 +382,7 @@ namespace ClosedXML_Tests
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:G4").AddConditionalFormat();
-            ws.Range("C2:D3").Clear(XLClearOptions.Formats);
+            ws.Range("C2:D3").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
             Assert.AreEqual("C3:G4", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());


### PR DESCRIPTION
Supercedes and uses #618 
Breaking change: Refactors XLClearOptions for more fine-grained control over what will be cleared.
Unit tests are work in progress.

Closes #618 
Closes #617 
