### PR TITLE
Add and implement XLNamedRangeScope

### DIFF
--- a/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace ClosedXML.Excel
 {
+    public enum XLNamedRangeScope
+    {
+        Worksheet,
+        Workbook
+    }
+
     public interface IXLNamedRange
     {
         /// <summary>
@@ -33,6 +39,11 @@ namespace ClosedXML.Excel
         ///   <c>true</c> if visible; otherwise, <c>false</c>.
         /// </value>
         Boolean Visible { get; set; }
+
+        /// <summary>
+        /// Gets the scope of this named range.
+        /// </summary>
+        XLNamedRangeScope Scope { get; }
 
         /// <summary>
         /// Adds the specified range to this named range.

--- a/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
@@ -53,6 +53,8 @@ namespace ClosedXML.Excel
 
         public Boolean Visible { get; set; }
 
+        public XLNamedRangeScope Scope { get { return _namedRanges.Scope; } }
+
         public IXLRanges Add(XLWorkbook workbook, String rangeAddress)
         {
             var ranges = new XLRanges();

--- a/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -36,6 +36,10 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual("Sheet1!$C$3,Sheet1!$C$4:$D$4,Sheet2!$D$3:$D$4,Sheet1!$7:$8,Sheet1!$G:$H",
                 sheet1.NamedRanges.First().RefersTo);
             Assert.AreEqual("Sheet1!B2,Sheet2!A1", sheet2.NamedRanges.First().RefersTo);
+
+            wb.NamedRanges.ForEach(nr => Assert.AreEqual(XLNamedRangeScope.Workbook, nr.Scope));
+            sheet1.NamedRanges.ForEach(nr => Assert.AreEqual(XLNamedRangeScope.Worksheet, nr.Scope));
+            sheet2.NamedRanges.ForEach(nr => Assert.AreEqual(XLNamedRangeScope.Worksheet, nr.Scope));
         }
 
         [Test]
@@ -54,6 +58,7 @@ namespace ClosedXML_Tests.Excel
             Boolean result1 = wb.NamedRanges.TryGetValue("Sheet1!Name", out IXLNamedRange range1);
             Assert.IsTrue(result1);
             Assert.IsNotNull(range1);
+            Assert.AreEqual(XLNamedRangeScope.Worksheet, range1.Scope);
 
             Boolean result2 = wb.NamedRanges.TryGetValue("Sheet1!NameX", out IXLNamedRange range2);
             Assert.IsFalse(result2);


### PR DESCRIPTION
Named Ranges can be at Worksheet or Workbook scope. Currently we use private properties and check for `Worksheet == null` to deduce the scope. This is a more explicit implementation.