### PR TITLE
Optimize the performance of searching range intersections on small collections

### DIFF
--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -30,8 +30,8 @@ namespace ClosedXML.Excel
 
                 var xxValues = xx.Values.Values.Where(v => v == null || !v.IsFormula).Select(v => v?.Value);
                 var yyValues = yy.Values.Values.Where(v => v == null || !v.IsFormula).Select(v => v?.Value);
-                var xxFormulas = x.Ranges.Any() ? xx.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)x.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
-                var yyFormulas = y.Ranges.Any() ? yy.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)y.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
+                var xxFormulas = x.Ranges.Count > 0 ? xx.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)x.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
+                var yyFormulas = y.Ranges.Count > 0 ? yy.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)y.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
 
                 var xStyle = xx.StyleValue;
                 var yStyle = yy.StyleValue;
@@ -61,7 +61,7 @@ namespace ClosedXML.Excel
                 var xx = (XLConditionalFormat)obj;
                 var xStyle = (obj.Style as XLStyle).Value;
                 var xValues = xx.Values.Values.Where(v => !v.IsFormula).Select(v => v.Value);
-                if (obj.Ranges.Any())
+                if (obj.Ranges.Count > 0)
                     xValues = xValues
                     .Union(xx.Values.Values.Where(v => v.IsFormula).Select(f => ((XLCell)obj.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)));
 

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -69,7 +69,9 @@ namespace ClosedXML.Excel
                         var intersectsSkipped =
                             skippedRanges.Any(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any());
 
-                        if (IsSameFormat(nextFormat) && !intersectsSkipped)
+                        var isSameFormat = IsSameFormat(nextFormat);
+
+                        if (isSameFormat && !intersectsSkipped)
                         {
                             similarFormats.Add(nextFormat);
                             nextFormat.Ranges.ForEach(r => rangesToJoin.Add(r));
@@ -80,7 +82,9 @@ namespace ClosedXML.Excel
                             // if we reached the rule intersecting any of captured ranges stop for not breaking the priorities
                             stop = true;
                         }
-                        nextFormat.Ranges.ForEach(r => skippedRanges.Add(r));
+
+                        if (!isSameFormat)
+                            nextFormat.Ranges.ForEach(r => skippedRanges.Add(r));
                     }
 
                     i++;

--- a/ClosedXML/Excel/Ranges/Index/XLRangeIndex.cs
+++ b/ClosedXML/Excel/Ranges/Index/XLRangeIndex.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel.Ranges.Index
         public XLRangeIndex(IXLWorksheet worksheet)
         {
             _worksheet = worksheet;
-            _quadTree = new Quadrant();
+            _rangeList = new List<IXLRangeBase>();
         }
 
         #endregion Public Constructors
@@ -32,18 +32,79 @@ namespace ClosedXML.Excel.Ranges.Index
 
             CheckWorksheet(range.Worksheet);
 
+            _count++;
+            if (_count < MinimumCountForIndexing)
+            {
+                if (_rangeList.Any(r => r == range))
+                    return false;
+
+                _rangeList.Add(range);
+                return true;
+            }
+
+            if (_quadTree == null)
+                InitializeTree();
+
             return _quadTree.Add(range);
         }
 
         public bool Contains(in XLAddress address)
         {
             CheckWorksheet(address.Worksheet);
+
+            if (_quadTree == null)
+            {
+                var addr = address;
+                return _rangeList.Any(r => r.RangeAddress.Contains(addr));
+            }
+
             return _quadTree.GetIntersectedRanges(address).Any();
+        }
+
+        public IEnumerable<IXLRangeBase> GetAll()
+        {
+            if (_quadTree == null)
+            {
+                return _rangeList.AsEnumerable();
+            }
+
+            return _quadTree.GetAll();
+        }
+
+        public IEnumerable<IXLRangeBase> GetIntersectedRanges(XLRangeAddress rangeAddress)
+        {
+            CheckWorksheet(rangeAddress.Worksheet);
+
+            if (_quadTree == null)
+            {
+                return _rangeList.Where(r => r.RangeAddress.Intersects(rangeAddress));
+            }
+
+            return _quadTree.GetIntersectedRanges(rangeAddress);
+        }
+
+        public IEnumerable<IXLRangeBase> GetIntersectedRanges(XLAddress address)
+        {
+            CheckWorksheet(address.Worksheet);
+
+            if (_quadTree == null)
+            {
+                return _rangeList.Where(r => r.RangeAddress.Contains(address));
+            }
+
+            return _quadTree.GetIntersectedRanges(address);
         }
 
         public bool Intersects(in XLRangeAddress rangeAddress)
         {
             CheckWorksheet(rangeAddress.Worksheet);
+
+            if (_quadTree == null)
+            {
+                var addr = rangeAddress;
+                return _rangeList.Any(r => r.RangeAddress.Intersects(addr));
+            }
+
             return _quadTree.GetIntersectedRanges(rangeAddress).Any();
         }
 
@@ -54,39 +115,47 @@ namespace ClosedXML.Excel.Ranges.Index
 
             CheckWorksheet(range.Worksheet);
 
+            if (_quadTree == null)
+            {
+                return _rangeList.Remove(range);
+            }
+
             return _quadTree.Remove(range);
         }
 
         public int RemoveAll(Predicate<IXLRangeBase> predicate = null)
         {
-            return _quadTree.RemoveAll(predicate ?? (_ => true)).Count();
-        }
+            predicate = predicate ?? (_ => true);
 
-        public IEnumerable<IXLRangeBase> GetAll()
-        {
-            return _quadTree.GetAll();
-        }
+            if (_quadTree == null)
+            {
+                return _rangeList.RemoveAll(predicate);
+            }
 
-        public IEnumerable<IXLRangeBase> GetIntersectedRanges(XLRangeAddress rangeAddress)
-        {
-            CheckWorksheet(rangeAddress.Worksheet);
-
-            return _quadTree.GetIntersectedRanges(rangeAddress);
-        }
-
-        public IEnumerable<IXLRangeBase> GetIntersectedRanges(XLAddress address)
-        {
-            CheckWorksheet(address.Worksheet);
-
-            return _quadTree.GetIntersectedRanges(address);
+            return _quadTree.RemoveAll(predicate).Count();
         }
 
         #endregion Public Methods
 
+
+
         #region Private Fields
 
-        private readonly Quadrant _quadTree;
+        /// <summary>
+        /// The minimum number of ranges to be included into a QuadTree. Until it is reached the ranges
+        /// are added into a simple list to minimize the overhead of searching intersections on small collections.
+        /// </summary>
+        private const int MinimumCountForIndexing = 20;
+
+        /// <summary>
+        /// A collection of ranges used before the QuadTree is initialized (until <see cref="MinimumCountForIndexing"/>
+        /// is reached.
+        /// </summary>
+        private readonly List<IXLRangeBase> _rangeList;
+
         private readonly IXLWorksheet _worksheet;
+        private int _count = 0;
+        private Quadrant _quadTree;
 
         #endregion Private Fields
 
@@ -96,6 +165,13 @@ namespace ClosedXML.Excel.Ranges.Index
         {
             if (worksheet != _worksheet)
                 throw new ArgumentException("Range belongs to a different worksheet");
+        }
+
+        private void InitializeTree()
+        {
+            _quadTree = new Quadrant();
+            _rangeList.ForEach(r => _quadTree.Add(r));
+            _rangeList.Clear();
         }
 
         #endregion Private Methods

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel
         /// Normally, XLRanges collection includes ranges from a single worksheet, but not necessarily.
         /// </summary>
         private readonly Dictionary<IXLWorksheet, IXLRangeIndex<XLRange>> _indexes;
-        private IEnumerable<XLRange> Ranges => _indexes.Values.SelectMany(index => index.GetAll()).ToList();
+        private IEnumerable<XLRange> Ranges => _indexes.Values.SelectMany(index => index.GetAll());
 
 
         private IXLRangeIndex<XLRange> GetRangeIndex(IXLWorksheet worksheet)
@@ -78,9 +78,7 @@ namespace ClosedXML.Excel
 
         public IEnumerator<IXLRange> GetEnumerator()
         {
-            var retList = new List<IXLRange>();
-            retList.AddRange(Ranges.Where(r => XLHelper.IsValidRangeAddress(r.RangeAddress)).Cast<IXLRange>());
-            return retList.GetEnumerator();
+            return Ranges.Cast<IXLRange>().GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
This PR partially fixes #993. I used a worksheet 2510 from the original file. Before this PR saving took 69.5 sec, now it takes only 12.7 sec. Still far from perfect but definitely much better.

To achieve this I modified a ranges indexing algorithm so it wouldn't apply to small collections (less than 20 items). The number 20 was chosen empirically: our QuadTree implementation is 10 levels deep and each level may require one or a few checks for intersections. Changing the constant value in a range (10 .. 70) barely affected the performance (the difference was <1%).

[993_sample2.xlsx](https://github.com/ClosedXML/ClosedXML/files/2476134/993_sample2.xlsx)
