### PR TITLE
Exclude full span addresses from range change notifications

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1,12 +1,12 @@
 using ClosedXML.Excel.Caching;
 using ClosedXML.Excel.CalcEngine;
 using ClosedXML.Excel.Drawings;
+using ClosedXML.Excel.Ranges.Index;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using ClosedXML.Excel.Ranges.Index;
 
 namespace ClosedXML.Excel
 {
@@ -31,6 +31,7 @@ namespace ClosedXML.Excel
         /// Fake address to be used everywhere the invalid address is needed.
         /// </summary>
         internal readonly XLAddress InvalidAddress;
+
         #endregion Fields
 
         #region Constructor
@@ -1219,7 +1220,6 @@ namespace ClosedXML.Excel
             int rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
             var model = Row(rowNum).AsRange();
 
-
             foreach (var cf in ConditionalFormats.ToList())
             {
                 var cfRanges = cf.Ranges.ToList();
@@ -1288,8 +1288,13 @@ namespace ClosedXML.Excel
                 WorksheetRangeShiftedRows(range, rowsShifted);
                 foreach (var storedRange in rangesToShift)
                 {
-                    if (!ReferenceEquals(range, storedRange))
-                        storedRange.WorksheetRangeShiftedRows(range, rowsShifted);
+                    if (storedRange.IsEntireColumn())
+                        continue;
+
+                    if (ReferenceEquals(range, storedRange))
+                        continue;
+
+                    storedRange.WorksheetRangeShiftedRows(range, rowsShifted);
                 }
                 range.WorksheetRangeShiftedRows(range, rowsShifted);
             }
@@ -1309,9 +1314,13 @@ namespace ClosedXML.Excel
                 WorksheetRangeShiftedColumns(range, columnsShifted);
                 foreach (var storedRange in rangesToShift)
                 {
-                    var addr = storedRange.RangeAddress;
-                    if (!ReferenceEquals(range, storedRange))
-                        storedRange.WorksheetRangeShiftedColumns(range, columnsShifted);
+                    if (storedRange.IsEntireRow())
+                        continue;
+
+                    if (ReferenceEquals(range, storedRange))
+                        continue;
+
+                    storedRange.WorksheetRangeShiftedColumns(range, columnsShifted);
                 }
                 range.WorksheetRangeShiftedColumns(range, columnsShifted);
             }
@@ -1370,7 +1379,7 @@ namespace ClosedXML.Excel
             else
                 rangeAddress = range.RangeAddress;
 
-            var table = (XLTable) _rangeRepository.GetOrCreate(new XLRangeKey(XLRangeType.Table, rangeAddress));
+            var table = (XLTable)_rangeRepository.GetOrCreate(new XLRangeKey(XLRangeType.Table, rangeAddress));
 
             if (table.Name != name)
                 table.Name = name;
@@ -1385,6 +1394,7 @@ namespace ClosedXML.Excel
 
             return table;
         }
+
         private void CheckRangeNotInTable(XLRange range)
         {
             var overlappingTables = Tables.Where(t => t.RangeUsed().Intersects(range));
@@ -1700,6 +1710,5 @@ namespace ClosedXML.Excel
         {
             _rangeRepository.Remove(new XLRangeKey(XLRangeType.Range, rangeAddress));
         }
-
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -180,6 +180,31 @@ namespace ClosedXML_Tests
             Assert.AreEqual("#REF!#REF!", address.ToStringRelative());
             Assert.AreEqual("#REF!#REF!", address.ToStringRelative(true));
         }
+
+        [Test]
+        public void FullSpanAddressCannotChange()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+
+                var wsRange = ws.AsRange();
+                var row = ws.FirstRow().RowBelow(4).AsRange();
+                var column = ws.FirstColumn().ColumnRight(4).AsRange();
+
+                Assert.AreEqual("A1:XFD1048576", wsRange.RangeAddress.ToString());
+                Assert.AreEqual("A5:XFD5", row.RangeAddress.ToString());
+                Assert.AreEqual("E1:E1048576", column.RangeAddress.ToString());
+
+                ws.Columns("Y:Z").Delete();
+                ws.Rows("9:10").Delete();
+
+                Assert.AreEqual("A1:XFD1048576", wsRange.RangeAddress.ToString());
+                Assert.AreEqual("A5:XFD5", row.RangeAddress.ToString());
+                Assert.AreEqual("E1:E1048576", column.RangeAddress.ToString());
+            }
+        }
+
         #region Private Methods
 
         private IXLRangeAddress ProduceInvalidAddress()


### PR DESCRIPTION
Full span ranges (e.g. full rows, full columns and entire worksheets) should not be affected by range deletions and insertions.

Basing this on `develop`