### PR TITLE
Improve implicit string casting

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -163,7 +163,7 @@ namespace ClosedXML.Excel.CalcEngine
             }
 
             // handle everything else
-            return (double)x == 0 ? false : true;
+            return (double)Convert.ChangeType(v, typeof(double)) != 0;
         }
 
         public static implicit operator DateTime(Expression x)
@@ -180,8 +180,8 @@ namespace ClosedXML.Excel.CalcEngine
                 return (DateTime)v;
             }
 
-            // handle doubles
-            if (v is double || v is int)
+            // handle numbers
+            if (v.IsNumber())
             {
                 return DateTime.FromOADate((double)x);
             }

--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -84,7 +84,14 @@ namespace ClosedXML.Excel.CalcEngine
                 (x as ErrorExpression).ThrowApplicableException();
 
             var v = x.Evaluate();
-            return v == null ? string.Empty : v.ToString();
+
+            if (v == null)
+                return string.Empty;
+
+            if (v is bool b)
+                return b.ToString().ToUpper();
+
+            return v.ToString();
         }
 
         public static implicit operator double(Expression x)
@@ -487,7 +494,7 @@ namespace ClosedXML.Excel.CalcEngine
         public IEnumerator GetEnumerator()
         {
             if (_value is string)
-                return new [] {(string) _value}.GetEnumerator();
+                return new[] { (string)_value }.GetEnumerator();
 
             return (_value as IEnumerable).GetEnumerator();
         }

--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -103,26 +103,26 @@ namespace ClosedXML.Excel.CalcEngine
             var v = x.Evaluate();
 
             // handle doubles
-            if (v is double)
+            if (v is double dbl)
             {
-                return (double)v;
+                return dbl;
             }
 
             // handle booleans
-            if (v is bool)
+            if (v is bool b)
             {
-                return (bool)v ? 1 : 0;
+                return b ? 1 : 0;
             }
 
             // handle dates
-            if (v is DateTime)
+            if (v is DateTime dt)
             {
-                return ((DateTime)v).ToOADate();
+                return dt.ToOADate();
             }
 
-            if (v is TimeSpan)
+            if (v is TimeSpan ts)
             {
-                return ((TimeSpan)v).TotalDays;
+                return ts.TotalDays;
             }
 
             // handle nulls
@@ -145,9 +145,9 @@ namespace ClosedXML.Excel.CalcEngine
             var v = x.Evaluate();
 
             // handle booleans
-            if (v is bool)
+            if (v is bool b)
             {
-                return (bool)v;
+                return b;
             }
 
             // handle nulls
@@ -157,9 +157,9 @@ namespace ClosedXML.Excel.CalcEngine
             }
 
             // handle doubles
-            if (v is double)
+            if (v is double dbl)
             {
-                return (double)v == 0 ? false : true;
+                return dbl != 0;
             }
 
             // handle everything else
@@ -175,9 +175,9 @@ namespace ClosedXML.Excel.CalcEngine
             var v = x.Evaluate();
 
             // handle dates
-            if (v is DateTime)
+            if (v is DateTime dt)
             {
-                return (DateTime)v;
+                return dt;
             }
 
             // handle numbers

--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -180,6 +180,11 @@ namespace ClosedXML.Excel.CalcEngine
                 return dt;
             }
 
+            if (v is TimeSpan ts)
+            {
+                return new DateTime().Add(ts);
+            }
+
             // handle numbers
             if (v.IsNumber())
             {


### PR DESCRIPTION
- When implicitly casting bool to string, use upper case (in line with Excel)
- Small improvement in type casting
- Use inline parameter declaration
- Add case for casting timespan to datetime