### PR TITLE
Added '[' as a valid character to begin Named Ranges

### DIFF
--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -333,7 +333,7 @@ namespace ClosedXML.Excel
                 return false;
             }
 
-            var allowedFirstCharacters = new[] { '_', '\\' };
+            var allowedFirstCharacters = new[] { '_', '\\', '[' };
             if (!allowedFirstCharacters.Contains(newName[0]) && !char.IsLetter(newName[0]))
             {
                 message = $"The {objectType} name '{newName}' does not begin with a letter, an underscore or a backslash.";


### PR DESCRIPTION
#### What's this PR do?
Added '[' as a valid starting character in named ranges (fixes #1011)
