### PR TITLE
Fix COUNTBLANK for invalid ranges

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -486,6 +486,9 @@ namespace ClosedXML.Excel.CalcEngine
 
         public IEnumerator GetEnumerator()
         {
+            if (_value is string)
+                return new [] {(string) _value}.GetEnumerator();
+
             return (_value as IEnumerable).GetEnumerator();
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Collections;
 using System.Collections.Generic;
+using ClosedXML.Excel.CalcEngine.Exceptions;
 
 namespace ClosedXML.Excel.CalcEngine
 {
@@ -117,23 +118,18 @@ namespace ClosedXML.Excel.CalcEngine
         static object CountBlank(List<Expression> p)
         {
             var cnt = 0.0;
-            foreach (Expression e in p)
+
+            if (p == null || p.Count != 1 ||
+                (p[0] as XObjectExpression)?.Value as CellRangeReference == null)
+                throw new NoValueAvailableException("COUNTBLANK should have a single argument which is a range reference");
+
+            var e = p[0] as XObjectExpression;
+            foreach (var value in e)
             {
-                var ienum = e as IEnumerable;
-                if (ienum != null)
-                {
-                    foreach (var value in ienum)
-                    {
-                        if (IsBlank(value))
-                            cnt++;
-                    }
-                }
-                else
-                {
-                    if (IsBlank(e.Evaluate()))
-                        cnt++;
-                }
+                if (IsBlank(value))
+                    cnt++;
             }
+
             return cnt;
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -1,8 +1,7 @@
+using ClosedXML.Excel.CalcEngine.Exceptions;
 using System;
-using System.Net;
 using System.Collections;
 using System.Collections.Generic;
-using ClosedXML.Excel.CalcEngine.Exceptions;
 
 namespace ClosedXML.Excel.CalcEngine
 {
@@ -97,32 +96,32 @@ namespace ClosedXML.Excel.CalcEngine
             //ZTEST	Returns the one-tailed probability-value of a z-test
         }
 
-
-
-        static object Average(List<Expression> p)
+        private static object Average(List<Expression> p)
         {
             return GetTally(p, true).Average();
         }
-        static object AverageA(List<Expression> p)
+
+        private static object AverageA(List<Expression> p)
         {
             return GetTally(p, false).Average();
         }
-        static object Count(List<Expression> p)
+
+        private static object Count(List<Expression> p)
         {
             return GetTally(p, true).Count();
         }
-        static object CountA(List<Expression> p)
+
+        private static object CountA(List<Expression> p)
         {
             return GetTally(p, false).Count();
         }
-        static object CountBlank(List<Expression> p)
-        {
-            var cnt = 0.0;
 
-            if (p == null || p.Count != 1 ||
-                (p[0] as XObjectExpression)?.Value as CellRangeReference == null)
+        private static object CountBlank(List<Expression> p)
+        {
+            if ((p[0] as XObjectExpression)?.Value as CellRangeReference == null)
                 throw new NoValueAvailableException("COUNTBLANK should have a single argument which is a range reference");
 
+            var cnt = 0.0;
             var e = p[0] as XObjectExpression;
             foreach (var value in e)
             {
@@ -140,7 +139,7 @@ namespace ClosedXML.Excel.CalcEngine
                 value is string && ((string)value).Length == 0;
         }
 
-        static object CountIf(List<Expression> p)
+        private static object CountIf(List<Expression> p)
         {
             CalcEngine ce = new CalcEngine();
             var cnt = 0.0;
@@ -206,59 +205,68 @@ namespace ClosedXML.Excel.CalcEngine
             return count;
         }
 
-        static object Max(List<Expression> p)
+        private static object Max(List<Expression> p)
         {
             return GetTally(p, true).Max();
         }
 
-        static object MaxA(List<Expression> p)
+        private static object MaxA(List<Expression> p)
         {
             return GetTally(p, false).Max();
         }
 
-        static object Min(List<Expression> p)
+        private static object Min(List<Expression> p)
         {
             return GetTally(p, true).Min();
         }
-        static object MinA(List<Expression> p)
+
+        private static object MinA(List<Expression> p)
         {
             return GetTally(p, false).Min();
         }
-        static object StDev(List<Expression> p)
+
+        private static object StDev(List<Expression> p)
         {
             return GetTally(p, true).Std();
         }
-        static object StDevA(List<Expression> p)
+
+        private static object StDevA(List<Expression> p)
         {
             return GetTally(p, false).Std();
         }
-        static object StDevP(List<Expression> p)
+
+        private static object StDevP(List<Expression> p)
         {
             return GetTally(p, true).StdP();
         }
-        static object StDevPA(List<Expression> p)
+
+        private static object StDevPA(List<Expression> p)
         {
             return GetTally(p, false).StdP();
         }
-        static object Var(List<Expression> p)
+
+        private static object Var(List<Expression> p)
         {
             return GetTally(p, true).Var();
         }
-        static object VarA(List<Expression> p)
+
+        private static object VarA(List<Expression> p)
         {
             return GetTally(p, false).Var();
         }
-        static object VarP(List<Expression> p)
+
+        private static object VarP(List<Expression> p)
         {
             return GetTally(p, true).VarP();
         }
-        static object VarPA(List<Expression> p)
+
+        private static object VarPA(List<Expression> p)
         {
             return GetTally(p, false).VarP();
         }
 
         // utility for tallying statistics
-        static Tally GetTally(List<Expression> p, bool numbersOnly)
+        private static Tally GetTally(List<Expression> p, bool numbersOnly)
         {
             return new Tally(p, numbersOnly);
         }

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -81,6 +81,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.AreEqual(1, value);
 
             Assert.Throws<NoValueAvailableException>(() => workbook.Evaluate(@"=COUNTBLANK(E3:E45)"));
+            Assert.Throws<ExpressionParseException>(() => ws.Evaluate(@"=COUNTBLANK()"));
             Assert.Throws<ExpressionParseException>(() => ws.Evaluate(@"=COUNTBLANK(A3:A45,E3:E45)"));
         }
 

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -2,6 +2,8 @@ using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using ClosedXML.Excel.CalcEngine;
+using ClosedXML.Excel.CalcEngine.Exceptions;
 
 namespace ClosedXML_Tests.Excel.CalcEngine
 {
@@ -72,8 +74,14 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=COUNTBLANK(D43:D49)").CastTo<int>();
             Assert.AreEqual(4, value);
 
-            value = workbook.Evaluate(@"=COUNTBLANK(E3:E45)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTBLANK(E3:E45)").CastTo<int>();
             Assert.AreEqual(0, value);
+
+            value = ws.Evaluate(@"=COUNTBLANK(A1)").CastTo<int>();
+            Assert.AreEqual(1, value);
+
+            Assert.Throws<NoValueAvailableException>(() => workbook.Evaluate(@"=COUNTBLANK(E3:E45)"));
+            Assert.Throws<ExpressionParseException>(() => ws.Evaluate(@"=COUNTBLANK(A3:A45,E3:E45)"));
         }
 
         [Test]


### PR DESCRIPTION
In the test ```CountBlank``` there was a mistake causing a range ```E3:E45``` to be not parsed properly as no worksheet was specified. By accident, the test worked fine, however.

This PR fixes and extends the original test, makes ```COUNTBLANK``` function more strict (it accepts only a single argument which must be either a cell range reference), and, in addition, prevents non-parsed strings from being split into chars during enumeration

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer