### PR TITLE
Fix issues with copying worksheets across workbooks

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -2308,7 +2308,7 @@ namespace ClosedXML.Excel
 
         public IXLCell CopyFrom(IXLCell otherCell, Boolean copyDataValidations)
         {
-            return CopyFrom(otherCell, copyDataValidations, copyConditionalFormats : true);
+            return CopyFrom(otherCell, copyDataValidations, copyConditionalFormats: true);
         }
 
         public IXLCell CopyFrom(IXLCell otherCell, Boolean copyDataValidations, bool copyConditionalFormats)

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -2308,23 +2308,32 @@ namespace ClosedXML.Excel
 
         public IXLCell CopyFrom(IXLCell otherCell, Boolean copyDataValidations)
         {
+            return CopyFrom(otherCell, copyDataValidations, copyConditionalFormats : true);
+        }
+
+        public IXLCell CopyFrom(IXLCell otherCell, Boolean copyDataValidations, bool copyConditionalFormats)
+        {
             var source = otherCell as XLCell; // To expose GetFormulaR1C1, etc
 
             CopyFromInternal(source, copyDataValidations);
 
-            var conditionalFormats = source.Worksheet.ConditionalFormats.Where(c => c.Ranges.Any(range => range.Contains(source))).ToList();
-            foreach (var cf in conditionalFormats)
+            if (copyConditionalFormats)
             {
-                if (source.Worksheet == Worksheet)
+                var conditionalFormats = source.Worksheet.ConditionalFormats
+                    .Where(c => c.Ranges.Any(range => range.Contains(source))).ToList();
+                foreach (var cf in conditionalFormats)
                 {
-                    if (!cf.Ranges.Any(range => range.Contains(this)))
+                    if (source.Worksheet == Worksheet)
                     {
-                        cf.Ranges.Add(this);
+                        if (!cf.Ranges.Any(range => range.Contains(this)))
+                        {
+                            cf.Ranges.Add(this);
+                        }
                     }
-                }
-                else
-                {
-                    CopyConditionalFormatsFrom(source.AsRange());
+                    else
+                    {
+                        CopyConditionalFormatsFrom(source.AsRange());
+                    }
                 }
             }
 

--- a/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
@@ -171,7 +171,5 @@ namespace ClosedXML.Excel
         IXLConditionalFormat SetStopIfTrue();
 
         IXLConditionalFormat SetStopIfTrue(Boolean value);
-
-        IXLConditionalFormat CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
@@ -134,27 +134,44 @@ namespace ClosedXML.Excel
         IXLCFIconSet IconSet(XLIconSetStyle iconSetStyle, Boolean reverseIconOrder = false, Boolean showIconOnly = false);
 
         XLConditionalFormatType ConditionalFormatType { get; }
+
         XLIconSetStyle IconSetStyle { get; }
+
         XLTimePeriod TimePeriod { get; }
+
         Boolean ReverseIconOrder { get; }
+
         Boolean ShowIconOnly { get; }
+
         Boolean ShowBarOnly { get; }
+
         Boolean StopIfTrue { get; }
+
         /// <summary>
         /// The first of the <see cref="Ranges"/>.
         /// </summary>
         IXLRange Range { get; set; }
+
         IXLRanges Ranges { get; }
+
         XLDictionary<XLFormula> Values { get; }
+
         XLDictionary<XLColor> Colors { get; }
+
         XLDictionary<XLCFContentType> ContentTypes { get; }
+
         XLDictionary<XLCFIconSetOperator> IconSetOperators { get; }
 
         XLCFOperator Operator { get; }
+
         Boolean Bottom { get; }
+
         Boolean Percent { get; }
 
         IXLConditionalFormat SetStopIfTrue();
+
         IXLConditionalFormat SetStopIfTrue(Boolean value);
+
+        IXLConditionalFormat CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
@@ -171,5 +171,7 @@ namespace ClosedXML.Excel
         IXLConditionalFormat SetStopIfTrue();
 
         IXLConditionalFormat SetStopIfTrue(Boolean value);
+
+        IXLConditionalFormat CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -149,17 +149,7 @@ namespace ClosedXML.Excel
         {
             if (targetRange != null)
                 Ranges.Add(targetRange);
-
-            ConditionalFormatType = conditionalFormat.ConditionalFormatType;
-            TimePeriod = conditionalFormat.TimePeriod;
-            IconSetStyle = conditionalFormat.IconSetStyle;
-            Operator = conditionalFormat.Operator;
-            Bottom = conditionalFormat.Bottom;
-            Percent = conditionalFormat.Percent;
-            ReverseIconOrder = conditionalFormat.ReverseIconOrder;
-            ShowIconOnly = conditionalFormat.ShowIconOnly;
-            ShowBarOnly = conditionalFormat.ShowBarOnly;
-            StopIfTrue = OpenXmlHelper.GetBooleanValueAsBool(conditionalFormat.StopIfTrue, true);
+            CopyFrom(conditionalFormat);
         }
         #endregion Constructors
 
@@ -220,6 +210,19 @@ namespace ClosedXML.Excel
         {
             this.StopIfTrue = value;
             return this;
+        }
+
+        public IXLConditionalFormat CopyTo(IXLWorksheet targetSheet)
+        {
+            var targetRange = targetSheet.Range(Range.RangeAddress.WithoutWorksheet());
+            var newCf = new XLConditionalFormat(this, targetRange);
+            if (Ranges.Count > 1)
+            {
+                Ranges.Skip(1).ForEach(r => newCf.Ranges.Add(targetSheet.Range(r.RangeAddress)));
+            }
+
+            targetSheet.ConditionalFormats.Add(newCf);
+            return newCf;
         }
 
         public void CopyFrom(IXLConditionalFormat other)

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -234,7 +234,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        internal IXLConditionalFormat CopyTo(IXLWorksheet targetSheet)
+        public IXLConditionalFormat CopyTo(IXLWorksheet targetSheet)
         {
             if (targetSheet == Range?.Worksheet)
                 throw new InvalidOperationException("Cannot copy conditional format to the worksheet it already belongs to.");

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using ClosedXML.Utils;
 
 namespace ClosedXML.Excel
 {
@@ -22,14 +21,14 @@ namespace ClosedXML.Excel
 
             public bool Equals(IXLConditionalFormat x, IXLConditionalFormat y)
             {
-                var xx = (XLConditionalFormat) x;
-                var yy = (XLConditionalFormat) y;
+                var xx = (XLConditionalFormat)x;
+                var yy = (XLConditionalFormat)y;
                 if (ReferenceEquals(xx, yy)) return true;
                 if (ReferenceEquals(xx, null)) return false;
                 if (ReferenceEquals(yy, null)) return false;
                 if (xx.GetType() != yy.GetType()) return false;
 
-                var xxValues = xx.Values.Values.Where(v => !v.IsFormula).Select(v=>v.Value);
+                var xxValues = xx.Values.Values.Where(v => !v.IsFormula).Select(v => v.Value);
                 var yyValues = yy.Values.Values.Where(v => !v.IsFormula).Select(v => v.Value);
                 var xxFormulas = x.Ranges.Any() ? xx.Values.Values.Where(v => v.IsFormula).Select(f => ((XLCell)x.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
                 var yyFormulas = y.Ranges.Any() ? yy.Values.Values.Where(v => v.IsFormula).Select(f => ((XLCell)y.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
@@ -105,12 +104,14 @@ namespace ClosedXML.Excel
         }
 
         private static readonly IEqualityComparer<IXLConditionalFormat> FullComparerInstance = new FullEqualityComparer(true);
+
         public static IEqualityComparer<IXLConditionalFormat> FullComparer
         {
             get { return FullComparerInstance; }
         }
 
         private static readonly IEqualityComparer<IXLConditionalFormat> NoRangeComparerInstance = new FullEqualityComparer(false);
+
         public static IEqualityComparer<IXLConditionalFormat> NoRangeComparer
         {
             get { return NoRangeComparerInstance; }
@@ -145,16 +146,23 @@ namespace ClosedXML.Excel
         }
 
         public XLConditionalFormat(XLConditionalFormat conditionalFormat, IXLRange targetRange)
+            : this(conditionalFormat, new[] { targetRange })
+        {
+        }
+
+        public XLConditionalFormat(XLConditionalFormat conditionalFormat, IEnumerable<IXLRange> targetRanges)
             : this(conditionalFormat.StyleValue)
         {
-            if (targetRange != null)
-                Ranges.Add(targetRange);
+            targetRanges?.ForEach(range => Ranges.Add(range));
             CopyFrom(conditionalFormat);
         }
+
         #endregion Constructors
 
         public Guid Id { get; internal set; }
+
         internal Int32 OriginalPriority { get; set; }
+
         public Boolean CopyDefaultModify { get; set; }
 
         public override IEnumerable<IXLStyle> Styles
@@ -169,15 +177,18 @@ namespace ClosedXML.Excel
         {
             get { yield break; }
         }
-        
+
         public override IXLRanges RangesUsed
         {
             get { return new XLRanges(); }
         }
 
         public XLDictionary<XLFormula> Values { get; private set; }
+
         public XLDictionary<XLColor> Colors { get; private set; }
+
         public XLDictionary<XLCFContentType> ContentTypes { get; private set; }
+
         public XLDictionary<XLCFIconSetOperator> IconSetOperators { get; private set; }
 
         public IXLRange Range
@@ -189,16 +200,27 @@ namespace ClosedXML.Excel
                 Ranges.Add(value);
             }
         }
+
         public IXLRanges Ranges { get; private set; }
+
         public XLConditionalFormatType ConditionalFormatType { get; set; }
+
         public XLTimePeriod TimePeriod { get; set; }
+
         public XLIconSetStyle IconSetStyle { get; set; }
+
         public XLCFOperator Operator { get; set; }
+
         public Boolean Bottom { get; set; }
+
         public Boolean Percent { get; set; }
+
         public Boolean ReverseIconOrder { get; set; }
+
         public Boolean ShowIconOnly { get; set; }
+
         public Boolean ShowBarOnly { get; set; }
+
         public Boolean StopIfTrue { get; set; }
 
         public IXLConditionalFormat SetStopIfTrue()
@@ -206,21 +228,18 @@ namespace ClosedXML.Excel
             return SetStopIfTrue(true);
         }
 
-            public IXLConditionalFormat SetStopIfTrue(bool value)
+        public IXLConditionalFormat SetStopIfTrue(bool value)
         {
             this.StopIfTrue = value;
             return this;
         }
 
-        public IXLConditionalFormat CopyTo(IXLWorksheet targetSheet)
+        internal IXLConditionalFormat CopyTo(IXLWorksheet targetSheet)
         {
-            var targetRange = targetSheet.Range(Range.RangeAddress.WithoutWorksheet());
-            var newCf = new XLConditionalFormat(this, targetRange);
-            if (Ranges.Count > 1)
-            {
-                Ranges.Skip(1).ForEach(r => newCf.Ranges.Add(targetSheet.Range(r.RangeAddress)));
-            }
-
+            if (targetSheet == Range?.Worksheet)
+                throw new InvalidOperationException("Cannot copy conditional format to the worksheet it already belongs to.");
+            var targetRanges = Ranges.Select(r => targetSheet.Range(((XLRangeAddress)r.RangeAddress).WithoutWorksheet()));
+            var newCf = new XLConditionalFormat(this, targetRanges);
             targetSheet.ConditionalFormats.Add(newCf);
             return newCf;
         }
@@ -258,27 +277,32 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.IsBlank;
             return Style;
         }
+
         public IXLStyle WhenNotBlank()
         {
             ConditionalFormatType = XLConditionalFormatType.NotBlank;
             return Style;
         }
+
         public IXLStyle WhenIsError()
         {
             ConditionalFormatType = XLConditionalFormatType.IsError;
             return Style;
         }
+
         public IXLStyle WhenNotError()
         {
             ConditionalFormatType = XLConditionalFormatType.NotError;
             return Style;
         }
+
         public IXLStyle WhenDateIs(XLTimePeriod timePeriod)
         {
             TimePeriod = timePeriod;
             ConditionalFormatType = XLConditionalFormatType.TimePeriod;
             return Style;
         }
+
         public IXLStyle WhenContains(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -286,6 +310,7 @@ namespace ClosedXML.Excel
             Operator = XLCFOperator.Contains;
             return Style;
         }
+
         public IXLStyle WhenNotContains(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -293,6 +318,7 @@ namespace ClosedXML.Excel
             Operator = XLCFOperator.NotContains;
             return Style;
         }
+
         public IXLStyle WhenStartsWith(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -300,6 +326,7 @@ namespace ClosedXML.Excel
             Operator = XLCFOperator.StartsWith;
             return Style;
         }
+
         public IXLStyle WhenEndsWith(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -315,6 +342,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenNotEquals(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -322,6 +350,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenGreaterThan(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -329,6 +358,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenLessThan(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -336,6 +366,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenEqualOrGreaterThan(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -343,6 +374,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenEqualOrLessThan(String value)
         {
             Values.Initialize(new XLFormula { Value = value });
@@ -350,6 +382,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenBetween(String minValue, String maxValue)
         {
             Values.Initialize(new XLFormula { Value = minValue });
@@ -358,6 +391,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenNotBetween(String minValue, String maxValue)
         {
             Values.Initialize(new XLFormula { Value = minValue });
@@ -374,6 +408,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenNotEquals(Double value)
         {
             Values.Initialize(new XLFormula(value));
@@ -381,6 +416,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenGreaterThan(Double value)
         {
             Values.Initialize(new XLFormula(value));
@@ -388,6 +424,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenLessThan(Double value)
         {
             Values.Initialize(new XLFormula(value));
@@ -395,6 +432,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenEqualOrGreaterThan(Double value)
         {
             Values.Initialize(new XLFormula(value));
@@ -402,6 +440,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenEqualOrLessThan(Double value)
         {
             Values.Initialize(new XLFormula(value));
@@ -409,6 +448,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenBetween(Double minValue, Double maxValue)
         {
             Values.Initialize(new XLFormula(minValue));
@@ -417,6 +457,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.CellIs;
             return Style;
         }
+
         public IXLStyle WhenNotBetween(Double minValue, Double maxValue)
         {
             Values.Initialize(new XLFormula(minValue));
@@ -431,11 +472,13 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.IsDuplicate;
             return Style;
         }
+
         public IXLStyle WhenIsUnique()
         {
             ConditionalFormatType = XLConditionalFormatType.IsUnique;
             return Style;
         }
+
         public IXLStyle WhenIsTrue(String formula)
         {
             String f = formula.TrimStart()[0] == '=' ? formula : "=" + formula;
@@ -443,6 +486,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.Expression;
             return Style;
         }
+
         public IXLStyle WhenIsTop(Int32 value, XLTopBottomType topBottomType = XLTopBottomType.Items)
         {
             Values.Initialize(new XLFormula(value));
@@ -451,6 +495,7 @@ namespace ClosedXML.Excel
             Bottom = false;
             return Style;
         }
+
         public IXLStyle WhenIsBottom(Int32 value, XLTopBottomType topBottomType = XLTopBottomType.Items)
         {
             Values.Initialize(new XLFormula(value));
@@ -465,6 +510,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.ColorScale;
             return new XLCFColorScaleMin(this);
         }
+
         public IXLCFDataBarMin DataBar(XLColor color, Boolean showBarOnly = false)
         {
             Colors.Initialize(color);
@@ -472,6 +518,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.DataBar;
             return new XLCFDataBarMin(this);
         }
+
         public IXLCFDataBarMin DataBar(XLColor positiveColor, XLColor negativeColor, Boolean showBarOnly = false)
         {
             Colors.Initialize(positiveColor);
@@ -480,6 +527,7 @@ namespace ClosedXML.Excel
             ConditionalFormatType = XLConditionalFormatType.DataBar;
             return new XLCFDataBarMin(this);
         }
+
         public IXLCFIconSet IconSet(XLIconSetStyle iconSetStyle, Boolean reverseIconOrder = false, Boolean showIconOnly = false)
         {
             IconSetOperators.Clear();
@@ -497,10 +545,12 @@ namespace ClosedXML.Excel
         IEqualityComparer<Dictionary<TKey, TValue>>
     {
         private readonly IEqualityComparer<TValue> _valueComparer;
+
         public DictionaryComparer(IEqualityComparer<TValue> valueComparer = null)
         {
             this._valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
         }
+
         public bool Equals(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y)
         {
             if (x.Count != y.Count)
@@ -524,6 +574,7 @@ namespace ClosedXML.Excel
     internal class EnumerableComparer<T> : IEqualityComparer<IEnumerable<T>>
     {
         private readonly IEqualityComparer<T> _valueComparer;
+
         public EnumerableComparer(IEqualityComparer<T> valueComparer = null)
         {
             this._valueComparer = valueComparer ?? EqualityComparer<T>.Default;
@@ -547,4 +598,3 @@ namespace ClosedXML.Excel
         }
     }
 }
-

--- a/ClosedXML/Excel/Coordinates/IXLAddress.cs
+++ b/ClosedXML/Excel/Coordinates/IXLAddress.cs
@@ -27,7 +27,5 @@ namespace ClosedXML.Excel
 
 
         String ToStringRelative(Boolean includeSheet);
-
-        IXLAddress WithoutWorksheet();
     }
 }

--- a/ClosedXML/Excel/Coordinates/IXLAddress.cs
+++ b/ClosedXML/Excel/Coordinates/IXLAddress.cs
@@ -27,5 +27,7 @@ namespace ClosedXML.Excel
 
 
         String ToStringRelative(Boolean includeSheet);
+
+        IXLAddress WithoutWorksheet();
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLAddress.cs
+++ b/ClosedXML/Excel/Coordinates/XLAddress.cs
@@ -390,6 +390,11 @@ namespace ClosedXML.Excel
             return GetTrimmedAddress();
         }
 
+        public IXLAddress WithoutWorksheet()
+        {
+            return new XLAddress(RowNumber, ColumnNumber, FixedRow, FixedColumn);
+        }
+
         public String ToStringFixed(XLReferenceStyle referenceStyle)
         {
             return ToStringFixed(referenceStyle, false);

--- a/ClosedXML/Excel/Coordinates/XLAddress.cs
+++ b/ClosedXML/Excel/Coordinates/XLAddress.cs
@@ -390,7 +390,7 @@ namespace ClosedXML.Excel
             return GetTrimmedAddress();
         }
 
-        public IXLAddress WithoutWorksheet()
+        internal XLAddress WithoutWorksheet()
         {
             return new XLAddress(RowNumber, ColumnNumber, FixedRow, FixedColumn);
         }

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -9,6 +9,14 @@ namespace ClosedXML.Excel.Drawings
         IXLAddress BottomRightCellAddress { get; }
 
         /// <summary>
+        /// Create a copy of the picture.
+        /// </summary>
+        /// <param name="targetSheet">A worksheet where put the copy to. When null the copy of the picture is created
+        /// on the same worksheet as the original and picture name is generated automatically.</param>
+        /// <returns>A created copy of the picture.</returns>
+        IXLPicture CopyTo(IXLWorksheet targetSheet = null);
+
+        /// <summary>
         /// Type of image. The supported formats are defined by OpenXML's ImagePartType.
         /// Default value is "jpeg"
         /// </summary>
@@ -68,7 +76,5 @@ namespace ClosedXML.Excel.Drawings
         IXLPicture WithPlacement(XLPicturePlacement value);
 
         IXLPicture WithSize(Int32 width, Int32 height);
-
-        IXLPicture CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -68,7 +68,5 @@ namespace ClosedXML.Excel.Drawings
         IXLPicture WithPlacement(XLPicturePlacement value);
 
         IXLPicture WithSize(Int32 width, Int32 height);
-
-        IXLPicture CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -9,10 +9,9 @@ namespace ClosedXML.Excel.Drawings
         IXLAddress BottomRightCellAddress { get; }
 
         /// <summary>
-        /// Create a copy of the picture.
+        /// Create a copy of the picture on a different worksheet.
         /// </summary>
-        /// <param name="targetSheet">A worksheet where put the copy to. When null the copy of the picture is created
-        /// on the same worksheet as the original and picture name is generated automatically.</param>
+        /// <param name="targetSheet">The worksheet to which the picture will be copied.</param>
         /// <returns>A created copy of the picture.</returns>
         IXLPicture CopyTo(IXLWorksheet targetSheet = null);
 

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -68,5 +68,7 @@ namespace ClosedXML.Excel.Drawings
         IXLPicture WithPlacement(XLPicturePlacement value);
 
         IXLPicture WithSize(Int32 width, Int32 height);
+
+        IXLPicture CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel.Drawings
         /// </summary>
         /// <param name="targetSheet">The worksheet to which the picture will be copied.</param>
         /// <returns>A created copy of the picture.</returns>
-        IXLPicture CopyTo(IXLWorksheet targetSheet = null);
+        IXLPicture CopyTo(IXLWorksheet targetSheet);
 
         /// <summary>
         /// Create a copy of the picture on the same worksheet.

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -17,6 +17,12 @@ namespace ClosedXML.Excel.Drawings
         IXLPicture CopyTo(IXLWorksheet targetSheet = null);
 
         /// <summary>
+        /// Create a copy of the picture on the same worksheet.
+        /// </summary>
+        /// <returns>A created copy of the picture.</returns>
+        IXLPicture Duplicate();
+
+        /// <summary>
         /// Type of image. The supported formats are defined by OpenXML's ImagePartType.
         /// Default value is "jpeg"
         /// </summary>

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -327,14 +327,22 @@ namespace ClosedXML.Excel.Drawings
         }
 
         /// <summary>
-        /// Create a copy of the picture.
+        /// Create a copy of the picture on a different worksheet.
         /// </summary>
-        /// <param name="targetSheet">A worksheet where put the copy to. When null the copy of the picture is created
-        /// on the same worksheet as the original and picture name is generated automatically.</param>
+        /// <param name="targetSheet">The worksheet to which the picture will be copied.</param>
         /// <returns>A created copy of the picture.</returns>
-        public IXLPicture CopyTo(IXLWorksheet targetSheet = null)
+        public IXLPicture CopyTo(IXLWorksheet targetSheet)
         {
             return CopyTo((XLWorksheet) targetSheet);
+        }
+
+        /// <summary>
+        /// Create a copy of the picture on the same worksheet.
+        /// </summary>
+        /// <returns>A created copy of the picture.</returns>
+        public IXLPicture Duplicate()
+        {
+            return CopyTo(Worksheet);
         }
 
         internal IXLPicture CopyTo(XLWorksheet targetSheet)

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -326,6 +326,44 @@ namespace ClosedXML.Excel.Drawings
             return this;
         }
 
+        public IXLPicture CopyTo(IXLWorksheet targetSheet)
+        {
+            return CopyTo((XLWorksheet) targetSheet);
+        }
+
+        internal IXLPicture CopyTo(XLWorksheet targetSheet)
+        {
+            var newPicture = targetSheet.AddPicture(ImageStream, Format, Name)
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .WithSize(Width, Height)
+                .WithPlacement(Placement);
+
+            switch (Placement)
+            {
+                case XLPicturePlacement.FreeFloating:
+                    newPicture.MoveTo(Left, Top);
+                    break;
+
+                case XLPicturePlacement.Move:
+                    var newAddress = new XLAddress(targetSheet, TopLeftCellAddress.RowNumber,
+                        TopLeftCellAddress.ColumnNumber, false, false);
+                    newPicture.MoveTo(newAddress, GetOffset(XLMarkerPosition.TopLeft));
+                    break;
+
+                case XLPicturePlacement.MoveAndSize:
+                    var newFromAddress = new XLAddress(targetSheet, TopLeftCellAddress.RowNumber,
+                        TopLeftCellAddress.ColumnNumber, false, false);
+                    var newToAddress = new XLAddress(targetSheet, BottomRightCellAddress.RowNumber,
+                        BottomRightCellAddress.ColumnNumber, false, false);
+
+                    newPicture.MoveTo(newFromAddress, GetOffset(XLMarkerPosition.TopLeft), newToAddress,
+                        GetOffset(XLMarkerPosition.BottomRight));
+                    break;
+            }
+
+            return newPicture;
+        }
+
         internal void SetName(string value)
         {
             if (String.IsNullOrWhiteSpace(value))

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -326,11 +326,6 @@ namespace ClosedXML.Excel.Drawings
             return this;
         }
 
-        public IXLPicture CopyTo(IXLWorksheet targetSheet)
-        {
-            return CopyTo((XLWorksheet) targetSheet);
-        }
-
         internal IXLPicture CopyTo(XLWorksheet targetSheet)
         {
             var newPicture = targetSheet.AddPicture(ImageStream, Format, Name)

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -326,6 +326,11 @@ namespace ClosedXML.Excel.Drawings
             return this;
         }
 
+        public IXLPicture CopyTo(IXLWorksheet targetSheet)
+        {
+            return CopyTo((XLWorksheet) targetSheet);
+        }
+
         internal IXLPicture CopyTo(XLWorksheet targetSheet)
         {
             var newPicture = targetSheet.AddPicture(ImageStream, Format, Name)

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -326,17 +326,32 @@ namespace ClosedXML.Excel.Drawings
             return this;
         }
 
-        public IXLPicture CopyTo(IXLWorksheet targetSheet)
+        /// <summary>
+        /// Create a copy of the picture.
+        /// </summary>
+        /// <param name="targetSheet">A worksheet where put the copy to. When null the copy of the picture is created
+        /// on the same worksheet as the original and picture name is generated automatically.</param>
+        /// <returns>A created copy of the picture.</returns>
+        public IXLPicture CopyTo(IXLWorksheet targetSheet = null)
         {
             return CopyTo((XLWorksheet) targetSheet);
         }
 
         internal IXLPicture CopyTo(XLWorksheet targetSheet)
         {
-            var newPicture = targetSheet.AddPicture(ImageStream, Format, Name)
-                .WithPlacement(XLPicturePlacement.FreeFloating)
-                .WithSize(Width, Height)
-                .WithPlacement(Placement);
+            if (targetSheet == null)
+                targetSheet = Worksheet as XLWorksheet;
+
+            IXLPicture newPicture;
+            if (targetSheet == Worksheet)
+                newPicture = targetSheet.AddPicture(ImageStream, Format);
+            else
+                newPicture = targetSheet.AddPicture(ImageStream, Format, Name);
+
+            newPicture = newPicture
+                    .WithPlacement(XLPicturePlacement.FreeFloating)
+                    .WithSize(Width, Height)
+                    .WithPlacement(Placement);
 
             switch (Placement)
             {

--- a/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
@@ -67,7 +67,6 @@ namespace ClosedXML.Excel
         /// <param name="ranges">The ranges to add.</param>
         IXLRanges Add(IXLRanges ranges);
 
-
         /// <summary>
         /// Deletes this named range (not the cells).
         /// </summary>
@@ -100,11 +99,14 @@ namespace ClosedXML.Excel
         /// <param name="ranges">The ranges to remove.</param>
         void Remove(IXLRanges ranges);
 
-
         IXLNamedRange SetRefersTo(String range);
+
         IXLNamedRange SetRefersTo(IXLRangeBase range);
+
         IXLNamedRange SetRefersTo(IXLRanges ranges);
 
         String RefersTo { get; set; }
+
+        IXLNamedRange CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
@@ -10,6 +10,16 @@ namespace ClosedXML.Excel
 
     public interface IXLNamedRange
     {
+        #region Public Properties
+
+        /// <summary>
+        /// Gets or sets the comment for this named range.
+        /// </summary>
+        /// <value>
+        /// The comment for this named range.
+        /// </value>
+        String Comment { get; set; }
+
         /// <summary>
         /// Gets or sets the name of the range.
         /// </summary>
@@ -23,14 +33,12 @@ namespace ClosedXML.Excel
         /// <para>Note: A named range can point to multiple ranges.</para>
         /// </summary>
         IXLRanges Ranges { get; }
+        String RefersTo { get; set; }
 
         /// <summary>
-        /// Gets or sets the comment for this named range.
+        /// Gets the scope of this named range.
         /// </summary>
-        /// <value>
-        /// The comment for this named range.
-        /// </value>
-        String Comment { get; set; }
+        XLNamedRangeScope Scope { get; }
 
         /// <summary>
         /// Gets or sets the visibility of this named range.
@@ -40,10 +48,9 @@ namespace ClosedXML.Excel
         /// </value>
         Boolean Visible { get; set; }
 
-        /// <summary>
-        /// Gets the scope of this named range.
-        /// </summary>
-        XLNamedRangeScope Scope { get; }
+        #endregion Public Properties
+
+        #region Public Methods
 
         /// <summary>
         /// Adds the specified range to this named range.
@@ -68,16 +75,17 @@ namespace ClosedXML.Excel
         IXLRanges Add(IXLRanges ranges);
 
         /// <summary>
-        /// Deletes this named range (not the cells).
-        /// </summary>
-        void Delete();
-
-        /// <summary>
         /// Clears the list of ranges associated with this named range.
         /// <para>(it does not clear the cells)</para>
         /// </summary>
         void Clear();
 
+        IXLNamedRange CopyTo(IXLWorksheet targetSheet);
+
+        /// <summary>
+        /// Deletes this named range (not the cells).
+        /// </summary>
+        void Delete();
         /// <summary>
         /// Removes the specified range from this named range.
         /// <para>Note: A named range can point to multiple ranges.</para>
@@ -105,8 +113,6 @@ namespace ClosedXML.Excel
 
         IXLNamedRange SetRefersTo(IXLRanges ranges);
 
-        String RefersTo { get; set; }
-
-        IXLNamedRange CopyTo(IXLWorksheet targetSheet);
+        #endregion Public Methods
     }
 }

--- a/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
@@ -151,14 +151,15 @@ namespace ClosedXML.Excel
 
         public IXLNamedRange CopyTo(IXLWorksheet targetSheet)
         {
+            if (targetSheet == _namedRanges.Worksheet)
+                throw new InvalidOperationException("Cannot copy named range to the worksheet it already belongs to.");
+
             var ranges = new XLRanges();
             foreach (var r in Ranges)
             {
                 if (_namedRanges.Worksheet == r.Worksheet)
                     // Named ranges on the source worksheet have to point to the new destination sheet
-                    ranges.Add(targetSheet.Range(r.RangeAddress.FirstAddress.RowNumber,
-                        r.RangeAddress.FirstAddress.ColumnNumber, r.RangeAddress.LastAddress.RowNumber,
-                        r.RangeAddress.LastAddress.ColumnNumber));
+                    ranges.Add(targetSheet.Range(((XLRangeAddress)r.RangeAddress).WithoutWorksheet()));
                 else
                     ranges.Add(r);
             }

--- a/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
@@ -149,6 +149,23 @@ namespace ClosedXML.Excel
             }
         }
 
+        public IXLNamedRange CopyTo(IXLWorksheet targetSheet)
+        {
+            var ranges = new XLRanges();
+            foreach (var r in Ranges)
+            {
+                if (_namedRanges.Worksheet == r.Worksheet)
+                    // Named ranges on the source worksheet have to point to the new destination sheet
+                    ranges.Add(targetSheet.Range(r.RangeAddress.FirstAddress.RowNumber,
+                        r.RangeAddress.FirstAddress.ColumnNumber, r.RangeAddress.LastAddress.RowNumber,
+                        r.RangeAddress.LastAddress.ColumnNumber));
+                else
+                    ranges.Add(r);
+            }
+
+            return targetSheet.NamedRanges.Add(Name, ranges);
+        }
+
         internal IList<String> RangeList { get; set; } = new List<String>();
 
         public IXLNamedRange SetRefersTo(String range)

--- a/ClosedXML/Excel/PageSetup/XLPageSetup.cs
+++ b/ClosedXML/Excel/PageSetup/XLPageSetup.cs
@@ -18,6 +18,12 @@ namespace ClosedXML.Excel
                 HorizontalDpi = defaultPageOptions.HorizontalDpi;
                 PageOrientation = defaultPageOptions.PageOrientation;
                 VerticalDpi = defaultPageOptions.VerticalDpi;
+                FirstRowToRepeatAtTop = defaultPageOptions.FirstRowToRepeatAtTop;
+                LastRowToRepeatAtTop = defaultPageOptions.LastRowToRepeatAtTop;
+                FirstColumnToRepeatAtLeft = defaultPageOptions.FirstColumnToRepeatAtLeft;
+                LastColumnToRepeatAtLeft = defaultPageOptions.LastColumnToRepeatAtLeft;
+                ShowComments = defaultPageOptions.ShowComments;
+
 
                 PaperSize = defaultPageOptions.PaperSize;
                 _pagesTall = defaultPageOptions.PagesTall;

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -47,7 +47,5 @@ namespace ClosedXML.Excel
         bool Intersects(IXLRangeAddress otherAddress);
 
         bool Contains(IXLAddress address);
-
-        IXLRangeAddress WithoutWorksheet();
     }
 }

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -47,5 +47,7 @@ namespace ClosedXML.Excel
         bool Intersects(IXLRangeAddress otherAddress);
 
         bool Contains(IXLAddress address);
+
+        IXLRangeAddress WithoutWorksheet();
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -196,7 +196,7 @@ namespace ClosedXML.Excel
 
         public bool Intersects(IXLRangeAddress otherAddress)
         {
-            var xlOtherAddress = (XLRangeAddress) otherAddress;
+            var xlOtherAddress = (XLRangeAddress)otherAddress;
             return Intersects(in xlOtherAddress);
         }
 
@@ -216,11 +216,11 @@ namespace ClosedXML.Excel
             return Contains(in xlAddress);
         }
 
-        public IXLRangeAddress WithoutWorksheet()
+        internal IXLRangeAddress WithoutWorksheet()
         {
             return new XLRangeAddress(
-                (XLAddress)FirstAddress.WithoutWorksheet(),
-                (XLAddress)LastAddress.WithoutWorksheet());
+                FirstAddress.WithoutWorksheet(),
+                LastAddress.WithoutWorksheet());
         }
 
         internal bool Contains(in XLAddress address)
@@ -307,6 +307,7 @@ namespace ClosedXML.Excel
         {
             return !(left == right);
         }
-        #endregion
+
+        #endregion Operators
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -216,6 +216,13 @@ namespace ClosedXML.Excel
             return Contains(in xlAddress);
         }
 
+        public IXLRangeAddress WithoutWorksheet()
+        {
+            return new XLRangeAddress(
+                (XLAddress)FirstAddress.WithoutWorksheet(),
+                (XLAddress)LastAddress.WithoutWorksheet());
+        }
+
         internal bool Contains(in XLAddress address)
         {
             return FirstAddress.RowNumber <= address.RowNumber &&

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -912,13 +912,16 @@ namespace ClosedXML.Excel
 
         public XLRange Range(IXLRangeAddress rangeAddress)
         {
-            var newFirstCellAddress = new XLAddress((XLWorksheet)rangeAddress.FirstAddress.Worksheet,
+            var ws = (XLWorksheet) rangeAddress.FirstAddress.Worksheet ??
+                     (XLWorksheet) rangeAddress.LastAddress.Worksheet ??
+                     Worksheet;
+            var newFirstCellAddress = new XLAddress(ws,
                                  rangeAddress.FirstAddress.RowNumber + RangeAddress.FirstAddress.RowNumber - 1,
                                  rangeAddress.FirstAddress.ColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1,
                                  rangeAddress.FirstAddress.FixedRow,
                                  rangeAddress.FirstAddress.FixedColumn);
 
-            var newLastCellAddress = new XLAddress((XLWorksheet)rangeAddress.LastAddress.Worksheet,
+            var newLastCellAddress = new XLAddress(ws,
                                 rangeAddress.LastAddress.RowNumber + RangeAddress.FirstAddress.RowNumber - 1,
                                 rangeAddress.LastAddress.ColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1,
                                 rangeAddress.LastAddress.FixedRow,

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -407,6 +407,7 @@ namespace ClosedXML.Excel
             row.Clear();
             var newRow = (XLRow)row;
             newRow._height = _height;
+            newRow.HeightChanged = HeightChanged;
             newRow.InnerStyle = GetStyle();
 
             AsRange().CopyTo(row);

--- a/ClosedXML/Excel/Tables/IXLTable.cs
+++ b/ClosedXML/Excel/Tables/IXLTable.cs
@@ -129,5 +129,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <returns></returns>
         DataTable AsNativeDataTable();
+
+        IXLTable CopyTo(IXLWorksheet targetSheet);
     }
 }

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -823,10 +823,19 @@ namespace ClosedXML.Excel
             return CopyTo((XLWorksheet) targetSheet);
         }
 
-        internal IXLTable CopyTo(XLWorksheet targetSheet)
+        internal IXLTable CopyTo(XLWorksheet targetSheet, bool copyData = true)
         {
+            if (targetSheet == Worksheet)
+                throw new InvalidOperationException("Cannot copy table to the worksheet it already belongs to.");
+
+            var targetRange = targetSheet.Range(RangeAddress.WithoutWorksheet());
+            if (copyData)
+                RangeUsed().CopyTo(targetRange);
+            else
+                HeadersRow().CopyTo(targetRange.FirstRow());
+
             String tableName = Name;
-            var newTable = (XLTable)targetSheet.Table(targetSheet.Range(RangeAddress.ToString()), tableName, true);
+            var newTable = (XLTable)targetSheet.Table(targetRange, tableName, true);
 
             newTable.RelId = RelId;
             newTable.EmphasizeFirstColumn = EmphasizeFirstColumn;
@@ -836,9 +845,7 @@ namespace ClosedXML.Excel
             newTable.ShowAutoFilter = ShowAutoFilter;
             newTable.Theme = Theme;
             newTable._showTotalsRow = ShowTotalsRow;
-            newTable._uniqueNames.Clear();
 
-            _uniqueNames.ForEach(n => newTable._uniqueNames.Add(n));
             Int32 fieldCount = ColumnCount();
             for (Int32 f = 0; f < fieldCount; f++)
             {

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -817,5 +817,39 @@ namespace ClosedXML.Excel
 
             return table;
         }
+
+        public IXLTable CopyTo(IXLWorksheet targetSheet)
+        {
+            return CopyTo((XLWorksheet) targetSheet);
+        }
+
+        internal IXLTable CopyTo(XLWorksheet targetSheet)
+        {
+            String tableName = Name;
+            var newTable = (XLTable)targetSheet.Table(targetSheet.Range(RangeAddress.ToString()), tableName, true);
+
+            newTable.RelId = RelId;
+            newTable.EmphasizeFirstColumn = EmphasizeFirstColumn;
+            newTable.EmphasizeLastColumn = EmphasizeLastColumn;
+            newTable.ShowRowStripes = ShowRowStripes;
+            newTable.ShowColumnStripes = ShowColumnStripes;
+            newTable.ShowAutoFilter = ShowAutoFilter;
+            newTable.Theme = Theme;
+            newTable._showTotalsRow = ShowTotalsRow;
+            newTable._uniqueNames.Clear();
+
+            _uniqueNames.ForEach(n => newTable._uniqueNames.Add(n));
+            Int32 fieldCount = ColumnCount();
+            for (Int32 f = 0; f < fieldCount; f++)
+            {
+                var tableField = newTable.Field(f) as XLTableField;
+                var tField = Field(f) as XLTableField;
+                tableField.Index = tField.Index;
+                tableField.Name = tField.Name;
+                tableField.totalsRowLabel = tField.totalsRowLabel;
+                tableField.totalsRowFunction = tField.totalsRowFunction;
+            }
+            return newTable;
+        }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -582,16 +582,16 @@ namespace ClosedXML.Excel
             targetSheet.SheetView = new XLSheetView(SheetView);
             targetSheet.SelectedRanges.RemoveAll();
 
-            Pictures.ForEach(picture => picture.CopyTo(targetSheet));
+            Pictures.Cast<XLPicture>().ForEach(picture => picture.CopyTo(targetSheet));
             NamedRanges.ForEach(nr => nr.CopyTo(targetSheet));
             Tables.ForEach(t => t.CopyTo(targetSheet));
-            ConditionalFormats.ForEach(cf => cf.CopyTo(targetSheet));
-            MergedRanges.ForEach(mr => targetSheet.Range(mr.RangeAddress.WithoutWorksheet()).Merge());
-            SelectedRanges.ForEach(sr => targetSheet.SelectedRanges.Add(targetSheet.Range(sr.RangeAddress.WithoutWorksheet())));
+            ConditionalFormats.Cast<XLConditionalFormat>().ForEach(cf => cf.CopyTo(targetSheet));
+            MergedRanges.ForEach(mr => targetSheet.Range(((XLRangeAddress)mr.RangeAddress).WithoutWorksheet()).Merge());
+            SelectedRanges.ForEach(sr => targetSheet.SelectedRanges.Add(targetSheet.Range(((XLRangeAddress)sr.RangeAddress).WithoutWorksheet())));
 
             if (AutoFilter.Enabled)
             {
-                var range = targetSheet.Range(AutoFilter.Range.RangeAddress.WithoutWorksheet());
+                var range = targetSheet.Range(((XLRangeAddress)AutoFilter.Range.RangeAddress).WithoutWorksheet());
                 range.SetAutoFilter();
             }
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -585,6 +585,7 @@ namespace ClosedXML.Excel
             NamedRanges.ForEach(nr => nr.CopyTo(targetSheet));
             Tables.ForEach(t => t.CopyTo(targetSheet));
             ConditionalFormats.ForEach(cf => cf.CopyTo(targetSheet));
+            MergedRanges.ForEach(mr => targetSheet.Range(mr.RangeAddress.WithoutWorksheet()).Merge());
 
             if (AutoFilter.Enabled)
             {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -580,12 +580,14 @@ namespace ClosedXML.Excel
             (targetSheet.PageSetup.Footer as XLHeaderFooter).Changed = true;
             targetSheet.Outline = new XLOutline(Outline);
             targetSheet.SheetView = new XLSheetView(SheetView);
+            targetSheet.SelectedRanges.RemoveAll();
 
             Pictures.ForEach(picture => picture.CopyTo(targetSheet));
             NamedRanges.ForEach(nr => nr.CopyTo(targetSheet));
             Tables.ForEach(t => t.CopyTo(targetSheet));
             ConditionalFormats.ForEach(cf => cf.CopyTo(targetSheet));
             MergedRanges.ForEach(mr => targetSheet.Range(mr.RangeAddress.WithoutWorksheet()).Merge());
+            SelectedRanges.ForEach(sr => targetSheet.SelectedRanges.Add(targetSheet.Range(sr.RangeAddress.WithoutWorksheet())));
 
             if (AutoFilter.Enabled)
             {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -567,7 +567,7 @@ namespace ClosedXML.Excel
             var targetSheet = (XLWorksheet)workbook.WorksheetsInternal.Add(newSheetName, position);
             Internals.ColumnsCollection.ForEach(kp => kp.Value.CopyTo(targetSheet.Column(kp.Key)));
             Internals.RowsCollection.ForEach(kp => kp.Value.CopyTo(targetSheet.Row(kp.Key)));
-            Internals.CellsCollection.GetCells().ForEach(c => targetSheet.Cell(c.Address).CopyFrom(c, false));
+            Internals.CellsCollection.GetCells().ForEach(c => targetSheet.Cell(c.Address).CopyFrom(c, false, false));
             DataValidations.ForEach(dv => targetSheet.DataValidations.Add(new XLDataValidation(dv)));
             targetSheet.Visibility = Visibility;
             targetSheet.ColumnWidth = ColumnWidth;

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -581,89 +581,14 @@ namespace ClosedXML.Excel
             targetSheet.Outline = new XLOutline(Outline);
             targetSheet.SheetView = new XLSheetView(SheetView);
 
-            foreach (var picture in Pictures)
-            {
-                var newPic = targetSheet.AddPicture(picture.ImageStream, picture.Format, picture.Name)
-                    .WithPlacement(XLPicturePlacement.FreeFloating)
-                    .WithSize(picture.Width, picture.Height)
-                    .WithPlacement(picture.Placement);
-
-                switch (picture.Placement)
-                {
-                    case XLPicturePlacement.FreeFloating:
-                        newPic.MoveTo(picture.Left, picture.Top);
-                        break;
-
-                    case XLPicturePlacement.Move:
-                        var newAddress = new XLAddress(targetSheet, picture.TopLeftCellAddress.RowNumber,
-                            picture.TopLeftCellAddress.ColumnNumber, false, false);
-                        newPic.MoveTo(newAddress, picture.GetOffset(XLMarkerPosition.TopLeft));
-                        break;
-
-                    case XLPicturePlacement.MoveAndSize:
-                        var newFromAddress = new XLAddress(targetSheet, picture.TopLeftCellAddress.RowNumber,
-                            picture.TopLeftCellAddress.ColumnNumber, false, false);
-                        var newToAddress = new XLAddress(targetSheet, picture.BottomRightCellAddress.RowNumber,
-                            picture.BottomRightCellAddress.ColumnNumber, false, false);
-
-                        newPic.MoveTo(newFromAddress, picture.GetOffset(XLMarkerPosition.TopLeft), newToAddress,
-                            picture.GetOffset(XLMarkerPosition.BottomRight));
-                        break;
-                }
-            }
-
-            foreach (var nr in NamedRanges)
-            {
-                var ranges = new XLRanges();
-                foreach (var r in nr.Ranges)
-                {
-                    if (this == r.Worksheet)
-                        // Named ranges on the source worksheet have to point to the new destination sheet
-                        ranges.Add(targetSheet.Range(r.RangeAddress.FirstAddress.RowNumber,
-                            r.RangeAddress.FirstAddress.ColumnNumber, r.RangeAddress.LastAddress.RowNumber,
-                            r.RangeAddress.LastAddress.ColumnNumber));
-                    else
-                        ranges.Add(r);
-                }
-
-                targetSheet.NamedRanges.Add(nr.Name, ranges);
-            }
-
-            foreach (var t in Tables.Cast<XLTable>())
-            {
-                String tableName = t.Name;
-                var table = (XLTable)targetSheet.Table(targetSheet.Range(t.RangeAddress.ToString()), tableName, true);
-
-                table.RelId = t.RelId;
-                table.EmphasizeFirstColumn = t.EmphasizeFirstColumn;
-                table.EmphasizeLastColumn = t.EmphasizeLastColumn;
-                table.ShowRowStripes = t.ShowRowStripes;
-                table.ShowColumnStripes = t.ShowColumnStripes;
-                table.ShowAutoFilter = t.ShowAutoFilter;
-                table.Theme = t.Theme;
-                table._showTotalsRow = t.ShowTotalsRow;
-                table._uniqueNames.Clear();
-
-                t._uniqueNames.ForEach(n => table._uniqueNames.Add(n));
-                Int32 fieldCount = t.ColumnCount();
-                for (Int32 f = 0; f < fieldCount; f++)
-                {
-                    var tableField = table.Field(f) as XLTableField;
-                    var tField = t.Field(f) as XLTableField;
-                    tableField.Index = tField.Index;
-                    tableField.Name = tField.Name;
-                    tableField.totalsRowLabel = tField.totalsRowLabel;
-                    tableField.totalsRowFunction = tField.totalsRowFunction;
-                }
-            }
+            Pictures.ForEach(picture => picture.CopyTo(targetSheet));
+            NamedRanges.ForEach(nr => nr.CopyTo(targetSheet));
+            Tables.ForEach(t => t.CopyTo(targetSheet));
+            ConditionalFormats.ForEach(cf => cf.CopyTo(targetSheet));
 
             if (AutoFilter.Enabled)
             {
-                var range = targetSheet.Range(
-                    AutoFilter.Range.RangeAddress.FirstAddress.RowNumber,
-                    AutoFilter.Range.RangeAddress.FirstAddress.ColumnNumber,
-                    AutoFilter.Range.RangeAddress.LastAddress.RowNumber,
-                    AutoFilter.Range.RangeAddress.LastAddress.ColumnNumber);
+                var range = targetSheet.Range(AutoFilter.Range.RangeAddress.WithoutWorksheet());
                 range.SetAutoFilter();
             }
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -582,10 +582,10 @@ namespace ClosedXML.Excel
             targetSheet.SheetView = new XLSheetView(SheetView);
             targetSheet.SelectedRanges.RemoveAll();
 
-            Pictures.Cast<XLPicture>().ForEach(picture => picture.CopyTo(targetSheet));
+            Pictures.ForEach(picture => picture.CopyTo(targetSheet));
             NamedRanges.ForEach(nr => nr.CopyTo(targetSheet));
             Tables.Cast<XLTable>().ForEach(t => t.CopyTo(targetSheet, false));
-            ConditionalFormats.Cast<XLConditionalFormat>().ForEach(cf => cf.CopyTo(targetSheet));
+            ConditionalFormats.ForEach(cf => cf.CopyTo(targetSheet));
             MergedRanges.ForEach(mr => targetSheet.Range(((XLRangeAddress)mr.RangeAddress).WithoutWorksheet()).Merge());
             SelectedRanges.ForEach(sr => targetSheet.SelectedRanges.Add(targetSheet.Range(((XLRangeAddress)sr.RangeAddress).WithoutWorksheet())));
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -584,7 +584,7 @@ namespace ClosedXML.Excel
 
             Pictures.Cast<XLPicture>().ForEach(picture => picture.CopyTo(targetSheet));
             NamedRanges.ForEach(nr => nr.CopyTo(targetSheet));
-            Tables.ForEach(t => t.CopyTo(targetSheet));
+            Tables.Cast<XLTable>().ForEach(t => t.CopyTo(targetSheet, false));
             ConditionalFormats.Cast<XLConditionalFormat>().ForEach(cf => cf.CopyTo(targetSheet));
             MergedRanges.ForEach(mr => targetSheet.Range(((XLRangeAddress)mr.RangeAddress).WithoutWorksheet()).Merge());
             SelectedRanges.ForEach(sr => targetSheet.SelectedRanges.Add(targetSheet.Range(((XLRangeAddress)sr.RangeAddress).WithoutWorksheet())));

--- a/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
@@ -329,5 +329,72 @@ namespace ClosedXML_Tests
                 }
             }
         }
+
+        [Test]
+        public void CopyImageSameWorksheet()
+        {
+            var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet1");
+
+            IXLPicture original;
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML_Tests.Resource.Images.ImageHandling.png"))
+            {
+                original = (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
+                    .WithPlacement(XLPicturePlacement.FreeFloating)
+                    .MoveTo(220, 155) as XLPicture;
+            }
+
+            var copy = original.CopyTo()
+                .MoveTo(300, 200) as XLPicture;
+
+            Assert.AreEqual(2, ws1.Pictures.Count());
+            Assert.AreEqual(ws1, copy.Worksheet);
+            Assert.AreEqual(original.Format, copy.Format);
+            Assert.AreEqual(original.Height, copy.Height);
+            Assert.AreEqual(original.Placement, copy.Placement);
+            Assert.AreEqual(original.TopLeftCellAddress.ToString(), copy.TopLeftCellAddress.ToString());
+            Assert.AreEqual(original.Width, copy.Width);
+            Assert.AreEqual(original.ImageStream.ToArray(), copy.ImageStream.ToArray(), "Image streams differ");
+
+            Assert.AreEqual(200, copy.Top);
+            Assert.AreEqual(300, copy.Left);
+            Assert.AreNotEqual(original.Id, copy.Id);
+            Assert.AreNotEqual(original.Name, copy.Name);
+        }
+
+        [Test]
+        public void CopyImageDifferentWorksheets()
+        {
+            var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet1");
+            IXLPicture original;
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML_Tests.Resource.Images.ImageHandling.png"))
+            {
+                original = (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
+                    .WithPlacement(XLPicturePlacement.FreeFloating)
+                    .MoveTo(220, 155) as XLPicture;
+
+            }
+            var ws2 = wb.Worksheets.Add("Sheet2");
+
+            var copy = original.CopyTo(ws2);
+
+            Assert.AreEqual(1, ws1.Pictures.Count());
+            Assert.AreEqual(1, ws2.Pictures.Count());
+
+            Assert.AreEqual(ws2, copy.Worksheet);
+
+            Assert.AreEqual(original.Format, copy.Format);
+            Assert.AreEqual(original.Height, copy.Height);
+            Assert.AreEqual(original.Left, copy.Left);
+            Assert.AreEqual(original.Name, copy.Name);
+            Assert.AreEqual(original.Placement, copy.Placement);
+            Assert.AreEqual(original.Top, copy.Top);
+            Assert.AreEqual(original.TopLeftCellAddress.ToString(), copy.TopLeftCellAddress.ToString());
+            Assert.AreEqual(original.Width, copy.Width);
+            Assert.AreEqual(original.ImageStream.ToArray(), copy.ImageStream.ToArray(), "Image streams differ");
+
+            Assert.AreNotEqual(original.Id, copy.Id);
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
@@ -344,7 +344,7 @@ namespace ClosedXML_Tests
                     .MoveTo(220, 155) as XLPicture;
             }
 
-            var copy = original.CopyTo()
+            var copy = original.Duplicate()
                 .MoveTo(300, 200) as XLPicture;
 
             Assert.AreEqual(2, ws1.Pictures.Count());

--- a/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -285,5 +285,43 @@ namespace ClosedXML_Tests.Excel
                 Assert.AreEqual(0.6, (double)ws1.Cell(4, 1).Value, XLHelper.Epsilon);
             }
         }
+
+        [Test]
+        public void CopyNamedRangeSameWorksheet()
+        {
+            var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet1");
+            ws1.Range("B2:E6").AddToNamed("Named range", XLScope.Worksheet);
+            var nr = ws1.NamedRange("Named range");
+
+            TestDelegate action = () => nr.CopyTo(ws1);
+
+            Assert.Throws(typeof(InvalidOperationException), action);
+        }
+
+        [Test]
+        public void CopyNamedRangeDifferentWorksheets()
+        {
+            var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet1");
+            var ws2 = wb.Worksheets.Add("Sheet2");
+            var ranges = new XLRanges();
+            ranges.Add(ws1.Range("B2:E6"));
+            ranges.Add(ws2.Range("D1:E2"));
+            var original = ws1.NamedRanges.Add("Named range", ranges);
+
+            var copy = original.CopyTo(ws2);
+
+            Assert.AreEqual(1, ws1.NamedRanges.Count());
+            Assert.AreEqual(1, ws2.NamedRanges.Count());
+            Assert.AreEqual(2, original.Ranges.Count);
+            Assert.AreEqual(2, copy.Ranges.Count);
+            Assert.AreEqual(original.Name, copy.Name);
+            Assert.AreEqual(original.Scope, copy.Scope);
+            Assert.AreEqual("Sheet1!B2:E6", original.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("Sheet2!D1:E2", original.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("Sheet2!B2:E6", copy.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("Sheet2!D1:E2", copy.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true));
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -442,7 +442,6 @@ namespace ClosedXML_Tests.Excel.Saving
 
                     ws.CopyTo("Sheet2");
                     wb.SaveAs(ms);
-                    wb.SaveAs(@"e:\ClosedXML\829_width.xlsx");
                 }
 
                 ms.Seek(0, SeekOrigin.Begin);

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -393,5 +393,73 @@ namespace ClosedXML_Tests.Excel.Saving
                 }
             }
         }
+
+        [Test]
+        public void PreserveHeightOfEmptyRowsOnSaving()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    var ws = wb.AddWorksheet("Sheet1");
+                    ws.RowHeight = 50;
+                    ws.Row(2).Height = 0;
+                    ws.Row(3).Height = 20;
+                    ws.Row(4).Height = 100;
+
+                    ws.CopyTo("Sheet2");
+                    wb.SaveAs(ms);
+                }
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    foreach (var sheetName in new []{"Sheet1", "Sheet2"})
+                    {
+                        var ws = wb.Worksheet(sheetName);
+
+                        Assert.AreEqual(50, ws.Row(1).Height);
+                        Assert.AreEqual(0, ws.Row(2).Height);
+                        Assert.AreEqual(20, ws.Row(3).Height);
+                        Assert.AreEqual(100, ws.Row(4).Height);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void PreserveWidthOfEmptyColumnsOnSaving()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    var ws = wb.AddWorksheet("Sheet1");
+                    ws.Column(2).Width = 0;
+                    ws.Column(3).Width = 20;
+                    ws.Column(4).Width = 100;
+
+                    ws.CopyTo("Sheet2");
+                    wb.SaveAs(ms);
+                    wb.SaveAs(@"e:\ClosedXML\829_width.xlsx");
+                }
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    foreach (var sheetName in new[] {"Sheet1", "Sheet2"})
+                    {
+                        var ws = wb.Worksheet(sheetName);
+
+                        Assert.AreEqual(ws.ColumnWidth, ws.Column(1).Width);
+                        Assert.AreEqual(0, ws.Column(2).Width);
+                        Assert.AreEqual(20, ws.Column(3).Width);
+                        Assert.AreEqual(100, ws.Column(4).Width);
+                    }
+                }
+            }
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -716,6 +716,75 @@ namespace ClosedXML_Tests
             }
         }
 
+        [Test]
+        public void CopyWorksheetPreservesPageSetup()
+        {
+            using (var wb1 = new XLWorkbook())
+            using (var wb2 = new XLWorkbook())
+            {
+                var ws1 = wb1.Worksheets.Add("Original");
+
+                ws1.PageSetup.AddHorizontalPageBreak(15);
+                ws1.PageSetup.AddVerticalPageBreak(5);
+                ws1.PageSetup
+                    .SetBlackAndWhite()
+                    .SetCenterHorizontally()
+                    .SetCenterVertically()
+                    .SetFirstPageNumber(200)
+                    .SetPageOrientation(XLPageOrientation.Landscape)
+                    .SetPaperSize(XLPaperSize.A5Paper)
+                    .SetScale(89)
+                    .SetShowGridlines()
+                    .SetHorizontalDpi(200)
+                    .SetVerticalDpi(300)
+                    .SetPagesTall(5)
+                    .SetPagesWide(2)
+                    .SetColumnsToRepeatAtLeft(1, 3);
+                ws1.PageSetup.PrintAreas.Clear();
+                ws1.PageSetup.PrintAreas.Add("A1:Z200");
+                ws1.PageSetup.Margins.SetBottom(5).SetTop(6).SetLeft(7).SetRight(8).SetFooter(9).SetHeader(10);
+                ws1.PageSetup.Header.Left.AddText(XLHFPredefinedText.FullPath, XLHFOccurrence.AllPages);
+                ws1.PageSetup.Footer.Right.AddText(XLHFPredefinedText.PageNumber, XLHFOccurrence.OddPages);
+
+                var ws2 = ws1.CopyTo(wb2, "Copy");
+
+                Assert.AreEqual(ws1.PageSetup.FirstRowToRepeatAtTop, ws2.PageSetup.FirstRowToRepeatAtTop);
+                Assert.AreEqual(ws1.PageSetup.LastRowToRepeatAtTop, ws2.PageSetup.LastRowToRepeatAtTop);
+                Assert.AreEqual(ws1.PageSetup.FirstColumnToRepeatAtLeft, ws2.PageSetup.FirstColumnToRepeatAtLeft);
+                Assert.AreEqual(ws1.PageSetup.LastColumnToRepeatAtLeft, ws2.PageSetup.LastColumnToRepeatAtLeft);
+                Assert.AreEqual(ws1.PageSetup.PageOrientation, ws2.PageSetup.PageOrientation);
+                Assert.AreEqual(ws1.PageSetup.PagesWide, ws2.PageSetup.PagesWide);
+                Assert.AreEqual(ws1.PageSetup.PagesTall, ws2.PageSetup.PagesTall);
+                Assert.AreEqual(ws1.PageSetup.Scale, ws2.PageSetup.Scale);
+                Assert.AreEqual(ws1.PageSetup.HorizontalDpi, ws2.PageSetup.HorizontalDpi);
+                Assert.AreEqual(ws1.PageSetup.VerticalDpi, ws2.PageSetup.VerticalDpi);
+                Assert.AreEqual(ws1.PageSetup.FirstPageNumber, ws2.PageSetup.FirstPageNumber);
+                Assert.AreEqual(ws1.PageSetup.CenterHorizontally, ws2.PageSetup.CenterHorizontally);
+                Assert.AreEqual(ws1.PageSetup.CenterVertically, ws2.PageSetup.CenterVertically);
+                Assert.AreEqual(ws1.PageSetup.PaperSize, ws2.PageSetup.PaperSize);
+                Assert.AreEqual(ws1.PageSetup.Margins.Bottom, ws2.PageSetup.Margins.Bottom);
+                Assert.AreEqual(ws1.PageSetup.Margins.Top, ws2.PageSetup.Margins.Top);
+                Assert.AreEqual(ws1.PageSetup.Margins.Left, ws2.PageSetup.Margins.Left);
+                Assert.AreEqual(ws1.PageSetup.Margins.Right, ws2.PageSetup.Margins.Right);
+                Assert.AreEqual(ws1.PageSetup.Margins.Footer, ws2.PageSetup.Margins.Footer);
+                Assert.AreEqual(ws1.PageSetup.Margins.Header, ws2.PageSetup.Margins.Header);
+                Assert.AreEqual(ws1.PageSetup.ScaleHFWithDocument, ws2.PageSetup.ScaleHFWithDocument);
+                Assert.AreEqual(ws1.PageSetup.AlignHFWithMargins, ws2.PageSetup.AlignHFWithMargins);
+                Assert.AreEqual(ws1.PageSetup.ShowGridlines, ws2.PageSetup.ShowGridlines);
+                Assert.AreEqual(ws1.PageSetup.ShowRowAndColumnHeadings, ws2.PageSetup.ShowRowAndColumnHeadings);
+                Assert.AreEqual(ws1.PageSetup.BlackAndWhite, ws2.PageSetup.BlackAndWhite);
+                Assert.AreEqual(ws1.PageSetup.DraftQuality, ws2.PageSetup.DraftQuality);
+                Assert.AreEqual(ws1.PageSetup.PageOrder, ws2.PageSetup.PageOrder);
+                Assert.AreEqual(ws1.PageSetup.ShowComments, ws2.PageSetup.ShowComments);
+                Assert.AreEqual(ws1.PageSetup.PrintErrorValue, ws2.PageSetup.PrintErrorValue);
+
+                Assert.AreEqual(ws1.PageSetup.PrintAreas.Count(), ws2.PageSetup.PrintAreas.Count());
+
+                Assert.AreEqual(ws1.PageSetup.Header.Left.GetText(XLHFOccurrence.AllPages), ws2.PageSetup.Header.Left.GetText(XLHFOccurrence.AllPages));
+                Assert.AreEqual(ws1.PageSetup.Footer.Right.GetText(XLHFOccurrence.OddPages), ws2.PageSetup.Footer.Right.GetText(XLHFOccurrence.OddPages));
+            }
+        }
+
         [Test, Ignore("Muted until #836 is fixed")]
         public void CopyWorksheetChangesAbsoluteReferencesInFormulae()
         {

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -28,7 +28,8 @@ namespace ClosedXML_Tests
         {
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-            ws.FirstCell().AddConditionalFormat().WhenContains("1").Fill.SetBackgroundColor(XLColor.Blue);
+            ws.Range("A1:C3").AddConditionalFormat().WhenContains("1").Fill.SetBackgroundColor(XLColor.Blue);
+            ws.Range("A1:C3").Value = 1;
             IXLWorksheet ws2 = ws.CopyTo("Sheet2");
             Assert.AreEqual(1, ws2.ConditionalFormats.Count());
         }

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -340,9 +340,8 @@ namespace ClosedXML_Tests
         }
         
         [Test]
-        public void CopyWorksheetPreservesRowHeightsAfterSave()
+        public void CopyWorksheetPreservesRowHeights()
         {
-            using (var ms = new MemoryStream())
             using (var wb1 = new XLWorkbook())
             {
                 var ws1 = wb1.Worksheets.Add("Original");
@@ -359,27 +358,13 @@ namespace ClosedXML_Tests
                     {
                         Assert.AreEqual(ws1.Row(i).Height, ws2.Row(i).Height);
                     }
-
-                    wb2.SaveAs(ms);
-                }
-
-                using (var wb2 = new XLWorkbook(ms))
-                {
-                    var ws2 = wb2.Worksheets.First();
-
-                    Assert.AreEqual(ws1.RowHeight, ws2.RowHeight);
-                    for (int i = 1; i <= 3; i++)
-                    {
-                        Assert.AreEqual(ws1.Row(i).Height, ws2.Row(i).Height);
-                    }
                 }
             }
         }
 
         [Test]
-        public void CopyWorksheetPreservesColumnWidthsAfterSave()
+        public void CopyWorksheetPreservesColumnWidths()
         {
-            using (var ms = new MemoryStream())
             using (var wb1 = new XLWorkbook())
             {
                 var ws1 = wb1.Worksheets.Add("Original");
@@ -395,19 +380,6 @@ namespace ClosedXML_Tests
                     for (int i = 1; i <= 3; i++)
                     {
                         Assert.AreEqual(ws1.Column(i).Width, ws2.Column(i).Width);
-                    }
-
-                    wb2.SaveAs(ms);
-                }
-
-                using (var wb2 = new XLWorkbook(ms))
-                {
-                    var ws2 = wb2.Worksheets.First();
-
-                    Assert.AreEqual(ws1.ColumnWidth, ws2.ColumnWidth, 1);
-                    for (int i = 1; i <= 3; i++)
-                    {
-                        Assert.AreEqual(ws1.Column(i).Width, ws2.Column(i).Width, 1);
                     }
                 }
             }

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1,11 +1,11 @@
 using ClosedXML.Excel;
+using ClosedXML.Excel.Drawings;
 using NUnit.Framework;
 using System;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using ClosedXML.Excel.Drawings;
 
 namespace ClosedXML_Tests
 {
@@ -338,7 +338,7 @@ namespace ClosedXML_Tests
                 Assert.AreEqual("A1 * 2", ws2.Cell("A2").FormulaA1);
             }
         }
-        
+
         [Test]
         public void CopyWorksheetPreservesRowHeights()
         {
@@ -434,7 +434,6 @@ namespace ClosedXML_Tests
             }
         }
 
-
         [Test]
         public void CopyWorksheeInsideWorkbookMakesNamedRangesLocal()
         {
@@ -518,7 +517,6 @@ namespace ClosedXML_Tests
                 var cf = ws1.Range("B1:C2").AddConditionalFormat();
                 cf.Ranges.Add(ws1.Range("D4:D5"));
                 cf.WhenEqualOrGreaterThan(100).Font.SetBold();
-                
 
                 var ws2 = ws1.CopyTo(wb2, "Copy");
 
@@ -533,7 +531,7 @@ namespace ClosedXML_Tests
                         Assert.AreEqual(original.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false),
                             copy.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false));
                     }
-                    
+
                     Assert.AreEqual((original.Style as XLStyle).Value, (copy.Style as XLStyle).Value);
                     Assert.AreEqual(original.Values.Single().Value.Value, copy.Values.Single().Value.Value);
                 }
@@ -563,7 +561,7 @@ namespace ClosedXML_Tests
                     .SetShowRowStripes(true);
                 table1.Theme = XLTableTheme.TableStyleDark8;
                 table1.Field(1).TotalsRowFunction = XLTotalsRowFunction.Sum;
-                
+
                 var ws2 = ws1.CopyTo(wb2, "Copy");
 
                 Assert.AreEqual(ws1.Tables.Count(), ws2.Tables.Count());
@@ -607,7 +605,7 @@ namespace ClosedXML_Tests
                 dv1.ErrorStyle = XLErrorStyle.Warning;
                 dv1.ErrorTitle = "Number out of range";
                 dv1.ErrorMessage = "This cell only allows the number 2.";
-                
+
                 var dv2 = ws1.Ranges("B2:C3,D4:E5").SetDataValidation();
                 dv2.Decimal.GreaterThan(5);
                 dv2.ErrorStyle = XLErrorStyle.Stop;
@@ -619,7 +617,7 @@ namespace ClosedXML_Tests
                 dv3.ErrorStyle = XLErrorStyle.Information;
                 dv3.ErrorTitle = "Text length out of range";
                 dv3.ErrorMessage = "You entered more than 10 characters.";
-                
+
                 var ws2 = ws1.CopyTo(wb2, "Copy");
 
                 Assert.AreEqual(ws1.DataValidations.Count(), ws2.DataValidations.Count());

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -542,20 +542,27 @@ namespace ClosedXML_Tests
 
                 ws1.Range("A:A").AddConditionalFormat()
                     .WhenContains("0").Fill.SetBackgroundColor(XLColor.Red);
-                ws1.Range("B1:C2").AddConditionalFormat()
-                    .WhenEqualOrGreaterThan(100).Font.SetBold();
+                var cf = ws1.Range("B1:C2").AddConditionalFormat();
+                cf.Ranges.Add(ws1.Range("D4:D5"));
+                cf.WhenEqualOrGreaterThan(100).Font.SetBold();
+                
 
                 var ws2 = ws1.CopyTo(wb2, "Copy");
 
                 Assert.AreEqual(ws1.ConditionalFormats.Count(), ws2.ConditionalFormats.Count());
                 for (int i = 0; i < ws1.ConditionalFormats.Count(); i++)
                 {
-                    Assert.AreEqual(ws1.ConditionalFormats.ElementAt(i).Ranges.ToString(),
-                                    ws2.ConditionalFormats.ElementAt(i).Ranges.ToString());
-                    Assert.AreEqual(ws1.ConditionalFormats.ElementAt(i).Style,
-                                    ws2.ConditionalFormats.ElementAt(i).Style);
-                    Assert.AreEqual(ws1.ConditionalFormats.ElementAt(i).Values.Single(),
-                                    ws2.ConditionalFormats.ElementAt(i).Values.Single());
+                    var original = ws1.ConditionalFormats.ElementAt(i);
+                    var copy = ws2.ConditionalFormats.ElementAt(i);
+                    Assert.AreEqual(original.Ranges.Count, copy.Ranges.Count);
+                    for (int j = 0; j < original.Ranges.Count; j++)
+                    {
+                        Assert.AreEqual(original.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false),
+                            copy.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false));
+                    }
+                    
+                    Assert.AreEqual((original.Style as XLStyle).Value, (copy.Style as XLStyle).Value);
+                    Assert.AreEqual(original.Values.Single().Value.Value, copy.Values.Single().Value.Value);
                 }
             }
         }


### PR DESCRIPTION
This PR addresses #829.

Here I added unit tests covering different aspects of worksheets copying and implemented missing functionality.
To simplify the worksheet's method `CopyTo` I extracted part of the logic into corresponding classes (XLTable, XLPicture).

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer