### PR TITLE
Consolidate XLCell.InsertData and XLCell.InsertTable

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -176,9 +176,9 @@ namespace ClosedXML.Excel
         /// Inserts the IEnumerable data elements and returns the range it occupies.
         /// </summary>
         /// <param name="data">The IEnumerable data.</param>
-        /// <param name="tranpose">if set to <c>true</c> the data will be transposed before inserting.</param>
+        /// <param name="transpose">if set to <c>true</c> the data will be transposed before inserting.</param>
         /// <returns></returns>
-        IXLRange InsertData(IEnumerable data, Boolean tranpose);
+        IXLRange InsertData(IEnumerable data, Boolean transpose);
 
         /// <summary>
         /// Inserts the data of a data table.

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -944,23 +944,42 @@ namespace ClosedXML.Excel
                 IEnumerable<MemberInfo> members = null;
                 TypeAccessor accessor = null;
 
-                foreach (var m in data)
+                void incrementFieldPosition()
                 {
-                    var itemType = m.GetType();
+                    if (transpose)
+                        rowNumber++;
+                    else
+                        columnNumber++;
+                }
 
+                void incrementRecordPosition()
+                {
+                    if (transpose)
+                        columnNumber++;
+                    else
+                        rowNumber++;
+                }
+
+
+                void resetRecordPosition()
+                {
                     if (transpose)
                         rowNumber = _rowNumber;
                     else
                         columnNumber = _columnNumber;
+                }
+
+                foreach (var m in data)
+                {
+                    var itemType = m.GetType();
+
+                    resetRecordPosition();
 
                     if (itemType.IsPrimitive || itemType == typeof(String) || itemType == typeof(DateTime) || itemType.IsNumber())
                     {
                         Worksheet.SetValue(m, rowNumber, columnNumber);
 
-                        if (transpose)
-                            rowNumber++;
-                        else
-                            columnNumber++;
+                        incrementFieldPosition();
                     }
                     else if (itemType.IsArray)
                     {
@@ -968,10 +987,7 @@ namespace ClosedXML.Excel
                         {
                             Worksheet.SetValue(item, rowNumber, columnNumber);
 
-                            if (transpose)
-                                rowNumber++;
-                            else
-                                columnNumber++;
+                            incrementFieldPosition();
                         }
                     }
                     else if (isDataTable || m is DataRow)
@@ -983,10 +999,7 @@ namespace ClosedXML.Excel
                         {
                             Worksheet.SetValue(item, rowNumber, columnNumber);
 
-                            if (transpose)
-                                rowNumber++;
-                            else
-                                columnNumber++;
+                            incrementFieldPosition();
                         }
                     }
                     else if (isDataReader || m is IDataRecord)
@@ -1001,10 +1014,7 @@ namespace ClosedXML.Excel
                         {
                             Worksheet.SetValue(record[i], rowNumber, columnNumber);
 
-                            if (transpose)
-                                rowNumber++;
-                            else
-                                columnNumber++;
+                            incrementFieldPosition();
                         }
                     }
                     else
@@ -1034,17 +1044,11 @@ namespace ClosedXML.Excel
                             else
                                 Worksheet.SetValue(accessor[m, mi.Name], rowNumber, columnNumber);
 
-                            if (transpose)
-                                rowNumber++;
-                            else
-                                columnNumber++;
+                            incrementFieldPosition();
                         }
                     }
 
-                    if (transpose)
-                        columnNumber++;
-                    else
-                        rowNumber++;
+                    incrementRecordPosition();
 
                     if (columnNumber > maxColumnNumber)
                         maxColumnNumber = columnNumber;

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -786,12 +786,12 @@ namespace ClosedXML.Excel
 
             if (!data.Any())
             {
-                if (itemType.IsPrimitive || itemType == typeof(String) || itemType == typeof(DateTime) || itemType.IsNumber())
+                if (itemType.IsSimpleType())
                     maximumColumnNumber = _columnNumber;
                 else
                     maximumColumnNumber = _columnNumber + itemType.GetFields().Length + itemType.GetProperties().Length - 1;
             }
-            else if (itemType.IsPrimitive || itemType == typeof(String) || itemType == typeof(DateTime) || itemType.IsNumber())
+            else if (itemType.IsSimpleType())
             {
                 foreach (object o in data)
                 {
@@ -835,7 +835,7 @@ namespace ClosedXML.Excel
                 {
                     resetRecordPosition();
 
-                    if (m.GetType().IsPrimitive || m is String || m is DateTime || m is TimeSpan || m.IsNumber())
+                    if (m.GetType().IsSimpleType())
                     {
                         if (addHeadings && !hasHeadings)
                         {

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -858,8 +858,11 @@ namespace ClosedXML.Excel
                     maxCo - 1);
 
                 if (createTable)
+                    // Create a table and save it in the file
                     return tableName == null ? range.CreateTable() : range.CreateTable(tableName);
-                return tableName == null ? range.AsTable() : range.AsTable(tableName);
+                else
+                    // Create a table, but keep it in memory. Saved file will contain only "raw" data and column headers
+                    return tableName == null ? range.AsTable() : range.AsTable(tableName);
             }
 
             return null;
@@ -905,9 +908,12 @@ namespace ClosedXML.Excel
                 ro,
                 co - 1);
 
-            if (createTable) return tableName == null ? range.CreateTable() : range.CreateTable(tableName);
-
-            return tableName == null ? range.AsTable() : range.AsTable(tableName);
+            if (createTable)
+                // Create a table and save it in the file
+                return tableName == null ? range.CreateTable() : range.CreateTable(tableName);
+            else
+                // Create a table, but keep it in memory. Saved file will contain only "raw" data and column headers
+                return tableName == null ? range.AsTable() : range.AsTable(tableName);
         }
 
         public XLTableCellType TableCellType()
@@ -959,7 +965,6 @@ namespace ClosedXML.Excel
                     else
                         rowNumber++;
                 }
-
 
                 void resetRecordPosition()
                 {

--- a/ClosedXML/Extensions.cs
+++ b/ClosedXML/Extensions.cs
@@ -314,6 +314,15 @@ namespace ClosedXML.Excel
                     || type == typeof(double)
                     || type == typeof(decimal);
         }
+
+        public static bool IsSimpleType(this Type type)
+        {
+            return type.IsPrimitive
+                || type == typeof(String)
+                || type == typeof(DateTime)
+                || type == typeof(TimeSpan)
+                || type.IsNumber();
+        }
     }
 
     internal static class ObjectExtensions


### PR DESCRIPTION
Before continuing work on #908 , let's first clean up and consolidate `XLCell.InsertData` and `XLCell.InsertTable`, which share a lot of logic. 