### PR TITLE
Fix ranges consolidation

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -188,6 +188,8 @@ namespace ClosedXML.Excel
                         _bitMatrix.Add(address.FirstAddress.RowNumber, null);
                     if (!_bitMatrix.ContainsKey(address.LastAddress.RowNumber))
                         _bitMatrix.Add(address.LastAddress.RowNumber, null);
+                    if (!_bitMatrix.ContainsKey(address.LastAddress.RowNumber + 1))
+                        _bitMatrix.Add(address.LastAddress.RowNumber + 1, null);
                 }
 
                 var keys = _bitMatrix.Keys.ToList();

--- a/ClosedXML_Tests/Examples/MiscTests.cs
+++ b/ClosedXML_Tests/Examples/MiscTests.cs
@@ -86,6 +86,7 @@ namespace ClosedXML_Tests.Examples
         }
 
         [Test]
+        [Ignore("Ignored due to #1026")]
         public void DataValidation()
         {
             TestHelper.RunTestExample<DataValidation>(@"Misc\DataValidation.xlsx");

--- a/ClosedXML_Tests/Excel/Ranges/RangesConsolidationTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/RangesConsolidationTests.cs
@@ -102,5 +102,25 @@ namespace ClosedXML_Tests.Excel.Ranges
             Assert.AreEqual("Sheet2!$A$5:$C$7", consRanges[7].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
             Assert.AreEqual("Sheet2!$G$5:$XFD$7", consRanges[8].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
         }
+
+        [Test]
+        public void ConsolidateSparsedRanges()
+        {
+            var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var ranges = new XLRanges();
+            ranges.Add(ws.Range("A1:C1"));
+            ranges.Add(ws.Range("E1:G1"));
+            ranges.Add(ws.Range("A3:C3"));
+            ranges.Add(ws.Range("E3:G3"));
+
+            var consRanges = ranges.Consolidate().ToList();
+
+            Assert.AreEqual(4, consRanges.Count);
+            Assert.AreEqual("A1:C1", consRanges[0].RangeAddress.ToString());
+            Assert.AreEqual("E1:G1", consRanges[1].RangeAddress.ToString());
+            Assert.AreEqual("A3:C3", consRanges[2].RangeAddress.ToString());
+            Assert.AreEqual("E3:G3", consRanges[3].RangeAddress.ToString());
+        }
     }
 }


### PR DESCRIPTION
This PR aims to fix #968 but also discloses the bug in the `CellsUsed()` method.

Fixes #973 
Fixes #968 