### PR TITLE
Implement indexing of XLRanges

### DIFF
--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -67,14 +67,14 @@ namespace ClosedXML.Excel
                         var nextFormat = formats[i];
 
                         var intersectsSkipped =
-                            skippedRanges.Any(left => nextFormat.Ranges.Any(right => left.Intersects(right)));
+                            skippedRanges.Any(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any());
 
                         if (IsSameFormat(nextFormat) && !intersectsSkipped)
                         {
                             similarFormats.Add(nextFormat);
                             nextFormat.Ranges.ForEach(r => rangesToJoin.Add(r));
                         }
-                        else if (rangesToJoin.Any(left => nextFormat.Ranges.Any(right => left.Intersects(right))) ||
+                        else if (rangesToJoin.Any(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any()) ||
                                  intersectsSkipped)
                         {
                             // if we reached the rule intersecting any of captured ranges stop for not breaking the priorities

--- a/ClosedXML/Excel/Patterns/Quadrant.cs
+++ b/ClosedXML/Excel/Patterns/Quadrant.cs
@@ -1,0 +1,343 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.Patterns
+{
+    /// <summary>
+    /// Implementation of QuadTree adapted to Excel worksheet specifics. Differences with the classic implementation
+    /// are that the topmost level is split to 128 square parts (2 columns of 64 blocks, each 8192*8192 cells) and that splitting
+    /// the quadrand onto 4 smaller quadrants does not depent on the number of items in this quadrant. When the range is added to the
+    /// QuadTree it is placed on the bottommost level where it fits to a single quadrant. That means, row-wide and column-wide ranges
+    /// are always placed at the level 0, and the smaller the range is the deeper it goes down the tree. This approach eliminates
+    /// the need of trasferring ranges between levels.
+    /// </summary>
+    internal class Quadrant
+    {
+        #region Public Properties
+
+        /// <summary>
+        /// Smaller quadrants which the current one is splitted to. Is NULL until ranges are added to child quadrants.
+        /// </summary>
+        public IEnumerable<Quadrant> Children { get; private set; }
+
+        /// <summary>
+        /// The level of current quadrant. Top most has level 0, child quadrants has levels (Level + 1).
+        /// </summary>
+        public byte Level { get; }
+
+        /// <summary>
+        /// Minimum column included in this quadrant.
+        /// </summary>
+        public int MinimumColumn { get; }
+
+        /// <summary>
+        /// Minimun row included in this quadrant.
+        /// </summary>
+        public int MinimumRow { get; }
+
+        /// <summary>
+        /// Maximum column included in this quadrant.
+        /// </summary>
+        public int MaximumColumn { get; }
+
+        /// <summary>
+        /// Maximum row included in this quadrant.
+        /// </summary>
+        public int MaximumRow { get; }
+
+        /// <summary>
+        /// Collection of ranges belonging to this quadrant (does not include ranges from child quadrants).
+        /// </summary>
+        public IEnumerable<IXLRangeBase> Ranges
+        {
+            get => _ranges?.AsEnumerable();
+        }
+
+        /// <summary>
+        /// The number of current quadrant by horizontal axis.
+        /// </summary>
+        public short X { get; private set; }
+
+        /// <summary>
+        /// The number of current quadrant by vertical axis.
+        /// </summary>
+        public short Y { get; private set; }
+
+        #endregion Public Properties
+
+        #region Constructors
+
+        public Quadrant() : this(0, 0, 0)
+        { }
+
+        private Quadrant(byte level, short x, short y)
+        {
+            Level = level;
+            X = x;
+            Y = y;
+
+            MinimumColumn = (Level == 0) ? 1 : 1 + XLHelper.MaxColumnNumber / (int)Math.Pow(2, Level) * X;
+            MinimumRow = (Level == 0) ? 1 : 1 + XLHelper.MaxColumnNumber / (int)Math.Pow(2, Level) * Y; //MaxColumnNumber here is not a mistake
+            MaximumColumn = (Level == 0)
+                ? XLHelper.MaxColumnNumber
+                : XLHelper.MaxColumnNumber / (int)Math.Pow(2, Level) * (X + 1);
+            MaximumRow = (Level == 0)
+                ? XLHelper.MaxRowNumber
+                : XLHelper.MaxColumnNumber / (int)Math.Pow(2, Level) * (Y + 1); //MaxColumnNumber here is not a mistake
+        }
+
+        #endregion Constructors
+
+        #region Public Methods
+
+        /// <summary>
+        /// Add a range to the quadrant or to one of the child quadrants (recursively).
+        /// </summary>
+        /// <returns>True, if range was successfully added, false if it has been added before.</returns>
+        public bool Add(IXLRangeBase range)
+        {
+            bool res = false;
+            var children = Children ?? CreateChildren().ToList();
+            bool addToChild = false;
+            foreach (var childQuadrant in children)
+            {
+                var rangeAddress = range.RangeAddress;
+                if (childQuadrant.Covers(in rangeAddress))
+                {
+                    res |= childQuadrant.Add(range);
+                    addToChild = true;
+                    break;
+                }
+            }
+
+            if (!addToChild)
+                res = AddInternal(range);
+
+            if (Children == null && addToChild)
+                Children = children;
+
+            return res;
+        }
+
+        /// <summary>
+        /// Get all ranges from the quadrant and all child quadrants (recursively).
+        /// </summary>
+        public IEnumerable<IXLRangeBase> GetAll()
+        {
+            if (Ranges != null)
+            {
+                foreach (var range in Ranges)
+                    yield return range;
+            }
+
+            if (Children != null)
+            {
+                foreach (var childQuadrant in Children)
+                {
+                    var childRanges = childQuadrant.GetAll();
+                    foreach (var range in childRanges)
+                        yield return range;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get all ranges from the quadrant and all child quadrants (recursively) that intersect the specified address.
+        /// </summary>
+        public IEnumerable<IXLRangeBase> GetIntersectedRanges(IXLRangeAddress rangeAddress)
+        {
+            if (Ranges != null)
+            {
+                foreach (var range in Ranges)
+                {
+                    if (range.RangeAddress.Intersects(rangeAddress))
+                        yield return range;
+                }
+            }
+
+            if (Children != null)
+            {
+                foreach (var childQuadrant in Children)
+                {
+                    if (childQuadrant.Intersects(in rangeAddress))
+                    {
+                        var childRanges = childQuadrant.GetIntersectedRanges(rangeAddress);
+                        foreach (var range in childRanges)
+                            yield return range;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get all ranges from the quadrant and all child quadrants (recursively) that cover the specified address.
+        /// </summary>
+        public IEnumerable<IXLRangeBase> GetIntersectedRanges(IXLAddress address)
+        {
+            if (Ranges != null)
+            {
+                foreach (var range in Ranges)
+                {
+                    if (range.RangeAddress.Contains(address))
+                        yield return range;
+                }
+            }
+
+            if (Children != null)
+            {
+                foreach (var childQuadrant in Children)
+                {
+                    if (childQuadrant.Covers(in address))
+                    {
+                        var childRanges = childQuadrant.GetIntersectedRanges(address);
+                        foreach (var range in childRanges)
+                            yield return range;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove the range from the quadrant or from child quadrants (recursively).
+        /// </summary>
+        /// <returns>True if the range was removed, false if it does not exist in the QuadTree.</returns>
+        public bool Remove(IXLRangeBase range)
+        {
+            bool res = false;
+            var rangeAddress = range.RangeAddress;
+
+            bool coveredByChild = false;
+            if (Children != null)
+            {
+                foreach (var childQuadrant in Children)
+                {
+                    if (childQuadrant.Covers(in rangeAddress))
+                    {
+                        res |= childQuadrant.Remove(range);
+                        coveredByChild = true;
+                    }
+                }
+            }
+
+            if (!coveredByChild)
+            {
+                if (_ranges?.Remove(range) == true)
+                    res = true;
+            }
+
+            return res; ;
+        }
+
+        /// <summary>
+        /// Remove all the ranges matching specified criteria from the quadrant and its child quadrants (recursively).
+        /// Don't use it for searching intersections as it would be much less efficient than <see cref="GetIntersectedRanges(IXLRangeAddress)"/>.
+        /// </summary>
+        public IEnumerable<IXLRangeBase> RemoveAll(Predicate<IXLRangeBase> predicate)
+        {
+            if (_ranges != null)
+            {
+                var ranges = _ranges.Where(r => predicate(r));
+                foreach (var range in ranges)
+                {
+                    yield return range;
+                }
+                _ranges.RemoveWhere(predicate);
+            }
+
+            if (Children != null)
+            {
+                foreach (var childQuadrant in Children)
+                    foreach (var childRange in childQuadrant.RemoveAll(predicate))
+                    {
+                        yield return childRange;
+                    }
+            }
+        }
+
+        #endregion Public Methods
+
+        #region Private Fields
+
+        /// <summary>
+        /// Maximum depth of the QuadTree. Value 10 corresponds to the smallest quadrants having size 16*16 cells.
+        /// </summary>
+        private const byte MAX_LEVEL = 10;
+
+        /// <summary>
+        /// Collection of ranges belonging to the current quandrant (that cannot fit into child quadrants).
+        /// </summary>
+        private HashSet<IXLRangeBase> _ranges;
+
+        #endregion Private Fields
+
+        #region Private Methods
+
+        /// <summary>
+        /// Add a range to the collection of quandrant's own ranges.
+        /// </summary>
+        /// <returns>True if the range was succesfully added, false if it had been added before.</returns>
+        private bool AddInternal(IXLRangeBase range)
+        {
+            if (_ranges == null)
+                _ranges = new HashSet<IXLRangeBase>();
+            return _ranges.Add(range);
+        }
+
+        /// <summary>
+        /// Check if the current quadrant fully covers the specified address.
+        /// </summary>
+        private bool Covers(in IXLRangeAddress rangeAddress)
+        {
+            return MinimumColumn <= rangeAddress.FirstAddress.ColumnNumber &&
+                   MaximumColumn >= rangeAddress.LastAddress.ColumnNumber &&
+                   MinimumRow <= rangeAddress.FirstAddress.RowNumber &&
+                   MaximumRow >= rangeAddress.LastAddress.RowNumber;
+        }
+
+        /// <summary>
+        /// Check if the current quadrant covers the specified address.
+        /// </summary>
+        private bool Covers(in IXLAddress address)
+        {
+            return MinimumColumn <= address.ColumnNumber &&
+                   MaximumColumn >= address.ColumnNumber &&
+                   MinimumRow <= address.RowNumber &&
+                   MaximumRow >= address.RowNumber;
+        }
+
+        /// <summary>
+        /// Check if the current quadrant intersects the specified address.
+        /// </summary>
+        private bool Intersects(in IXLRangeAddress rangeAddress)
+        {
+            return ((MinimumRow <= rangeAddress.FirstAddress.RowNumber && rangeAddress.FirstAddress.RowNumber <= MaximumRow) ||
+                    (rangeAddress.FirstAddress.RowNumber <= MinimumRow && MinimumRow <= rangeAddress.LastAddress.RowNumber))
+                   &&
+                   ((MinimumColumn <= rangeAddress.FirstAddress.ColumnNumber && rangeAddress.FirstAddress.ColumnNumber <= MaximumColumn) ||
+                    (rangeAddress.FirstAddress.ColumnNumber <= MinimumColumn && MinimumColumn <= rangeAddress.LastAddress.ColumnNumber));
+        }
+
+        /// <summary>
+        /// Create a collection of child quadrants dividing the current one.
+        /// </summary>
+        private IEnumerable<Quadrant> CreateChildren()
+        {
+            byte childLevel = (byte)(Level + 1);
+            if (childLevel > MAX_LEVEL)
+                yield break;
+            byte xCount = 2; // Always divide on halfs
+            byte yCount = (byte)((Level == 0) ? (XLHelper.MaxRowNumber / XLHelper.MaxColumnNumber) : 2); // Level 0 divide onto 64 parts, the rest - on halfs
+
+            for (byte dy = 0; dy < yCount; dy++)
+            {
+                for (byte dx = 0; dx < xCount; dx++)
+                {
+                    yield return new Quadrant(childLevel, (short)(X * 2 + dx), (short)(Y * 2 + dy));
+                }
+            }
+        }
+
+        #endregion Private Methods
+    }
+}

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -43,5 +43,9 @@ namespace ClosedXML.Excel
         String ToStringRelative();
 
         String ToStringRelative(Boolean includeSheet);
+
+        bool Intersects(IXLRangeAddress otherAddress);
+
+        bool Contains(IXLAddress address);
     }
 }

--- a/ClosedXML/Excel/Ranges/IXLRanges.cs
+++ b/ClosedXML/Excel/Ranges/IXLRanges.cs
@@ -32,6 +32,19 @@ namespace ClosedXML.Excel
 
         Boolean Contains(IXLRange range);
 
+        /// <summary>
+        /// Filter ranges from a collection that intersect the specified address. Is much more efficient
+        /// that using Linq expression .Where().
+        /// </summary>
+        IEnumerable<IXLRange> GetIntersectedRanges(IXLRangeAddress rangeAddress);
+
+        /// <summary>
+        /// Filter ranges from a collection that intersect the specified address. Is much more efficient
+        /// that using Linq expression .Where().
+        /// </summary>
+        IEnumerable<IXLRange> GetIntersectedRanges(IXLAddress address);
+
+
         IXLStyle Style { get; set; }
 
         IXLDataValidation SetDataValidation();

--- a/ClosedXML/Excel/Ranges/Index/IXLRangeIndex.cs
+++ b/ClosedXML/Excel/Ranges/Index/IXLRangeIndex.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.Ranges.Index
+{
+    /// <summary>
+    /// Interface for the engine aimed to speed-up the search for the range intersections.
+    /// </summary>
+    internal interface IXLRangeIndex
+    {
+        bool Add(IXLRangeBase range);
+
+        bool Remove(IXLRangeBase range);
+
+        int RemoveAll(Predicate<IXLRangeBase> predicate = null);
+
+        IEnumerable<IXLRangeBase> GetIntersectedRanges(XLRangeAddress rangeAddress);
+
+        IEnumerable<IXLRangeBase> GetIntersectedRanges(XLAddress address);
+
+        IEnumerable<IXLRangeBase> GetAll();
+
+        bool Intersects(in XLRangeAddress rangeAddress);
+
+        bool Contains(in XLAddress address);
+    }
+
+    internal interface IXLRangeIndex<T> : IXLRangeIndex
+        where T : IXLRangeBase
+    {
+        bool Add(T range);
+
+        bool Remove(T range);
+
+        int RemoveAll(Predicate<T> predicate = null);
+
+        new IEnumerable<T> GetIntersectedRanges(XLRangeAddress rangeAddress);
+
+        new IEnumerable<T> GetIntersectedRanges(XLAddress address);
+
+        new IEnumerable<T> GetAll();
+    }
+}

--- a/ClosedXML/Excel/Ranges/Index/XLRangeIndex.cs
+++ b/ClosedXML/Excel/Ranges/Index/XLRangeIndex.cs
@@ -1,0 +1,144 @@
+﻿using ClosedXML.Excel.Patterns;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.Ranges.Index
+{
+    /// <summary>
+    /// Implementation of <see cref="IXLRangeIndex"/> internally using QuadTree.
+    /// </summary>
+    internal class XLRangeIndex : IXLRangeIndex
+    {
+        #region Public Constructors
+
+        public XLRangeIndex(IXLWorksheet worksheet)
+        {
+            _worksheet = worksheet;
+            _quadTree = new Quadrant();
+        }
+
+        #endregion Public Constructors
+
+        #region Public Methods
+
+        public bool Add(IXLRangeBase range)
+        {
+            if (range == null)
+                throw new ArgumentNullException(nameof(range));
+
+            if (!range.RangeAddress.IsValid)
+                throw new ArgumentException("Range is invalid");
+
+            CheckWorksheet(range.Worksheet);
+
+            return _quadTree.Add(range);
+        }
+
+        public bool Contains(in XLAddress address)
+        {
+            CheckWorksheet(address.Worksheet);
+            return _quadTree.GetIntersectedRanges(address).Any();
+        }
+
+        public bool Intersects(in XLRangeAddress rangeAddress)
+        {
+            CheckWorksheet(rangeAddress.Worksheet);
+            return _quadTree.GetIntersectedRanges(rangeAddress).Any();
+        }
+
+        public bool Remove(IXLRangeBase range)
+        {
+            if (range == null)
+                throw new ArgumentNullException(nameof(range));
+
+            CheckWorksheet(range.Worksheet);
+
+            return _quadTree.Remove(range);
+        }
+
+        public int RemoveAll(Predicate<IXLRangeBase> predicate = null)
+        {
+            return _quadTree.RemoveAll(predicate ?? (_ => true)).Count();
+        }
+
+        public IEnumerable<IXLRangeBase> GetAll()
+        {
+            return _quadTree.GetAll();
+        }
+
+        public IEnumerable<IXLRangeBase> GetIntersectedRanges(XLRangeAddress rangeAddress)
+        {
+            CheckWorksheet(rangeAddress.Worksheet);
+
+            return _quadTree.GetIntersectedRanges(rangeAddress);
+        }
+
+        public IEnumerable<IXLRangeBase> GetIntersectedRanges(XLAddress address)
+        {
+            CheckWorksheet(address.Worksheet);
+
+            return _quadTree.GetIntersectedRanges(address);
+        }
+
+        #endregion Public Methods
+
+        #region Private Fields
+
+        private readonly Quadrant _quadTree;
+        private readonly IXLWorksheet _worksheet;
+
+        #endregion Private Fields
+
+        #region Private Methods
+
+        private void CheckWorksheet(IXLWorksheet worksheet)
+        {
+            if (worksheet != _worksheet)
+                throw new ArgumentException("Range belongs to a different worksheet");
+        }
+
+        #endregion Private Methods
+    }
+
+    /// <summary>
+    /// Generic version of <see cref="XLRangeIndex"/>.
+    /// </summary>
+    internal class XLRangeIndex<T> : XLRangeIndex, IXLRangeIndex<T>
+        where T : IXLRangeBase
+    {
+        public XLRangeIndex(IXLWorksheet worksheet) : base(worksheet)
+        {
+        }
+
+        public bool Add(T range)
+        {
+            return base.Add(range);
+        }
+
+        public bool Remove(T range)
+        {
+            return base.Remove(range);
+        }
+
+        public int RemoveAll(Predicate<T> predicate)
+        {
+            return base.RemoveAll(r => predicate((T)r));
+        }
+
+        public new IEnumerable<T> GetIntersectedRanges(XLRangeAddress rangeAddress)
+        {
+            return base.GetIntersectedRanges(rangeAddress).Cast<T>();
+        }
+
+        public new IEnumerable<T> GetIntersectedRanges(XLAddress address)
+        {
+            return base.GetIntersectedRanges(address).Cast<T>();
+        }
+
+        public new IEnumerable<T> GetAll()
+        {
+            return base.GetAll().Cast<T>();
+        }
+    }
+}

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -194,6 +194,36 @@ namespace ClosedXML.Excel
                     LastAddress.ToStringRelative());
         }
 
+        public bool Intersects(IXLRangeAddress otherAddress)
+        {
+            var xlOtherAddress = (XLRangeAddress) otherAddress;
+            return Intersects(in xlOtherAddress);
+        }
+
+        internal bool Intersects(in XLRangeAddress otherAddress)
+        {
+            return !( // See if the two ranges intersect...
+                       otherAddress.FirstAddress.ColumnNumber > LastAddress.ColumnNumber
+                    || otherAddress.LastAddress.ColumnNumber < FirstAddress.ColumnNumber
+                    || otherAddress.FirstAddress.RowNumber > LastAddress.RowNumber
+                    || otherAddress.LastAddress.RowNumber < FirstAddress.RowNumber
+                );
+        }
+
+        public bool Contains(IXLAddress address)
+        {
+            var xlAddress = (XLAddress)address;
+            return Contains(in xlAddress);
+        }
+
+        internal bool Contains(in XLAddress address)
+        {
+            return FirstAddress.RowNumber <= address.RowNumber &&
+                   address.RowNumber <= LastAddress.RowNumber &&
+                   FirstAddress.ColumnNumber <= address.ColumnNumber &&
+                   address.ColumnNumber <= LastAddress.ColumnNumber;
+        }
+
         public String ToStringFixed(XLReferenceStyle referenceStyle)
         {
             return ToStringFixed(referenceStyle, false);

--- a/ClosedXML_Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML_Tests/Excel/Ranges/RangeIndexTest.cs
@@ -1,0 +1,270 @@
+﻿using ClosedXML.Excel;
+using ClosedXML.Excel.Patterns;
+using ClosedXML.Excel.Ranges.Index;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.Ranges
+{
+    [TestFixture]
+    public class RangeIndexTest
+    {
+        private const int TEST_COUNT = 10000;
+
+        [Test]
+        public void FindExistingMatches()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                for (int i = 1; i <= TEST_COUNT; i++)
+                {
+                    for (int j = 2; j <= 4; j++)
+                    {
+                        var address = new XLAddress(ws, i * 2, j, false, false);
+                        Assert.True(index.Contains(in address));
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void FindNonExistingMatches()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                for (int i = 1; i <= TEST_COUNT; i++)
+                {
+                    var address = new XLAddress(ws, i * 2 + 1, 3, false, false);
+                    Assert.False(index.Contains(in address));
+                }
+            }
+        }
+
+        [Test]
+        public void FindExistingIntersections()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                for (int i = 1; i <= TEST_COUNT; i++)
+                {
+                    var rangeAddress = new XLRangeAddress(
+                        new XLAddress(ws, i * 2, 1 + i % 4, false, false),
+                        new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
+
+                    Assert.True(index.Intersects(in rangeAddress));
+                }
+
+                for (int i = 2; i < 4; i++)
+                {
+                    var columnAddress = XLRangeAddress.EntireColumn(ws, i);
+                    Assert.True(index.Intersects(in columnAddress));
+                }
+            }
+        }
+
+        [Test]
+        public void FindNonExistingIntersections()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                for (int i = 1; i <= TEST_COUNT; i++)
+                {
+                    var rangeAddress = new XLRangeAddress(
+                        new XLAddress(ws, i * 2 + 1, 1 + i % 4, false, false),
+                        new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
+
+                    Assert.False(index.Intersects(in rangeAddress));
+                }
+
+                var columnAddress = XLRangeAddress.EntireColumn(ws, 1);
+                Assert.False(index.Intersects(in columnAddress));
+                columnAddress = XLRangeAddress.EntireColumn(ws, 5);
+                Assert.False(index.Intersects(in columnAddress));
+            }
+        }
+
+        [Test]
+        public void FindMatchAfterColumnShifting()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                ws.Column(3).InsertColumnsBefore(2);
+
+                var address = new XLAddress(ws, 102, 6, false, false);
+
+                Assert.True(index.Contains(in address));
+            }
+        }
+
+        [Test]
+        public void FindIntersectionsAfterColumnShifting()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                ws.Column(3).InsertColumnsBefore(2);
+
+                var rangeAddress = new XLRangeAddress(ws, "F102:E103");
+
+                Assert.True(index.Intersects(in rangeAddress));
+            }
+        }
+
+        [Test]
+        public void FindMatchAfterRowShifting()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                ws.Row(10).InsertRowsBelow(3);
+
+                var address = new XLAddress(ws, 103, 4, false, false);
+
+                Assert.True(index.Contains(in address));
+            }
+        }
+
+        [Test]
+        public void FindIntersectionsAfterRowShifting()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var index = FillIndexWithTestData(ws);
+
+                ws.Row(10).InsertRowsBelow(3);
+
+                var rangeAddress = new XLRangeAddress(ws, "C103:E103");
+
+                Assert.True(index.Intersects(in rangeAddress));
+            }
+        }
+
+        [Test]
+        public void CreateQuadTree()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var quadTree = new Quadrant();
+                var range = ws.Range("BT76:CA87");
+
+                quadTree.Add(range);
+
+                var level0 = quadTree;
+                Assert.AreEqual(1, level0.MinimumColumn);
+                Assert.AreEqual(XLHelper.MaxColumnNumber, level0.MaximumColumn);
+                Assert.AreEqual(1, level0.MinimumRow);
+                Assert.AreEqual(XLHelper.MaxRowNumber, level0.MaximumRow);
+                Assert.IsNull(level0.Ranges);
+                Assert.AreEqual(128, level0.Children.Count());
+                Assert.True(level0.Children.All(child => child.Level == 1));
+                Assert.AreEqual(64, level0.Children.Count(child =>
+                    child.MinimumColumn == 1 &&
+                    child.MaximumColumn == 8192 &&
+                    child.X == 0));
+                Assert.AreEqual(64, level0.Children.Count(child =>
+                    child.MinimumColumn == 8193 &&
+                    child.MaximumColumn == 16384 &&
+                    child.X == 1));
+                Assert.AreEqual(2, level0.Children.Count(child =>
+                    child.MinimumRow == 1 &&
+                    child.MaximumRow == 8192 &&
+                    child.Y == 0));
+                Assert.AreEqual(2, level0.Children.Count(child =>
+                    child.MinimumRow == 16385 &&
+                    child.MaximumRow == 24576 &&
+                    child.Y == 2));
+
+                Assert.True(level0.Children.ElementAt(0).Children.Any());
+                Assert.True(level0.Children.Skip(1).All(child => child.Children == null));
+
+                var level8 = level0
+                    .Children.First() // 1
+                    .Children.First() // 2
+                    .Children.First() // 3
+                    .Children.First() // 4
+                    .Children.First() // 5
+                    .Children.First() // 6
+                    .Children.First() // 7
+                    .Children.Last(); // 8
+
+                Assert.AreEqual(65, level8.MinimumColumn);
+                Assert.AreEqual(65, level8.MinimumRow);
+                Assert.AreEqual(128, level8.MaximumColumn);
+                Assert.AreEqual(128, level8.MaximumRow);
+
+                var level9 = level8.Children.First();
+                Assert.NotNull(level9.Ranges);
+                Assert.AreEqual(range, level9.Ranges.Single());
+            }
+        }
+
+        [Test]
+        public void XLRangesCountChangesCorrectly()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+                var range1 = ws.Range("A1:B2");
+                var range2 = ws.Range("A2:B3");
+                var range3 = ws.Range("A1:B2"); // same as range1
+
+                var ranges = new XLRanges();
+                ranges.Add(range1);
+                Assert.AreEqual(1, ranges.Count);
+                ranges.Add(range2);
+                Assert.AreEqual(2, ranges.Count);
+                ranges.Add(range3);
+                Assert.AreEqual(2, ranges.Count);
+
+                Assert.AreEqual(ranges.Count, ranges.Count());
+
+                ranges.Remove(range3);
+                Assert.AreEqual(1, ranges.Count);
+                ranges.Remove(range2);
+                Assert.AreEqual(0, ranges.Count);
+                ranges.Remove(range1);
+                Assert.AreEqual(0, ranges.Count);
+            }
+        }
+
+        private IXLRangeIndex CreateRangeIndex(IXLWorksheet worksheet)
+        {
+            return new XLRangeIndex((XLWorksheet)worksheet);
+        }
+
+        private IXLRangeIndex FillIndexWithTestData(IXLWorksheet worksheet)
+        {
+            var ranges = new List<IXLRange>();
+            for (int i = 1; i <= TEST_COUNT; i++)
+            {
+                ranges.Add(worksheet.Range(i * 2, 2, i * 2, 4));
+            }
+
+            var index = CreateRangeIndex(worksheet);
+            ranges.ForEach(r => index.Add(r));
+            return index;
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/Ranges/RangesConsolidationTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/RangesConsolidationTests.cs
@@ -47,7 +47,11 @@ namespace ClosedXML_Tests.Excel.Ranges
             ranges.Add(ws.Column("F"));
             ranges.Add(ws.Column("E"));
 
-            var consRanges = ranges.Consolidate().ToList();
+            var consRanges = ranges.Consolidate()
+                .OrderBy(r => r.Worksheet.Name)
+                .ThenBy(r => r.RangeAddress.FirstAddress.RowNumber)
+                .ThenBy(r => r.RangeAddress.FirstAddress.ColumnNumber)
+                .ToList();
 
             Assert.AreEqual(3, consRanges.Count);
             Assert.AreEqual("D1:F1048576", consRanges[0].RangeAddress.ToString());
@@ -80,7 +84,11 @@ namespace ClosedXML_Tests.Excel.Ranges
             ranges.Add(ws1.Range("I9:I13"));
             ranges.Add(ws1.Range("C4:D5"));
             
-            var consRanges = ranges.Consolidate().ToList();
+            var consRanges = ranges.Consolidate()
+                .OrderBy(r => r.Worksheet.Name)
+                .ThenBy(r => r.RangeAddress.FirstAddress.RowNumber)
+                .ThenBy(r => r.RangeAddress.FirstAddress.ColumnNumber)
+                .ToList();
 
             Assert.AreEqual(9, consRanges.Count);
             Assert.AreEqual("Sheet1!$A$1:$E$9", consRanges[0].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));


### PR DESCRIPTION
This is an alternative way to fix #796 (depends on #766, that's why so many changes in here). 
This fixes #792 accidentally too :). 

The solution @crypto-rsa has prepared is fine but, in my opinion, is too specific, since it addresses only issues with merged ranges. 

In this PR I define as interface `IXLRangeIndex` aimed to improve the performance of selecting intersecting ranges from the `XLRanges` collection. The implementation of this interface internally uses a [QuadTree](https://en.wikipedia.org/wiki/Quadtree) that splits entire worksheet to the squares from 16384×16384 at level 1 to 16×16 at level 10. To see how much performance is affected I prepared a few tests with 20000 merged ranges where I check if the target address hits in these ranges for 20000 times. With the default implementation that we used before it took minutes to execute. Now each of these tests takes around one second or even less. *(In the final commit I decreased the number of repetitions to 10000 for not slowing down the entire test suite).*

As for the original example from #796, it finishes in approximately 0.5 seconds.