### PR TITLE
Take into account connection shapes when rebasing picture IDs

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_ImageHandling.cs
+++ b/ClosedXML/Excel/XLWorkbook_ImageHandling.cs
@@ -43,13 +43,13 @@ namespace ClosedXML.Excel
             if (!IsAllowedAnchor(anchor))
                 return null;
 
-            var picture = anchor
-                .Descendants<Xdr.Picture>()
-                .FirstOrDefault();
+            // Maybe we should not restrict here, and just search for all NonVisualDrawingProperties in an anchor?
+            var shape = anchor.Descendants<Xdr.Picture>().Cast<OpenXmlCompositeElement>().FirstOrDefault()
+                        ?? anchor.Descendants<Xdr.ConnectionShape>().Cast<OpenXmlCompositeElement>().FirstOrDefault();
 
-            if (picture == null) return null;
+            if (shape == null) return null;
 
-            return picture
+            return shape
                 .Descendants<Xdr.NonVisualDrawingProperties>()
                 .FirstOrDefault();
         }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -104,7 +104,7 @@ namespace ClosedXML.Excel
 
             if (errors.Any())
             {
-                var message = string.Join("\r\n", errors.Select(e => string.Format("{0} in {1}", e.Description, e.Path.XPath)).ToArray());
+                var message = string.Join("\r\n", errors.Select(e => string.Format("Part {0}, Path {1}: {2}", e.Part.Uri, e.Path.XPath, e.Description)).ToArray());
                 throw new ApplicationException(message);
             }
             return true;
@@ -3075,14 +3075,22 @@ namespace ClosedXML.Excel
             }
         }
 
-        private static void RebasePictureIds(WorksheetPart worksheetPart)
+        // Still not fully implemented for all shapes
+        private static void RebaseShapeIds(WorksheetPart worksheetPart)
         {
-            for (var i = 0; i < worksheetPart.DrawingsPart.WorksheetDrawing.ChildElements.Count; i++)
+            var worksheetDrawing = worksheetPart.DrawingsPart.WorksheetDrawing;
+            for (var i = 0; i < worksheetDrawing.ChildElements.Count; i++)
             {
-                var anchor = worksheetPart.DrawingsPart.WorksheetDrawing.ElementAt(i);
+                var anchor = worksheetDrawing.ElementAt(i);
                 var props = GetPropertiesFromAnchor(anchor);
                 if (props != null)
-                    props.Id = Convert.ToUInt32(i + 1);
+                {
+                    var offset = 1;
+                    while (worksheetDrawing.Descendants<NonVisualDrawingProperties>().Any(p => p.Id == Convert.ToUInt32(i + offset)))
+                        offset++;
+
+                    props.Id = Convert.ToUInt32(i + offset);
+                }
             }
         }
 
@@ -5437,7 +5445,7 @@ namespace ClosedXML.Excel
             }
 
             if (xlWorksheet.Pictures.Any())
-                RebasePictureIds(worksheetPart);
+                RebaseShapeIds(worksheetPart);
 
             var tableParts = worksheetPart.Worksheet.Elements<TableParts>().First();
             if (xlWorksheet.Pictures.Any() && !worksheetPart.Worksheet.OfType<Drawing>().Any())


### PR DESCRIPTION
Take into account connection shapes when rebasing picture IDs. 
Fixes #769 