### PR TITLE
Aggregate color conversion in one place

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -1024,7 +1024,7 @@ namespace ClosedXML.Excel
             { Val = rt.VerticalAlignment.ToOpenXml() };
             var shadow = rt.Shadow ? new Shadow() : null;
             var fontSize = new FontSize { Val = rt.FontSize };
-            var color = GetNewColor(rt.FontColor);
+            var color = new Color().FromClosedXMLColor<Color>(rt.FontColor);
             var fontName = new RunFont { Val = rt.FontName };
             var fontFamilyNumbering = new FontFamily { Val = (Int32)rt.FontFamilyNumbering };
 
@@ -3837,7 +3837,7 @@ namespace ClosedXML.Excel
                 var leftBorder = new LeftBorder { Style = borderInfo.Border.LeftBorder.ToOpenXml() };
                 if (borderInfo.Border.LeftBorderColor != XLBorderValue.Default.LeftBorderColor || ignoreMod)
                 {
-                    var leftBorderColor = GetNewColor(borderInfo.Border.LeftBorderColor);
+                    var leftBorderColor = new Color().FromClosedXMLColor<Color>(borderInfo.Border.LeftBorderColor);
                     leftBorder.AppendChild(leftBorderColor);
                 }
                 border.AppendChild(leftBorder);
@@ -3848,7 +3848,7 @@ namespace ClosedXML.Excel
                 var rightBorder = new RightBorder { Style = borderInfo.Border.RightBorder.ToOpenXml() };
                 if (borderInfo.Border.RightBorderColor != XLBorderValue.Default.RightBorderColor || ignoreMod)
                 {
-                    var rightBorderColor = GetNewColor(borderInfo.Border.RightBorderColor);
+                    var rightBorderColor = new Color().FromClosedXMLColor<Color>(borderInfo.Border.RightBorderColor);
                     rightBorder.AppendChild(rightBorderColor);
                 }
                 border.AppendChild(rightBorder);
@@ -3859,7 +3859,7 @@ namespace ClosedXML.Excel
                 var topBorder = new TopBorder { Style = borderInfo.Border.TopBorder.ToOpenXml() };
                 if (borderInfo.Border.TopBorderColor != XLBorderValue.Default.TopBorderColor || ignoreMod)
                 {
-                    var topBorderColor = GetNewColor(borderInfo.Border.TopBorderColor);
+                    var topBorderColor = new Color().FromClosedXMLColor<Color>(borderInfo.Border.TopBorderColor);
                     topBorder.AppendChild(topBorderColor);
                 }
                 border.AppendChild(topBorder);
@@ -3870,7 +3870,7 @@ namespace ClosedXML.Excel
                 var bottomBorder = new BottomBorder { Style = borderInfo.Border.BottomBorder.ToOpenXml() };
                 if (borderInfo.Border.BottomBorderColor != XLBorderValue.Default.BottomBorderColor || ignoreMod)
                 {
-                    var bottomBorderColor = GetNewColor(borderInfo.Border.BottomBorderColor);
+                    var bottomBorderColor = new Color().FromClosedXMLColor<Color>(borderInfo.Border.BottomBorderColor);
                     bottomBorder.AppendChild(bottomBorderColor);
                 }
                 border.AppendChild(bottomBorder);
@@ -3882,7 +3882,7 @@ namespace ClosedXML.Excel
                 if (borderInfo.Border.DiagonalBorderColor != XLBorderValue.Default.DiagonalBorderColor || ignoreMod)
                     if (borderInfo.Border.DiagonalBorderColor != null)
                     {
-                        var DiagonalBorderColor = GetNewColor(borderInfo.Border.DiagonalBorderColor);
+                        var DiagonalBorderColor = new Color().FromClosedXMLColor<Color>(borderInfo.Border.DiagonalBorderColor);
                         DiagonalBorder.AppendChild(DiagonalBorderColor);
                     }
                 border.AppendChild(DiagonalBorder);
@@ -3904,45 +3904,40 @@ namespace ClosedXML.Excel
             {
                 if (b.DiagonalBorder.Style != null)
                     nb.DiagonalBorder = b.DiagonalBorder.Style.Value.ToClosedXml();
-                var bColor = GetColor(b.DiagonalBorder.Color);
-                if (bColor.HasValue)
-                    nb.DiagonalBorderColor = bColor.Key;
+                if (b.DiagonalBorder.Color != null)
+                    nb.DiagonalBorderColor = b.DiagonalBorder.Color.ToClosedXMLColor(_colorList).Key;
             }
 
             if (b.LeftBorder != null)
             {
                 if (b.LeftBorder.Style != null)
                     nb.LeftBorder = b.LeftBorder.Style.Value.ToClosedXml();
-                var bColor = GetColor(b.LeftBorder.Color);
-                if (bColor.HasValue)
-                    nb.LeftBorderColor = bColor.Key;
+                if (b.LeftBorder.Color != null)
+                    nb.LeftBorderColor = b.LeftBorder.Color.ToClosedXMLColor(_colorList).Key;
             }
 
             if (b.RightBorder != null)
             {
                 if (b.RightBorder.Style != null)
                     nb.RightBorder = b.RightBorder.Style.Value.ToClosedXml();
-                var bColor = GetColor(b.RightBorder.Color);
-                if (bColor.HasValue)
-                    nb.RightBorderColor = bColor.Key;
+                if (b.RightBorder.Color != null)
+                    nb.RightBorderColor = b.RightBorder.Color.ToClosedXMLColor(_colorList).Key;
             }
 
             if (b.TopBorder != null)
             {
                 if (b.TopBorder.Style != null)
                     nb.TopBorder = b.TopBorder.Style.Value.ToClosedXml();
-                var bColor = GetColor(b.TopBorder.Color);
-                if (bColor.HasValue)
-                    nb.TopBorderColor = bColor.Key;
+                if (b.TopBorder.Color != null)
+                    nb.TopBorderColor = b.TopBorder.Color.ToClosedXMLColor(_colorList).Key;
             }
 
             if (b.BottomBorder != null)
             {
                 if (b.BottomBorder.Style != null)
                     nb.BottomBorder = b.BottomBorder.Style.Value.ToClosedXml();
-                var bColor = GetColor(b.BottomBorder.Color);
-                if (bColor.HasValue)
-                    nb.BottomBorderColor = bColor.Key;
+                if (b.BottomBorder.Color != null)
+                    nb.BottomBorderColor = b.BottomBorder.Color.ToClosedXMLColor(_colorList).Key;
             }
 
             return nb.Equals(xlBorder.Key);
@@ -4014,61 +4009,18 @@ namespace ClosedXML.Excel
                     break;
 
                 case XLFillPatternValues.Solid:
+
                     if (differentialFillFormat)
                     {
                         patternFill.AppendChild(new ForegroundColor { Auto = true });
-                        backgroundColor = new BackgroundColor();
-                        switch (fillInfo.Fill.BackgroundColor.ColorType)
-                        {
-                            case XLColorType.Color:
-                                backgroundColor.Rgb = fillInfo.Fill.BackgroundColor.Color.ToHex();
-                                break;
-
-                            case XLColorType.Indexed:
-                                // 64 is 'transparent' and should be ignored for differential formats
-                                if (fillInfo.Fill.BackgroundColor.Indexed != 64)
-                                    backgroundColor.Indexed = (UInt32)fillInfo.Fill.BackgroundColor.Indexed;
-                                break;
-
-                            case XLColorType.Theme:
-                                backgroundColor.Theme = (UInt32)fillInfo.Fill.BackgroundColor.ThemeColor;
-
-                                if (fillInfo.Fill.BackgroundColor.ThemeTint != 0)
-                                    backgroundColor.Tint = fillInfo.Fill.BackgroundColor.ThemeTint;
-
-                                break;
-                        }
-
+                        backgroundColor = new BackgroundColor().FromClosedXMLColor<BackgroundColor>(fillInfo.Fill.BackgroundColor, true);
                         if (backgroundColor.HasAttributes)
                             patternFill.AppendChild(backgroundColor);
                     }
                     else
                     {
                         // ClosedXML Background color to be populated into OpenXML fgColor
-                        foregroundColor = new ForegroundColor();
-                        switch (fillInfo.Fill.BackgroundColor.ColorType)
-                        {
-                            case XLColorType.Color:
-                                foregroundColor.Rgb = fillInfo.Fill.BackgroundColor.Color.ToHex();
-                                break;
-
-                            case XLColorType.Indexed:
-                                // 64 is 'transparent' and should be ignored for differential formats
-                                if (fillInfo.Fill.BackgroundColor.Indexed != 64)
-                                    foregroundColor.Indexed = (UInt32)fillInfo.Fill.BackgroundColor.Indexed;
-
-                                //foregroundColor.Indexed = (UInt32)fillInfo.Fill.BackgroundColor.Indexed;
-                                break;
-
-                            case XLColorType.Theme:
-                                foregroundColor.Theme = (UInt32)fillInfo.Fill.BackgroundColor.ThemeColor;
-
-                                if (fillInfo.Fill.BackgroundColor.ThemeTint != 0)
-                                    foregroundColor.Tint = fillInfo.Fill.BackgroundColor.ThemeTint;
-
-                                break;
-                        }
-
+                        foregroundColor = new ForegroundColor().FromClosedXMLColor<ForegroundColor>(fillInfo.Fill.BackgroundColor);
                         if (foregroundColor.HasAttributes)
                             patternFill.AppendChild(foregroundColor);
                     }
@@ -4076,49 +4028,11 @@ namespace ClosedXML.Excel
 
                 default:
 
-                    foregroundColor = new ForegroundColor();
-                    switch (fillInfo.Fill.PatternColor.ColorType)
-                    {
-                        case XLColorType.Color:
-                            foregroundColor.Rgb = fillInfo.Fill.PatternColor.Color.ToHex();
-                            break;
-
-                        case XLColorType.Indexed:
-                            foregroundColor.Indexed = (UInt32)fillInfo.Fill.PatternColor.Indexed;
-                            break;
-
-                        case XLColorType.Theme:
-                            foregroundColor.Theme = (UInt32)fillInfo.Fill.PatternColor.ThemeColor;
-
-                            if (fillInfo.Fill.PatternColor.ThemeTint != 0)
-                                foregroundColor.Tint = fillInfo.Fill.PatternColor.ThemeTint;
-
-                            break;
-                    }
-
+                    foregroundColor = new ForegroundColor().FromClosedXMLColor<ForegroundColor>(fillInfo.Fill.PatternColor);
                     if (foregroundColor.HasAttributes)
                         patternFill.AppendChild(foregroundColor);
 
-                    backgroundColor = new BackgroundColor();
-                    switch (fillInfo.Fill.BackgroundColor.ColorType)
-                    {
-                        case XLColorType.Color:
-                            backgroundColor.Rgb = fillInfo.Fill.BackgroundColor.Color.ToHex();
-                            break;
-
-                        case XLColorType.Indexed:
-                            backgroundColor.Indexed = (UInt32)fillInfo.Fill.BackgroundColor.Indexed;
-                            break;
-
-                        case XLColorType.Theme:
-                            backgroundColor.Theme = (UInt32)fillInfo.Fill.BackgroundColor.ThemeColor;
-
-                            if (fillInfo.Fill.BackgroundColor.ThemeTint != 0)
-                                backgroundColor.Tint = fillInfo.Fill.BackgroundColor.ThemeTint;
-
-                            break;
-                    }
-
+                    backgroundColor = new BackgroundColor().FromClosedXMLColor<BackgroundColor>(fillInfo.Fill.BackgroundColor);
                     if (backgroundColor.HasAttributes)
                         patternFill.AppendChild(backgroundColor);
 
@@ -4193,7 +4107,7 @@ namespace ClosedXML.Excel
             var fontSize = fontInfo.Font.FontSize != XLFontValue.Default.FontSize || ignoreMod
                 ? new FontSize { Val = fontInfo.Font.FontSize }
                 : null;
-            var color = fontInfo.Font.FontColor != XLFontValue.Default.FontColor || ignoreMod ? GetNewColor(fontInfo.Font.FontColor) : null;
+            var color = fontInfo.Font.FontColor != XLFontValue.Default.FontColor || ignoreMod ? new Color().FromClosedXMLColor<Color>(fontInfo.Font.FontColor) : null;
 
             var fontName = fontInfo.Font.FontName != XLFontValue.Default.FontName || ignoreMod
                 ? new FontName { Val = fontInfo.Font.FontName }
@@ -4232,38 +4146,6 @@ namespace ClosedXML.Excel
             return font;
         }
 
-        private static Color GetNewColor(XLColor xlColor)
-        {
-            var color = new Color();
-            if (xlColor.ColorType == XLColorType.Color)
-                color.Rgb = xlColor.Color.ToHex();
-            else if (xlColor.ColorType == XLColorType.Indexed)
-                color.Indexed = (UInt32)xlColor.Indexed;
-            else
-            {
-                color.Theme = (UInt32)xlColor.ThemeColor;
-                if (xlColor.ThemeTint != 0)
-                    color.Tint = xlColor.ThemeTint;
-            }
-            return color;
-        }
-
-        private static TabColor GetTabColor(XLColor xlColor)
-        {
-            var color = new TabColor();
-            if (xlColor.ColorType == XLColorType.Color)
-                color.Rgb = xlColor.Color.ToHex();
-            else if (xlColor.ColorType == XLColorType.Indexed)
-                color.Indexed = (UInt32)xlColor.Indexed;
-            else
-            {
-                color.Theme = (UInt32)xlColor.ThemeColor;
-                if (xlColor.ThemeTint != 0)
-                    color.Tint = xlColor.ThemeTint;
-            }
-            return color;
-        }
-
         private bool FontsAreEqual(Font f, XLFontValue xlFont)
         {
             var nf = XLFontValue.Default.Key;
@@ -4286,9 +4168,8 @@ namespace ClosedXML.Excel
             nf.Shadow = f.Shadow != null;
             if (f.FontSize != null)
                 nf.FontSize = f.FontSize.Val;
-            var fColor = GetColor(f.Color);
-            if (fColor.HasValue)
-                nf.FontColor = fColor.Key;
+            if (f.Color != null)
+                nf.FontColor = f.Color.ToClosedXMLColor(_colorList).Key;
             if (f.FontName != null)
                 nf.FontName = f.FontName.Val;
             if (f.FontFamilyNumbering != null)
@@ -4389,7 +4270,7 @@ namespace ClosedXML.Excel
                 worksheetPart.Worksheet.SheetProperties = new SheetProperties();
 
             worksheetPart.Worksheet.SheetProperties.TabColor = xlWorksheet.TabColor.HasValue
-                ? GetTabColor(xlWorksheet.TabColor)
+                ? new TabColor().FromClosedXMLColor<TabColor>(xlWorksheet.TabColor)
                 : null;
 
             cm.SetElement(XLWorksheetContents.SheetProperties, worksheetPart.Worksheet.SheetProperties);

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -1,9 +1,50 @@
-﻿using DocumentFormat.OpenXml;
+﻿// Keep this file CodeMaid organised and cleaned
+using ClosedXML.Excel;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+using Drawing = System.Drawing;
+using X14 = DocumentFormat.OpenXml.Office2010.Excel;
 
 namespace ClosedXML.Utils
 {
     internal static class OpenXmlHelper
     {
+        #region Public Methods
+
+        /// <summary>
+        /// Convert color in ClosedXML representation to specified OpenXML type.
+        /// </summary>
+        /// <typeparam name="T">The descendant of <see cref="ColorType"/>.</typeparam>
+        /// <param name="openXMLColor">The existing instance of ColorType.</param>
+        /// <param name="xlColor">Color in ClosedXML format.</param>
+        /// <param name="isDifferential">Flag specifiying that the color should be saved in
+        /// differential format (affects the transparent color processing).</param>
+        /// <returns>The original color in OpenXML format.</returns>
+        public static T FromClosedXMLColor<T>(this ColorType openXMLColor, XLColor xlColor, bool isDifferential = false)
+            where T : ColorType
+        {
+            FillFromClosedXMLColor(openXMLColor, xlColor, isDifferential);
+            return (T)openXMLColor;
+        }
+
+        /// <summary>
+        /// Convert color in ClosedXML representation to specified OpenXML type.
+        /// </summary>
+        /// <typeparam name="T">The descendant of <see cref="X14.ColorType"/>.</typeparam>
+        /// <param name="openXMLColor">The existing instance of ColorType.</param>
+        /// <param name="xlColor">Color in ClosedXML format.</param>
+        /// <param name="isDifferential">Flag specifiying that the color should be saved in
+        /// differential format (affects the transparent color processing).</param>
+        /// <returns>The original color in OpenXML format.</returns>
+        public static T FromClosedXMLColor<T>(this X14.ColorType openXMLColor, XLColor xlColor, bool isDifferential = false)
+            where T : X14.ColorType
+        {
+            FillFromClosedXMLColor(openXMLColor, xlColor, isDifferential);
+            return (T)openXMLColor;
+        }
+
         public static BooleanValue GetBooleanValue(bool value, bool defaultValue)
         {
             return value == defaultValue ? null : new BooleanValue(value);
@@ -13,5 +54,111 @@ namespace ClosedXML.Utils
         {
             return (value?.HasValue ?? false) ? value.Value : defaultValue;
         }
+
+        /// <summary>
+        /// Convert color in OpenXML representation to ClosedXML type.
+        /// </summary>
+        /// <param name="openXMLColor">Color in OpenXML format.</param>
+        /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
+        /// <returns>The color in ClosedXML format.</returns>
+        public static XLColor ToClosedXMLColor(this ColorType openXMLColor, IDictionary<string, Drawing.Color> colorCache = null)
+        {
+            return ConvertToClosedXMLColor(openXMLColor, colorCache);
+        }
+
+        /// <summary>
+        /// Convert color in OpenXML representation to ClosedXML type.
+        /// </summary>
+        /// <param name="openXMLColor">Color in OpenXML format.</param>
+        /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
+        /// <returns>The color in ClosedXML format.</returns>
+        public static XLColor ToClosedXMLColor(this X14.ColorType openXMLColor, IDictionary<string, Drawing.Color> colorCache = null)
+        {
+            return ConvertToClosedXMLColor(openXMLColor, colorCache);
+        }
+
+        #endregion Public Methods
+
+        #region Private Methods
+
+        /// <summary>
+        /// Here we perform the actual convertion from OpenXML color to ClosedXML color.
+        /// </summary>
+        /// <param name="openXMLColor">OpenXML color. Must be either <see cref="ColorType"/> or <see cref="X14.ColorType"/>. 
+        /// Since these types do not implement a common interface we use dynamic.</param>
+        /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
+        /// <returns>The color in ClosedXML format.</returns>
+        private static XLColor ConvertToClosedXMLColor(dynamic openXMLColor, IDictionary<string, Drawing.Color> colorCache )
+        {
+            XLColor retVal = null;
+            if (openXMLColor != null)
+            {
+                if (openXMLColor.Rgb != null)
+                {
+                    String htmlColor = "#" + openXMLColor.Rgb.Value;
+                    Drawing.Color thisColor;
+                    if (colorCache?.ContainsKey(htmlColor) ?? false)
+                    {
+                        thisColor = colorCache[htmlColor];
+                    }
+                    else
+                    {
+                        thisColor = ColorStringParser.ParseFromHtml(htmlColor);
+                        colorCache?.Add(htmlColor, thisColor);
+                    }
+
+                    retVal = XLColor.FromColor(thisColor);
+                }
+                else if (openXMLColor.Indexed != null && openXMLColor.Indexed <= 64)
+                    retVal = XLColor.FromIndex((Int32)openXMLColor.Indexed.Value);
+                else if (openXMLColor.Theme != null)
+                {
+                    retVal = openXMLColor.Tint != null
+                        ? XLColor.FromTheme((XLThemeColor)openXMLColor.Theme.Value, openXMLColor.Tint.Value)
+                        : XLColor.FromTheme((XLThemeColor)openXMLColor.Theme.Value);
+                }
+            }
+            return retVal ?? XLColor.NoColor;
+        }
+
+        /// <summary>
+        /// Initialize properties of the existing instance of the color in OpenXML format basing on properties of the color 
+        /// in ClosedXML format.
+        /// </summary>
+        /// <param name="openXMLColor">OpenXML color. Must be either <see cref="ColorType"/> or <see cref="X14.ColorType"/>. 
+        /// Since these types do not implement a common interface we use dynamic.</param>
+        /// <param name="xlColor">Color in ClosedXML format.</param>
+        /// <param name="isDifferential">Flag specifiying that the color should be saved in
+        /// differential format (affects the transparent color processing).</param>
+        private static void FillFromClosedXMLColor(dynamic openXMLColor, XLColor xlColor, bool isDifferential)
+        {
+            if (openXMLColor == null)
+                throw new ArgumentNullException(nameof(openXMLColor));
+
+            if (xlColor == null)
+                throw new ArgumentNullException(nameof(xlColor));
+
+            switch (xlColor.ColorType)
+            {
+                case XLColorType.Color:
+                    openXMLColor.Rgb = xlColor.Color.ToHex();
+                    break;
+
+                case XLColorType.Indexed:
+                    // 64 is 'transparent' and should be ignored for differential formats
+                    if (!isDifferential || xlColor.Indexed != 64)
+                        openXMLColor.Indexed = (UInt32)xlColor.Indexed;
+                    break;
+
+                case XLColorType.Theme:
+                    openXMLColor.Theme = (UInt32)xlColor.ThemeColor;
+
+                    if (xlColor.ThemeTint != 0)
+                        openXMLColor.Tint = xlColor.ThemeTint;
+                    break;
+            }
+        }
+
+        #endregion Private Methods
     }
 }

--- a/ClosedXML_Tests/Excel/Styles/ColorTests.cs
+++ b/ClosedXML_Tests/Excel/Styles/ColorTests.cs
@@ -1,6 +1,9 @@
-using System.Drawing;
 using ClosedXML.Excel;
+using ClosedXML.Utils;
+using DocumentFormat.OpenXml.Spreadsheet;
 using NUnit.Framework;
+using Color = System.Drawing.Color;
+using X14 = DocumentFormat.OpenXml.Office2010.Excel;
 
 namespace ClosedXML_Tests.Excel
 {
@@ -37,6 +40,138 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual(XLColorType.Indexed, color.ColorType);
             Assert.AreEqual(64, color.Indexed);
             Assert.AreEqual(Color.Transparent, color.Color);
+        }
+
+        [Test]
+        public void CanConvertXLColorToColorType()
+        {
+            var xlColor1 = XLColor.Red;
+            var xlColor2 = XLColor.FromIndex(20);
+            var xlColor3 = XLColor.FromTheme(XLThemeColor.Accent1);
+            var xlColor4 = XLColor.FromTheme(XLThemeColor.Accent2, 0.4);
+
+            var color1 = new ForegroundColor().FromClosedXMLColor<ForegroundColor>(xlColor1);
+            var color2 = new ForegroundColor().FromClosedXMLColor<ForegroundColor>(xlColor2);
+            var color3 = new BackgroundColor().FromClosedXMLColor<BackgroundColor>(xlColor3);
+            var color4 = new BackgroundColor().FromClosedXMLColor<BackgroundColor>(xlColor4);
+
+            Assert.AreEqual("FFFF0000", color1.Rgb.Value);
+            Assert.IsNull(color1.Indexed);
+            Assert.IsNull(color1.Theme);
+            Assert.IsNull(color1.Tint);
+
+            Assert.IsNull(color2.Rgb);
+            Assert.AreEqual(20, color2.Indexed.Value);
+            Assert.IsNull(color2.Theme);
+            Assert.IsNull(color2.Tint);
+
+            Assert.IsNull(color3.Rgb);
+            Assert.IsNull(color3.Indexed);
+            Assert.AreEqual(4, color3.Theme.Value);
+            Assert.IsNull(color3.Tint);
+
+            Assert.IsNull(color4.Rgb);
+            Assert.IsNull(color4.Indexed);
+            Assert.AreEqual(5, color4.Theme.Value);
+            Assert.AreEqual(0.4, color4.Tint.Value);
+        }
+
+        [Test]
+        public void CanConvertXlColorToX14ColorType()
+        {
+            var xlColor1 = XLColor.Red;
+            var xlColor2 = XLColor.FromIndex(20);
+            var xlColor3 = XLColor.FromTheme(XLThemeColor.Accent1);
+            var xlColor4 = XLColor.FromTheme(XLThemeColor.Accent2, 0.4);
+
+            var color1 = new X14.AxisColor().FromClosedXMLColor<X14.AxisColor>(xlColor1);
+            var color2 = new X14.BorderColor().FromClosedXMLColor<X14.BorderColor>(xlColor2);
+            var color3 = new X14.FillColor().FromClosedXMLColor<X14.FillColor>(xlColor3);
+            var color4 = new X14.HighMarkerColor().FromClosedXMLColor<X14.HighMarkerColor>(xlColor4);
+
+            Assert.AreEqual("FFFF0000", color1.Rgb.Value);
+            Assert.IsNull(color1.Indexed);
+            Assert.IsNull(color1.Theme);
+            Assert.IsNull(color1.Tint);
+
+            Assert.IsNull(color2.Rgb);
+            Assert.AreEqual(20, color2.Indexed.Value);
+            Assert.IsNull(color2.Theme);
+            Assert.IsNull(color2.Tint);
+
+            Assert.IsNull(color3.Rgb);
+            Assert.IsNull(color3.Indexed);
+            Assert.AreEqual(4, color3.Theme.Value);
+            Assert.IsNull(color3.Tint);
+
+            Assert.IsNull(color4.Rgb);
+            Assert.IsNull(color4.Indexed);
+            Assert.AreEqual(5, color4.Theme.Value);
+            Assert.AreEqual(0.4, color4.Tint.Value);
+        }
+
+        [Test]
+        public void CanConvertColorTypeToXlColor()
+        {
+            var color1 = new ForegroundColor { Rgb = new DocumentFormat.OpenXml.HexBinaryValue("FFFF0000") };
+            var color2 = new ForegroundColor { Indexed = new DocumentFormat.OpenXml.UInt32Value((uint)20) };
+            var color3 = new BackgroundColor { Theme = new DocumentFormat.OpenXml.UInt32Value((uint)4) };
+            var color4 = new BackgroundColor
+            {
+                Theme = new DocumentFormat.OpenXml.UInt32Value((uint)4),
+                Tint = new DocumentFormat.OpenXml.DoubleValue(0.4)
+            };
+
+            var xlColor1 = color1.ToClosedXMLColor();
+            var xlColor2 = color2.ToClosedXMLColor();
+            var xlColor3 = color3.ToClosedXMLColor();
+            var xlColor4 = color4.ToClosedXMLColor();
+
+            Assert.AreEqual(XLColorType.Color, xlColor1.ColorType);
+            Assert.AreEqual(XLColor.Red.Color, xlColor1.Color);
+
+            Assert.AreEqual(XLColorType.Indexed, xlColor2.ColorType);
+            Assert.AreEqual(20, xlColor2.Indexed);
+
+            Assert.AreEqual(XLColorType.Theme, xlColor3.ColorType);
+            Assert.AreEqual(XLThemeColor.Accent1, xlColor3.ThemeColor);
+            Assert.AreEqual(0, xlColor3.ThemeTint, XLHelper.Epsilon);
+
+            Assert.AreEqual(XLColorType.Theme, xlColor4.ColorType);
+            Assert.AreEqual(XLThemeColor.Accent1, xlColor4.ThemeColor);
+            Assert.AreEqual(0.4, xlColor4.ThemeTint, XLHelper.Epsilon);
+        }
+
+        [Test]
+        public void CanConvertX14ColorTypeToXlColor()
+        {
+            var color1 = new X14.AxisColor { Rgb = new DocumentFormat.OpenXml.HexBinaryValue("FFFF0000") };
+            var color2 = new X14.BorderColor { Indexed = new DocumentFormat.OpenXml.UInt32Value((uint)20) };
+            var color3 = new X14.FillColor { Theme = new DocumentFormat.OpenXml.UInt32Value((uint)4) };
+            var color4 = new X14.HighMarkerColor
+            {
+                Theme = new DocumentFormat.OpenXml.UInt32Value((uint)4),
+                Tint = new DocumentFormat.OpenXml.DoubleValue(0.4)
+            };
+
+            var xlColor1 = color1.ToClosedXMLColor();
+            var xlColor2 = color2.ToClosedXMLColor();
+            var xlColor3 = color3.ToClosedXMLColor();
+            var xlColor4 = color4.ToClosedXMLColor();
+
+            Assert.AreEqual(XLColorType.Color, xlColor1.ColorType);
+            Assert.AreEqual(XLColor.Red.Color, xlColor1.Color);
+
+            Assert.AreEqual(XLColorType.Indexed, xlColor2.ColorType);
+            Assert.AreEqual(20, xlColor2.Indexed);
+
+            Assert.AreEqual(XLColorType.Theme, xlColor3.ColorType);
+            Assert.AreEqual(XLThemeColor.Accent1, xlColor3.ThemeColor);
+            Assert.AreEqual(0, xlColor3.ThemeTint, XLHelper.Epsilon);
+
+            Assert.AreEqual(XLColorType.Theme, xlColor4.ColorType);
+            Assert.AreEqual(XLThemeColor.Accent1, xlColor4.ThemeColor);
+            Assert.AreEqual(0.4, xlColor4.ThemeTint, XLHelper.Epsilon);
         }
     }
 }


### PR DESCRIPTION
Currently, we have 6 nearly identical `switch`-es to convert ClosedXML colors to OpenXML format. For sparklines, we'd have to add 8 more as each color to be saved must be converted to its own class (`FirstMarkerColor`, `LastMarkerColor`, etc.). That's obviously insane.

This PR replaces all those `switch`-es with a single method that may be utilized by sparklines too.