### PR TITLE
Make cell addresses immutable

### DIFF
--- a/ClosedXML/Excel/Coordinates/XLAddress.cs
+++ b/ClosedXML/Excel/Coordinates/XLAddress.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 
 namespace ClosedXML.Excel
 {
-    internal class XLAddress : IXLAddress
+    internal struct XLAddress : IXLAddress, IEquatable<XLAddress>
     {
         #region Static
 
@@ -16,11 +16,6 @@ namespace ClosedXML.Excel
         public static XLAddress Create(string cellAddressString)
         {
             return Create(null, cellAddressString);
-        }
-
-        public static XLAddress Create(XLAddress cellAddress)
-        {
-            return new XLAddress(cellAddress.Worksheet, cellAddress.RowNumber, cellAddress.ColumnNumber, cellAddress.FixedRow, cellAddress.FixedColumn);
         }
 
         public static XLAddress Create(XLWorksheet worksheet, string cellAddressString)
@@ -85,9 +80,6 @@ namespace ClosedXML.Excel
         private bool _fixedColumn;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string _columnLetter;
-
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly int _rowNumber;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -100,7 +92,7 @@ namespace ClosedXML.Excel
         #region Constructors
 
         /// <summary>
-        /// 	Initializes a new <see cref = "XLAddress" /> struct using a mixed notation.  Attention: without worksheet for calculation only!
+        /// Initializes a new <see cref = "XLAddress" /> struct using a mixed notation.  Attention: without worksheet for calculation only!
         /// </summary>
         /// <param name = "rowNumber">The row number of the cell address.</param>
         /// <param name = "columnLetter">The column letter of the cell address.</param>
@@ -112,7 +104,7 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
-        /// 	Initializes a new <see cref = "XLAddress" /> struct using a mixed notation.
+        /// Initializes a new <see cref = "XLAddress" /> struct using a mixed notation.
         /// </summary>
         /// <param name = "worksheet"></param>
         /// <param name = "rowNumber">The row number of the cell address.</param>
@@ -122,11 +114,10 @@ namespace ClosedXML.Excel
         public XLAddress(XLWorksheet worksheet, int rowNumber, string columnLetter, bool fixedRow, bool fixedColumn)
                 : this(worksheet, rowNumber, XLHelper.GetColumnNumberFromLetter(columnLetter), fixedRow, fixedColumn)
         {
-            _columnLetter = columnLetter;
         }
 
         /// <summary>
-        /// 	Initializes a new <see cref = "XLAddress" /> struct using R1C1 notation. Attention: without worksheet for calculation only!
+        /// Initializes a new <see cref = "XLAddress" /> struct using R1C1 notation. Attention: without worksheet for calculation only!
         /// </summary>
         /// <param name = "rowNumber">The row number of the cell address.</param>
         /// <param name = "columnNumber">The column number of the cell address.</param>
@@ -138,21 +129,20 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
-        /// 	Initializes a new <see cref = "XLAddress" /> struct using R1C1 notation.
+        /// Initializes a new <see cref = "XLAddress" /> struct using R1C1 notation.
         /// </summary>
         /// <param name = "worksheet"></param>
         /// <param name = "rowNumber">The row number of the cell address.</param>
         /// <param name = "columnNumber">The column number of the cell address.</param>
         /// <param name = "fixedRow"></param>
         /// <param name = "fixedColumn"></param>
-        public XLAddress(XLWorksheet worksheet, int rowNumber, int columnNumber, bool fixedRow, bool fixedColumn)
+        public XLAddress(XLWorksheet worksheet, int rowNumber, int columnNumber, bool fixedRow, bool fixedColumn) : this()
 
         {
             Worksheet = worksheet;
 
             _rowNumber = rowNumber;
             _columnNumber = columnNumber;
-            _columnLetter = null;
             _fixedColumn = fixedColumn;
             _fixedRow = fixedRow;
         }
@@ -188,7 +178,7 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
-        /// 	Gets the row number of this address.
+        /// Gets the row number of this address.
         /// </summary>
         public Int32 RowNumber
         {
@@ -196,7 +186,7 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
-        /// 	Gets the column number of this address.
+        /// Gets the column number of this address.
         /// </summary>
         public Int32 ColumnNumber
         {
@@ -204,11 +194,11 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
-        /// 	Gets the column letter(s) of this address.
+        /// Gets the column letter(s) of this address.
         /// </summary>
         public String ColumnLetter
         {
-            get { return _columnLetter ?? (_columnLetter = XLHelper.GetColumnLetterFromNumber(_columnNumber)); }
+            get { return XLHelper.GetColumnLetterFromNumber(_columnNumber); }
         }
 
         #endregion Properties
@@ -355,17 +345,21 @@ namespace ClosedXML.Excel
 
         public bool Equals(IXLAddress other)
         {
-            var right = other as XLAddress;
-            if (ReferenceEquals(right, null))
-            {
+            if (other == null)
                 return false;
-            }
-            return _rowNumber == right._rowNumber && _columnNumber == right._columnNumber;
+
+            return _rowNumber == other.RowNumber &&
+                   _columnNumber == other.ColumnNumber;
+        }
+        public bool Equals(XLAddress other)
+        {
+            return _rowNumber == other._rowNumber &&
+                   _columnNumber == other._columnNumber;
         }
 
         public override Boolean Equals(Object other)
         {
-            return Equals((XLAddress)other);
+            return Equals(other as IXLAddress);
         }
 
         #endregion IEquatable<XLCellAddress> Members

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -26,8 +26,8 @@ namespace ClosedXML.Excel
         public XLRangeAddress(XLAddress firstAddress, XLAddress lastAddress)
         {
             Worksheet = firstAddress.Worksheet;
-            FirstAddress = XLAddress.Create(firstAddress);
-            LastAddress = XLAddress.Create(lastAddress);
+            FirstAddress = firstAddress;
+            LastAddress = lastAddress;
         }
 
         public XLRangeAddress(XLWorksheet worksheet, String rangeAddress)
@@ -113,14 +113,26 @@ namespace ClosedXML.Excel
         {
             [DebuggerStepThrough]
             get { return FirstAddress; }
-            set { FirstAddress = value as XLAddress; }
+            set
+            {
+                if (value is XLAddress)
+                    FirstAddress = (XLAddress)value;
+                else
+                    FirstAddress = new XLAddress(value.RowNumber, value.ColumnNumber, value.FixedRow, value.FixedColumn);
+            }
         }
 
         IXLAddress IXLRangeAddress.LastAddress
         {
             [DebuggerStepThrough]
             get { return LastAddress; }
-            set { LastAddress = value as XLAddress; }
+            set
+            {
+                if (value is XLAddress)
+                    LastAddress = (XLAddress)value;
+                else
+                    LastAddress = new XLAddress(value.RowNumber, value.ColumnNumber, value.FixedRow, value.FixedColumn);
+            }
         }
 
         public bool IsValid { get; set; } = true;

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -863,8 +863,8 @@ namespace ClosedXML.Excel
 
         public XLRange Range(IXLCell firstCell, IXLCell lastCell)
         {
-            var newFirstCellAddress = firstCell.Address as XLAddress;
-            var newLastCellAddress = lastCell.Address as XLAddress;
+            var newFirstCellAddress = (XLAddress)firstCell.Address;
+            var newLastCellAddress = (XLAddress)lastCell.Address;
 
             return GetRange(newFirstCellAddress, newLastCellAddress);
         }
@@ -908,7 +908,7 @@ namespace ClosedXML.Excel
 
         public XLRange Range(IXLAddress firstCellAddress, IXLAddress lastCellAddress)
         {
-            var rangeAddress = new XLRangeAddress(firstCellAddress as XLAddress, lastCellAddress as XLAddress);
+            var rangeAddress = new XLRangeAddress((XLAddress)firstCellAddress, (XLAddress)lastCellAddress);
             return Range(rangeAddress);
         }
 
@@ -1428,7 +1428,7 @@ namespace ClosedXML.Excel
 
         public Boolean Contains(IXLCell cell)
         {
-            return Contains(cell.Address as XLAddress);
+            return Contains((XLAddress)cell.Address);
         }
 
         public bool Contains(XLAddress first, XLAddress last)

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -49,8 +49,10 @@ namespace ClosedXML.Excel
             RangeShiftedColumns = new XLReentrantEnumerableSet<XLCallbackAction>();
 
             RangeAddress.Worksheet = this;
-            RangeAddress.FirstAddress.Worksheet = this;
-            RangeAddress.LastAddress.Worksheet = this;
+            RangeAddress.FirstAddress = new XLAddress(this, RangeAddress.FirstAddress.RowNumber, RangeAddress.FirstAddress.ColumnNumber,
+                                                            RangeAddress.FirstAddress.FixedRow, RangeAddress.FirstAddress.FixedColumn);
+            RangeAddress.LastAddress = new XLAddress(this, RangeAddress.LastAddress.RowNumber, RangeAddress.LastAddress.ColumnNumber,
+                                                           RangeAddress.LastAddress.FixedRow, RangeAddress.LastAddress.FixedColumn);
 
             Pictures = new XLPictures(this);
             NamedRanges = new XLNamedRanges(this);


### PR DESCRIPTION
This is another small step in a refactoring of addresses and ranges handling.

With this PR I propose the following changes:
1. There was an optimization letting column letter of cell address to be initialized only once per instance of ```XLAddress```. After the initialization, it was being stored in the private field. The thing is, that the gain of this optimization would be less than 0.1 microseconds, so it would become noticeable only if the column letter of the **same** ```XLAddress``` instance is determined millions of times (which does not look as an ordinary scenario). And the drawback of such optimization was that **each** instance of ```XLAddress``` held a reference to a string value. And since the number of instances can easily reach a few million, the drawback overweights. So I suggest not to store a column letter in ```XLAddress```, but read it on demand, by accessing an element in a pre-initialized array by its index.
2. If an address is mutable there is always a risk that multiple entities referring to the same instance of ```XLAddress``` will affect each other. To avoid this, the new instance should have been created from the existing one (```FirstAddress = XLAddress.Create(firstAddress);```). When the ```XLAddress``` is immutable, this is not needed anymore; entities are protected from affecting each other "by design". 

Here are results of profiling using the code of Pitterling.
**develop branch**
Objects: 31 671 019, Heap size 2 042 171.63 KB
![image](https://user-images.githubusercontent.com/19576939/37581998-49bdd39c-2b64-11e8-89cc-3e7f393e0cc3.png)

**This PR**
Objects: 25 186 160, Heap size 1 840 127.19 KB
![image](https://user-images.githubusercontent.com/19576939/37582052-7e954ed8-2b64-11e8-858d-6007e3725f8c.png)

The weight of ```XLRangeAddress``` instances grew, but this class is next on the list to be refactored.

Execution time has not been affected.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer