### PR TITLE
Make TryGetValue_decimal_Good2test environment-independent

### DIFF
--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -372,6 +372,8 @@ namespace ClosedXML_Tests
         [Test]
         public void TryGetValue_decimal_Good2()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             var cell = ws.Cell("A1").SetValue("1.60000001869776E-06");
             bool success = cell.TryGetValue(out decimal outValue);


### PR DESCRIPTION
The test TryGetValue_decimal_Good2 fails on my machine. My settings are:
![image](https://user-images.githubusercontent.com/19576939/48246916-b9a1e180-e40a-11e8-87e3-e1f1081f67fd.png)

This PR make the test culture-independent.