### PR TITLE
Add flag MergedRanges to XLClearOptions to unify with XLCellUsedOptions

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1195,6 +1195,11 @@ namespace ClosedXML.Excel
                     var validation = NewDataValidation;
                     Worksheet.DataValidations.Delete(validation);
                 }
+
+                if (clearOptions.HasFlag(XLClearOptions.MergedRanges) && IsMerged())
+                {
+                    ClearMerged();
+                }
             }
 
             return this;

--- a/ClosedXML/Excel/XLCellsUsedOptions.cs
+++ b/ClosedXML/Excel/XLCellsUsedOptions.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.Excel
         MergedRanges            = 1 << 6,
 
         AllFormats = NormalFormats | ConditionalFormats,
-        AllContents = Contents | DataType | Comments | MergedRanges,
+        AllContents = Contents | DataType | Comments,
         All = Contents | DataType | NormalFormats | ConditionalFormats | Comments | DataValidation | MergedRanges
     }
 

--- a/ClosedXML/Excel/XLClearOptions.cs
+++ b/ClosedXML/Excel/XLClearOptions.cs
@@ -11,10 +11,11 @@ namespace ClosedXML.Excel
         ConditionalFormats      = 1 << 3,
         Comments                = 1 << 4,
         DataValidation          = 1 << 5,
+        MergedRanges            = 1 << 6,
 
         AllFormats = NormalFormats | ConditionalFormats,
         AllContents = Contents | DataType | Comments,
-        All = Contents | DataType | NormalFormats | ConditionalFormats | Comments | DataValidation
+        All = Contents | DataType | NormalFormats | ConditionalFormats | Comments | DataValidation | MergedRanges
     }
 
     internal static class XLClearOptionsExtensions

--- a/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
+++ b/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
@@ -283,5 +283,27 @@ namespace ClosedXML_Tests
                 }
             }
         }
+
+        [TestCase(XLClearOptions.All, 2)]
+        [TestCase(XLClearOptions.AllContents, 4)]
+        [TestCase(XLClearOptions.AllFormats, 4)]
+        [TestCase(XLClearOptions.Contents, 4)]
+        [TestCase(XLClearOptions.MergedRanges, 2)]
+        public void CanClearMergedRanges(XLClearOptions options, int expectedCount)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Test");
+
+                ws.Range("A1:C3").Merge();
+                ws.Range("A4:B6").Merge();
+                ws.Range("D1:F3").Merge();
+                ws.Range("E4:F6").Merge();
+
+                ws.Range("C1:D6").Clear(options);
+
+                Assert.AreEqual(expectedCount, ws.MergedRanges.Count);
+            }
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -170,7 +170,7 @@ namespace ClosedXML_Tests.Excel.Ranges
 
                 var options = includeFormatting
                     ? XLCellsUsedOptions.All
-                    : XLCellsUsedOptions.AllContents;
+                    : XLCellsUsedOptions.AllContents | XLCellsUsedOptions.MergedRanges;
                 var actual = ws.RangeUsed(options).RangeAddress;
 
                 Assert.AreEqual(expectedRange, actual.ToString());


### PR DESCRIPTION
This PR unifies `XLClearOptions` with `XLCellUsedOptions` by adding a `MergedRanges` flag. For now, we use the `NormalFormats` flag to specify that merged ranges have to be cleared which looks counter-intuitive.

I'd suggest to include this in 0.94 too so that changes related to these flags came all at once.