### PR TITLE
String comparisons should be case-insensitive. 

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -240,8 +240,11 @@ namespace ClosedXML.Excel.CalcEngine
                 catch (ArgumentNullException) { return -1; }
             }
 
-            // compare
-            return c1.CompareTo(c2);
+            // String comparisons should be case insensitive
+            if (c1 is string s1 && c2 is string s2)
+                return StringComparer.OrdinalIgnoreCase.Compare(s1, s2);
+            else
+                return c1.CompareTo(c2);
         }
 
         #endregion ** IComparable<Expression>

--- a/ClosedXML_Tests/Excel/CalcEngine/LogicalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/LogicalTests.cs
@@ -1,10 +1,9 @@
-using System;
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
 
 namespace ClosedXML_Tests.Excel.CalcEngine
 {
-
     [TestFixture]
     public class LogicalTests
     {
@@ -14,6 +13,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Object actual = XLWorkbook.EvaluateExpr(@"if(1 = 1, ""T"")");
             Assert.AreEqual("T", actual);
         }
+
         [Test]
         public void If_2_Params_false()
         {
@@ -27,6 +27,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Object actual = XLWorkbook.EvaluateExpr(@"if(1 = 1, ""T"", ""F"")");
             Assert.AreEqual("T", actual);
         }
+
         [Test]
         public void If_3_Params_false()
         {
@@ -49,6 +50,14 @@ namespace ClosedXML_Tests.Excel.CalcEngine
 
             actual = XLWorkbook.EvaluateExpr(@"if("""" = """", ""A"",""B"")");
             Assert.AreEqual("A", actual);
+        }
+
+        [Test]
+        public void If_Case_Insensitivity()
+        {
+            Object actual;
+            actual = XLWorkbook.EvaluateExpr(@"IF(""text""=""TEXT"", 1, 2)");
+            Assert.AreEqual(1, actual);
         }
     }
 }

--- a/ClosedXML_Tests/Excel/CalcEngine/LookupTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/LookupTests.cs
@@ -103,6 +103,10 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             value = workbook.Evaluate(@"=VLOOKUP(""Central"",Data!D:E,2,FALSE)");
             Assert.AreEqual("Kivell", value);
 
+            // Case insensitive lookup
+            value = workbook.Evaluate(@"=VLOOKUP(""central"",Data!D:E,2,FALSE)");
+            Assert.AreEqual("Kivell", value);
+
             // Range lookup true
             value = workbook.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,8,TRUE)");
             Assert.AreEqual(179.64, value);


### PR DESCRIPTION
I couldn't find any cases where they should be case sensitive. All tests pass currently. Not ruling out the fact that there might be exceptions.

Fixes #861 