### PR TITLE
Allow names to start with backslash

### DIFF
--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -333,9 +333,10 @@ namespace ClosedXML.Excel
                 return false;
             }
 
-            if (newName[0] != '_' && !char.IsLetter(newName[0]))
+            var allowedFirstCharacters = new[] { '_', '\\' };
+            if (!allowedFirstCharacters.Contains(newName[0]) && !char.IsLetter(newName[0]))
             {
-                message = $"The {objectType} name '{newName}' does not begin with a letter or an underscore";
+                message = $"The {objectType} name '{newName}' does not begin with a letter, an underscore or a backslash.";
                 return false;
             }
 

--- a/ClosedXML_Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML_Tests/Excel/Tables/TablesTests.cs
@@ -669,6 +669,12 @@ namespace ClosedXML_Tests.Excel
                 table1.Name = "table1";
                 Assert.AreEqual("table1", table1.Name);
 
+                table1.Name = "_table1";
+                Assert.AreEqual("_table1", table1.Name);
+
+                table1.Name = "\\table1";
+                Assert.AreEqual("\\table1", table1.Name);
+
                 Assert.Throws<ArgumentException>(() => table1.Name = "");
                 Assert.Throws<ArgumentException>(() => table1.Name = "R");
                 Assert.Throws<ArgumentException>(() => table1.Name = "C");


### PR DESCRIPTION
http://www.criticaltosuccess.com/allowed-characters-in-range-names/

> Range names must start with a letter, underscore, or backslash. Following characters must be letters or numbers, periods, or underscores. You cannot use spaces or any character combination that looks like a cell reference.

Fixes #997 