### PR TITLE
Add RemoveAll method to IXLRanges

### DIFF
--- a/ClosedXML/Excel/Ranges/IXLRanges.cs
+++ b/ClosedXML/Excel/Ranges/IXLRanges.cs
@@ -20,10 +20,13 @@ namespace ClosedXML.Excel
         void Remove(IXLRange range);
 
         /// <summary>
-        /// Removes all ranges from the collection optionally disposing them.
+        /// Removes ranges matching the criteria from the collection, optionally releasing their event handlers.
         /// </summary>
-        /// <param name="dispose"></param>
-        void RemoveAll(bool dispose = true);
+        /// <param name="match">Criteria to filter ranges. Only those ranges that satisfy the criteria will be removed.
+        /// Null means the entire collection should be cleared.</param>
+        /// <param name="releaseEventHandlers">Specify whether or not should removed ranges be unsubscribed from 
+        /// row/column shifting events. Until ranges are unsubscribed they cannot be collected by GC.</param>
+        void RemoveAll(Predicate<IXLRange> match = null, bool releaseEventHandlers = true);
 
         Int32 Count { get; }
 

--- a/ClosedXML/Excel/Ranges/IXLRanges.cs
+++ b/ClosedXML/Excel/Ranges/IXLRanges.cs
@@ -19,6 +19,12 @@ namespace ClosedXML.Excel
         /// <param name="range">The range to remove from this group.</param>
         void Remove(IXLRange range);
 
+        /// <summary>
+        /// Removes all ranges from the collection optionally disposing them.
+        /// </summary>
+        /// <param name="dispose"></param>
+        void RemoveAll(bool dispose = true);
+
         Int32 Count { get; }
 
         Boolean Contains(IXLRange range);

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -47,12 +47,25 @@ namespace ClosedXML.Excel
             _ranges.RemoveAll(r => r.ToString() == range.ToString());
         }
 
-        public void RemoveAll(bool dispose = true)
+        /// <summary>
+        /// Removes ranges matching the criteria from the collection, optionally releasing their event handlers.
+        /// </summary>
+        /// <param name="match">Criteria to filter ranges. Only those ranges that satisfy the criteria will be removed.
+        /// Null means the entire collection should be cleared.</param>
+        /// <param name="releaseEventHandlers">Specify whether or not should removed ranges be unsubscribed from 
+        /// row/column shifting events. Until ranges are unsubscribed they cannot be collected by GC.</param>
+        public void RemoveAll(Predicate<IXLRange> match = null, bool releaseEventHandlers = true)
         {
-            Count = 0;
-            if (dispose)
-                _ranges.ForEach(r => r.Dispose());
-            _ranges.Clear();
+            match = match ?? (_ => true);
+
+            if (releaseEventHandlers)
+            {
+                _ranges
+                    .Where(r => match(r))
+                    .ForEach(r => r.Dispose());
+            }
+
+            Count -= _ranges.RemoveAll(match);
         }
 
         public int Count { get; private set; }

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -47,6 +47,14 @@ namespace ClosedXML.Excel
             _ranges.RemoveAll(r => r.ToString() == range.ToString());
         }
 
+        public void RemoveAll(bool dispose = true)
+        {
+            Count = 0;
+            if (dispose)
+                _ranges.ForEach(r => r.Dispose());
+            _ranges.Clear();
+        }
+
         public int Count { get; private set; }
 
         public IEnumerator<IXLRange> GetEnumerator()

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -415,13 +415,30 @@ namespace ClosedXML_Tests
             ranges.Add(ws.Range("B1:B2"));
             var rangesCopy = ranges.ToList();
 
-            ranges.RemoveAll(false);
+            ranges.RemoveAll(null, false);
             ws.FirstColumn().InsertColumnsBefore(1);
 
             Assert.AreEqual(0, ranges.Count);
             // if ranges were not disposed they addresses should change
             Assert.AreEqual("B1:B2", rangesCopy.First().RangeAddress.ToString());
             Assert.AreEqual("C1:C2", rangesCopy.Last().RangeAddress.ToString());
+        }
+
+
+        [Test]
+        public void RangesRemoveAllByCriteria()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            var ranges = new XLRanges();
+            ranges.Add(ws.Range("A1:A2"));
+            ranges.Add(ws.Range("B1:B3"));
+            ranges.Add(ws.Range("C1:C4"));
+            var otherRange = ws.Range("A3:D3");
+
+            ranges.RemoveAll(r => r.Intersects(otherRange));
+
+            Assert.AreEqual(1, ranges.Count);
+            Assert.AreEqual("A1:A2", ranges.Single().RangeAddress.ToString());
         }
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -387,5 +387,41 @@ namespace ClosedXML_Tests
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
             Assert.AreEqual("C3:G4", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
         }
+
+        [Test]
+        public void RangesRemoveAllWithDispose()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            var ranges = new XLRanges();
+            ranges.Add(ws.Range("A1:A2"));
+            ranges.Add(ws.Range("B1:B2"));
+            var rangesCopy = ranges.ToList();
+
+            ranges.RemoveAll();
+            ws.FirstColumn().InsertColumnsBefore(1);
+
+            Assert.AreEqual(0, ranges.Count);
+            // if ranges were disposed they addresses didn't change
+            Assert.AreEqual("A1:A2", rangesCopy.First().RangeAddress.ToString());
+            Assert.AreEqual("B1:B2", rangesCopy.Last().RangeAddress.ToString());
+        }
+
+        [Test]
+        public void RangesRemoveAllWithoutDispose()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            var ranges = new XLRanges();
+            ranges.Add(ws.Range("A1:A2"));
+            ranges.Add(ws.Range("B1:B2"));
+            var rangesCopy = ranges.ToList();
+
+            ranges.RemoveAll(false);
+            ws.FirstColumn().InsertColumnsBefore(1);
+
+            Assert.AreEqual(0, ranges.Count);
+            // if ranges were not disposed they addresses should change
+            Assert.AreEqual("B1:B2", rangesCopy.First().RangeAddress.ToString());
+            Assert.AreEqual("C1:C2", rangesCopy.Last().RangeAddress.ToString());
+        }
     }
 }


### PR DESCRIPTION
```IXLRanges``` has a method ```Clear()``` which I personally tried to use for removing all ranges from the collection, while it serves to a completely different purpose (to _clear_ data, formats, etc. for cells included in the ranges). To prevent such a confusion and to simplify collection clearing I propose adding ```RemoveAll()``` method to the interface. By default, it will dispose removed ranges, but this is optional.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer