### PR TITLE
Add table helper methods

### DIFF
--- a/ClosedXML/Excel/Drawings/XLPictures.cs
+++ b/ClosedXML/Excel/Drawings/XLPictures.cs
@@ -106,6 +106,9 @@ namespace ClosedXML.Excel.Drawings
                 .Where(picture => picture.Name.Equals(pictureName, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
+            if (!picturesToDelete.Any())
+                throw new ArgumentOutOfRangeException(nameof(pictureName), $"Picture {pictureName} was not found.");
+
             foreach (var picture in picturesToDelete)
             {
                 if (!string.IsNullOrEmpty(picture.RelId))
@@ -135,7 +138,7 @@ namespace ClosedXML.Excel.Drawings
             if (TryGetPicture(pictureName, out IXLPicture p))
                 return p;
 
-            throw new ArgumentException($"There isn't a picture named '{pictureName}'.");
+            throw new ArgumentOutOfRangeException(nameof(pictureName), $"Picture {pictureName} was not found.");
         }
 
         public bool TryGetPicture(string pictureName, out IXLPicture picture)

--- a/ClosedXML/Excel/IXLWorkbook.cs
+++ b/ClosedXML/Excel/IXLWorkbook.cs
@@ -223,6 +223,15 @@ namespace ClosedXML.Excel
 
         XLWorkbook SetUse1904DateSystem(Boolean value);
 
+        /// <summary>
+        /// Gets the Excel table of the given name
+        /// </summary>
+        /// <param name="tableName">Name of the table to return.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies how the strings will be compared.</param>
+        /// <returns>The table with given name</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If no tables with this name could be found in the workbook.</exception>
+        IXLTable Table(string tableName, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase);
+
         Boolean TryGetWorksheet(String name, out IXLWorksheet worksheet);
 
         void Unprotect();

--- a/ClosedXML/Excel/IXLWorkbook.cs
+++ b/ClosedXML/Excel/IXLWorkbook.cs
@@ -1,3 +1,4 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -140,11 +141,6 @@ namespace ClosedXML.Excel
 
         Object Evaluate(String expression);
 
-        /// <summary>
-        /// Force recalculation of all cell formulas.
-        /// </summary>
-        void RecalculateAllFormulas();
-
         IXLCells FindCells(Func<IXLCell, Boolean> predicate);
 
         IXLColumns FindColumns(Func<IXLColumn, Boolean> predicate);
@@ -168,6 +164,11 @@ namespace ClosedXML.Excel
         IXLRange RangeFromFullAddress(String rangeAddress, out IXLWorksheet ws);
 
         IXLRanges Ranges(String ranges);
+
+        /// <summary>
+        /// Force recalculation of all cell formulas.
+        /// </summary>
+        void RecalculateAllFormulas();
 
         /// <summary>
         ///   Saves the current workbook.

--- a/ClosedXML/Excel/Tables/IXLTables.cs
+++ b/ClosedXML/Excel/Tables/IXLTables.cs
@@ -1,3 +1,4 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
 
@@ -22,5 +23,7 @@ namespace ClosedXML.Excel
         IXLTable Table(Int32 index);
 
         IXLTable Table(String name);
+
+        Boolean TryGetTable(String tableName, out IXLTable table);
     }
 }

--- a/ClosedXML/Excel/Tables/XLTables.cs
+++ b/ClosedXML/Excel/Tables/XLTables.cs
@@ -70,7 +70,21 @@ namespace ClosedXML.Excel
 
         public IXLTable Table(String name)
         {
-            return _tables[name];
+            if (TryGetTable(name, out IXLTable table))
+                return table;
+
+            throw new ArgumentOutOfRangeException(nameof(name), $"Table {name} was not found.");
+        }
+
+        public bool TryGetTable(string tableName, out IXLTable table)
+        {
+            if (_tables.ContainsKey(tableName))
+            {
+                table = _tables[tableName];
+                return true;
+            }
+            table = null;
+            return false;
         }
 
         #endregion IXLTables Members

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -44,6 +44,7 @@ namespace ClosedXML.Excel
     public partial class XLWorkbook : IXLWorkbook
     {
         #region Static
+
         public static IXLStyle DefaultStyle
         {
             get
@@ -134,7 +135,7 @@ namespace ClosedXML.Excel
             RecalculationCounter++;
         }
 
-        #region  Nested Type : XLLoadSource
+        #region Nested Type : XLLoadSource
 
         private enum XLLoadSource
         {
@@ -143,7 +144,7 @@ namespace ClosedXML.Excel
             Stream
         };
 
-        #endregion Nested Type: XLLoadSource
+        #endregion Nested Type : XLLoadSource
 
         internal XLWorksheets WorksheetsInternal { get; private set; }
 
@@ -592,6 +593,18 @@ namespace ClosedXML.Excel
                 output.Write(buffer, 0, len);
             // dm 20130422, and flushing the output after write
             output.Flush();
+        }
+
+        public IXLTable Table(string tableName, StringComparison comparisonType = StringComparison.OrdinalIgnoreCase)
+        {
+            var table = this.Worksheets
+                .SelectMany(ws => ws.Tables)
+                .FirstOrDefault(t => t.Name.Equals(tableName, comparisonType));
+
+            if (table == null)
+                throw new ArgumentOutOfRangeException($"Table {tableName} was not found.");
+
+            return table;
         }
 
         public IXLWorksheet Worksheet(String name)

--- a/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML_Tests/Excel/ImageHandling/PictureTests.cs
@@ -412,5 +412,16 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(25, picture.TopLeftCell.Address.RowNumber);
             }
         }
+
+        [Test]
+        public void PictureNotFound()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Picture("dummy"));
+                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Pictures.Delete("dummy"));
+            }
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML_Tests/Excel/Tables/TablesTests.cs
@@ -1078,6 +1078,17 @@ namespace ClosedXML_Tests.Excel
             }
         }
 
+        [Test]
+        public void TableNotFound()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Table("dummy"));
+                Assert.Throws<ArgumentOutOfRangeException>(() => wb.Table("dummy"));
+            }
+        }
+
         private void AssertTablesAreEqual(IXLTable table1, IXLTable table2)
         {
             Assert.AreEqual(table1.RangeAddress.ToString(XLReferenceStyle.A1, false), table2.RangeAddress.ToString(XLReferenceStyle.A1, false));


### PR DESCRIPTION
Some helper methods added.

I'm not convinced about replacing `ArgumentException` with `ClosedXMLEntityNotFoundException`. I can see the use of having our own exception, but it also feels inconsistent with other places where `ArgumentException` is thrown.