### PR TITLE
Fix check for missing file extension on saving

### DIFF
--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -480,7 +480,7 @@ namespace ClosedXML.Excel
         {
             var extension = Path.GetExtension(filePath);
 
-            if (extension == null) throw new ArgumentException("Empty extension is not supported.");
+            if (string.IsNullOrEmpty(extension)) throw new ArgumentException("Empty extension is not supported.");
             extension = extension.Substring(1).ToLowerInvariant();
 
             switch (extension)

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -146,7 +146,7 @@ namespace ClosedXML_Tests.Excel.Saving
                 }
             }
         }
-        
+
         [Test]
         public void SaveCachedValueWhenFlagIsTrue()
         {
@@ -370,6 +370,32 @@ namespace ClosedXML_Tests.Excel.Saving
         }
 
         [Test]
+        public void SaveAsWithNoExtensionFails()
+        {
+            using (var tf = new TemporaryFile("FileWithNoExtension"))
+            using (var wb = new XLWorkbook())
+            {
+                wb.Worksheets.Add("Sheet1");
+                TestDelegate action = () => wb.SaveAs(tf.Path);
+
+                Assert.Throws<ArgumentException>(action);
+            }
+        }
+
+        [Test]
+        public void SaveAsWithUnsupportedExtensionFails()
+        {
+            using (var tf = new TemporaryFile("FileWithBadExtension.bad"))
+            using (var wb = new XLWorkbook())
+            {
+                wb.Worksheets.Add("Sheet1");
+                TestDelegate action = () => wb.SaveAs(tf.Path);
+
+                Assert.Throws<ArgumentException>(action);
+            }
+        }
+
+        [Test]
         public void SaveCellValueWithLeadingQuotationMarkCorrectly()
         {
             var quotedFormulaValue = "'=IF(TRUE, 1, 0)";
@@ -419,7 +445,7 @@ namespace ClosedXML_Tests.Excel.Saving
 
                 using (var wb = new XLWorkbook(ms))
                 {
-                    foreach (var sheetName in new []{"Sheet1", "Sheet2"})
+                    foreach (var sheetName in new[] { "Sheet1", "Sheet2" })
                     {
                         var ws = wb.Worksheet(sheetName);
 
@@ -452,7 +478,7 @@ namespace ClosedXML_Tests.Excel.Saving
 
                 using (var wb = new XLWorkbook(ms))
                 {
-                    foreach (var sheetName in new[] {"Sheet1", "Sheet2"})
+                    foreach (var sheetName in new[] { "Sheet1", "Sheet2" })
                     {
                         var ws = wb.Worksheet(sheetName);
 


### PR DESCRIPTION
This PR fixes a minor bug: on workbook saving, we checked if the provided file name has an extension. The thing is, however, when the file name has no extension the `extension` variable is not null but is an empty string. The exception was thrown anyway (on the next line, in `extension.Substring(1)`), but not the proper kind.