### PR TITLE
Change the way invalid ranges are saved

### DIFF
--- a/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel
         public XLNamedRange(XLNamedRanges namedRanges, String rangeName, String range, String comment = null)
             : this(namedRanges, rangeName, comment)
         {
-            RangeList.Add(range);
+            range.Split(',').ForEach(r => RangeList.Add(r));
         }
 
         public XLNamedRange(XLNamedRanges namedRanges, String rangeName, IXLRanges ranges, String comment = null)

--- a/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
@@ -15,6 +15,7 @@ namespace ClosedXML.Excel
         public XLNamedRange(XLNamedRanges namedRanges, String rangeName, String range, String comment = null)
             : this(namedRanges, rangeName, comment)
         {
+            //TODO range.Split(',') may produce incorrect result if a worksheet name contains comma. Refactoring needed.
             range.Split(',').ForEach(r => RangeList.Add(r));
         }
 

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -866,12 +866,15 @@ namespace ClosedXML.Excel
                 definedNames.AppendChild(definedName2);
             }
 
-            foreach (var nr in NamedRanges)
+            foreach (XLNamedRange nr in NamedRanges)
             {
+                var refersTo = string.Join(",", nr.RangeList
+                    .Select(r => r.StartsWith("#REF!") ? "#REF!" : r));
+
                 var definedName = new DefinedName
                 {
                     Name = nr.Name,
-                    Text = nr.ToString()
+                    Text = refersTo
                 };
 
                 if (!nr.Visible)

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -866,7 +866,7 @@ namespace ClosedXML.Excel
                 definedNames.AppendChild(definedName2);
             }
 
-            foreach (XLNamedRange nr in NamedRanges)
+            foreach (var nr in NamedRanges.OfType<XLNamedRange>())
             {
                 var refersTo = string.Join(",", nr.RangeList
                     .Select(r => r.StartsWith("#REF!") ? "#REF!" : r));

--- a/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -423,12 +423,12 @@ namespace ClosedXML_Tests.Excel
 
                     Assert.AreEqual("Named range 4", wb.NamedRanges.ElementAt(1).Name);
                     Assert.AreEqual(XLNamedRangeScope.Workbook, wb.NamedRanges.ElementAt(1).Scope);
-                    Assert.AreEqual("#REF!$A$4:$D$4", wb.NamedRanges.ElementAt(1).RefersTo);
+                    Assert.AreEqual("#REF!", wb.NamedRanges.ElementAt(1).RefersTo);
                     Assert.IsFalse(wb.NamedRanges.ElementAt(1).Ranges.Any());
 
                     Assert.AreEqual("Named range 5", wb.NamedRanges.ElementAt(2).Name);
                     Assert.AreEqual(XLNamedRangeScope.Workbook, wb.NamedRanges.ElementAt(2).Scope);
-                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5,#REF!$A$5:$D$5", wb.NamedRanges.ElementAt(2).RefersTo);
+                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5,#REF!", wb.NamedRanges.ElementAt(2).RefersTo);
                     Assert.AreEqual(1, wb.NamedRanges.ElementAt(2).Ranges.Count);
                     Assert.AreEqual("'Sheet 1'!A5:D5",
                         wb.NamedRanges.ElementAt(2).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));

--- a/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -525,6 +525,31 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
+        public void NamedRangesFromDeletedSheetAreSavedWithoutAddress()
+        {
+            // Range address referring to the deleted sheet look like #REF!A1:B2.
+            // But workbooks with such references in named ranges Excel considers as broken files.
+            // It requires #REF!
+
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    wb.Worksheets.Add("Sheet 1");
+                    var ws2 = wb.Worksheets.Add("Sheet 2");
+                    ws2.Range("A4:D4").AddToNamed("Test named range", XLScope.Workbook);
+                    ws2.Delete();
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    Assert.AreEqual("#REF!", wb.NamedRanges.Single().RefersTo);
+                }
+            }
+        }
+
+        [Test]
         public void CanGetValidNamedRanges()
         {
             using (var wb = new XLWorkbook())

--- a/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -436,6 +436,39 @@ namespace ClosedXML_Tests.Excel
             }
         }
 
+        [Test]
+        public void NamedRangeReferringToMultipleRangesCanBeSavedAndLoaded()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    var ws = wb.Worksheets.Add("Sheet 1");
+
+                    wb.NamedRanges.Add("Multirange named range", new XLRanges
+                    {
+                        ws.Range("A5:D5"),
+                        ws.Range("A15:D15")
+                    });
+
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    Assert.AreEqual(1, wb.NamedRanges.Count());
+                    var nr = wb.NamedRanges.Single() as XLNamedRange;
+                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5,'Sheet 1'!$A$15:$D$15", nr.RefersTo);
+                    Assert.AreEqual(2, nr.Ranges.Count);
+                    Assert.AreEqual("'Sheet 1'!A5:D5", nr.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
+                    Assert.AreEqual("'Sheet 1'!A15:D15", nr.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true));
+                    Assert.AreEqual(2, nr.RangeList.Count);
+                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5", nr.RangeList.First());
+                    Assert.AreEqual("'Sheet 1'!$A$15:$D$15", nr.RangeList.Last());
+                }
+            }
+        }
+
         [Test, Ignore("Muted until shifting is fixed (see #880)")]
         public void NamedRangeBecomesInvalidOnRangeDeleting()
         {


### PR DESCRIPTION
Fixes #1007 

Ranges referring to the deleted worksheets must be saved as `#REF!`, not `#REF!$A$1:$B$2`, otherwise, Excel complains that the file is corrupted.
Besides, I found that `RangeList` is not initialized properly. It does not seem to affect any other functionality as `Ranges` property was still correct, and `ToString()` method aggregated `RangeList` items to a single string anyway. But after I changed the saving logic it became essential.