### PR TITLE
Fix for ShiftConditionalFormattingRows Error

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1231,14 +1231,14 @@ namespace ClosedXML.Excel
                     {
                         newRange = Range(cfAddress.FirstAddress.RowNumber,
                                          cfAddress.FirstAddress.ColumnNumber,
-                                         cfAddress.LastAddress.RowNumber + rowsShifted,
+                                         Math.Min(XLHelper.MaxRowNumber, cfAddress.LastAddress.RowNumber + rowsShifted),
                                          cfAddress.LastAddress.ColumnNumber);
                     }
                     else if (cfAddress.FirstAddress.RowNumber >= firstRow)
                     {
                         newRange = Range(Math.Max(cfAddress.FirstAddress.RowNumber + rowsShifted, firstRow),
                                          cfAddress.FirstAddress.ColumnNumber,
-                                         cfAddress.LastAddress.RowNumber + rowsShifted,
+                                         Math.Min(XLHelper.MaxRowNumber, cfAddress.LastAddress.RowNumber + rowsShifted),
                                          cfAddress.LastAddress.ColumnNumber);
                     }
                     else


### PR DESCRIPTION
Fix ShiftConditionalFormattingRows if conditionalformat already reaches to the last row.

#### What's this PR do?
Fixes a bug that happens when rows are inserted and an existing conditional formatting already reaches to the end of a column (last row in sheet)
#### Where should the reviewer start?
There are only two lines changed :-)
#### How should this be manually tested?
Create an Excel-File with a conditional formatting that reaches to the last rows. (I use an existing excel file as a template and add rows programatically)
#### Any background context you want to provide?

#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post? 
No 
- Does the knowledge base need an update?
No
- Does this add new (C#) dependencies?
No

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer