### PR TITLE
Correctly determine used range when there are merged ranges on a worksheet (fix #881)

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -635,16 +635,19 @@ namespace ClosedXML.Excel
                         if (!cell.IsEmpty(true)) return cell;
                     }
                 }
+            }
 
-                var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
-                    .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
-                if (intersectedRanges.Any())
-                {
-                    Int32 minRo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.RowNumber);
-                    Int32 minCo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.ColumnNumber);
+            var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
+                .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
+            if (intersectedRanges.Any())
+            {
+                Int32 minRo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.RowNumber);
+                Int32 minCo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.ColumnNumber);
 
-                    return Worksheet.Cell(minRo, minCo);
-                }
+                if (0 < sp.Row && sp.Row < minRo) minRo = sp.Row;
+                if (0 < sp.Column && sp.Column < minCo) minCo = sp.Column;
+
+                return Worksheet.Cell(minRo, minCo);
             }
 
             if (sp.Row > 0)
@@ -726,16 +729,19 @@ namespace ClosedXML.Excel
                         if (!cell.IsEmpty(true)) return cell;
                     }
                 }
+            }
 
-                var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
-                    .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
-                if (intersectedRanges.Any())
-                {
-                    Int32 minRo = intersectedRanges.Max(r => r.RangeAddress.LastAddress.RowNumber);
-                    Int32 minCo = intersectedRanges.Max(r => r.RangeAddress.LastAddress.ColumnNumber);
+            var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
+                .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
+            if (intersectedRanges.Any())
+            {
+                Int32 maxRo = intersectedRanges.Max(r => r.RangeAddress.LastAddress.RowNumber);
+                Int32 maxCo = intersectedRanges.Max(r => r.RangeAddress.LastAddress.ColumnNumber);
 
-                    return Worksheet.Cell(minRo, minCo);
-                }
+                if (sp.Row > maxRo) maxRo = sp.Row;
+                if (sp.Column > maxCo) maxCo = sp.Column;
+
+                return Worksheet.Cell(maxRo, maxCo);
             }
 
             if (sp.Row > 0)

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -644,8 +644,8 @@ namespace ClosedXML.Excel
                 Int32 minRo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.RowNumber);
                 Int32 minCo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.ColumnNumber);
 
-                if (0 < sp.Row && sp.Row < minRo) minRo = sp.Row;
-                if (0 < sp.Column && sp.Column < minCo) minCo = sp.Column;
+                if (sp.Row.Between(1, minRo - 1))  minRo = sp.Row;
+                if (sp.Column.Between(1, minCo - 1)) minCo = sp.Column;
 
                 return Worksheet.Cell(minRo, minCo);
             }

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -638,7 +638,7 @@ namespace ClosedXML.Excel
             }
 
             var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
-                .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
+                .Where(r => predicate?.Invoke(r.FirstCell()) ?? true).ToList();
             if (intersectedRanges.Any())
             {
                 Int32 minRo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.RowNumber);
@@ -732,7 +732,7 @@ namespace ClosedXML.Excel
             }
 
             var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
-                .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
+                .Where(r => predicate?.Invoke(r.FirstCell()) ?? true).ToList();
             if (intersectedRanges.Any())
             {
                 Int32 maxRo = intersectedRanges.Max(r => r.RangeAddress.LastAddress.RowNumber);

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -636,7 +636,8 @@ namespace ClosedXML.Excel
                     }
                 }
 
-                var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress).ToList();
+                var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
+                    .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
                 if (intersectedRanges.Any())
                 {
                     Int32 minRo = intersectedRanges.Min(r => r.RangeAddress.FirstAddress.RowNumber);
@@ -726,7 +727,8 @@ namespace ClosedXML.Excel
                     }
                 }
 
-                var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress).ToList();
+                var intersectedRanges = Worksheet.MergedRanges.GetIntersectedRanges(RangeAddress)
+                    .Where(r => predicate == null || predicate(r.FirstCell())).ToList();
                 if (intersectedRanges.Any())
                 {
                     Int32 minRo = intersectedRanges.Max(r => r.RangeAddress.LastAddress.RowNumber);

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -145,5 +145,33 @@ namespace ClosedXML_Tests.Excel.Ranges
                 Assert.AreEqual("A1:E2", used);
             }
         }
+
+        [TestCase(true, "A1:D2", "A1")]
+        [TestCase(true, "A2:D2", "A2")]
+        [TestCase(true, "A1:D2", "A1", "B2")]
+        [TestCase(true, "B2:D3", "C3")]
+        [TestCase(true, "B2:F4", "F4")]
+        [TestCase(false, "A1:D2", "A1")]
+        [TestCase(false, "A2:D2", "A2")]
+        [TestCase(false, "A1:D2", "A1", "B2")]
+        [TestCase(false, "B2:D3", "C3")]
+        [TestCase(false, "B2:F4", "F4")]
+        public void RangeUsedIncludesMergedCells(bool includeFormatting, string expectedRange,
+            params string[] cellsWithValues)
+        {
+            using (XLWorkbook wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                foreach (var cellAddress in cellsWithValues)
+                {
+                    ws.Cell(cellAddress).Value = "Not empty";
+                }
+                ws.Range("B2:D2").Merge();
+
+                var actual = ws.RangeUsed(includeFormatting).RangeAddress;
+
+                Assert.AreEqual(expectedRange, actual.ToString());
+            }
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -173,5 +173,43 @@ namespace ClosedXML_Tests.Excel.Ranges
                 Assert.AreEqual(expectedRange, actual.ToString());
             }
         }
+
+        [Test]
+        public void LastCellUsedPredicateConsidersMergedRanges()
+        {
+            using (XLWorkbook wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
+                ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
+                ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
+                ws.Range("A1:C1").Merge();
+                ws.Range("A2:C2").Merge();
+                ws.Range("A3:C3").Merge();
+
+                var actual = ws.LastCellUsed(true, c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
+
+                Assert.AreEqual("C2", actual.Address.ToString());
+            }
+        }
+
+        [Test]
+        public void FirstCellUsedPredicateConsidersMergedRanges()
+        {
+            using (XLWorkbook wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
+                ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
+                ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
+                ws.Range("A1:C1").Merge();
+                ws.Range("A2:C2").Merge();
+                ws.Range("A3:C3").Merge();
+
+                var actual = ws.FirstCellUsed(true, c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
+
+                Assert.AreEqual("A2", actual.Address.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes #881.

The code for getting the first and the last used cells of the range had following problems:

1. It analyzed merged ranges only when `includeFormat` flag was true. I am convinced that merged ranges had to be considered even if `includeFormat` is false because it's not just the matter of formatting but it specifies how far the data extends.
2. When merged ranges were analyzed all other cells were ignored. Say, for the `FirstUsedCell` the first cell of merged ranges was returned even if there exist other cells with lower coordinates (see the original issue)
3. Besides, when merged ranges were analyzed the predicate passed into method was ignored. It did not affect `RangeUsed` method as it does not use predicate but produced an incorrect result if `FirstCellUsed` and `LastCellUsed` methods were called directly.

There still is the problem with applying a predicate to rows and columns (it is ignored there too) but that is another issue (#889), which is harder to fix.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer