### PR TITLE
Implemented support of storing cell calculated values using DateTime

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -87,6 +87,8 @@ namespace ClosedXML.Excel.CalcEngine
         {
             foreach (var value in _list)
             {
+                if (value is double)
+                    yield return (double)value;
                 double tmp;
                 var vEnumerable = value as IEnumerable;
                 if (vEnumerable == null || vEnumerable is string)

--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -88,7 +88,11 @@ namespace ClosedXML.Excel.CalcEngine
             foreach (var value in _list)
             {
                 if (value is double)
+                {
                     yield return (double)value;
+                    continue;
+                }
+
                 double tmp;
                 var vEnumerable = value as IEnumerable;
                 if (vEnumerable == null || vEnumerable is string)

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -310,7 +310,30 @@ namespace ClosedXML.Excel
 
         IXLCell CopyTo(String target);
 
+        /// <summary>
+        /// Textual representation of cell calculated value (as it is saved to a workbook or read from it)
+        /// </summary>
         String ValueCached { get; }
+
+        /// <summary>
+        /// Calculated value of cell formula. Is used for decreasing number of computations perfromed.
+        /// May hold invalid value when <see cref="RecalculationNeeded"/> flag is True.
+        /// </summary>
+        Object ValueCalculated { get; }
+
+        /// <summary>
+        /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
+        /// </summary>
+        Boolean RecalculationNeeded { get; }
+
+        /// <summary>
+        /// Perform an evaluation of cell formula. If cell does not contain formula nothing happens, if cell does not need
+        /// recalculation (<see cref="RecalculationNeeded"/> is False) nothing happens either, unless <paramref name="force"/> flag is specified.
+        /// Otherwise recalculation is perfomed, result value is preserved in <see cref="ValueCalculated"/> and returned.
+        /// </summary>
+        /// <param name="force">Flag indicating whether a recalculation must be performed even is cell does not need it.</param>
+        /// <returns>Null if cell does not contain a formula. Calculated value otherwise.</returns>
+        object Evaluate(bool force = false);
 
         IXLRichText RichText { get; }
         Boolean HasRichText { get; }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -64,7 +64,6 @@ namespace ClosedXML.Excel
         private static readonly Regex utfPattern = new Regex(@"(?<!_x005F)_x(?!005F)([0-9A-F]{4})_", RegexOptions.Compiled);
 
         #region Fields
-
         private readonly XLWorksheet _worksheet;
 
         internal string _cellValue = String.Empty;
@@ -364,34 +363,48 @@ namespace ClosedXML.Excel
         /// </summary>
         internal bool IsEvaluating { get; private set; }
 
-        public object Value
+        /// <summary>
+        /// Calculate a value of the specified formula.
+        /// </summary>
+        /// <param name="fA1">Cell formula to evaluate.</param>
+        /// <returns>Null if formula is empty or null, calculated value otherwise.</returns>
+        private object RecalculateFormula(string fA1)
         {
-            get
+            if (string.IsNullOrEmpty(fA1))
+                return null;
+
+            if (fA1[0] == '{')
+                fA1 = fA1.Substring(1, fA1.Length - 2);
+
+            string sName;
+            string cAddress;
+            if (fA1.Contains('!'))
             {
-                var fA1 = FormulaA1;
-                if (!String.IsNullOrWhiteSpace(fA1))
-                {
+                sName = fA1.Substring(0, fA1.IndexOf('!'));
+                if (sName[0] == '\'')
+                    sName = sName.Substring(1, sName.Length - 2);
                     if (IsEvaluating)
                         throw new InvalidOperationException("Circular Reference");
 
-                    if (fA1[0] == '{')
-                        fA1 = fA1.Substring(1, fA1.Length - 2);
+                cAddress = fA1.Substring(fA1.IndexOf('!') + 1);
+            }
+            else
+            {
+                sName = Worksheet.Name;
+                cAddress = fA1;
+            }
 
-                    string sName;
-                    string cAddress;
-                    if (fA1.Contains('!'))
-                    {
-                        sName = fA1.Substring(0, fA1.IndexOf('!'));
-                        if (sName[0] == '\'')
-                            sName = sName.Substring(1, sName.Length - 2);
-
-                        cAddress = fA1.Substring(fA1.IndexOf('!') + 1);
-                    }
-                    else
-                    {
-                        sName = Worksheet.Name;
-                        cAddress = fA1;
-                    }
+            if (_worksheet.Workbook.WorksheetsInternal.Any<XLWorksheet>(
+                w => String.Compare(w.Name, sName, true) == 0)
+                && XLHelper.IsValidA1Address(cAddress)
+                )
+            {
+                var referenceCell = _worksheet.Workbook.Worksheet(sName).Cell(cAddress);
+                if (referenceCell.IsEmpty(false))
+                    return 0;
+                else
+                    return referenceCell.Value;
+            }
 
                     object retVal;
                     try
@@ -418,42 +431,72 @@ namespace ClosedXML.Excel
                         IsEvaluating = false;
                     }
 
-                    var retValEnumerable = retVal as IEnumerable;
+            if (retValEnumerable != null && !(retVal is String))
+                return retValEnumerable.Cast<object>().First();
 
-                    if (retValEnumerable != null && !(retVal is String))
-                        return retValEnumerable.Cast<object>().First();
+            return retVal;
+        }
 
-                    return retVal;
+        /// <summary>
+        /// Perform an evaluation of cell formula. If cell does not contain formula nothing happens, if cell does not need
+        /// recalculation (<see cref="RecalculationNeeded"/> is False) nothing happens either, unless <paramref name="force"/> flag is specified.
+        /// Otherwise recalculation is perfomed, result value is preserved in <see cref="ValueCalculated"/> and returned.
+        /// </summary>
+        /// <param name="force">Flag indicating whether a recalculation must be performed even is cell does not need it.</param>
+        /// <returns>Null if cell does not contain a formula. Calculated value otherwise.</returns>
+        public object Evaluate(bool force = false)
+        {
+            if (RecalculationNeeded || force)
+            {
+                ValueCalculated = RecalculateFormula(FormulaA1);
+                EvaluatedAtVersion = Worksheet.Workbook.RecalculationCounter;
+                RecalculationNeeded = false;
+            }
+            return ValueCalculated;
+        }
+
+        private object StringToCellDataType(string cellValue)
+        {
+            if (_dataType == XLDataType.Boolean)
+                return cellValue != "0";
+
+            if (_dataType == XLDataType.DateTime)
+            {
+                Double d;
+                if (Double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d)
+                    && d.IsValidOADateNumber())
+                    return DateTime.FromOADate(d);
+            }
+
+            if (_dataType == XLDataType.Number)
+            {
+                Double d;
+                if (double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d))
+                    return d;
+            }
+
+            if (_dataType == XLDataType.TimeSpan)
+            {
+                TimeSpan t;
+                if (TimeSpan.TryParse(cellValue, out t))
+                    return t;
+            }
+
+            return cellValue;
+        }
+
+        public object Value
+        {
+            get
+            {
+                if (!String.IsNullOrWhiteSpace(_formulaA1) ||
+                    !String.IsNullOrEmpty(_formulaR1C1))
+                {
+                    return Evaluate();
                 }
 
                 var cellValue = HasRichText ? _richText.ToString() : _cellValue;
-
-                if (_dataType == XLDataType.Boolean)
-                    return cellValue != "0";
-
-                if (_dataType == XLDataType.DateTime)
-                {
-                    Double d;
-                    if (Double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d)
-                        && d.IsValidOADateNumber())
-                        return DateTime.FromOADate(d);
-                }
-
-                if (_dataType == XLDataType.Number)
-                {
-                    Double d;
-                    if (double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d))
-                        return d;
-                }
-
-                if (_dataType == XLDataType.TimeSpan)
-                {
-                    TimeSpan t;
-                    if (TimeSpan.TryParse(cellValue, out t))
-                        return t;
-                }
-
-                return cellValue;
+                return StringToCellDataType(cellValue);
             }
 
             set
@@ -1101,6 +1144,9 @@ namespace ClosedXML.Excel
 
             set
             {
+                Worksheet.Workbook.NotifyRecalculationNeeded();
+                EditedAtVersion = Worksheet.Workbook.RecalculationCounter;
+
                 _formulaA1 = String.IsNullOrWhiteSpace(value) ? null : value;
 
                 _formulaR1C1 = null;
@@ -1119,6 +1165,9 @@ namespace ClosedXML.Excel
 
             set
             {
+                Worksheet.Workbook.NotifyRecalculationNeeded();
+                EditedAtVersion = Worksheet.Workbook.RecalculationCounter;
+
                 _formulaR1C1 = String.IsNullOrWhiteSpace(value) ? null : value;
 
                 _formulaA1 = null;
@@ -1198,6 +1247,66 @@ namespace ClosedXML.Excel
             AsRange().AddToNamed(rangeName, scope, comment);
             return this;
         }
+
+
+        private bool _recalculationNeededLastValue;
+
+        /// <summary>
+        /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
+        /// </summary>
+        public bool RecalculationNeeded
+        {
+            get
+            {
+                if (String.IsNullOrWhiteSpace(_formulaA1) && String.IsNullOrEmpty(_formulaR1C1))
+                    return false;
+
+                if (NeedRecalculateEvaluatedAtVersion == Worksheet.Workbook.RecalculationCounter)
+                    return _recalculationNeededLastValue;
+
+                bool res = EvaluatedAtVersion < EditedAtVersion ||                                          // the cell itself was modified
+                           GetAffectingCells().Any(cell => cell.EditedAtVersion > EvaluatedAtVersion ||     // the affecting cell was modified after this one was evaluated
+                                                           cell.EvaluatedAtVersion > EvaluatedAtVersion ||  // the affecting cell was evaluated after this one (normally this should not happen)
+                                                           cell.RecalculationNeeded);                       // the affecting cell needs recalculation (recursion to walk through dependencies)
+
+                RecalculationNeeded = res;
+                return res;
+            }
+            private set
+            {
+                _recalculationNeededLastValue = value;
+                NeedRecalculateEvaluatedAtVersion = Worksheet.Workbook.RecalculationCounter;
+            }
+        }
+
+        private IEnumerable<XLCell> GetAffectingCells()
+        {
+            return Worksheet.CalcEngine.GetAffectingCells(_formulaA1).Cast<XLCell>();
+        }
+
+        /// <summary>
+        /// The value of <see cref="XLWorkbook.RecalculationCounter"/> that workbook had at the moment of cell last modification.
+        /// If this value is greater than <see cref="EvaluatedAtVersion"/> then cell needs re-evaluation, as well as all dependent cells do.
+        /// </summary>
+        internal long EditedAtVersion { get; private set; }
+
+        /// <summary>
+        /// The value of <see cref="XLWorkbook.RecalculationCounter"/> that workbook had at the moment of cell formula evaluation.
+        /// If this value equals to <see cref="XLWorkbook.RecalculationCounter"/> it indicates that <see cref="ValueCalculated"/> stores
+        /// correct value and no re-evaluation has to be performed.
+        /// </summary>
+        internal long EvaluatedAtVersion { get; private set; }
+
+        /// <summary>
+        /// The value of <see cref="XLWorkbook.RecalculationCounter"/> that workbook had at the moment of determining whether the cell
+        /// needs re-evaluation (due to it has been edited or some of the affecting cells has). If thie value equals to <see cref="XLWorkbook.RecalculationCounter"/>
+        /// it indicates that <see cref="_recalculationNeededLastValue"/> stores correct value and no check has to be performed.
+        /// </summary>
+        internal long NeedRecalculateEvaluatedAtVersion { get; private set; }
+
+        public object ValueCalculated { get; private set; }
+
+
 
         public string ValueCached { get; internal set; }
 

--- a/ClosedXML/Excel/IXLWorkbook.cs
+++ b/ClosedXML/Excel/IXLWorkbook.cs
@@ -140,6 +140,11 @@ namespace ClosedXML.Excel
 
         Object Evaluate(String expression);
 
+        /// <summary>
+        /// Force recalculation of all cell formulas.
+        /// </summary>
+        void RecalculateAllFormulas();
+
         IXLCells FindCells(Func<IXLCell, Boolean> predicate);
 
         IXLColumns FindColumns(Func<IXLColumn, Boolean> predicate);

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -430,6 +430,11 @@ namespace ClosedXML.Excel
 
         Object Evaluate(String expression);
 
+        /// <summary>
+        /// Force recalculation of all cell formulas.
+        /// </summary>
+        void RecalculateAllFormulas();
+
         String Author { get; set; }
 
         IXLPictures Pictures { get; }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -120,10 +120,10 @@ namespace ClosedXML.Excel
         public XLEventTracking EventTracking { get; set; }
 
         /// <summary>
-        /// Counter increasing at workbook data change. Serves to determine if the cell formula
-        /// has to be recalculated.
+        /// Date and time when the workbook data was modified (only formulas and cell values are taken
+        /// into account).
         /// </summary>
-        internal long RecalculationCounter { get; private set; }
+        internal DateTime LastModifiedAt { get; private set; }
 
         /// <summary>
         /// Notify that workbook data has been changed which means that cached formula values
@@ -131,7 +131,7 @@ namespace ClosedXML.Excel
         /// </summary>
         internal void NotifyRecalculationNeeded()
         {
-            RecalculationCounter++;
+            LastModifiedAt = DateTime.UtcNow;
         }
 
         #region  Nested Type : XLLoadSource

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -119,27 +119,6 @@ namespace ClosedXML.Excel
 
         public XLEventTracking EventTracking { get; set; }
 
-<<<<<<< HEAD
-        #region Nested Type: XLLoadSource
-=======
-        internal Int32 GetStyleId(IXLStyle style)
-        {
-            Int32 cached;
-            if (_stylesByStyle.TryGetValue(style, out cached))
-                return cached;
-
-            var count = _stylesByStyle.Count;
-            var styleToUse = new XLStyle(null, style);
-            _stylesByStyle.Add(styleToUse, count);
-            _stylesById.Add(count, styleToUse);
-            return count;
-        }
-
-        internal IXLStyle GetStyleById(Int32 id)
-        {
-            return _stylesById[id];
-        }
-
         /// <summary>
         /// Counter increasing at workbook data change. Serves to determine if the cell formula
         /// has to be recalculated.
@@ -155,19 +134,7 @@ namespace ClosedXML.Excel
             RecalculationCounter++;
         }
 
-        /// <summary>
-        /// Check if the formula of the particular cell have to be re-evaluated.
-        /// </summary>
-        /// <param name="cellLastRecalculation">Value of <see cref="RecalculationCounter"/> that the cell had
-        /// at the moment of the previous evaluation.</param>
-        /// <returns>True if the cell should be re-evaluated, false otherwise.</returns>
-        internal bool NeedRecalculate(long cellLastRecalculation)
-        {
-            return RecalculationCounter != cellLastRecalculation;
-        }
-
         #region  Nested Type : XLLoadSource
->>>>>>> 8743ecd2... Implemented support of storing cell calculated values
 
         private enum XLLoadSource
         {

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -119,7 +119,55 @@ namespace ClosedXML.Excel
 
         public XLEventTracking EventTracking { get; set; }
 
+<<<<<<< HEAD
         #region Nested Type: XLLoadSource
+=======
+        internal Int32 GetStyleId(IXLStyle style)
+        {
+            Int32 cached;
+            if (_stylesByStyle.TryGetValue(style, out cached))
+                return cached;
+
+            var count = _stylesByStyle.Count;
+            var styleToUse = new XLStyle(null, style);
+            _stylesByStyle.Add(styleToUse, count);
+            _stylesById.Add(count, styleToUse);
+            return count;
+        }
+
+        internal IXLStyle GetStyleById(Int32 id)
+        {
+            return _stylesById[id];
+        }
+
+        /// <summary>
+        /// Counter increasing at workbook data change. Serves to determine if the cell formula
+        /// has to be recalculated.
+        /// </summary>
+        internal long RecalculationCounter { get; private set; }
+
+        /// <summary>
+        /// Notify that workbook data has been changed which means that cached formula values
+        /// need to be re-evaluated.
+        /// </summary>
+        internal void NotifyRecalculationNeeded()
+        {
+            RecalculationCounter++;
+        }
+
+        /// <summary>
+        /// Check if the formula of the particular cell have to be re-evaluated.
+        /// </summary>
+        /// <param name="cellLastRecalculation">Value of <see cref="RecalculationCounter"/> that the cell had
+        /// at the moment of the previous evaluation.</param>
+        /// <returns>True if the cell should be re-evaluated, false otherwise.</returns>
+        internal bool NeedRecalculate(long cellLastRecalculation)
+        {
+            return RecalculationCounter != cellLastRecalculation;
+        }
+
+        #region  Nested Type : XLLoadSource
+>>>>>>> 8743ecd2... Implemented support of storing cell calculated values
 
         private enum XLLoadSource
         {
@@ -829,6 +877,15 @@ namespace ClosedXML.Excel
         public Object Evaluate(String expression)
         {
             return CalcEngine.Evaluate(expression);
+        }
+
+        /// <summary>
+        /// Force recalculation of all cell formulas.
+        /// </summary>
+        public void RecalculateAllFormulas()
+        {
+            NotifyRecalculationNeeded();
+            Worksheets.ForEach(sheet => sheet.RecalculateAllFormulas());
         }
 
         private static XLCalcEngine _calcEngineExpr;

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -5548,7 +5548,7 @@ namespace ClosedXML.Excel
                 var cellValue = new CellValue();
                 try
                 {
-                    cellValue.Text = xlCell.Value.ToString();
+                    cellValue.Text = xlCell.Value.ToInvariantString();
                     openXmlCell.DataType = new EnumValue<CellValues>(CellValues.String);
                 }
                 catch

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -4841,7 +4841,20 @@ namespace ClosedXML.Excel
                                     cell.CellFormula.Text = formula;
                                 }
 
-                                cell.CellValue = null;
+                                if (!evaluateFormulae || xlCell.ValueCalculated == null || xlCell.RecalculationNeeded)
+                                    cell.CellValue = null;
+                                else
+                                {
+                                    string valueCalculated;
+                                    if (xlCell.ValueCalculated is int)
+                                        valueCalculated = ((int)xlCell.ValueCalculated).ToInvariantString();
+                                    else if (xlCell.ValueCalculated is double)
+                                        valueCalculated = ((double)xlCell.ValueCalculated).ToInvariantString();
+                                    else
+                                        valueCalculated = xlCell.ValueCalculated.ToString();
+                                    
+                                    cell.CellValue = new CellValue(valueCalculated);
+                                }
                             }
                             else if (tableTotalCells.Contains(xlCell.Address))
                             {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1465,7 +1465,7 @@ namespace ClosedXML.Excel
 
         private XLCalcEngine _calcEngine;
 
-        private XLCalcEngine CalcEngine
+        internal XLCalcEngine CalcEngine
         {
             get { return _calcEngine ?? (_calcEngine = new XLCalcEngine(this)); }
         }
@@ -1473,6 +1473,14 @@ namespace ClosedXML.Excel
         public Object Evaluate(String expression)
         {
             return CalcEngine.Evaluate(expression);
+        }
+
+        /// <summary>
+        /// Force recalculation of all cell formulas.
+        /// </summary>
+        public void RecalculateAllFormulas()
+        {
+            CellsUsed().ForEach(cell => cell.Evaluate(true));
         }
 
         public String Author { get; set; }

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -136,6 +136,7 @@ namespace ClosedXML.Excel
             _worksheets.RemoveAll(w => w.Position == position);
             _worksheets.Values.Where(w => w.Position > position).ForEach(w => w._position -= 1);
             _workbook.UnsupportedSheets.Where(w => w.Position > position).ForEach(w => w.Position -= 1);
+            _workbook.NotifyRecalculationNeeded();
         }
 
         IEnumerator<IXLWorksheet> IEnumerable<IXLWorksheet>.GetEnumerator()

--- a/ClosedXML_Sandbox/PerformanceRunner.cs
+++ b/ClosedXML_Sandbox/PerformanceRunner.cs
@@ -135,5 +135,35 @@ namespace ClosedXML_Sandbox
 
             return row;
         }
+        
+        public static void PerformHeavyCalculation()
+        {
+            int rows = 200;
+            int columns = 200;
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var lastColumnLetter = sheet.Column(columns).ColumnLetter();
+                for (int i = 1; i <= rows; i++)
+                {
+                    for (int j = 1; j <= columns; j++)
+                    {
+                        if (i == 1)
+                        {
+                            sheet.Cell(i, j).FormulaA1 = string.Format("=ROUND({0}*SIN({0}),2)", j);
+                        }
+                        else
+                        {
+                            sheet.Cell(i, j).FormulaA1 = string.Format("=SUM({0}$1:{0}{1})/SUM($A{1}:${2}{1})",
+                                sheet.Column(j).ColumnLetter(), i - 1, lastColumnLetter); // i.e. for K8 there will be =SUM(K$1:K7)/SUM($A7:$GR7)
+                        }
+                    }
+                }
+
+                var cells = sheet.CellsUsed();
+                var sum1 = cells.Sum(cell => (double)cell.Value);
+                Console.WriteLine("Total sum: {0:N2}", sum1);
+            }
+        }
     }
 }

--- a/ClosedXML_Sandbox/Program.cs
+++ b/ClosedXML_Sandbox/Program.cs
@@ -18,6 +18,10 @@ namespace ClosedXML_Sandbox
             Console.WriteLine();
 #endif
 
+            Console.WriteLine("Running {0}", nameof(PerformanceRunner.PerformHeavyCalculation));
+            PerformanceRunner.TimeAction(PerformanceRunner.PerformHeavyCalculation);
+            Console.WriteLine();
+
             Console.WriteLine("Press any key to continue");
             Console.ReadKey();
         }

--- a/ClosedXML_Tests/Excel/CalcEngine/AffectingCellsTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/AffectingCellsTests.cs
@@ -1,0 +1,86 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System.IO;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.CalcEngine
+{
+    [TestFixture]
+    public class AffectingCellsTests
+    {
+        [Test]
+        public void GetAffectingRangesPreventsDuplication()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (XLWorkbook wb = new XLWorkbook())
+                {
+                    var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+                    var sheet2 = wb.AddWorksheet("Sheet2");
+                    var formula = "=MAX(A2:E2)/COUNTBLANK(A2:E2)*MAX(B1:C3)+SUM(Sheet2!B1:C3)+SUM($A$2:$E$2)+A2+B$2+$C$2";
+
+                    var ranges = sheet1.CalcEngine.GetAffectingRanges(formula);
+
+                    Assert.AreEqual(6, ranges.Count());
+                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "A2:E2"));
+                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "B1:C3"));
+                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet2" && r.RangeAddress.ToString() == "B1:C3"));
+                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "A2:A2"));
+                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "B$2:B$2"));
+                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "$C$2:$C$2"));
+                }
+            }
+        }
+
+        [Test]
+        public void GetAffectingRangesDealsWithNamedRanges()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (XLWorkbook wb = new XLWorkbook())
+                {
+                    var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+                    sheet1.NamedRanges.Add("NAMED_RANGE", sheet1.Range("A2:B3"));
+                    var formula = "=SUM(NAMED_RANGE)";
+
+                    var ranges = sheet1.CalcEngine.GetAffectingRanges(formula);
+
+                    Assert.AreEqual(1, ranges.Count());
+                    Assert.AreEqual("$A$2:$B$3", ranges.First().RangeAddress.ToString());
+                }
+            }
+        }
+
+        [Test]
+        public void GetAffectingCells()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (XLWorkbook wb = new XLWorkbook())
+                {
+                    var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+                    var sheet2 = wb.AddWorksheet("Sheet2");
+                    var formula = "=MAX(A2:E2)/COUNTBLANK(A2:E2)*MAX(B1:C3)+SUM(Sheet2!B1:C3)+SUM($A$2:$E$2)+A2+B$2+$C$2";
+                    var expectedAtSheet1 = new string[]
+                        { "A2", "B2", "C2", "D2", "E2", "B1", "C1", "B3", "C3" };
+                    var expectedAtSheet2 = new string[]
+                        { "B1", "C1", "B2", "C2", "B3", "C3" };
+
+                    var cells = sheet1.CalcEngine.GetAffectingCells(formula);
+
+                    Assert.AreEqual(15, cells.Count());
+                    foreach (var address in expectedAtSheet1)
+                    {
+                        Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet1.Name && cell.Address.ToString() == address),
+                            string.Format("Address {0}!{1} is not presented", sheet1.Name, address));
+                    }
+                    foreach (var address in expectedAtSheet2)
+                    {
+                        Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet2.Name && cell.Address.ToString() == address),
+                            string.Format("Address {0}!{1} is not presented", sheet2.Name, address));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -1,0 +1,320 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.CalcEngine
+{
+    [TestFixture]
+    public class FormulaCachingTests
+    {
+        [Test]
+        public void NewWorkbookDoesNotNeedRecalculation()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var cell = sheet.Cell(1, 1);
+
+                Assert.AreEqual(0, wb.RecalculationCounter);
+                Assert.IsFalse(cell.RecalculationNeeded);
+            }
+        }
+
+        [Test]
+        public void EditCellCausesCounterIncreasing()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var cell = sheet.Cell(1, 1);
+                cell.Value = "1234567";
+
+                Assert.Greater(wb.RecalculationCounter, 0);
+            }
+        }
+
+        [Test]
+        public void StaticCellDoesNotNeedRecalculation()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var cell = sheet.Cell(1, 1);
+                cell.Value = "1234567";
+
+                Assert.IsFalse(cell.RecalculationNeeded);
+            }
+        }
+
+        [Test]
+        public void EditCellInvalidatesDependentCells()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var cell = sheet.Cell(1, 1);
+                var dependentCell = sheet.Cell(2, 1);
+                dependentCell.FormulaA1 = "=A1";
+                dependentCell.Evaluate();
+
+                cell.Value = "1234567";
+
+                Assert.IsTrue(dependentCell.RecalculationNeeded);
+            }
+        }
+
+
+        [Test]
+        public void EditFormulaA1InvalidatesDependentCells()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a1 = sheet.Cell("A1");
+                var a2 = sheet.Cell("A2");
+                var a3 = sheet.Cell("A3");
+                var a4 = sheet.Cell("A4");
+                a2.FormulaA1 = "=A1*10";
+                a3.FormulaA1 = "=A2*10";
+                a4.FormulaA1 = "=SUM(A1:A3)";
+                a1.Value = 15;
+
+                var res1 = a4.Value;
+                a2.FormulaA1 = "=A1*20";
+                var res2 = a4.Value;
+
+                Assert.AreEqual(15 + 150 + 1500, res1);
+                Assert.AreEqual(15 + 300 + 3000, res2);
+            }
+        }
+
+
+        [Test]
+        public void EditFormulaR1C1InvalidatesDependentCells()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a1 = sheet.Cell("A1");
+                var a2 = sheet.Cell("A2");
+                var a3 = sheet.Cell("A3");
+                var a4 = sheet.Cell("A4");
+                a2.FormulaA1 = "=A1*10";
+                a3.FormulaA1 = "=A2*10";
+                a4.FormulaA1 = "=SUM(A1:A3)";
+                a1.Value = 15;
+
+                var res1 = a4.Value;
+                a2.FormulaR1C1 = "=R[-1]C*2";
+                var res2 = a4.Value;
+
+                Assert.AreEqual(15 + 150 + 1500, res1);
+                Assert.AreEqual(15 + 30 + 300, res2);
+            }
+        }
+        [Test]
+        public void InsertRowInvalidatesValues()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a4 = sheet.Cell("A4");
+                a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
+
+                var res1 = a4.Value;
+                sheet.Row(2).InsertRowsAbove(2);
+                var res2 = a4.Value;
+
+                Assert.AreEqual(3, res1);
+                Assert.AreEqual(5, res2);
+            }
+        }
+
+
+        [Test]
+        public void DeleteRowInvalidatesValues()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a4 = sheet.Cell("A4");
+                a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
+
+                var res1 = a4.Value;
+                sheet.Row(2).Delete();
+                var res2 = a4.Value;
+
+                Assert.AreEqual(3, res1);
+                Assert.AreEqual(2, res2);
+            }
+        }
+
+        [Test]
+        public void ChainedCalculationPreservesIntermediateValues()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a1 = sheet.Cell("A1");
+                var a2 = sheet.Cell("A2");
+                var a3 = sheet.Cell("A3");
+                var a4 = sheet.Cell("A4");
+                a2.FormulaA1 = "=A1*10";
+                a3.FormulaA1 = "=A2*10";
+                a4.FormulaA1 = "=SUM(A1:A3)";
+
+                a1.Value = 15;
+                var res = a4.Value;
+
+                Assert.AreEqual(15 + 150 + 1500, res);
+                Assert.IsFalse(a4.RecalculationNeeded);
+                Assert.IsFalse(a3.RecalculationNeeded);
+                Assert.IsFalse(a2.RecalculationNeeded);
+                Assert.AreEqual(150, a2.ValueCalculated);
+                Assert.AreEqual(1500, a3.ValueCalculated);
+                Assert.AreEqual(15 + 150 + 1500, a4.ValueCalculated);
+            }
+        }
+
+        [Test]
+        public void EditingAffectsDependentCells()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a1 = sheet.Cell("A1");
+                var a2 = sheet.Cell("A2");
+                var a3 = sheet.Cell("A3");
+                var a4 = sheet.Cell("A4");
+                a2.FormulaA1 = "=A1*10";
+                a3.FormulaA1 = "=A2*10";
+                a4.FormulaA1 = "=SUM(A1:A3)";
+                a1.Value = 15;
+
+                var res1 = a4.Value;
+                a1.Value = 20;
+                var res2 = a4.Value;
+
+                Assert.AreEqual(15 + 150 + 1500, res1);
+                Assert.AreEqual(20 + 200 + 2000, res2);
+            }
+        }
+
+
+        [Test]
+        [TestCase("C4", new string[] {"C5"})]
+        [TestCase("D4", new string[] { })]
+        [TestCase("A1", new string[] {"A2", "A3", "A4", "C1", "C2", "C3", "C5" })]
+        [TestCase("B2", new string[] {"B3", "B4", "C2", "C3", "C5" })]
+        [TestCase("C2", new string[] {"C5" })]
+        public void EditingDoesNotAffectNonDependingCells(string changedCell, string[] affectedCells)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                sheet.Cell("A2").FormulaA1 = "A1+1";
+                sheet.Cell("A3").FormulaA1 = "SUM(A1:A2)";
+                sheet.Cell("A4").FormulaA1 = "SUM(A1:A3)";
+                sheet.Cell("B2").FormulaA1 = "B1+1";
+                sheet.Cell("B3").FormulaA1 = "SUM(B1:B2)";
+                sheet.Cell("B4").FormulaA1 = "SUM(B1:B3)";
+                sheet.Cell("C1").FormulaA1 = "SUM(A1:B1)";
+                sheet.Cell("C2").FormulaA1 = "SUM(A2:B2)";
+                sheet.Cell("C3").FormulaA1 = "SUM(A3:B3)";
+                sheet.Cell("C5").FormulaA1 = "SUM($A$1:$C$4)";
+                sheet.RecalculateAllFormulas();
+                var allCells = sheet.CellsUsed();
+
+                sheet.Cell(changedCell).Value = 100;
+                var modifiedCells = allCells.Where(cell => cell.RecalculationNeeded);
+
+                Assert.AreEqual(affectedCells.Length, modifiedCells.Count());
+                foreach (var cellAddress in affectedCells)
+                {
+                    Assert.IsTrue(modifiedCells.Any(cell => cell.Address.ToString() == cellAddress),
+                        string.Format("Cell {0} is expected to need recalculation, but it does not", cellAddress));
+                }
+            }
+        }
+
+        [Test]
+        public void CircularReferenceFailsCalculating()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a1 = sheet.Cell("A1");
+                var a2 = sheet.Cell("A2");
+                var a3 = sheet.Cell("A3");
+                var a4 = sheet.Cell("A4");
+
+                a2.FormulaA1 = "=A1*10";
+                a3.FormulaA1 = "=A2*10";
+                a4.FormulaA1 = "=A3*10";
+                a1.FormulaA1 = "=SUM(A2:A4)";
+
+                var getValueA1 = new TestDelegate(() => { var v = a1.Value; });
+                var getValueA2 = new TestDelegate(() => { var v = a2.Value; });
+                var getValueA3 = new TestDelegate(() => { var v = a3.Value; });
+                var getValueA4 = new TestDelegate(() => { var v = a4.Value; });
+
+                Assert.Throws(typeof(InvalidOperationException), getValueA1);
+                Assert.Throws(typeof(InvalidOperationException), getValueA2);
+                Assert.Throws(typeof(InvalidOperationException), getValueA3);
+                Assert.Throws(typeof(InvalidOperationException), getValueA4);
+            }
+        }
+
+
+        [Test]
+        public void CircularReferenceRecalculationNeededDoesNotFail()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet = wb.Worksheets.Add("TestSheet");
+                var a1 = sheet.Cell("A1");
+                var a2 = sheet.Cell("A2");
+                var a3 = sheet.Cell("A3");
+                var a4 = sheet.Cell("A4");
+
+                a2.FormulaA1 = "=A1*10";
+                a3.FormulaA1 = "=A2*10";
+                a4.FormulaA1 = "=A3*10";
+                a4.Evaluate();
+                a1.FormulaA1 = "=SUM(A2:A4)";
+
+                var recalcNeededA1 = a1.RecalculationNeeded;
+                var recalcNeededA2 = a2.RecalculationNeeded;
+                var recalcNeededA3 = a3.RecalculationNeeded;
+                var recalcNeededA4 = a4.RecalculationNeeded;
+
+                Assert.IsTrue(recalcNeededA1);
+                Assert.IsTrue(recalcNeededA2);
+                Assert.IsTrue(recalcNeededA3);
+                Assert.IsTrue(recalcNeededA4);
+            }
+        }
+
+        [Test]
+        public void DeleteWorksheetInvalidatesValues()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var sheet1 = wb.Worksheets.Add("Sheet1");
+                var sheet2 = wb.Worksheets.Add("Sheet2");
+                var sheet1_a1 = sheet1.Cell("A1");
+                var sheet2_a1 = sheet2.Cell("A1");
+                sheet1_a1.FormulaA1 = "Sheet2!A1";
+                sheet2_a1.Value = "TestValue";
+
+                var val1 = sheet1_a1.Value;
+                sheet2.Delete();
+                var getValue = new TestDelegate(() => { var val2 = sheet1_a1.Value; });
+
+                Assert.AreEqual("TestValue", val1.ToString());
+                Assert.Throws(typeof(ArgumentOutOfRangeException), getValue);
+            }
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 var sheet = wb.Worksheets.Add("TestSheet");
                 var cell = sheet.Cell(1, 1);
 
-                Assert.AreEqual(0, wb.RecalculationCounter);
+                Assert.AreEqual(0, wb.LastModifiedAt);
                 Assert.IsFalse(cell.RecalculationNeeded);
             }
         }
@@ -30,7 +30,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 var cell = sheet.Cell(1, 1);
                 cell.Value = "1234567";
 
-                Assert.Greater(wb.RecalculationCounter, 0);
+                Assert.Greater(wb.LastModifiedAt, 0);
             }
         }
 

--- a/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -16,21 +16,21 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 var sheet = wb.Worksheets.Add("TestSheet");
                 var cell = sheet.Cell(1, 1);
 
-                Assert.AreEqual(0, wb.LastModifiedAt);
                 Assert.IsFalse(cell.RecalculationNeeded);
             }
         }
 
         [Test]
-        public void EditCellCausesCounterIncreasing()
+        public void EditCellCausesLastModifiedChanged()
         {
             using (var wb = new XLWorkbook())
             {
+                var oldValue = wb.LastModifiedAt;
                 var sheet = wb.Worksheets.Add("TestSheet");
                 var cell = sheet.Cell(1, 1);
                 cell.Value = "1234567";
 
-                Assert.Greater(wb.LastModifiedAt, 0);
+                Assert.Greater(wb.LastModifiedAt, oldValue);
             }
         }
 

--- a/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -252,7 +252,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                 a2.FormulaA1 = "=A1*10";
                 a3.FormulaA1 = "=A2*10";
                 a4.FormulaA1 = "=A3*10";
-                a1.FormulaA1 = "=SUM(A2:A4)";
+                a1.FormulaA1 = "A2+A3+A4";
 
                 var getValueA1 = new TestDelegate(() => { var v = a1.Value; });
                 var getValueA2 = new TestDelegate(() => { var v = a2.Value; });


### PR DESCRIPTION
This is the alternative to #679 using ```DateTime``` value of last modification date instead of a ```long``` counter. After we choose which one to use I will delete a benchmark from the Sandbox.