### PR TITLE
Reference FastMember (unsigned) when building unsigned ClosedXML

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -68,6 +68,13 @@
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
     <PackageReference Include="ExcelNumberFormat" Version="1.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)'=='Release.Signed'">
     <PackageReference Include="FastMember.Signed" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)'!='Release.Signed'">
+    <PackageReference Include="FastMember" Version="1.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
To avoid unnecessary binding redirects, we can reference FastMember (unsigned) when building unsigned ClosedXML.