### PR TITLE
Change projects to use C# 7.2 by default.

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net40;net46</TargetFrameworks>
+    <LangVersion>7.2</LangVersion>
     <Version>0.93.0</Version>
     <Authors>Manuel de Leon, Amir Ghezelbash, Francois Botha</Authors>
     <Company />

--- a/ClosedXML_Examples/ClosedXML_Examples.csproj
+++ b/ClosedXML_Examples/ClosedXML_Examples.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net40;net46</TargetFrameworks>
+    <LangVersion>7.2</LangVersion>
     <OutputType>Exe</OutputType>
     <Version>0.93.0</Version>
     <SignAssembly>true</SignAssembly>

--- a/ClosedXML_Sandbox/ClosedXML_Sandbox.csproj
+++ b/ClosedXML_Sandbox/ClosedXML_Sandbox.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.0;net40;net46</TargetFrameworks>
+    <LangVersion>7.2</LangVersion>
     <Version>0.93.0</Version>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net40;net46</TargetFrameworks>
+    <LangVersion>7.2</LangVersion>
     <Version>0.93.0</Version>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);NU1605</NoWarn>


### PR DESCRIPTION
Change projects to use C# 7.2 by default.

I can't think of any possible side-effects, except that developers have to have a fairly recent version of Visual Studio or VS Code.