### PR TITLE
Delete table rows correctly

### DIFF
--- a/ClosedXML/Excel/Tables/IXLTableRange.cs
+++ b/ClosedXML/Excel/Tables/IXLTableRange.cs
@@ -1,27 +1,38 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
+
 namespace ClosedXML.Excel
 {
-
     public interface IXLTableRange : IXLRange
     {
+        IXLTable Table { get; }
+
         IXLTableRow FirstRow(Func<IXLTableRow, Boolean> predicate = null);
+
         IXLTableRow FirstRowUsed(Boolean includeFormats, Func<IXLTableRow, Boolean> predicate = null);
+
         IXLTableRow FirstRowUsed(Func<IXLTableRow, Boolean> predicate = null);
+
+        new IXLTableRows InsertRowsAbove(int numberOfRows);
+
+        new IXLTableRows InsertRowsBelow(int numberOfRows);
+
         IXLTableRow LastRow(Func<IXLTableRow, Boolean> predicate = null);
+
         IXLTableRow LastRowUsed(Boolean includeFormats, Func<IXLTableRow, Boolean> predicate = null);
+
         IXLTableRow LastRowUsed(Func<IXLTableRow, Boolean> predicate = null);
 
         new IXLTableRow Row(int row);
+
         IXLTableRows Rows(Func<IXLTableRow, Boolean> predicate = null);
+
         new IXLTableRows Rows(int firstRow, int lastRow);
+
         new IXLTableRows Rows(string rows);
+
         IXLTableRows RowsUsed(Boolean includeFormats, Func<IXLTableRow, Boolean> predicate = null);
+
         IXLTableRows RowsUsed(Func<IXLTableRow, Boolean> predicate = null);
-
-        IXLTable Table { get; }
-
-        new IXLTableRows InsertRowsAbove(int numberOfRows);
-        new IXLTableRows InsertRowsBelow(int numberOfRows);
     }
 }

--- a/ClosedXML/Excel/Tables/IXLTableRows.cs
+++ b/ClosedXML/Excel/Tables/IXLTableRows.cs
@@ -1,3 +1,4 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
 
@@ -5,6 +6,8 @@ namespace ClosedXML.Excel
 {
     public interface IXLTableRows : IEnumerable<IXLTableRow>
     {
+        IXLStyle Style { get; set; }
+
         /// <summary>
         /// Adds a table row to this group.
         /// </summary>
@@ -27,13 +30,13 @@ namespace ClosedXML.Excel
         /// <param name="includeFormats">if set to <c>true</c> will return all cells with a value or a style different than the default.</param>
         IXLCells CellsUsed(Boolean includeFormats);
 
-        IXLStyle Style { get; set; }
-
         /// <summary>
         /// Clears the contents of these rows.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>
         IXLTableRows Clear(XLClearOptions clearOptions = XLClearOptions.All);
+
+        void Delete();
 
         void Select();
     }

--- a/ClosedXML/Excel/Tables/XLTableRow.cs
+++ b/ClosedXML/Excel/Tables/XLTableRow.cs
@@ -110,7 +110,6 @@ namespace ClosedXML.Excel
         public new void Delete()
         {
             Delete(XLShiftDeletedCells.ShiftCellsUp);
-            _tableRange.Table.ExpandTableRows(-1);
         }
     }
 }

--- a/ClosedXML/Excel/Tables/XLTableRows.cs
+++ b/ClosedXML/Excel/Tables/XLTableRows.cs
@@ -1,19 +1,20 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    using System.Collections;
-
     internal class XLTableRows : XLStylizedBase, IXLTableRows, IXLStylized
     {
         private readonly List<XLTableRow> _ranges = new List<XLTableRow>();
-  
+
         public XLTableRows(IXLStyle defaultStyle) : base((defaultStyle as XLStyle).Value)
         {
         }
 
         #region IXLStylized Members
+
         public override IEnumerable<IXLStyle> Styles
         {
             get
@@ -63,9 +64,15 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public void Add(IXLTableRow range)
+        public void Delete()
         {
-            _ranges.Add((XLTableRow)range);
+            _ranges.OrderByDescending(r => r.RowNumber()).ForEach(r => r.Delete());
+            _ranges.Clear();
+        }
+
+        public void Add(IXLTableRow tableRow)
+        {
+            _ranges.Add((XLTableRow)tableRow);
         }
 
         public IEnumerator<IXLTableRow> GetEnumerator()

--- a/ClosedXML_Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML_Tests/Excel/Tables/TablesTests.cs
@@ -484,7 +484,9 @@ namespace ClosedXML_Tests.Excel
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("Sheet1");
-                var table = ws.FirstCell().InsertTable(l);
+                var table = ws.Cell("B2").InsertTable(l);
+
+                Assert.AreEqual("B2:E4", table.RangeAddress.ToString());
 
                 table.Field("SomeFieldNotProperty").Delete();
 
@@ -495,6 +497,37 @@ namespace ClosedXML_Tests.Excel
 
                 Assert.AreEqual("UnOrderedColumn", table.Fields.Last().Name);
                 Assert.AreEqual(2, table.Fields.Last().Index);
+
+                Assert.AreEqual("B2:D4", table.RangeAddress.ToString());
+            }
+        }
+
+        [Test]
+        public void CanDeleteTableRows()
+        {
+            var l = new List<TestObjectWithAttributes>()
+            {
+                new TestObjectWithAttributes() { Column1 = "a", Column2 = "b", MyField = 4, UnOrderedColumn = 999 },
+                new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 },
+                new TestObjectWithAttributes() { Column1 = "e", Column2 = "f", MyField = 6, UnOrderedColumn = 555 },
+                new TestObjectWithAttributes() { Column1 = "g", Column2 = "h", MyField = 7, UnOrderedColumn = 333 }
+            };
+
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                var table = ws.Cell("B2").InsertTable(l);
+
+                Assert.AreEqual("B2:E6", table.RangeAddress.ToString());
+
+                table.DataRange.Rows(3, 4).Delete();
+
+                Assert.AreEqual(2, table.DataRange.Rows().Count());
+
+                Assert.AreEqual("b", table.DataRange.FirstCell().Value);
+                Assert.AreEqual(777, table.DataRange.LastCell().Value);
+
+                Assert.AreEqual("B2:E4", table.RangeAddress.ToString());
             }
         }
 


### PR DESCRIPTION
Table row deletion not working correctly because row is deleted (range is shrunk) and then table is shrunk again.