### PR TITLE
Treat negative row and column numbers as invalid

### DIFF
--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -667,16 +667,19 @@ namespace ClosedXML.Excel
 
         private void WorksheetRangeShiftedColumns(XLRange range, int columnsShifted)
         {
-            if (range.RangeAddress.FirstAddress.ColumnNumber <= ColumnNumber())
+            if (!range.RangeAddress.IsInvalid &&
+                !RangeAddress.IsInvalid &&
+                range.RangeAddress.FirstAddress.ColumnNumber <= ColumnNumber())
                 SetColumnNumber(ColumnNumber() + columnsShifted);
         }
 
         private void SetColumnNumber(int column)
         {
             if (column <= 0)
-                RangeAddress.IsInvalid = false;
+                RangeAddress.IsInvalid = true;
             else
             {
+                RangeAddress.IsInvalid = false;
                 RangeAddress.FirstAddress = new XLAddress(Worksheet,
                                                           1,
                                                           column,

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -597,16 +597,19 @@ namespace ClosedXML.Excel
 
         private void WorksheetRangeShiftedRows(XLRange range, int rowsShifted)
         {
-            if (range.RangeAddress.FirstAddress.RowNumber <= RowNumber())
+            if (!range.RangeAddress.IsInvalid &&
+                !RangeAddress.IsInvalid &&
+                range.RangeAddress.FirstAddress.RowNumber <= RowNumber())
                 SetRowNumber(RowNumber() + rowsShifted);
         }
 
         private void SetRowNumber(Int32 row)
         {
             if (row <= 0)
-                RangeAddress.IsInvalid = false;
+                RangeAddress.IsInvalid = true;
             else
             {
+                RangeAddress.IsInvalid = false;
                 RangeAddress.FirstAddress = new XLAddress(Worksheet, row, 1, RangeAddress.FirstAddress.FixedRow,
                                                           RangeAddress.FirstAddress.FixedColumn);
                 RangeAddress.LastAddress = new XLAddress(Worksheet,

--- a/ClosedXML_Tests/Excel/Columns/ColumnTests.cs
+++ b/ClosedXML_Tests/Excel/Columns/ColumnTests.cs
@@ -237,5 +237,14 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual(2, lastCoUsed);
         }
 
+        [Test]
+        public void NegativeColumnNumberIsInvalid()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1") as XLWorksheet;
+
+            var column = new XLColumn(-1, new XLColumnParameters(ws, 0, false));
+
+            Assert.IsTrue(column.RangeAddress.IsInvalid);
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Rows/RowTests.cs
+++ b/ClosedXML_Tests/Excel/Rows/RowTests.cs
@@ -253,5 +253,15 @@ namespace ClosedXML_Tests.Excel
             ws.Rows(1, 2).Group();
             ws.Rows(1, 2).Ungroup(true);
         }
+
+        [Test]
+        public void NegativeRowNumberIsInvalid()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1") as XLWorksheet;
+
+            var row = new XLRow(-1, new XLRowParameters(ws, 0, false));
+
+            Assert.IsTrue(row.RangeAddress.IsInvalid);
+        }
     }
 }


### PR DESCRIPTION
Another funny mistake:
```
         if (row <= 0)
             RangeAddress.IsInvalid = false;
```
