### PR TITLE
Add helper property VisibleRows for autofilters

### DIFF
--- a/ClosedXML/Excel/AutoFilters/IXLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLAutoFilter.cs
@@ -1,4 +1,5 @@
 using System;
+
 namespace ClosedXML.Excel
 {
     using System.Collections.Generic;
@@ -6,11 +7,14 @@ namespace ClosedXML.Excel
     public interface IXLAutoFilter
     {
         IXLFilterColumn Column(String column);
+
         IXLFilterColumn Column(Int32 column);
 
         IXLAutoFilter Sort(Int32 columnToSortBy = 1, XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
+
         Boolean Sorted { get; set; }
         XLSortOrder SortOrder { get; set; }
         Int32 SortColumn { get; set; }
+        IEnumerable<IXLRangeRow> VisibleRows { get; }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/IXLBaseAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLBaseAutoFilter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
@@ -26,5 +27,6 @@ namespace ClosedXML.Excel
         Boolean Sorted { get; set; }
         XLSortOrder SortOrder { get; set; }
         Int32 SortColumn { get; set; }
+        IEnumerable<IXLRangeRow> VisibleRows { get; }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel
             return Sort(columnToSortBy, sortOrder, matchCase, ignoreBlanks);
         }
 
-        #endregion
+        #endregion IXLAutoFilter Members
 
         #region IXLBaseAutoFilter Members
 
@@ -74,7 +74,7 @@ namespace ClosedXML.Excel
             return filterColumn;
         }
 
-        #endregion
+        #endregion IXLBaseAutoFilter Members
 
         public XLAutoFilter Set(IXLRangeBase range)
         {
@@ -166,6 +166,14 @@ namespace ClosedXML.Excel
 
             ws.ResumeEvents();
             return this;
+        }
+
+        public IEnumerable<IXLRangeRow> VisibleRows
+        {
+            get
+            {
+                return Range.Rows(r => !r.WorksheetRow().IsHidden);
+            }
         }
     }
 }

--- a/ClosedXML_Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML_Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -33,6 +33,7 @@ namespace ClosedXML_Tests
                     table.DataRange.FirstCell().InsertData(listOfArr);
 
                     Assert.AreEqual("A1:A5", table.AutoFilter.Range.RangeAddress.ToStringRelative());
+                    Assert.AreEqual(5, table.AutoFilter.VisibleRows.Count());
                 }
             }
         }
@@ -49,7 +50,7 @@ namespace ClosedXML_Tests
                         .CellBelow().SetValue("Carlos")
                         .CellBelow().SetValue("Dominic");
                     ws.RangeUsed().SetAutoFilter().Sort();
-                    Assert.AreEqual(ws.Cell(4, 3).GetString(), "Carlos");
+                    Assert.AreEqual("Carlos", ws.Cell(4, 3).GetString());
                 }
             }
         }
@@ -156,5 +157,31 @@ namespace ClosedXML_Tests
                 }
             }
         }
+
+        [Test]
+        public void AutoFilterVisibleRows()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                using (var ws = wb.Worksheets.Add("Sheet1"))
+                {
+                    ws.Cell(3, 3).SetValue("Names")
+                        .CellBelow().SetValue("Manuel")
+                        .CellBelow().SetValue("Carlos")
+                        .CellBelow().SetValue("Dominic");
+
+                    var autoFilter = ws.RangeUsed()
+                        .SetAutoFilter();
+
+                    autoFilter.Column(1).AddFilter("Carlos");
+
+                    Assert.AreEqual("Carlos", ws.Cell(5, 3).GetString());
+                    Assert.AreEqual(2, autoFilter.VisibleRows.Count());
+                    Assert.AreEqual(3, autoFilter.VisibleRows.First().WorksheetRow().RowNumber());
+                    Assert.AreEqual(5, autoFilter.VisibleRows.Last().WorksheetRow().RowNumber());
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Triggered by https://stackoverflow.com/questions/50537114/excel-closedxml-best-way-to-get-visible-rows-following-applying-setautofilte

This PR adds a helper property `VisibleRows` on autofilters.