### PR TITLE
Invalidate named ranges when the worksheet is deleted

### DIFF
--- a/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
@@ -21,6 +21,11 @@ namespace ClosedXML.Excel
         String Comment { get; set; }
 
         /// <summary>
+        /// Checks if the named range contains invalid references (#REF!).
+        /// </summary>
+        bool IsValid { get; }
+
+        /// <summary>
         /// Gets or sets the name of the range.
         /// </summary>
         /// <value>

--- a/ClosedXML/Excel/NamedRanges/IXLNamedRanges.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRanges.cs
@@ -80,5 +80,15 @@ namespace ClosedXML.Excel
         Boolean TryGetValue(String name, out IXLNamedRange range);
 
         Boolean Contains(String name);
+
+        /// <summary>
+        /// Returns a subset of named ranges that do not have invalid references.
+        /// </summary>
+        IEnumerable<IXLNamedRange> ValidNamedRanges();
+
+        /// <summary>
+        /// Returns a subset of named ranges that do have invalid references.
+        /// </summary>
+        IEnumerable<IXLNamedRange> InvalidNamedRanges();
     }
 }

--- a/ClosedXML/Excel/NamedRanges/XLNamedRanges.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRanges.cs
@@ -7,8 +7,11 @@ namespace ClosedXML.Excel
     internal class XLNamedRanges : IXLNamedRanges
     {
         private readonly Dictionary<String, IXLNamedRange> _namedRanges = new Dictionary<String, IXLNamedRange>(StringComparer.OrdinalIgnoreCase);
+
         internal XLWorkbook Workbook { get; set; }
+
         internal XLWorksheet Worksheet { get; set; }
+
         internal XLNamedRangeScope Scope { get; }
 
         public XLNamedRanges(XLWorksheet worksheet)
@@ -134,6 +137,22 @@ namespace ClosedXML.Excel
             _namedRanges.Clear();
         }
 
+        /// <summary>
+        /// Returns a subset of named ranges that do not have invalid references.
+        /// </summary>
+        public IEnumerable<IXLNamedRange> ValidNamedRanges()
+        {
+            return this.Where(nr => nr.IsValid);
+        }
+
+        /// <summary>
+        /// Returns a subset of named ranges that do have invalid references.
+        /// </summary>
+        public IEnumerable<IXLNamedRange> InvalidNamedRanges()
+        {
+            return this.Where(nr => !nr.IsValid);
+        }
+
         #endregion IXLNamedRanges Members
 
         #region IEnumerable<IXLNamedRange> Members
@@ -172,6 +191,13 @@ namespace ClosedXML.Excel
                 return Workbook.NamedRange(name) != null;
             else
                 return false;
+        }
+
+        internal void OnWorksheetDeleted(string worksheetName)
+        {
+            _namedRanges.Values
+                .Cast<XLNamedRange>()
+                .ForEach(nr => nr.OnWorksheetDeleted(worksheetName));
         }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1282,20 +1282,17 @@ namespace ClosedXML.Excel
                 {
                     string text = definedName.Text;
 
-                    if (!(text.Equals("#REF") || text.EndsWith("#REF!")))
+                    var localSheetId = definedName.LocalSheetId;
+                    var comment = definedName.Comment;
+                    if (localSheetId == null)
                     {
-                        var localSheetId = definedName.LocalSheetId;
-                        var comment = definedName.Comment;
-                        if (localSheetId == null)
-                        {
-                            if (NamedRanges.All(nr => nr.Name != name))
-                                (NamedRanges as XLNamedRanges).Add(name, text, comment, true).Visible = visible;
-                        }
-                        else
-                        {
-                            if (Worksheet(Int32.Parse(localSheetId) + 1).NamedRanges.All(nr => nr.Name != name))
-                                (Worksheet(Int32.Parse(localSheetId) + 1).NamedRanges as XLNamedRanges).Add(name, text, comment, true).Visible = visible;
-                        }
+                        if (NamedRanges.All(nr => nr.Name != name))
+                            (NamedRanges as XLNamedRanges).Add(name, text, comment, true).Visible = visible;
+                    }
+                    else
+                    {
+                        if (Worksheet(Int32.Parse(localSheetId) + 1).NamedRanges.All(nr => nr.Name != name))
+                            (Worksheet(Int32.Parse(localSheetId) + 1).NamedRanges as XLNamedRanges).Add(name, text, comment, true).Visible = visible;
                     }
                 }
             }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -140,6 +140,8 @@ namespace ClosedXML.Excel
         public XLSheetProtection Protection { get; private set; }
         public XLAutoFilter AutoFilter { get; private set; }
 
+        public bool IsDeleted { get; private set; }
+
         #region IXLWorksheet Members
 
         public XLWorkbook Workbook { get; private set; }
@@ -524,6 +526,8 @@ namespace ClosedXML.Excel
 
         public void Delete()
         {
+            IsDeleted = true;
+            (Workbook.NamedRanges as XLNamedRanges).OnWorksheetDeleted(Name);
             Workbook.WorksheetsInternal.Delete(Name);
         }
 

--- a/ClosedXML_Tests/Excel/Coordinates/XLAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Coordinates/XLAddressTests.cs
@@ -53,5 +53,139 @@ namespace ClosedXML_Tests
             Assert.AreEqual("'Sheet 1'!R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
             Assert.AreEqual("'Sheet 1'!$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
         }
+
+        [Test]
+        public void InvalidAddressToStringTest()
+        {
+            var address = ProduceInvalidAddress();
+
+            Assert.AreEqual("#REF!", address.ToString());
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.Default));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.Default, true));
+        }
+
+        [Test]
+        public void InvalidAddressToStringFixedTest()
+        {
+            var address = ProduceInvalidAddress();
+
+            Assert.AreEqual("#REF!", address.ToStringFixed());
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.Default));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
+        }
+
+        [Test]
+        public void InvalidAddressToStringRelativeTest()
+        {
+            var address = ProduceInvalidAddress();
+
+            Assert.AreEqual("#REF!", address.ToStringRelative());
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringRelative(true));
+        }
+
+        [Test]
+        public void AddressOnDeletedWorksheetToStringTest()
+        {
+            var address = ProduceAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("A1", address.ToString());
+            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.A1));
+            Assert.AreEqual("R1C1", address.ToString(XLReferenceStyle.R1C1));
+            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!A1", address.ToString(XLReferenceStyle.Default, true));
+        }
+
+        [Test]
+        public void AddressOnDeletedWorksheetToStringFixedTest()
+        {
+            var address = ProduceAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("$A$1", address.ToStringFixed());
+            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.A1));
+            Assert.AreEqual("R1C1", address.ToStringFixed(XLReferenceStyle.R1C1));
+            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!$A$1", address.ToStringFixed(XLReferenceStyle.A1, true));
+            Assert.AreEqual("#REF!R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+            Assert.AreEqual("#REF!$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
+        }
+
+        [Test]
+        public void AddressOnDeletedWorksheetToStringRelativeTest()
+        {
+            var address = ProduceAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("A1", address.ToStringRelative());
+            Assert.AreEqual("#REF!A1", address.ToStringRelative(true));
+        }
+
+        [Test]
+        public void InvalidAddressOnDeletedWorksheetToStringTest()
+        {
+            var address = ProduceInvalidAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!", address.ToString());
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.Default, true));
+        }
+
+        [Test]
+        public void InvalidAddressOnDeletedWorksheetToStringFixedTest()
+        {
+            var address = ProduceInvalidAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!", address.ToStringFixed());
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
+        }
+
+        [Test]
+        public void InvalidAddressOnDeletedWorksheetToStringRelativeTest()
+        {
+            var address = ProduceInvalidAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!", address.ToStringRelative());
+            Assert.AreEqual("#REF!#REF!", address.ToStringRelative(true));
+        }
+
+        #region Private Methods
+
+        private IXLAddress ProduceInvalidAddress()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
+            var range = ws.Range("A1:B2");
+
+            ws.Rows(1, 5).Delete();
+            return range.RangeAddress.FirstAddress;
+        }
+
+        private IXLAddress ProduceAddressOnDeletedWorksheet()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
+            var address = ws.Cell("A1").Address;
+
+            ws.Delete();
+            return address;
+        }
+
+        private IXLAddress ProduceInvalidAddressOnDeletedWorksheet()
+        {
+            var address = ProduceInvalidAddress();
+            address.Worksheet.Delete();
+            return address;
+        }
+
+        #endregion Private Methods
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -69,5 +69,144 @@ namespace ClosedXML_Tests
             Assert.AreSame(ws, rangeAddress.Worksheet);
             Assert.AreEqual(expectedAddress, normalizedAddress.ToString());
         }
+
+        [Test]
+        public void InvalidRangeAddressToStringTest()
+        {
+            var address = ProduceInvalidAddress();
+
+            Assert.AreEqual("#REF!", address.ToString());
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.Default));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.R1C1));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.Default, true));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.R1C1, true));
+        }
+
+        [Test]
+        public void InvalidRangeAddressToStringFixedTest()
+        {
+            var address = ProduceInvalidAddress();
+
+            Assert.AreEqual("#REF!", address.ToStringFixed());
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+        }
+
+        [Test]
+        public void InvalidRangeAddressToStringRelativeTest()
+        {
+            var address = ProduceInvalidAddress();
+
+            Assert.AreEqual("#REF!", address.ToStringRelative());
+            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringRelative(true));
+        }
+
+        [Test]
+        public void RangeAddressOnDeletedWorksheetToStringTest()
+        {
+            var address = ProduceAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!A1:B2", address.ToString());
+            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!R1C1:R2C2", address.ToString(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.Default, true));
+            Assert.AreEqual("#REF!R1C1:R2C2", address.ToString(XLReferenceStyle.R1C1, true));
+        }
+
+        [Test]
+        public void RangeAddressOnDeletedWorksheetToStringFixedTest()
+        {
+            var address = ProduceAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed());
+            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!R1C1:R2C2", address.ToStringFixed(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.A1, true));
+            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.AreEqual("#REF!R1C1:R2C2", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+        }
+
+        [Test]
+        public void RangeAddressOnDeletedWorksheetToStringRelativeTest()
+        {
+            var address = ProduceAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!A1:B2", address.ToStringRelative());
+            Assert.AreEqual("#REF!A1:B2", address.ToStringRelative(true));
+        }
+
+        [Test]
+        public void InvalidRangeAddressOnDeletedWorksheetToStringTest()
+        {
+            var address = ProduceInvalidAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!#REF!", address.ToString());
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.Default, true));
+            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.R1C1, true));
+        }
+
+        [Test]
+        public void InvalidRangeAddressOnDeletedWorksheetToStringFixedTest()
+        {
+            var address = ProduceInvalidAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed());
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.A1));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.Default));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+        }
+
+        [Test]
+        public void InvalidRangeAddressOnDeletedWorksheetToStringRelativeTest()
+        {
+            var address = ProduceInvalidAddressOnDeletedWorksheet();
+
+            Assert.AreEqual("#REF!#REF!", address.ToStringRelative());
+            Assert.AreEqual("#REF!#REF!", address.ToStringRelative(true));
+        }
+        #region Private Methods
+
+        private IXLRangeAddress ProduceInvalidAddress()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
+            var range = ws.Range("A1:B2");
+
+            ws.Rows(1, 5).Delete();
+            return range.RangeAddress;
+        }
+
+        private IXLRangeAddress ProduceAddressOnDeletedWorksheet()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
+            var address = ws.Range("A1:B2").RangeAddress;
+
+            ws.Delete();
+            return address;
+        }
+
+        private IXLRangeAddress ProduceInvalidAddressOnDeletedWorksheet()
+        {
+            var address = ProduceInvalidAddress();
+            address.Worksheet.Delete();
+            return address;
+        }
+
+        #endregion Private Methods
     }
 }

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -815,5 +815,20 @@ namespace ClosedXML_Tests
                 Assert.AreEqual("Renamed!A1 * 3", ws1.Cell("A2").FormulaA1);
             }
         }
+
+        [Test]
+        public void RangesFromDeletedWorksheetContainREF()
+        {
+            using (var wb1 = new XLWorkbook())
+            {
+                wb1.Worksheets.Add("Sheet1");
+                var ws2 = wb1.Worksheets.Add("Sheet2");
+                var range = ws2.Range("A1:B2");
+
+                ws2.Delete();
+
+                Assert.AreEqual("#REF!A1:B2", range.RangeAddress.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #848.

When the worksheet is being deleted the references in named ranges are updated so that ranges from the deleted sheet were replaced with `#REF!`. For now, we do not support constructing invalid ranges from `#REF!` text so in `Ranges` getter we simply skip invalid ranges. 

To get collections of valid or invalid named ranges methods `ValidNamedRanges()` and `InvalidNamedRanges()` were added.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer