### PR TITLE
Template fix

### DIFF
--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -474,12 +474,16 @@ namespace ClosedXML.Excel
             switch (extension)
             {
                 case "xlsm":
-                case "xltm":
                     return SpreadsheetDocumentType.MacroEnabledWorkbook;
 
+                case "xltm":
+                    return SpreadsheetDocumentType.MacroEnabledTemplate;
+
                 case "xlsx":
-                case "xltx":
                     return SpreadsheetDocumentType.Workbook;
+
+                case "xltx":
+                    return SpreadsheetDocumentType.Template;
 
                 default:
                     throw new ArgumentException(String.Format("Extension '{0}' is not supported. Supported extensions are '.xlsx', '.xslm', '.xltx' and '.xltm'.", extension));

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -1,6 +1,8 @@
 using ClosedXML.Excel;
 using ClosedXML.Excel.Drawings;
 using ClosedXML_Tests.Utils;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 using NUnit.Framework;
 using System;
 using System.Drawing;
@@ -9,8 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Packaging;
 
 namespace ClosedXML_Tests.Excel.Saving
 {

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
 
 namespace ClosedXML_Tests.Excel.Saving
 {
@@ -339,6 +341,28 @@ namespace ClosedXML_Tests.Excel.Saving
 
                 return wb;
             }, @"Other\Drawings\NoDrawings\outputfile.xlsx");
+        }
+
+        [Test]
+        [TestCase("xlsx", SpreadsheetDocumentType.Workbook)]
+        [TestCase("xlsm", SpreadsheetDocumentType.MacroEnabledWorkbook)]
+        [TestCase("xltx", SpreadsheetDocumentType.Template)]
+        [TestCase("xltm", SpreadsheetDocumentType.MacroEnabledTemplate)]
+        public void SavesAsProperSpreadsheetDocumentType(string extension, SpreadsheetDocumentType expectedType)
+        {
+            using (var tf = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), extension)))
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    wb.Worksheets.Add("Sheet1");
+                    wb.SaveAs(tf.Path);
+                }
+
+                using (var package = SpreadsheetDocument.Open(tf.Path, false))
+                {
+                    Assert.AreEqual(expectedType, package.DocumentType);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes saving as .xltx and .xltm files. #267 

The `SpreadsheetDocumentType` was not being set correctly for these file types, and Excel would not open them.