### PR TITLE
Optimize tally computations

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -103,5 +103,27 @@ namespace ClosedXML.Excel.CalcEngine
             Debug.Assert(false, "failed to evaluate criteria in SumIf");
             return false;
         }
+
+        internal static bool ValueIsBlank(object value)
+        {
+            return
+                value == null ||
+                value is string && ((string)value).Length == 0;
+        }
+
+        /// <summary>
+        /// Get total count of cells in the specified range without initalizing them all
+        /// (which might cause serious performance issues on column-wide calculations).
+        /// </summary>
+        /// <param name="rangeExpression">Expression referring to the cell range.</param>
+        /// <returns>Total number of cells in the range.</returns>
+        internal static long GetTotalCellsCount(XObjectExpression rangeExpression)
+        {
+            var range = ((rangeExpression)?.Value as CellRangeReference)?.Range;
+            if (range == null)
+                return 0;
+            return (long)(range.LastColumn().ColumnNumber() - range.FirstColumn().ColumnNumber() + 1) *
+                   (long)(range.LastRow().RowNumber() - range.FirstRow().RowNumber() + 1);
+        }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -340,20 +340,22 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 rangeValues.Add(value);
             }
-            var sumRangeValues = new List<IXLCell>();
-            foreach (var cell in ((CellRangeReference)sumRange.Value).Range.Cells())
+            var sumRangeValues = new List<object>();
+            foreach (var value in sumRange)
             {
-                sumRangeValues.Add(cell);
+                sumRangeValues.Add(value);
             }
 
             // compute total
             var ce = new CalcEngine();
             var tally = new Tally();
-            for (var i = 0; i < Math.Min(rangeValues.Count, sumRangeValues.Count); i++)
+            for (var i = 0; i < Math.Max(rangeValues.Count, sumRangeValues.Count); i++)
             {
-                if (CalcEngineHelpers.ValueSatisfiesCriteria(rangeValues[i], criteria, ce))
+                var targetValue = i < rangeValues.Count ? rangeValues[i] : string.Empty;
+                if (CalcEngineHelpers.ValueSatisfiesCriteria(targetValue, criteria, ce))
                 {
-                    tally.AddValue(sumRangeValues[i].Value);
+                    var value = i < sumRangeValues.Count ? sumRangeValues[i] : 0d;
+                    tally.AddValue(value);
                 }
             }
 
@@ -401,7 +403,7 @@ namespace ClosedXML.Excel.CalcEngine
                 foreach (var criteriaPair in criteriaRanges)
                 {
                     if (!CalcEngineHelpers.ValueSatisfiesCriteria(
-                        criteriaPair.Item2[i],
+                        i < criteriaPair.Item2.Count ? criteriaPair.Item2[i] : string.Empty,
                         criteriaPair.Item1,
                         ce))
                     {

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -401,7 +401,7 @@ namespace ClosedXML.Excel.CalcEngine
                 foreach (var criteriaPair in criteriaRanges)
                 {
                     if (!CalcEngineHelpers.ValueSatisfiesCriteria(
-                        (i < criteriaPair.Item2.Count ? criteriaPair.Item2[i] : string.Empty),
+                        criteriaPair.Item2[i],
                         criteriaPair.Item1,
                         ce))
                     {

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -401,7 +401,7 @@ namespace ClosedXML.Excel.CalcEngine
                 foreach (var criteriaPair in criteriaRanges)
                 {
                     if (!CalcEngineHelpers.ValueSatisfiesCriteria(
-                        criteriaPair.Item2[i],
+                        (i < criteriaPair.Item2.Count ? criteriaPair.Item2[i] : string.Empty),
                         criteriaPair.Item1,
                         ce))
                     {

--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -80,7 +80,7 @@ namespace ClosedXML.Excel.CalcEngine
             if (numbersOnly)
                 return NumericValuesInternal().Length;
             else
-                return _list.Count(o => !Statistical.IsBlank(o));
+                return _list.Count(o => !CalcEngineHelpers.ValueIsBlank(o));
         }
 
         private IEnumerable<double> NumericValuesEnumerable()

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -82,7 +82,10 @@ namespace ClosedXML.Excel.CalcEngine
         // ** IEnumerable
         public IEnumerator GetEnumerator()
         {
-            return _range.Cells().Select(GetValue).GetEnumerator();
+            var maxRow = Math.Min(_range.RangeAddress.LastAddress.RowNumber, _range.Worksheet.LastCellUsed().Address.RowNumber);
+            var maxCol = Math.Min(_range.RangeAddress.LastAddress.ColumnNumber, _range.Worksheet.LastCellUsed().Address.ColumnNumber);
+            using (var trimmedRange = _range.Worksheet.Range(_range.FirstCell().Address, new XLAddress(maxRow, maxCol, false, false)))
+                return trimmedRange.Cells().Select(GetValue).GetEnumerator();
         }
 
         private Boolean _evaluating;

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -85,7 +85,7 @@ namespace ClosedXML.Excel.CalcEngine
             var maxRow = Math.Min(_range.RangeAddress.LastAddress.RowNumber, _range.Worksheet.LastCellUsed().Address.RowNumber);
             var maxCol = Math.Min(_range.RangeAddress.LastAddress.ColumnNumber, _range.Worksheet.LastCellUsed().Address.ColumnNumber);
             using (var trimmedRange = _range.Worksheet.Range(_range.FirstCell().Address, new XLAddress(maxRow, maxCol, false, false)))
-                return trimmedRange.Cells().Select(GetValue).GetEnumerator();
+                return trimmedRange.CellValues().GetEnumerator();
         }
 
         private Boolean _evaluating;

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             var maxRow = Math.Min(_range.RangeAddress.LastAddress.RowNumber, _range.Worksheet.LastCellUsed().Address.RowNumber);
             var maxCol = Math.Min(_range.RangeAddress.LastAddress.ColumnNumber, _range.Worksheet.LastCellUsed().Address.ColumnNumber);
-            using (var trimmedRange = _range.Worksheet.Range(_range.FirstCell().Address, new XLAddress(maxRow, maxCol, false, false)))
+            using (var trimmedRange = (XLRangeBase)_range.Worksheet.Range(_range.FirstCell().Address, new XLAddress(maxRow, maxCol, false, false)))
                 return trimmedRange.CellValues().GetEnumerator();
         }
 

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -95,11 +95,6 @@ namespace ClosedXML.Excel
         IXLCells CellsUsed(Boolean includeFormats, Func<IXLCell, Boolean> predicate);
 
         /// <summary>
-        /// Returns the collection of cell values not initializing empty cells.
-        /// </summary>
-        IEnumerable CellValues();
-
-        /// <summary>
         /// Searches the cells' contents for a given piece of text
         /// </summary>
         /// <param name="searchText">The search text.</param>

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Globalization;
 
 namespace ClosedXML.Excel
@@ -92,6 +93,11 @@ namespace ClosedXML.Excel
         IXLCells CellsUsed(Func<IXLCell, Boolean> predicate);
 
         IXLCells CellsUsed(Boolean includeFormats, Func<IXLCell, Boolean> predicate);
+
+        /// <summary>
+        /// Returns the collection of cell values not initializing empty cells.
+        /// </summary>
+        IEnumerable CellValues();
 
         /// <summary>
         /// Searches the cells' contents for a given piece of text

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -286,6 +286,9 @@ namespace ClosedXML.Excel
             return Cells(true);
         }
 
+        /// <summary>
+        /// Return the collection of cell values not initializing empty cells.
+        /// </summary>
         public IEnumerable CellValues()
         {
             for (int ro = RangeAddress.FirstAddress.RowNumber; ro <= RangeAddress.LastAddress.RowNumber; ro++)

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1,6 +1,7 @@
 using ClosedXML.Excel.Misc;
 using ClosedXML.Extensions;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -283,6 +284,17 @@ namespace ClosedXML.Excel
         public IXLCells CellsUsed()
         {
             return Cells(true);
+        }
+
+        public IEnumerable CellValues()
+        {
+            for (int ro = RangeAddress.FirstAddress.RowNumber; ro <= RangeAddress.LastAddress.RowNumber; ro++)
+            {
+                for (int co = RangeAddress.FirstAddress.ColumnNumber; co <= RangeAddress.LastAddress.ColumnNumber; co++)
+                {
+                    yield return Worksheet.GetCellValue(ro, co);
+                }
+            }
         }
 
         public IXLRange Merge()

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1581,7 +1581,11 @@ namespace ClosedXML.Excel
                 !Internals.CellsCollection.Contains(ro, co))
                 return string.Empty;
 
-            return Worksheet.Internals.CellsCollection.GetCell(ro, co).Value;
+            var cell = Worksheet.Internals.CellsCollection.GetCell(ro, co);
+            if (cell.IsEvaluating)
+                return string.Empty;
+
+            return cell.Value;
         }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1567,5 +1567,21 @@ namespace ClosedXML.Excel
             else
                 this.Cell(ro, co).SetValue(value);
         }
+
+        /// <summary>
+        /// Get a cell value not initializing it if it has not been initialized yet.
+        /// </summary>
+        /// <param name="ro">Row number</param>
+        /// <param name="co">Column number</param>
+        /// <returns>Current value of the specified cell. Empty string for non-initialized cells.</returns>
+        internal object GetCellValue(int ro, int co)
+        {
+            if (Internals.CellsCollection.MaxRowUsed < ro ||
+                Internals.CellsCollection.MaxColumnUsed < co ||
+                !Internals.CellsCollection.Contains(ro, co))
+                return string.Empty;
+
+            return Worksheet.Internals.CellsCollection.GetCell(ro, co).Value;
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -176,7 +176,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 ws.Cell(4, 3).Value = "Yes";
                 ws.Cell(4, 4).Value = "Yes";
 
-                Assert.AreEqual(expectedOutcome, (int)ws.Evaluate(formula));
+                Assert.AreEqual(expectedOutcome, ws.Evaluate(formula));
             }
         }
 
@@ -327,6 +327,32 @@ namespace ClosedXML_Tests.Excel.CalcEngine
 
             value = workbook.Evaluate(@"=VARP(Data!H:H)").CastTo<double>();
             Assert.AreEqual(2189.430863, value, tolerance);
+        }
+
+        [Test]
+        [TestCase("SUM(H:J)",  20501.15d, Description = "SUM columns")]
+        [TestCase("SUM(4:5)", 85366.12d, Description = "SUM rows")]
+        [TestCase("COUNT(G:I,G:G,H:I)", 258d, Description = "COUNT overlapping columns")]
+        [TestCase("COUNT(6:8,6:6,7:8)", 30d, Description = "COUNT overlapping rows")]
+        [TestCase("COUNTBLANK(H:J)", 3145640d, Description = "COUNTBLANK columns")]
+        [TestCase("COUNTBLANK(7:9)", 49128d, Description = "COUNTBLANK rows")]
+        [TestCase("COUNT(1:1048576)", 215d, Description = "COUNT worksheet")]
+        [TestCase("COUNTBLANK(1:1048576)", 17179868832d, Description = "COUNTBLANK worksheet")]
+        public void TallySkipsEmptyCells(string formulaA1, double expectedResult)
+        {
+            using (var wb = SetupWorkbook())
+            {
+                var ws = wb.Worksheets.First();
+                //Let's pre-initialize cells we need so they didn't affect the result
+                ws.Range("A1:J45").Style.Fill.BackgroundColor = XLColor.Amber;
+                int initialCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
+
+                var actualResult = (double)ws.Evaluate(formulaA1);
+                int cellsCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
+
+                Assert.AreEqual(expectedResult, actualResult, tolerance);
+                Assert.AreEqual(initialCount, cellsCount);
+            }
         }
 
         private XLWorkbook SetupWorkbook()

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -336,8 +336,8 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase("COUNT(6:8,6:6,7:8)", 30d, Description = "COUNT overlapping rows")]
         [TestCase("COUNTBLANK(H:J)", 3145640d, Description = "COUNTBLANK columns")]
         [TestCase("COUNTBLANK(7:9)", 49128d, Description = "COUNTBLANK rows")]
-        [TestCase("COUNT(1:1048576)", 215d, Description = "COUNT worksheet")]
-        [TestCase("COUNTBLANK(1:1048576)", 17179868832d, Description = "COUNTBLANK worksheet")]
+        [TestCase("COUNT(1:1048576)", 216d, Description = "COUNT worksheet")]
+        [TestCase("COUNTBLANK(1:1048576)", 17179868831d, Description = "COUNTBLANK worksheet")]
         public void TallySkipsEmptyCells(string formulaA1, double expectedResult)
         {
             using (var wb = SetupWorkbook())
@@ -345,6 +345,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 var ws = wb.Worksheets.First();
                 //Let's pre-initialize cells we need so they didn't affect the result
                 ws.Range("A1:J45").Style.Fill.BackgroundColor = XLColor.Amber;
+                ws.Cell("ZZ1000").Value = 1;
                 int initialCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
 
                 var actualResult = (double)ws.Evaluate(formulaA1);

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -330,14 +330,17 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         }
 
         [Test]
-        [TestCase("SUM(H:J)",  20501.15d, Description = "SUM columns")]
-        [TestCase("SUM(4:5)", 85366.12d, Description = "SUM rows")]
         [TestCase("COUNT(G:I,G:G,H:I)", 258d, Description = "COUNT overlapping columns")]
         [TestCase("COUNT(6:8,6:6,7:8)", 30d, Description = "COUNT overlapping rows")]
         [TestCase("COUNTBLANK(H:J)", 3145640d, Description = "COUNTBLANK columns")]
         [TestCase("COUNTBLANK(7:9)", 49128d, Description = "COUNTBLANK rows")]
         [TestCase("COUNT(1:1048576)", 216d, Description = "COUNT worksheet")]
         [TestCase("COUNTBLANK(1:1048576)", 17179868831d, Description = "COUNTBLANK worksheet")]
+        [TestCase("SUM(H:J)", 20501.15d, Description = "SUM columns")]
+        [TestCase("SUM(4:5)", 85366.12d, Description = "SUM rows")]
+        [TestCase("SUMIF(G:G,50,H:H)", 24.98d, Description = "SUMIF columns")]
+        [TestCase("SUMIF(G23:G52,\"\",H3:H32)", 53.24d, Description = "SUMIF ranges")]
+        [TestCase("SUMIFS(H:H,G:G,50,I:I,\">900\")", 19.99d, Description = "SUMIFS columns")]
         public void TallySkipsEmptyCells(string formulaA1, double expectedResult)
         {
             using (var wb = SetupWorkbook())


### PR DESCRIPTION
Calculation of formulas referring to wide ranges (such as entire rows or columns) required enumeration of all cells included. For a single column, this might take a few seconds (and huge memory allocation); for the entire worksheet, the computation would never end due to the out-of-memory.

This PR optimizes a computation in the following ways:

1. ```IXLRangeBase``` now implements the ```GetCellValues``` method which returns cell values without a need to initialize ```XLCell``` instances. This alone would increase the performance noticeably and would not require modification of math and statistical functions, but still would fail on extremely wide ranges.
2. When obtaining cell values for some range this range is trimmed by current worksheet's used range. Say, if we know that last used row on a worksheet is 5th, there is no need to enumerate each cell below A5 running through the range A:A since they all are obviously empty. This modification affects several functions that may actually depend on how much empty cells are there: ```COUNTBLANK```, ```COUNTIF```, ```SUMIF```, etc. All the rest (like ```MIN```, ```MAX```, ```AVG```) may safely ignore empty cells. 
Again, this optimization alone would bring performance gain but is not enough as it is not efficient in cases when there is a single initialized cell far-far away (i.e. ```ZZ100000```; I recall there was an issue reported with the example file matching this pattern).

I added a test performing wide-ranged computations (including a worksheet-wide), and even with this the total execution time of the test suite became twice lower (about 19 seconds against 40).

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer