### PR TITLE
Use current locale in the test instead of invariant culture

### DIFF
--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -402,19 +402,19 @@ namespace ClosedXML_Tests
                 object expected;
 
                 var date = new DateTime(2018, 4, 18);
-                expected = date.ToInvariantString();
+                expected = date.ToString();
                 cell.Value = expected;
                 Assert.AreEqual(XLDataType.DateTime, cell.DataType);
                 Assert.AreEqual(date, cell.Value);
 
                 var b = true;
-                expected = b.ToInvariantString();
+                expected = b.ToString();
                 cell.Value = expected;
                 Assert.AreEqual(XLDataType.Boolean, cell.DataType);
                 Assert.AreEqual(b, cell.Value);
 
                 var ts = new TimeSpan(8, 12, 4);
-                expected = ts.ToInvariantString();
+                expected = ts.ToString();
                 cell.Value = expected;
                 Assert.AreEqual(XLDataType.TimeSpan, cell.DataType);
                 Assert.AreEqual(ts, cell.Value);


### PR DESCRIPTION
`SetStringCellValues` test fails on my machine. It converts a typed value to a string and then applies string value to a cell expecting that cell format will be deduced from the value. But this works with string formatted in the current locale if I am not mistaken. So I replaced `.ToInvariantString()` to `.ToString()` and test became green.

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer