### PR TITLE
Disallow negative row or column count to be inserted

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1072,6 +1072,10 @@ namespace ClosedXML.Excel
 
         private IXLRangeColumns InsertColumnsBeforeInternal(Boolean onlyUsedCells, Int32 numberOfColumns, Boolean formatFromLeft = true, Boolean nullReturn = false)
         {
+            if (numberOfColumns < 0 || numberOfColumns > XLHelper.MaxColumnNumber)
+                throw new ArgumentOutOfRangeException(nameof(numberOfColumns),
+                    $"Number of columns to insert must be non-negative number no more than {XLHelper.MaxColumnNumber}");
+
             foreach (XLWorksheet ws in Worksheet.Workbook.WorksheetsInternal)
             {
                 foreach (XLCell cell in ws.Internals.CellsCollection.GetCells(c => !String.IsNullOrWhiteSpace(c.FormulaA1)))
@@ -1276,6 +1280,10 @@ namespace ClosedXML.Excel
 
         private IXLRangeRows InsertRowsAboveInternal(Boolean onlyUsedCells, Int32 numberOfRows, Boolean formatFromAbove, Boolean nullReturn)
         {
+            if (numberOfRows < 0 || numberOfRows > XLHelper.MaxRowNumber)
+                throw new ArgumentOutOfRangeException(nameof(numberOfRows),
+                    $"Number of rows to insert must be non-negative number no more than {XLHelper.MaxRowNumber}");
+
             var asRange = AsRange();
             foreach (XLWorksheet ws in Worksheet.Workbook.WorksheetsInternal)
             {

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1072,9 +1072,9 @@ namespace ClosedXML.Excel
 
         private IXLRangeColumns InsertColumnsBeforeInternal(Boolean onlyUsedCells, Int32 numberOfColumns, Boolean formatFromLeft = true, Boolean nullReturn = false)
         {
-            if (numberOfColumns < 0 || numberOfColumns > XLHelper.MaxColumnNumber)
+            if (numberOfColumns <= 0 || numberOfColumns > XLHelper.MaxColumnNumber)
                 throw new ArgumentOutOfRangeException(nameof(numberOfColumns),
-                    $"Number of columns to insert must be non-negative number no more than {XLHelper.MaxColumnNumber}");
+                    $"Number of columns to insert must be a positive number no more than {XLHelper.MaxColumnNumber}");
 
             foreach (XLWorksheet ws in Worksheet.Workbook.WorksheetsInternal)
             {
@@ -1280,9 +1280,9 @@ namespace ClosedXML.Excel
 
         private IXLRangeRows InsertRowsAboveInternal(Boolean onlyUsedCells, Int32 numberOfRows, Boolean formatFromAbove, Boolean nullReturn)
         {
-            if (numberOfRows < 0 || numberOfRows > XLHelper.MaxRowNumber)
+            if (numberOfRows <= 0 || numberOfRows > XLHelper.MaxRowNumber)
                 throw new ArgumentOutOfRangeException(nameof(numberOfRows),
-                    $"Number of rows to insert must be non-negative number no more than {XLHelper.MaxRowNumber}");
+                    $"Number of rows to insert must be a positive number no more than {XLHelper.MaxRowNumber}");
 
             var asRange = AsRange();
             foreach (XLWorksheet ws in Worksheet.Workbook.WorksheetsInternal)

--- a/ClosedXML_Tests/Excel/Ranges/InsertingRangesTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/InsertingRangesTests.cs
@@ -215,7 +215,16 @@ namespace ClosedXML_Tests
         }
 
         [Test]
-        public void InsertNegativeNumberOrColumnsFails()
+        public void InsertZeroColumnsFails()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            var range = ws.FirstCell().AsRange();
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertColumnsAfter(0));
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertColumnsBefore(0));
+        }
+
+        [Test]
+        public void InsertNegativeNumberOfColumnsFails()
         {
             var ws = new XLWorkbook().AddWorksheet("Sheet1");
             var range = ws.FirstCell().AsRange();
@@ -224,7 +233,7 @@ namespace ClosedXML_Tests
         }
 
         [Test]
-        public void InsertTooLargeNumberOrColumnsFails()
+        public void InsertTooLargeNumberOfColumnsFails()
         {
             var ws = new XLWorkbook().AddWorksheet("Sheet1");
             var range = ws.FirstCell().AsRange();
@@ -233,7 +242,16 @@ namespace ClosedXML_Tests
         }
 
         [Test]
-        public void InsertNegativeNumberOrRowsFails()
+        public void InsertZeroRowsFails()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            var range = ws.FirstCell().AsRange();
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertRowsAbove(0));
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertRowsBelow(0));
+        }
+
+        [Test]
+        public void InsertNegativeNumberOfRowsFails()
         {
             var ws = new XLWorkbook().AddWorksheet("Sheet1");
             var range = ws.FirstCell().AsRange();

--- a/ClosedXML_Tests/Excel/Ranges/InsertingRangesTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/InsertingRangesTests.cs
@@ -1,6 +1,7 @@
-using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
+using System.Linq;
 
 namespace ClosedXML_Tests
 {
@@ -211,6 +212,42 @@ namespace ClosedXML_Tests
 
                 Assert.IsFalse(thisRange.RangeAddress.IsValid);
             }
+        }
+
+        [Test]
+        public void InsertNegativeNumberOrColumnsFails()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            var range = ws.FirstCell().AsRange();
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertColumnsAfter(-1));
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertColumnsBefore(-1));
+        }
+
+        [Test]
+        public void InsertTooLargeNumberOrColumnsFails()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            var range = ws.FirstCell().AsRange();
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertColumnsAfter(16385));
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertColumnsBefore(16385));
+        }
+
+        [Test]
+        public void InsertNegativeNumberOrRowsFails()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            var range = ws.FirstCell().AsRange();
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertRowsAbove(-1));
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertRowsBelow(-1));
+        }
+
+        [Test]
+        public void InsertTooLargeNumberOrRowsFails()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            var range = ws.FirstCell().AsRange();
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertRowsAbove(1048577));
+            Assert.Throws(typeof(ArgumentOutOfRangeException), () => range.InsertRowsBelow(1048577));
         }
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/MergedRangesTests.cs
@@ -121,9 +121,8 @@ namespace ClosedXML_Tests
             }
         }
 
-        [TestCase(-2)]
-        [TestCase(2)]
-        public void RangeShiftHorizontallyBreaksMerges(int columnShift)
+        [Test]
+        public void ShiftRangeRightBreaksMerges()
         {
             using (var wb = new XLWorkbook())
             {
@@ -135,7 +134,7 @@ namespace ClosedXML_Tests
                 ws.Range("H1:I2").Merge();
                 ws.Range("H5:I6").Merge();
 
-                ws.Range("D3:E4").InsertColumnsAfter(columnShift);
+                ws.Range("D3:E4").InsertColumnsAfter(2);
 
                 var mr = ws.MergedRanges.ToArray();
                 Assert.AreEqual(4, mr.Length);
@@ -146,9 +145,32 @@ namespace ClosedXML_Tests
             }
         }
 
-        [TestCase(-2)]
-        [TestCase(2)]
-        public void RangeShiftVerticallyBreaksMerges(int rowShift)
+        [Test]
+        public void ShiftRangeLeftBreaksMerges()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("MRShift");
+                ws.Range("B2:C3").Merge();
+                ws.Range("B4:C5").Merge();
+                ws.Range("F2:G3").Merge(); // to be broken
+                ws.Range("F4:G5").Merge(); // to be broken
+                ws.Range("H1:I2").Merge();
+                ws.Range("H5:I6").Merge();
+
+                ws.Range("D3:E4").Delete(XLShiftDeletedCells.ShiftCellsLeft);
+
+                var mr = ws.MergedRanges.ToArray();
+                Assert.AreEqual(4, mr.Length);
+                Assert.AreEqual("B2:C3", mr[0].RangeAddress.ToString());
+                Assert.AreEqual("B4:C5", mr[1].RangeAddress.ToString());
+                Assert.AreEqual("H1:I2", mr[2].RangeAddress.ToString());
+                Assert.AreEqual("H5:I6", mr[3].RangeAddress.ToString());
+            }
+        }
+
+        [Test]
+        public void RangeShiftDownBreaksMerges()
         {
             using (var wb = new XLWorkbook())
             {
@@ -160,7 +182,31 @@ namespace ClosedXML_Tests
                 ws.Range("A8:B9").Merge();
                 ws.Range("E8:F9").Merge();
 
-                ws.Range("C4:D5").InsertRowsBelow(rowShift);
+                ws.Range("C4:D5").InsertRowsBelow(2);
+
+                var mr = ws.MergedRanges.ToArray();
+                Assert.AreEqual(4, mr.Length);
+                Assert.AreEqual("B2:C3", mr[0].RangeAddress.ToString());
+                Assert.AreEqual("D2:E3", mr[1].RangeAddress.ToString());
+                Assert.AreEqual("A8:B9", mr[2].RangeAddress.ToString());
+                Assert.AreEqual("E8:F9", mr[3].RangeAddress.ToString());
+            }
+        }
+
+        [Test]
+        public void RangeShiftUpBreaksMerges()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("MRShift");
+                ws.Range("B2:C3").Merge();
+                ws.Range("D2:E3").Merge();
+                ws.Range("B6:C7").Merge(); // to be broken
+                ws.Range("D6:E7").Merge(); // to be broken
+                ws.Range("A8:B9").Merge();
+                ws.Range("E8:F9").Merge();
+
+                ws.Range("C4:D5").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
                 var mr = ws.MergedRanges.ToArray();
                 Assert.AreEqual(4, mr.Length);


### PR DESCRIPTION
This PR fixes #855 by throwing the exception on an attempt to insert a negative or too big number of rows or columns. Existing tests for breaking merged ranges on shifting were split as they used a negative shift.

- [ ] C# Code Review: @ClosedXML/reviewers 
- [ ] Test Automation Review: @csreviewer