### PR TITLE
Get cell by full address

### DIFF
--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -353,12 +353,24 @@ namespace ClosedXML.Excel
             if (!rangeAddress.Contains('!')) return null;
 
             var split = rangeAddress.Split('!');
-            var first = split[0];
-            var wsName = first.StartsWith("'") ? first.Substring(1, first.Length - 2) : first;
-            var localRange = split[1];
+            var wsName = split[0].UnescapeSheetName();
             if (TryGetWorksheet(wsName, out ws))
             {
-                return ws.Range(localRange);
+                return ws.Range(split[1]);
+            }
+            return null;
+        }
+
+        public IXLCell CellFromFullAddress(String cellAddress, out IXLWorksheet ws)
+        {
+            ws = null;
+            if (!cellAddress.Contains('!')) return null;
+
+            var split = cellAddress.Split('!');
+            var wsName = split[0].UnescapeSheetName();
+            if (TryGetWorksheet(wsName, out ws))
+            {
+                return ws.Cell(split[1]);
             }
             return null;
         }
@@ -752,10 +764,12 @@ namespace ClosedXML.Excel
         public IXLCell Cell(String namedCell)
         {
             var namedRange = NamedRange(namedCell);
-            if (namedRange == null) return null;
-            var range = namedRange.Ranges.FirstOrDefault();
-            if (range == null) return null;
-            return range.FirstCell();
+            if (namedRange != null)
+            {
+                return namedRange.Ranges?.FirstOrDefault()?.FirstCell();
+            }
+            else
+                return CellFromFullAddress(namedCell, out _);
         }
 
         public IXLCells Cells(String namedCells)
@@ -769,7 +783,7 @@ namespace ClosedXML.Excel
             if (namedRange != null)
                 return namedRange.Ranges.FirstOrDefault();
             else
-                return RangeFromFullAddress(range, out IXLWorksheet ws);
+                return RangeFromFullAddress(range, out _);
         }
 
         public IXLRanges Ranges(String ranges)

--- a/ClosedXML_Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XLWorkbookTests.cs
@@ -79,14 +79,22 @@ namespace ClosedXML_Tests.Excel
         {
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            IXLWorksheet ws2 = wb.AddWorksheet("O'Sheet 2");
             var c1 = ws.Cell("C123");
+            var c2 = ws2.Cell("B7");
 
-            var c2 = wb.Cell("Sheet1!C123");
+            var c1_full = wb.Cell("Sheet1!C123");
+            var c2_full = wb.Cell("'O'Sheet 2'!B7");
 
-            Assert.AreSame(c1, c2);
-            Assert.NotNull(c2);
+            Assert.AreSame(c1, c1_full);
+            Assert.AreSame(c2, c2_full);
+            Assert.NotNull(c1_full);
+            Assert.NotNull(c2_full);
         }
 
+        [TestCase("Sheet1")]
+        [TestCase("Sheet1!")]
+        [TestCase("Sheet2!")]
         [TestCase("Sheet2!C1")]
         [TestCase("Sheet1!ZZZ1")]
         [TestCase("Sheet1!A")]

--- a/ClosedXML_Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XLWorkbookTests.cs
@@ -75,6 +75,46 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
+        public void GetCellFromFullAddress()
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            var c1 = ws.Cell("C123");
+
+            var c2 = wb.Cell("Sheet1!C123");
+
+            Assert.AreSame(c1, c2);
+            Assert.NotNull(c2);
+        }
+
+        [Test]
+        public void GetRangeFromFullAddress()
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            var r1 = ws.Range("C123:D125");
+
+            var r2 = wb.Range("Sheet1!C123:D125");
+
+            Assert.AreSame(r1, r2);
+            Assert.NotNull(r2);
+        }
+
+        [Test]
+        public void GetRangesFromFullAddress()
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            var r1 = ws.Ranges("A1:B2,C1:E3");
+
+            var r2 = wb.Ranges("Sheet1!A1:B2,Sheet1!C1:E3");
+
+            Assert.AreEqual(2, r2.Count);
+            Assert.AreSame(r1.First(), r2.First());
+            Assert.AreSame(r1.Last(), r2.Last());
+        }
+
+        [Test]
         public void NamedRange1()
         {
             var wb = new XLWorkbook();

--- a/ClosedXML_Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XLWorkbookTests.cs
@@ -87,6 +87,19 @@ namespace ClosedXML_Tests.Excel
             Assert.NotNull(c2);
         }
 
+        [TestCase("Sheet2!C1")]
+        [TestCase("Sheet1!ZZZ1")]
+        [TestCase("Sheet1!A")]
+        public void GetCellFromNonExistingFullAddress(string address)
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+
+            var c = wb.Cell(address);
+
+            Assert.IsNull(c);
+        }
+
         [Test]
         public void GetRangeFromFullAddress()
         {
@@ -98,6 +111,18 @@ namespace ClosedXML_Tests.Excel
 
             Assert.AreSame(r1, r2);
             Assert.NotNull(r2);
+        }
+
+        [TestCase("Sheet2!C1:D2")]
+        [TestCase("Sheet1!A")]
+        public void GetRangeFromNonExistingFullAddress(string rangeAddress)
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+
+            var r = wb.Range(rangeAddress);
+
+            Assert.IsNull(r);
         }
 
         [Test]
@@ -112,6 +137,20 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual(2, r2.Count);
             Assert.AreSame(r1.First(), r2.First());
             Assert.AreSame(r1.Last(), r2.Last());
+        }
+
+
+        [TestCase("Sheet2!C1:D2,Sheet2!F1:G4")]
+        [TestCase("Sheet1!A,Sheet1!B")]
+        public void GetRangesFromNonExistingFullAddress(string rangesAddress)
+        {
+            var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+
+            var r = wb.Ranges(rangesAddress);
+
+            Assert.NotNull(r);
+            Assert.False(r.Any());
         }
 
         [Test]


### PR DESCRIPTION
As revealed in #824, the cell cannot be accessed by its full address. E.g.
```
wb.Range("Sheet1!A1:B2");               // returns range
wb.Ranges("Sheet1!A1:B2,Sheet1!C1:E3"); // returns a collection of ranges
wb.Cell("Sheet1!C123");                 // returns null
```

In method `Cell()` we only searched for named ranges, not parsing the cell address.
This PR fixes this and adds a few unit tests for all these methods.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer