### PR TITLE
Improve XLCell.SetValue(object)

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -973,7 +973,7 @@ namespace ClosedXML.Excel
                 }
                 else
                 {
-                    var value = c.Value.ToInvariantString();                                        
+                    var value = c.Value.ToInvariantString();
                     if (newStrings.ContainsKey(value))
                         c.SharedStringId = newStrings[value];
                     else
@@ -4884,7 +4884,7 @@ namespace ClosedXML.Excel
                                         valueCalculated = ((double)xlCell.CachedValue).ToInvariantString();
                                     else
                                         valueCalculated = xlCell.CachedValue.ToString();
-                                    
+
                                     cell.CellValue = new CellValue(valueCalculated);
                                 }
                             }
@@ -5589,6 +5589,7 @@ namespace ClosedXML.Excel
                         case String s:
                             openXmlCell.DataType = new EnumValue<CellValues>(CellValues.String);
                             break;
+
                         case DateTime dt:
                             openXmlCell.DataType = new EnumValue<CellValues>(CellValues.Date);
                             break;
@@ -5644,8 +5645,7 @@ namespace ClosedXML.Excel
             {
                 var timeSpan = xlCell.GetTimeSpan();
                 var cellValue = new CellValue();
-                cellValue.Text =
-                    XLCell.BaseDate.Add(timeSpan).ToOADate().ToInvariantString();
+                cellValue.Text = timeSpan.TotalDays.ToInvariantString();
                 openXmlCell.CellValue = cellValue;
             }
             else if (dataType == XLDataType.DateTime || dataType == XLDataType.Number)

--- a/ClosedXML/Extensions.cs
+++ b/ClosedXML/Extensions.cs
@@ -172,11 +172,6 @@ namespace ClosedXML.Excel
 
     internal static class IntegerExtensions
     {
-        public static String ToInvariantString(this Int32 value)
-        {
-            return value.ToString(CultureInfo.InvariantCulture.NumberFormat);
-        }
-
         public static bool Between(this int val, int from, int to)
         {
             return val >= from && val <= to;
@@ -185,12 +180,6 @@ namespace ClosedXML.Excel
 
     internal static class DecimalExtensions
     {
-        //All numbers are stored in XL files as invarient culture this is just a easy helper
-        public static String ToInvariantString(this Decimal value)
-        {
-            return value.ToString(CultureInfo.InvariantCulture);
-        }
-
         public static Decimal SaveRound(this Decimal value)
         {
             return Math.Round(value, 6);
@@ -199,12 +188,6 @@ namespace ClosedXML.Excel
 
     internal static class DoubleExtensions
     {
-        //All numbers are stored in XL files as invarient culture this is just a easy helper
-        public static String ToInvariantString(this Double value)
-        {
-            return value.ToString(CultureInfo.InvariantCulture);
-        }
-
         public static Double SaveRound(this Double value)
         {
             return Math.Round(value, 6);
@@ -386,6 +369,12 @@ namespace ClosedXML.Excel
 
                 case decimal v:
                     return v.ToString(CultureInfo.InvariantCulture);
+
+                case TimeSpan ts:
+                    return ts.ToString("c", CultureInfo.InvariantCulture);
+
+                case DateTime d:
+                    return d.ToString(CultureInfo.InvariantCulture);
 
                 default:
                     return value.ToString();


### PR DESCRIPTION
Improve XLCell.SetValue(object) by removing unnecessary TryParse functions