### PR TITLE
Fix determining the FirstColumnUsed

### DIFF
--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -212,22 +212,28 @@ namespace ClosedXML.Excel
         {
             int finalRow = rowEnd > MaxRowUsed ? MaxRowUsed : rowEnd;
             int finalColumn = columnEnd > MaxColumnUsed ? MaxColumnUsed : columnEnd;
+            int firstColumnUsed = finalColumn;
+            var found = false;
             for (int ro = rowStart; ro <= finalRow; ro++)
             {
                 if (rowsCollection.TryGetValue(ro, out Dictionary<Int32, XLCell> columnsCollection))
                 {
-                    for (int co = columnStart; co <= finalColumn; co++)
+                    for (int co = columnStart; co <= firstColumnUsed; co++)
                     {
                         if (columnsCollection.TryGetValue(co, out XLCell cell)
                             && !cell.IsEmpty(includeFormats)
-                            && (predicate == null || predicate(cell)))
-
-                            return co;
+                            && (predicate == null || predicate(cell))
+                            && co <= firstColumnUsed)
+                        {
+                            firstColumnUsed = co;
+                            found = true;
+                            break;
+                        }
                     }
                 }
             }
 
-            return 0;
+            return found ? firstColumnUsed : 0;
         }
 
         public int LastRowUsed(int rowStart, int columnStart, int rowEnd, int columnEnd, Boolean includeFormats, Func<IXLCell, Boolean> predicate = null)

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -129,5 +129,21 @@ namespace ClosedXML_Tests.Excel.Ranges
             }
             Assert.AreEqual(15, i);
         }
+
+        [Test]
+        public void GetCellsUsedNonRectangular()
+        {
+            using (XLWorkbook wb = new XLWorkbook())
+            {
+                var sheet = wb.AddWorksheet("page1");
+
+                sheet.Range("C1:E1").Value = "row1";
+                sheet.Range("A2:E2").Value = "row2";
+
+                var used = sheet.RangeUsed().RangeAddress.ToString(XLReferenceStyle.A1);
+
+                Assert.AreEqual("A1:E2", used);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #339 
I can't believe it has not been unfixed for so long!

The original algorithm failed in cases like this:
```
| | |1|
| |1|1|
|1|1|1|
```