### PR TITLE
Don't choke on pivot table saving when formulas fail

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1568,11 +1568,22 @@ namespace ClosedXML.Excel
 
         public Boolean TryGetValue<T>(out T value)
         {
-            var currValue = Value;
+            Object currValue;
+            try
+            {
+                currValue = Value;
+            }
+            catch
+            {
+                // May fail for formula evaluation
+                value = default;
+                return false;
+            }
+            
 
             if (currValue == null)
             {
-                value = default(T);
+                value = default;
                 return true;
             }
 

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -2135,10 +2135,11 @@ namespace ClosedXML.Excel
                         ptfi.DataType = XLDataType.Number;
                         ptfi.MixedDataType = false;
                         ptfi.DistinctValues = fieldValueCells
-                                .Select(cell => cell.GetDouble())
-                                .Distinct()
-                                .Cast<object>()
-                                .ToArray();
+                            .Where(cell => cell.TryGetValue(out Double _))
+                            .Select(cell => cell.CachedValue.CastTo<Double>())
+                            .Distinct()
+                            .Cast<object>()
+                            .ToArray();
 
                         var allInteger = ptfi.DistinctValues.All(v => int.TryParse(v.ToString(), out int val));
                         if (allInteger) sharedItems.ContainsInteger = true;
@@ -2169,7 +2170,8 @@ namespace ClosedXML.Excel
                         ptfi.DataType = XLDataType.DateTime;
                         ptfi.MixedDataType = false;
                         ptfi.DistinctValues = fieldValueCells
-                            .Select(cell => cell.GetDateTime())
+                            .Where(cell => cell.TryGetValue(out DateTime _))
+                            .Select(cell => cell.CachedValue.CastTo<DateTime>())
                             .Distinct()
                             .Cast<object>()
                             .ToArray();
@@ -2198,12 +2200,13 @@ namespace ClosedXML.Excel
 
                         if (!ptfi.MixedDataType && ptfi.DataType == XLDataType.Text)
                             ptfi.DistinctValues = fieldValueCells
-                                .Select(cell => cell.Value)
-                                .Cast<String>()
+                                .Where(cell => cell.TryGetValue(out String _))
+                                .Select(cell => cell.CachedValue.CastTo<String>())
                                 .Distinct(StringComparer.OrdinalIgnoreCase)
                                 .ToArray();
                         else
                             ptfi.DistinctValues = fieldValueCells
+                                .Where(cell => cell.TryGetValue(out String _))
                                 .Select(cell => cell.GetString())
                                 .Distinct(StringComparer.OrdinalIgnoreCase)
                                 .ToArray();

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -792,5 +792,23 @@ namespace ClosedXML_Tests
                 var _ = cell.Value;
             });
         }
+
+        [Test]
+        public void TryGetValueFormulaEvaluation()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                var A1 = ws.Cell("A1");
+                var A2 = ws.Cell("A2");
+                var A3 = ws.Cell("A3");
+                A1.FormulaA1 = "A2 + 1";
+                A2.FormulaA1 = "A1 + 1";
+
+                Assert.IsFalse(A1.TryGetValue(out String _));
+                Assert.IsFalse(A2.TryGetValue(out String _));
+                Assert.IsTrue(A3.TryGetValue(out String _));
+            }
+        }
     }
 }


### PR DESCRIPTION
For generating `Item` elements in pivot table cache, the value of a cell is requested. For cells with formulas, this sometimes failed (e.g. an unsupported function). This should not prohibit the saving process from completing.

Depends on #904 