### PR TITLE
Propagate extra table columns when changing data

### DIFF
--- a/ClosedXML/Excel/Ranges/IXLRange.cs
+++ b/ClosedXML/Excel/Ranges/IXLRange.cs
@@ -39,8 +39,8 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets the specified column of the range.
         /// </summary>
-        /// <param name="columnNumber">The column number.</param>
-        /// <returns></returns>
+        /// <param name="columnNumber">1-based column number relative to the first column of this range.</param>
+        /// <returns>The relevant column</returns>
         IXLRangeColumn Column(int columnNumber);
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets a collection of the specified columns in this range.
         /// </summary>
-        /// <param name="firstColumn">The first column to return.</param>
-        /// <param name="lastColumn">The last column to return.</param>
+        /// <param name="firstColumn">The first column to return. 1-based column number relative to the first column of this range.</param>
+        /// <param name="lastColumn">The last column to return. 1-based column number relative to the first column of this range.</param>
         IXLRangeColumns Columns(int firstColumn, int lastColumn);
 
         /// <summary>
@@ -90,6 +90,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="firstColumn">The first column to return.</param>
         /// <param name="lastColumn">The last column to return.</param>
+        /// <returns>The relevant columns</returns>
         IXLRangeColumns Columns(string firstColumn, string lastColumn);
 
         /// <summary>
@@ -136,7 +137,8 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets the specified row of the range.
         /// </summary>
-        /// <param name="row">The range row.</param>
+        /// <param name="row">1-based row number relative to the first row of this range.</param>
+        /// <returns>The relevant row</returns>
         IXLRangeRow Row(int row);
 
         IXLRangeRows Rows(Func<IXLRangeRow, Boolean> predicate = null);
@@ -144,8 +146,8 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets a collection of the specified rows in this range.
         /// </summary>
-        /// <param name="firstRow">The first row to return.</param>
-        /// <param name="lastRow">The last row to return.</param>
+        /// <param name="firstRow">The first row to return. 1-based row number relative to the first row of this range.</param>
+        /// <param name="lastRow">The last row to return. 1-based row number relative to the first row of this range.</param>
         /// <returns></returns>
         IXLRangeRows Rows(int firstRow, int lastRow);
 

--- a/ClosedXML/Excel/Ranges/XLRange.cs
+++ b/ClosedXML/Excel/Ranges/XLRange.cs
@@ -659,14 +659,15 @@ namespace ClosedXML.Excel
 
         public XLRangeRow Row(Int32 row)
         {
-            if (row <= 0 || row > XLHelper.MaxRowNumber)
-                throw new IndexOutOfRangeException(String.Format("Row number must be between 1 and {0}", XLHelper.MaxRowNumber));
+            if (row <= 0 || row > XLHelper.MaxRowNumber + RangeAddress.FirstAddress.RowNumber - 1)
+                throw new ArgumentOutOfRangeException(nameof(row), String.Format("Row number must be between 1 and {0}", XLHelper.MaxRowNumber + RangeAddress.FirstAddress.RowNumber - 1));
 
             var firstCellAddress = new XLAddress(Worksheet,
                                                  RangeAddress.FirstAddress.RowNumber + row - 1,
                                                  RangeAddress.FirstAddress.ColumnNumber,
                                                  false,
                                                  false);
+
             var lastCellAddress = new XLAddress(Worksheet,
                                                 RangeAddress.FirstAddress.RowNumber + row - 1,
                                                 RangeAddress.LastAddress.ColumnNumber,
@@ -677,8 +678,8 @@ namespace ClosedXML.Excel
 
         public virtual XLRangeColumn Column(Int32 columnNumber)
         {
-            if (columnNumber <= 0 || columnNumber > XLHelper.MaxColumnNumber)
-                throw new IndexOutOfRangeException(String.Format("Column number must be between 1 and {0}", XLHelper.MaxColumnNumber));
+            if (columnNumber <= 0 || columnNumber > XLHelper.MaxColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1)
+                throw new ArgumentOutOfRangeException(nameof(columnNumber), String.Format("Column number must be between 1 and {0}", XLHelper.MaxColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1));
 
             var firstCellAddress = new XLAddress(Worksheet,
                                                  RangeAddress.FirstAddress.RowNumber,

--- a/ClosedXML/Excel/Tables/IXLTable.cs
+++ b/ClosedXML/Excel/Tables/IXLTable.cs
@@ -36,73 +36,85 @@ namespace ClosedXML.Excel
         /// Appends the IEnumerable data elements and returns the range of the new rows.
         /// </summary>
         /// <param name="data">The IEnumerable data.</param>
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
         /// <returns>
         /// The range of the new rows.
         /// </returns>
-        IXLRange AppendData(IEnumerable data);
+        IXLRange AppendData(IEnumerable data, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Appends the IEnumerable data elements and returns the range of the new rows.
         /// </summary>
         /// <param name="data">The IEnumerable data.</param>
         /// <param name="transpose">if set to <c>true</c> the data will be transposed before inserting.</param>
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
         /// <returns>
         /// The range of the new rows.
         /// </returns>
-        IXLRange AppendData(IEnumerable data, Boolean transpose);
+        IXLRange AppendData(IEnumerable data, Boolean transpose, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Appends the data of a data table and returns the range of the new rows.
         /// </summary>
         /// <param name="dataTable">The data table.</param>
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
         /// <returns>
         /// The range of the new rows.
         /// </returns>
-        IXLRange AppendData(DataTable dataTable);
+        IXLRange AppendData(DataTable dataTable, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Appends the IEnumerable data elements and returns the range of the new rows.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="data">The table data.</param>
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
         /// <returns>
         /// The range of the new rows.
         /// </returns>
-        IXLRange AppendData<T>(IEnumerable<T> data);
+        IXLRange AppendData<T>(IEnumerable<T> data, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Replaces the IEnumerable data elements and returns the table's data range.
         /// </summary>
         /// <param name="data">The IEnumerable data.</param>
-        /// <returns>The table's data range.</returns>
-        IXLRange ReplaceData(IEnumerable data);
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
+        /// <returns>
+        /// The table's data range.
+        /// </returns>
+        IXLRange ReplaceData(IEnumerable data, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Replaces the IEnumerable data elements and returns the table's data range.
         /// </summary>
         /// <param name="data">The IEnumerable data.</param>
         /// <param name="transpose">if set to <c>true</c> the data will be transposed before inserting.</param>
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
         /// <returns>
         /// The table's data range.
         /// </returns>
-        IXLRange ReplaceData(IEnumerable data, Boolean transpose);
+        IXLRange ReplaceData(IEnumerable data, Boolean transpose, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Replaces the data from the records of a data table and returns the table's data range.
         /// </summary>
         /// <param name="dataTable">The data table.</param>
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
         /// <returns>
         /// The table's data range.
         /// </returns>
-        IXLRange ReplaceData(DataTable dataTable);
+        IXLRange ReplaceData(DataTable dataTable, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Replaces the IEnumerable data elements as a table and the table's data range.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="data">The table data.</param>
-        /// <returns>The table's data range.</returns>
-        IXLRange ReplaceData<T>(IEnumerable<T> data);
+        /// <param name="propagateExtraColumns">if set to <c>true</c> propagate extra columns' values and formulas.</param>
+        /// <returns>
+        /// The table's data range.
+        /// </returns>
+        IXLRange ReplaceData<T>(IEnumerable<T> data, Boolean propagateExtraColumns = false);
 
         /// <summary>
         /// Resizes the table to the specified range address.

--- a/ClosedXML/Excel/Tables/IXLTableField.cs
+++ b/ClosedXML/Excel/Tables/IXLTableField.cs
@@ -20,11 +20,37 @@ namespace ClosedXML.Excel
     {
         /// <summary>
         /// Gets the corresponding column for this table field.
+        /// Includes the header and footer cells
         /// </summary>
         /// <value>
         /// The column.
         /// </value>
         IXLRangeColumn Column { get; }
+
+        /// <summary>
+        /// Gets the collection of data cells for this field
+        /// Excludes the header and footer cells
+        /// </summary>
+        /// <value>
+        /// The data cells
+        /// </value>
+        IXLCells DataCells { get; }
+
+        /// <summary>
+        /// Gets the footer cell for the table field.
+        /// </summary>
+        /// <value>
+        /// The footer cell.
+        /// </value>
+        IXLCell TotalsCell { get; }
+
+        /// <summary>
+        /// Gets the header cell for the table field.
+        /// </summary>
+        /// <value>
+        /// The header cell.
+        /// </value>
+        IXLCell HeaderCell { get; }
 
         /// <summary>
         /// Gets the index of the column (0-based).

--- a/ClosedXML/Excel/Tables/IXLTableRange.cs
+++ b/ClosedXML/Excel/Tables/IXLTableRange.cs
@@ -23,10 +23,21 @@ namespace ClosedXML.Excel
 
         IXLTableRow LastRowUsed(Func<IXLTableRow, Boolean> predicate = null);
 
+        /// <summary>
+        /// Rows the specified row.
+        /// </summary>
+        /// <param name="row">1-based row number relative to the first row of this range.</param>
+        /// <returns></returns>
         new IXLTableRow Row(int row);
 
         IXLTableRows Rows(Func<IXLTableRow, Boolean> predicate = null);
 
+        /// <summary>
+        /// Returns a subset of the rows
+        /// </summary>
+        /// <param name="firstRow">The first row to return. 1-based row number relative to the first row of this range.</param>
+        /// <param name="lastRow">The last row to return. 1-based row number relative to the first row of this range.</param>
+        /// <returns></returns>
         new IXLTableRows Rows(int firstRow, int lastRow);
 
         new IXLTableRows Rows(string rows);

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -245,6 +245,9 @@ namespace ClosedXML.Excel
 
                 _showTotalsRow = value;
 
+                // Invalidate fields' columns
+                this.Fields.Cast<XLTableField>().ForEach(f => f.Column = null);
+
                 if (_showTotalsRow)
                 {
                     AutoFilter.Range = Worksheet.Range(
@@ -668,6 +671,9 @@ namespace ClosedXML.Excel
                 }
 
                 _showHeaderRow = value;
+
+                // Invalidate fields' columns
+                this.Fields.Cast<XLTableField>().ForEach(f => f.Column = null);
 
                 if (_showHeaderRow)
                     HeadersRow().DataType = XLDataType.Text;

--- a/ClosedXML/Excel/Tables/XLTableField.cs
+++ b/ClosedXML/Excel/Tables/XLTableField.cs
@@ -32,6 +32,36 @@ namespace ClosedXML.Excel
                 }
                 return _column;
             }
+            internal set
+            {
+                _column = value;
+            }
+        }
+
+        public IXLCells DataCells
+        {
+            get
+            {
+                return Column.Cells(c =>
+                {
+                    if (table.ShowHeaderRow && c == HeaderCell)
+                        return false;
+                    if (table.ShowTotalsRow && c == TotalsCell)
+                        return false;
+                    return true;
+                });
+            }
+        }
+
+        public IXLCell HeaderCell
+        {
+            get
+            {
+                if (!table.ShowHeaderRow)
+                    return null;
+
+                return Column.FirstCell();
+            }
         }
 
         public Int32 Index
@@ -64,6 +94,17 @@ namespace ClosedXML.Excel
         }
 
         public IXLTable Table { get { return table; } }
+
+        public IXLCell TotalsCell
+        {
+            get
+            {
+                if (!table.ShowTotalsRow)
+                    return null;
+
+                return Column.LastCell();
+            }
+        }
 
         public String TotalsRowFormulaA1
         {

--- a/ClosedXML/Excel/Tables/XLTableRange.cs
+++ b/ClosedXML/Excel/Tables/XLTableRange.cs
@@ -123,10 +123,12 @@ namespace ClosedXML.Excel
         }
         public new XLTableRow Row(int row)
         {
-            if (row <= 0 || row > XLHelper.MaxRowNumber)
+            if (row <= 0 || row > XLHelper.MaxRowNumber + RangeAddress.FirstAddress.RowNumber - 1)
             {
-                throw new IndexOutOfRangeException(String.Format("Row number must be between 1 and {0}",
-                                                                 XLHelper.MaxRowNumber));
+                throw new ArgumentOutOfRangeException(
+                    nameof(row),
+                    String.Format("Row number must be between 1 and {0}", XLHelper.MaxRowNumber + RangeAddress.FirstAddress.RowNumber - 1)
+                );
             }
 
             return new XLTableRow(this, base.Row(row));
@@ -150,8 +152,9 @@ namespace ClosedXML.Excel
         {
             var retVal = new XLTableRows(Worksheet.Style);
 
-            for (int ro = firstRow; ro <= lastRow; ro++)
-                retVal.Add(Row(ro));
+            for (int rowNumber = firstRow; rowNumber <= lastRow; rowNumber++)
+                retVal.Add(Row(rowNumber));
+
             return retVal;
         }
 

--- a/ClosedXML_Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML_Tests/Excel/Tables/TablesTests.cs
@@ -461,6 +461,47 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
+        public void TestFieldCellTypes()
+        {
+            var l = new List<TestObjectWithAttributes>()
+            {
+                new TestObjectWithAttributes() { Column1 = "a", Column2 = "b", MyField = 4, UnOrderedColumn = 999 },
+                new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
+            };
+
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                var table = ws.Cell("B2").InsertTable(l);
+
+                Assert.AreEqual(4, table.Fields.Count());
+
+                Assert.AreEqual("B2", table.Field(0).HeaderCell.Address.ToString());
+                Assert.AreEqual("C2", table.Field(1).HeaderCell.Address.ToString());
+                Assert.AreEqual("D2", table.Field(2).HeaderCell.Address.ToString());
+                Assert.AreEqual("E2", table.Field(3).HeaderCell.Address.ToString());
+
+                Assert.IsNull(table.Field(0).TotalsCell);
+                Assert.IsNull(table.Field(1).TotalsCell);
+                Assert.IsNull(table.Field(2).TotalsCell);
+                Assert.IsNull(table.Field(3).TotalsCell);
+
+                table.SetShowTotalsRow();
+
+                Assert.AreEqual("B5", table.Field(0).TotalsCell.Address.ToString());
+                Assert.AreEqual("C5", table.Field(1).TotalsCell.Address.ToString());
+                Assert.AreEqual("D5", table.Field(2).TotalsCell.Address.ToString());
+                Assert.AreEqual("E5", table.Field(3).TotalsCell.Address.ToString());
+
+                var field = table.Fields.Last();
+
+                Assert.AreEqual("E2:E5", field.Column.RangeAddress.ToString());
+                Assert.AreEqual("E3", field.DataCells.First().Address.ToString());
+                Assert.AreEqual("E4", field.DataCells.Last().Address.ToString());
+            }
+        }
+
+        [Test]
         public void CanDeleteTable()
         {
             var l = new List<TestObjectWithAttributes>()


### PR DESCRIPTION
Depends on ~#908~

Some tables have "extra columns" with formulas and values. When replacing/appending data, one would sometimes want to propagate these extra columns down to the latest row. Very similar to what Excel will do in a table.