### PR TITLE
Speed up AdjustToContents

### DIFF
--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -70,37 +70,55 @@ namespace ClosedXML.Excel
 
         public IXLColumns AdjustToContents()
         {
-            _columns.ForEach(c => c.AdjustToContents());
+            using (new XLWorksheetMergedCellsCalculatorWrapper(_columns))
+            {
+                _columns.ForEach(c => c.AdjustToContents());
+            }
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow));
+            using (new XLWorksheetMergedCellsCalculatorWrapper(_columns))
+            {
+                _columns.ForEach(c => c.AdjustToContents(startRow));
+            }
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow, Int32 endRow)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow, endRow));
+            using (new XLWorksheetMergedCellsCalculatorWrapper(_columns))
+            {
+                _columns.ForEach(c => c.AdjustToContents(startRow, endRow));
+            }
             return this;
         }
 
         public IXLColumns AdjustToContents(Double minWidth, Double maxWidth)
         {
-            _columns.ForEach(c => c.AdjustToContents(minWidth, maxWidth));
+            using (new XLWorksheetMergedCellsCalculatorWrapper(_columns))
+            {
+                _columns.ForEach(c => c.AdjustToContents(minWidth, maxWidth));
+            }
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow, minWidth, maxWidth));
+            using (new XLWorksheetMergedCellsCalculatorWrapper(_columns))
+            {
+                _columns.ForEach(c => c.AdjustToContents(startRow, minWidth, maxWidth));
+            }
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow, endRow, minWidth, maxWidth));
+            using (new XLWorksheetMergedCellsCalculatorWrapper(_columns))
+            {
+                _columns.ForEach(c => c.AdjustToContents(startRow, endRow, minWidth, maxWidth));
+            }
             return this;
         }
 

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -10,6 +10,8 @@ namespace ClosedXML.Excel
     {
         private readonly List<XLRange> _ranges = new List<XLRange>();
 
+        private HashSet<IXLAddress> _mergedCellAddresses;
+
         public XLRanges() : base(XLWorkbook.DefaultStyleValue)
         {
         }
@@ -50,7 +52,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="match">Criteria to filter ranges. Only those ranges that satisfy the criteria will be removed.
         /// Null means the entire collection should be cleared.</param>
-        /// <param name="releaseEventHandlers">Specify whether or not should removed ranges be unsubscribed from 
+        /// <param name="releaseEventHandlers">Specify whether or not should removed ranges be unsubscribed from
         /// row/column shifting events. Until ranges are unsubscribed they cannot be collected by GC.</param>
         public void RemoveAll(Predicate<IXLRange> match = null, bool releaseEventHandlers = true)
         {
@@ -82,6 +84,9 @@ namespace ClosedXML.Excel
 
         public Boolean Contains(IXLCell cell)
         {
+            if (_mergedCellAddresses != null)
+                return _mergedCellAddresses.Contains(cell.Address);
+
             return _ranges.Any(r => r.RangeAddress.IsValid && r.Contains(cell));
         }
 
@@ -255,6 +260,16 @@ namespace ClosedXML.Excel
         {
             var engine = new XLRangeConsolidationEngine(this);
             return engine.Consolidate();
+        }
+
+        public void CalculateMergedCells()
+        {
+            _mergedCellAddresses = new HashSet<IXLAddress>(_ranges.Where(r => r.RangeAddress.IsValid).SelectMany(r => r.Cells().Select(c => c.Address)));
+        }
+
+        public void ResetMergedCells()
+        {
+            _mergedCellAddresses = null;
         }
     }
 }

--- a/ClosedXML/Excel/XLWorksheetMergedCellsCalculatorWrapper.cs
+++ b/ClosedXML/Excel/XLWorksheetMergedCellsCalculatorWrapper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel
+{
+    /// <summary>
+    /// A wrapper class which calculates the merged cells of a collection of worksheets
+    /// and resets them in the <see cref="Dispose"/> method
+    /// </summary>
+    internal class XLWorksheetMergedCellsCalculatorWrapper : IDisposable
+    {
+        private readonly List<XLWorksheet> _worksheets;
+
+        public XLWorksheetMergedCellsCalculatorWrapper(IEnumerable<XLColumn> columns)
+        {
+            _worksheets = columns.Select(c => c.Worksheet).Distinct().ToList();
+            _worksheets.ForEach(w => w.Internals.MergedRanges.CalculateMergedCells());
+        }
+
+        public void Dispose()
+        {
+            _worksheets.ForEach(w => w.Internals.MergedRanges.ResetMergedCells());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #796.

Introduces a cache for merged cell addresses in class `XLRanges`. It is only updated once, ie. subsequent changes in merged ranges are not considered. Therefore, it should only be used in a context where we are sure the merged ranges will not change. To this end, I also added class `XLWorksheetMergedCellsCalculatorWrapper` (feel free to suggest a shorter name 😄) which runs the calculation in the constructor and resets the cache in the `Dispose` method, allowing a simple usage with the `using` statement.
In the sheet from the linked issue, the time to run `AdjustToContents` has dropped from 150 to 2 seconds.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer