### PR TITLE
Alternative implementation of pivot table formats

### DIFF
--- a/ClosedXML/Excel/EnumConverter.cs
+++ b/ClosedXML/Excel/EnumConverter.cs
@@ -616,6 +616,7 @@ namespace ClosedXML.Excel
                     throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
             }
         }
+
         public static SheetViewValues ToOpenXml(this XLSheetViewOptions value)
         {
             switch (value)
@@ -777,6 +778,39 @@ namespace ClosedXML.Excel
 
                 default:
                     throw new ArgumentOutOfRangeException("Not implemented value!");
+            }
+        }
+
+        public static PivotAreaValues ToOpenXml(this XLPivotAreaValues value)
+        {
+            switch (value)
+            {
+                case XLPivotAreaValues.None:
+                    return PivotAreaValues.None;
+
+                case XLPivotAreaValues.Normal:
+                    return PivotAreaValues.Normal;
+
+                case XLPivotAreaValues.Data:
+                    return PivotAreaValues.Data;
+
+                case XLPivotAreaValues.All:
+                    return PivotAreaValues.All;
+
+                case XLPivotAreaValues.Origin:
+                    return PivotAreaValues.Origin;
+
+                case XLPivotAreaValues.Button:
+                    return PivotAreaValues.Button;
+
+                case XLPivotAreaValues.TopRight:
+                    return PivotAreaValues.TopRight;
+
+                case XLPivotAreaValues.TopEnd:
+                    return PivotAreaValues.TopEnd;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), "XLPivotAreaValues value not implemented");
             }
         }
 
@@ -1549,6 +1583,39 @@ namespace ClosedXML.Excel
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(value), "Not implemented value!");
+            }
+        }
+
+        public static XLPivotAreaValues ToClosedXml(this PivotAreaValues value)
+        {
+            switch (value)
+            {
+                case PivotAreaValues.None:
+                    return XLPivotAreaValues.None;
+
+                case PivotAreaValues.Normal:
+                    return XLPivotAreaValues.Normal;
+
+                case PivotAreaValues.Data:
+                    return XLPivotAreaValues.Data;
+
+                case PivotAreaValues.All:
+                    return XLPivotAreaValues.All;
+
+                case PivotAreaValues.Origin:
+                    return XLPivotAreaValues.Origin;
+
+                case PivotAreaValues.Button:
+                    return XLPivotAreaValues.Button;
+
+                case PivotAreaValues.TopRight:
+                    return XLPivotAreaValues.TopRight;
+
+                case PivotAreaValues.TopEnd:
+                    return XLPivotAreaValues.TopEnd;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), "PivotAreaValues value not implemented");
             }
         }
 

--- a/ClosedXML/Excel/PivotTables/IXLPivotField.cs
+++ b/ClosedXML/Excel/PivotTables/IXLPivotField.cs
@@ -19,7 +19,9 @@ namespace ClosedXML.Excel
         Variance,
         PopulationVariance,
     }
+
     public enum XLPivotLayout { Outline, Tabular, Compact }
+
     public interface IXLPivotField
     {
         String SourceName { get; }
@@ -33,28 +35,46 @@ namespace ClosedXML.Excel
         Boolean Compact { get; set; }
         Boolean? SubtotalsAtTop { get; set; }
         Boolean RepeatItemLabels { get; set; }
-        Boolean InsertBlankLines  { get; set; }
+        Boolean InsertBlankLines { get; set; }
         Boolean ShowBlankItems { get; set; }
         Boolean InsertPageBreaks { get; set; }
         Boolean Collapsed { get; set; }
         XLPivotSortType SortType { get; set; }
 
         IXLPivotField SetCustomName(String value);
+
         IXLPivotField SetSubtotalCaption(String value);
 
         IXLPivotField AddSubtotal(XLSubtotalFunction value);
+
         IXLPivotField SetIncludeNewItemsInFilter(); IXLPivotField SetIncludeNewItemsInFilter(Boolean value);
 
         IXLPivotField SetLayout(XLPivotLayout value);
+
         IXLPivotField SetSubtotalsAtTop(); IXLPivotField SetSubtotalsAtTop(Boolean value);
+
         IXLPivotField SetRepeatItemLabels(); IXLPivotField SetRepeatItemLabels(Boolean value);
+
         IXLPivotField SetInsertBlankLines(); IXLPivotField SetInsertBlankLines(Boolean value);
+
         IXLPivotField SetShowBlankItems(); IXLPivotField SetShowBlankItems(Boolean value);
+
         IXLPivotField SetInsertPageBreaks(); IXLPivotField SetInsertPageBreaks(Boolean value);
+
         IXLPivotField SetCollapsed(); IXLPivotField SetCollapsed(Boolean value);
+
         IXLPivotField SetSort(XLPivotSortType value);
 
         IList<Object> SelectedValues { get; }
+
         IXLPivotField AddSelectedValue(Object value);
+
+        IXLPivotFieldStyleFormats StyleFormats { get; }
+
+        Boolean IsOnRowAxis { get; }
+        Boolean IsOnColumnAxis { get; }
+        Boolean IsInFilterList { get; }
+
+        Int32 Offset { get; }
     }
 }

--- a/ClosedXML/Excel/PivotTables/IXLPivotFields.cs
+++ b/ClosedXML/Excel/PivotTables/IXLPivotFields.cs
@@ -1,3 +1,4 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
 
@@ -13,8 +14,13 @@ namespace ClosedXML.Excel
 
         Boolean Contains(String sourceName);
 
+        Boolean Contains(IXLPivotField pivotField);
+
         IXLPivotField Get(String sourceName);
 
+        IXLPivotField Get(Int32 index);
+
+        Int32 IndexOf(String sourceName);
         Int32 IndexOf(IXLPivotField pf);
 
         void Remove(String sourceName);

--- a/ClosedXML/Excel/PivotTables/IXLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/IXLPivotTable.cs
@@ -268,5 +268,7 @@ namespace ClosedXML.Excel
         IXLPivotTable SetInsertBlankLines(); IXLPivotTable SetInsertBlankLines(Boolean value);
 
         IXLWorksheet Worksheet { get; }
+
+        IXLPivotTableStyleFormats StyleFormats { get; }
     }
 }

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/AbstractPivotFieldReference.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/AbstractPivotFieldReference.cs
@@ -1,0 +1,19 @@
+﻿using DocumentFormat.OpenXml;
+using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel
+{
+    internal abstract class AbstractPivotFieldReference
+    {
+        public Boolean DefaultSubtotal { get; set; }
+
+        internal abstract UInt32Value GetFieldOffset();
+
+        /// <summary>
+        ///   <P>Helper function used during saving to calculate the indices of the filtered values</P>
+        /// </summary>
+        /// <returns>Indices of the filtered values</returns>
+        internal abstract IEnumerable<Int32> Match(XLWorkbook.PivotTableInfo pti, IXLPivotTable pt);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotFieldStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotFieldStyleFormats.cs
@@ -1,0 +1,11 @@
+﻿// Keep this file CodeMaid organised and cleaned
+namespace ClosedXML.Excel
+{
+    public interface IXLPivotFieldStyleFormats
+    {
+        IXLPivotValueStyleFormat DataValuesFormat { get; }
+        IXLPivotStyleFormat Header { get; }
+        IXLPivotStyleFormat Label { get; }
+        IXLPivotStyleFormat Subtotal { get; }
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormat.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormat.cs
@@ -1,0 +1,10 @@
+// Keep this file CodeMaid organised and cleaned
+namespace ClosedXML.Excel
+{
+    public interface IXLPivotStyleFormat
+    {
+        XLPivotStyleFormatElement AppliesTo { get; }
+        IXLPivotField PivotField { get; }
+        IXLStyle Style { get; set; }
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotStyleFormats.cs
@@ -1,0 +1,10 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel
+{
+    public interface IXLPivotStyleFormats : IEnumerable<IXLPivotStyleFormat>
+    {
+        IXLPivotStyleFormat ForElement(XLPivotStyleFormatElement element);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotTableStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotTableStyleFormats.cs
@@ -1,0 +1,9 @@
+﻿// Keep this file CodeMaid organised and cleaned
+namespace ClosedXML.Excel
+{
+    public interface IXLPivotTableStyleFormats
+    {
+        IXLPivotStyleFormats ColumnGrandTotalFormats { get; }
+        IXLPivotStyleFormats RowGrandTotalFormats { get; }
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotValueStyleFormat.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/IXLPivotValueStyleFormat.cs
@@ -1,0 +1,14 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+
+namespace ClosedXML.Excel
+{
+    public interface IXLPivotValueStyleFormat : IXLPivotStyleFormat
+    {
+        IXLPivotValueStyleFormat AndWith(IXLPivotField field);
+
+        IXLPivotValueStyleFormat AndWith(IXLPivotField field, Predicate<Object> predicate);
+
+        IXLPivotValueStyleFormat ForValueField(IXLPivotValue valueField);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/PivotLabelFieldReference.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/PivotLabelFieldReference.cs
@@ -1,0 +1,42 @@
+﻿using DocumentFormat.OpenXml;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel
+{
+    internal class PivotLabelFieldReference : AbstractPivotFieldReference
+    {
+        private readonly Predicate<Object> predicate;
+
+        public PivotLabelFieldReference(IXLPivotField pivotField)
+            : this(pivotField, null)
+        { }
+
+        public PivotLabelFieldReference(IXLPivotField pivotField, Predicate<Object> predicate)
+        {
+            this.PivotField = pivotField ?? throw new ArgumentNullException(nameof(pivotField));
+            this.predicate = predicate;
+        }
+
+        public IXLPivotField PivotField { get; set; }
+
+        internal override UInt32Value GetFieldOffset()
+        {
+            return UInt32Value.FromUInt32((uint)PivotField.Offset);
+        }
+
+        internal override IEnumerable<Int32> Match(XLWorkbook.PivotTableInfo pti, IXLPivotTable pt)
+        {
+            var values = pti.Fields[PivotField.SourceName].DistinctValues.ToList();
+
+            if (predicate == null)
+                return new Int32[] { };
+
+            return values.Select((Value, Index) => new { Value, Index })
+                .Where(v => predicate.Invoke(v.Value))
+                .Select(v => v.Index)
+                .ToList();
+        }
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/PivotValueFieldReference.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/PivotValueFieldReference.cs
@@ -1,0 +1,29 @@
+﻿using DocumentFormat.OpenXml;
+using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel
+{
+    internal class PivotValueFieldReference : AbstractPivotFieldReference
+    {
+        public PivotValueFieldReference(String value)
+        {
+            this.Value = value;
+        }
+
+        public String Value { get; }
+
+        internal override UInt32Value GetFieldOffset()
+        {
+            return UInt32Value.FromUInt32(unchecked((uint)-2));
+        }
+
+        internal override IEnumerable<Int32> Match(XLWorkbook.PivotTableInfo pti, IXLPivotTable pt)
+        {
+            return new Int32[]
+            {
+                pt.Values.IndexOf(Value.ToString())
+            };
+        }
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotFieldStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotFieldStyleFormats.cs
@@ -1,0 +1,82 @@
+﻿// Keep this file CodeMaid organised and cleaned
+
+namespace ClosedXML.Excel
+{
+    internal class XLPivotFieldStyleFormats : IXLPivotFieldStyleFormats
+    {
+        private IXLPivotValueStyleFormat dataValuesFormat;
+        private IXLPivotStyleFormat headerFormat;
+        private IXLPivotStyleFormat labelFormat;
+        private IXLPivotStyleFormat subtotalFormat;
+
+        public XLPivotFieldStyleFormats(IXLPivotField field)
+        {
+            this.PivotField = field;
+        }
+
+        public IXLPivotField PivotField { get; }
+
+        #region IXLPivotFieldStyleFormats
+
+        public IXLPivotValueStyleFormat DataValuesFormat
+        {
+            get
+            {
+                if (dataValuesFormat == null)
+                {
+                    dataValuesFormat = new XLPivotValueStyleFormat(PivotField)
+                    {
+                        AppliesTo = XLPivotStyleFormatElement.Data
+                    };
+                }
+                return dataValuesFormat;
+            }
+            set { dataValuesFormat = value; }
+        }
+
+        public IXLPivotStyleFormat Header
+        {
+            get
+            {
+                if (headerFormat == null)
+                {
+                    headerFormat = new XLPivotStyleFormat(PivotField);
+                }
+                return headerFormat;
+            }
+            set { headerFormat = value; }
+        }
+
+        public IXLPivotStyleFormat Label
+        {
+            get
+            {
+                if (labelFormat == null)
+                {
+                    labelFormat = new XLPivotStyleFormat(PivotField)
+                    {
+                        AppliesTo = XLPivotStyleFormatElement.Label
+                    };
+                }
+                return labelFormat;
+            }
+            set { labelFormat = value; }
+        }
+
+        public IXLPivotStyleFormat Subtotal
+        {
+            get
+            {
+                if (subtotalFormat == null)
+                {
+                    subtotalFormat = new XLPivotStyleFormat(PivotField);
+                }
+
+                return subtotalFormat;
+            }
+            set { subtotalFormat = value; }
+        }
+
+        #endregion IXLPivotFieldStyleFormats
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormat.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormat.cs
@@ -1,0 +1,27 @@
+// Keep this file CodeMaid organised and cleaned
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel
+{
+    internal class XLPivotStyleFormat : IXLPivotStyleFormat
+    {
+        public XLPivotStyleFormat(IXLPivotField field = null, IXLStyle style = null)
+        {
+            PivotField = field;
+            Style = style ?? XLStyle.Default;
+        }
+
+        #region IXLPivotStyleFormat members
+
+        public XLPivotStyleFormatElement AppliesTo { get; set; } = XLPivotStyleFormatElement.Data;
+        public IXLPivotField PivotField { get; set; }
+        public IXLStyle Style { get; set; }
+
+        #endregion IXLPivotStyleFormat members
+
+        internal XLPivotAreaValues AreaType { get; set; } = XLPivotAreaValues.Normal;
+        internal bool CollapsedLevelsAreSubtotals { get; set; } = false;
+        internal IList<AbstractPivotFieldReference> FieldReferences { get; } = new List<AbstractPivotFieldReference>();
+        internal bool Outline { get; set; } = true;
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatEnums.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatEnums.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace ClosedXML.Excel
+{
+    [Flags]
+    public enum XLPivotStyleFormatElement
+    {
+        None = 0,
+        Label = 1 << 1,
+        Data = 1 << 2,
+
+        All = Label | Data
+    }
+
+    internal enum XLPivotStyleFormatTarget
+    {
+        PivotTable,
+        GrandTotal,
+        Subtotal,
+        Header,
+        Label,
+        Data
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormats.cs
@@ -1,0 +1,58 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel
+{
+    internal class XLPivotStyleFormats : IXLPivotStyleFormats
+    {
+        private readonly IXLPivotField _pivotField;
+        private readonly Dictionary<XLPivotStyleFormatElement, IXLPivotStyleFormat> _styleFormats = new Dictionary<XLPivotStyleFormatElement, IXLPivotStyleFormat>();
+
+        public XLPivotStyleFormats()
+            : this(null)
+        { }
+
+        public XLPivotStyleFormats(IXLPivotField pivotField)
+        {
+            this._pivotField = pivotField;
+        }
+
+        #region IXLPivotStyleFormats members
+
+        public IXLPivotStyleFormat ForElement(XLPivotStyleFormatElement element)
+        {
+            if (element == XLPivotStyleFormatElement.None)
+                throw new ArgumentException("Choose an enum value that represents an element", nameof(element));
+
+            if (!_styleFormats.ContainsKey(element))
+                _styleFormats.Add(element, new XLPivotStyleFormat(_pivotField) { AppliesTo = element });
+
+            return _styleFormats[element];
+        }
+
+        public IEnumerator<IXLPivotStyleFormat> GetEnumerator()
+        {
+            return _styleFormats.Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        #endregion IXLPivotStyleFormats members
+
+        public void Add(IXLPivotStyleFormat styleFormat)
+        {
+            _styleFormats.Add(styleFormat.AppliesTo, styleFormat);
+        }
+
+        public void AddRange(IEnumerable<IXLPivotStyleFormat> styleFormats)
+        {
+            foreach (var styleFormat in styleFormats)
+                Add(styleFormat);
+        }
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotTableStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotTableStyleFormats.cs
@@ -1,0 +1,25 @@
+﻿// Keep this file CodeMaid organised and cleaned
+namespace ClosedXML.Excel
+{
+    internal class XLPivotTableStyleFormats : IXLPivotTableStyleFormats
+    {
+        private IXLPivotStyleFormats columnGrandTotalFormats;
+        private IXLPivotStyleFormats rowGrandTotalFormats;
+
+        #region IXLPivotTableStyleFormats members
+
+        public IXLPivotStyleFormats ColumnGrandTotalFormats
+        {
+            get { return columnGrandTotalFormats ?? (columnGrandTotalFormats = new XLPivotStyleFormats()); }
+            set { columnGrandTotalFormats = value; }
+        }
+
+        public IXLPivotStyleFormats RowGrandTotalFormats
+        {
+            get { return rowGrandTotalFormats ?? (rowGrandTotalFormats = new XLPivotStyleFormats()); }
+            set { rowGrandTotalFormats = value; }
+        }
+
+        #endregion IXLPivotTableStyleFormats members
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
@@ -1,0 +1,33 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+
+namespace ClosedXML.Excel
+{
+    internal class XLPivotValueStyleFormat : XLPivotStyleFormat, IXLPivotValueStyleFormat
+    {
+        public XLPivotValueStyleFormat(IXLPivotField field = null, IXLStyle style = null)
+            : base(field, style)
+        { }
+
+        #region IXLPivotValueStyleFormat members
+
+        public IXLPivotValueStyleFormat AndWith(IXLPivotField field)
+        {
+            return AndWith(field, null);
+        }
+
+        public IXLPivotValueStyleFormat AndWith(IXLPivotField field, Predicate<Object> predicate)
+        {
+            FieldReferences.Add(new PivotLabelFieldReference(field, predicate));
+            return this;
+        }
+
+        public IXLPivotValueStyleFormat ForValueField(IXLPivotValue valueField)
+        {
+            FieldReferences.Add(new PivotValueFieldReference(valueField.SourceName));
+            return this;
+        }
+
+        #endregion IXLPivotValueStyleFormat members
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValues.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValues.cs
@@ -1,15 +1,29 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLPivotValues: IEnumerable<IXLPivotValue>
+    public interface IXLPivotValues : IEnumerable<IXLPivotValue>
     {
         IXLPivotValue Add(String sourceName);
+
         IXLPivotValue Add(String sourceName, String customName);
+
         void Clear();
+
+        Boolean Contains(String sourceName);
+
+        Boolean Contains(IXLPivotValue pivotValue);
+
+        IXLPivotValue Get(String sourceName);
+
+        IXLPivotValue Get(Int32 index);
+
+        Int32 IndexOf(String sourceName);
+
+        Int32 IndexOf(IXLPivotValue pivotValue);
+
         void Remove(String sourceName);
     }
 }

--- a/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValues.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValues.cs
@@ -1,4 +1,6 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,23 +8,12 @@ namespace ClosedXML.Excel
 {
     internal class XLPivotValues : IXLPivotValues
     {
-        private readonly Dictionary<String, IXLPivotValue> _pivotValues = new Dictionary<string, IXLPivotValue>();
-
         private readonly IXLPivotTable _pivotTable;
+        private readonly Dictionary<String, IXLPivotValue> _pivotValues = new Dictionary<string, IXLPivotValue>(StringComparer.OrdinalIgnoreCase);
 
         internal XLPivotValues(IXLPivotTable pivotTable)
         {
             this._pivotTable = pivotTable;
-        }
-
-        public IEnumerator<IXLPivotValue> GetEnumerator()
-        {
-            return _pivotValues.Values.GetEnumerator();
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
         }
 
         public IXLPivotValue Add(String sourceName)
@@ -32,7 +23,7 @@ namespace ClosedXML.Excel
 
         public IXLPivotValue Add(String sourceName, String customName)
         {
-            if (sourceName != XLConstants.PivotTableValuesSentinalLabel && !this._pivotTable.SourceRangeFieldsAvailable.Contains(sourceName, StringComparer.OrdinalIgnoreCase))
+            if (sourceName != XLConstants.PivotTableValuesSentinalLabel && !this._pivotTable.SourceRangeFieldsAvailable.Contains(sourceName))
                 throw new ArgumentOutOfRangeException(nameof(sourceName), String.Format("The column '{0}' does not appear in the source range.", sourceName));
 
             var pivotValue = new XLPivotValue(sourceName) { CustomName = customName };
@@ -47,6 +38,50 @@ namespace ClosedXML.Excel
         public void Clear()
         {
             _pivotValues.Clear();
+        }
+
+        public Boolean Contains(String sourceName)
+        {
+            return _pivotValues.ContainsKey(sourceName);
+        }
+
+        public Boolean Contains(IXLPivotValue pivotValue)
+        {
+            return _pivotValues.ContainsKey(pivotValue.SourceName);
+        }
+
+        public IXLPivotValue Get(String sourceName)
+        {
+            return _pivotValues[sourceName];
+        }
+
+        public IXLPivotValue Get(Int32 index)
+        {
+            return _pivotValues.Values.ElementAt(index);
+        }
+
+        public IEnumerator<IXLPivotValue> GetEnumerator()
+        {
+            return _pivotValues.Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public Int32 IndexOf(String sourceName)
+        {
+            var selectedItem = _pivotValues.Select((item, index) => new { Item = item, Position = index }).FirstOrDefault(i => i.Item.Key == sourceName);
+            if (selectedItem == null)
+                throw new ArgumentNullException(nameof(sourceName), "Invalid field name.");
+
+            return selectedItem.Position;
+        }
+
+        public Int32 IndexOf(IXLPivotValue pivotValue)
+        {
+            return IndexOf(pivotValue.SourceName);
         }
 
         public void Remove(String sourceName)

--- a/ClosedXML/Excel/PivotTables/XLPivotAreaValues.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotAreaValues.cs
@@ -1,0 +1,14 @@
+﻿namespace ClosedXML.Excel
+{
+    internal enum XLPivotAreaValues
+    {
+        None = 0,
+        Normal = 1,
+        Data = 2,
+        All = 3,
+        Origin = 4,
+        Button = 5,
+        TopRight = 6,
+        TopEnd = 7
+    }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotField.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotField.cs
@@ -1,19 +1,24 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace ClosedXML.Excel
 {
     [DebuggerDisplay("{SourceName}")]
     internal class XLPivotField : IXLPivotField
     {
-        public XLPivotField(string sourceName)
+        private readonly IXLPivotTable _pivotTable;
+        public XLPivotField(IXLPivotTable pivotTable, string sourceName)
         {
+            this._pivotTable = pivotTable;
             SourceName = sourceName;
             Subtotals = new List<XLSubtotalFunction>();
             SelectedValues = new List<Object>();
             SortType = XLPivotSortType.Default;
             SetExcelDefaults();
+
+            StyleFormats = new XLPivotFieldStyleFormats(this);
         }
 
         public String SourceName { get; private set; }
@@ -91,6 +96,7 @@ namespace ClosedXML.Excel
         public IXLPivotField SetSort(XLPivotSortType value) { SortType = value; return this; }
 
         public IList<Object> SelectedValues { get; private set; }
+
         public IXLPivotField AddSelectedValue(Object value)
         {
             SelectedValues.Add(value);
@@ -109,5 +115,15 @@ namespace ClosedXML.Excel
             SubtotalsAtTop = true;
             Collapsed = false;
         }
+
+        public IXLPivotFieldStyleFormats StyleFormats { get; set; }
+
+        public Boolean IsOnRowAxis => _pivotTable.RowLabels.Contains(this.SourceName);
+
+        public Boolean IsOnColumnAxis => _pivotTable.ColumnLabels.Contains(this.SourceName);
+
+        public Boolean IsInFilterList => _pivotTable.ReportFilters.Contains(this.SourceName);
+
+        public Int32 Offset => _pivotTable.SourceRangeFieldsAvailable.ToList().IndexOf(this.SourceName);
     }
 }

--- a/ClosedXML/Excel/PivotTables/XLPivotFields.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFields.cs
@@ -1,3 +1,4 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,14 +7,15 @@ namespace ClosedXML.Excel
 {
     internal class XLPivotFields : IXLPivotFields
     {
-
-        private readonly Dictionary<String, IXLPivotField> _pivotFields = new Dictionary<string, IXLPivotField>();
+        private readonly Dictionary<String, IXLPivotField> _pivotFields = new Dictionary<string, IXLPivotField>(StringComparer.OrdinalIgnoreCase);
         private readonly IXLPivotTable _pivotTable;
 
         internal XLPivotFields(IXLPivotTable pivotTable)
         {
             this._pivotTable = pivotTable;
         }
+
+        #region IXLPivotFields members
 
         public IXLPivotField Add(String sourceName)
         {
@@ -22,10 +24,10 @@ namespace ClosedXML.Excel
 
         public IXLPivotField Add(String sourceName, String customName)
         {
-            if (sourceName != XLConstants.PivotTableValuesSentinalLabel && !this._pivotTable.SourceRangeFieldsAvailable.Contains(sourceName, StringComparer.OrdinalIgnoreCase))
+            if (sourceName != XLConstants.PivotTableValuesSentinalLabel && !this._pivotTable.SourceRangeFieldsAvailable.Contains(sourceName))
                 throw new ArgumentOutOfRangeException(nameof(sourceName), String.Format("The column '{0}' does not appear in the source range.", sourceName));
 
-            var pivotField = new XLPivotField(sourceName) { CustomName = customName };
+            var pivotField = new XLPivotField(_pivotTable, sourceName) { CustomName = customName };
             _pivotFields.Add(sourceName, pivotField);
             return pivotField;
         }
@@ -40,9 +42,19 @@ namespace ClosedXML.Excel
             return _pivotFields.ContainsKey(sourceName);
         }
 
-        public IXLPivotField Get(string sourceName)
+        public bool Contains(IXLPivotField pivotField)
+        {
+            return _pivotFields.ContainsKey(pivotField.SourceName);
+        }
+
+        public IXLPivotField Get(String sourceName)
         {
             return _pivotFields[sourceName];
+        }
+
+        public IXLPivotField Get(Int32 index)
+        {
+            return _pivotFields.Values.ElementAt(index);
         }
 
         public IEnumerator<IXLPivotField> GetEnumerator()
@@ -55,18 +67,25 @@ namespace ClosedXML.Excel
             return GetEnumerator();
         }
 
-        public Int32 IndexOf(IXLPivotField pf)
+        public Int32 IndexOf(String sourceName)
         {
-            var selectedItem = _pivotFields.Select((item, index) => new { Item = item, Position = index }).FirstOrDefault(i => i.Item.Key == pf.SourceName);
+            var selectedItem = _pivotFields.Select((item, index) => new { Item = item, Position = index }).FirstOrDefault(i => i.Item.Key == sourceName);
             if (selectedItem == null)
-                throw new ArgumentNullException(nameof(pf), "Invalid field name.");
+                throw new ArgumentNullException(nameof(sourceName), "Invalid field name.");
 
             return selectedItem.Position;
+        }
+
+        public Int32 IndexOf(IXLPivotField pf)
+        {
+            return IndexOf(pf.SourceName);
         }
 
         public void Remove(String sourceName)
         {
             _pivotFields.Remove(sourceName);
         }
+
+        #endregion IXLPivotFields members
     }
 }

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -63,6 +63,21 @@ namespace ClosedXML.Excel
         public IXLPivotFields RowLabels { get; private set; }
         public IXLPivotValues Values { get; private set; }
 
+        public IEnumerable<IXLPivotField> ImplementedFields
+        {
+            get
+            {
+                foreach (var pf in ReportFilters)
+                    yield return pf;
+
+                foreach (var pf in RowLabels)
+                    yield return pf;
+
+                foreach (var pf in ColumnLabels)
+                    yield return pf;
+            }
+        }
+
         public XLPivotTableTheme Theme { get; set; }
 
         public IXLPivotTable SetTheme(XLPivotTableTheme value) { Theme = value; return this; }
@@ -371,5 +386,27 @@ namespace ClosedXML.Excel
         }
 
         public IXLWorksheet Worksheet { get; }
+
+        public IXLPivotTableStyleFormats StyleFormats { get; } = new XLPivotTableStyleFormats();
+
+        public IEnumerable<IXLPivotStyleFormat> AllStyleFormats
+        {
+            get
+            {
+                foreach (var styleFormat in this.StyleFormats.RowGrandTotalFormats)
+                    yield return styleFormat;
+
+                foreach (var styleFormat in this.StyleFormats.ColumnGrandTotalFormats)
+                    yield return styleFormat;
+
+                foreach (var pivotField in ImplementedFields)
+                {
+                    yield return pivotField.StyleFormats.Subtotal;
+                    yield return pivotField.StyleFormats.Header;
+                    yield return pivotField.StyleFormats.Label;
+                    yield return pivotField.StyleFormats.DataValuesFormat;
+                }
+            }
+        }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -2289,7 +2289,7 @@ namespace ClosedXML.Excel
 
         // Generates content of pivotTablePart
         private static void GeneratePivotTablePartContent(
-            PivotTablePart pivotTablePart, IXLPivotTable pt,
+            PivotTablePart pivotTablePart, XLPivotTable pt,
             uint cacheId, SaveContext context)
         {
             var pti = context.PivotTables[(pt as XLPivotTable).Guid];
@@ -2839,6 +2839,33 @@ namespace ClosedXML.Excel
 
             pivotTableDefinition.AppendChild(pts);
 
+            // Pivot formats
+            if (pivotTableDefinition.Formats == null)
+                pivotTableDefinition.Formats = new Formats();
+            else
+                pivotTableDefinition.Formats.RemoveAllChildren();
+
+            foreach (var styleFormat in pt.StyleFormats.RowGrandTotalFormats)
+                GeneratePivotTableFormat(isRow: true, (XLPivotStyleFormat)styleFormat, pivotTableDefinition, context);
+
+            foreach (var styleFormat in pt.StyleFormats.ColumnGrandTotalFormats)
+                GeneratePivotTableFormat(isRow: false, (XLPivotStyleFormat)styleFormat, pivotTableDefinition, context);
+
+            foreach (var pivotField in pt.ImplementedFields)
+            {
+                GeneratePivotFieldFormat(XLPivotStyleFormatTarget.Header, pt, (XLPivotField)pivotField, (XLPivotStyleFormat)pivotField.StyleFormats.Header, pivotTableDefinition, context);
+                GeneratePivotFieldFormat(XLPivotStyleFormatTarget.Subtotal, pt, (XLPivotField)pivotField, (XLPivotStyleFormat)pivotField.StyleFormats.Subtotal, pivotTableDefinition, context);
+                GeneratePivotFieldFormat(XLPivotStyleFormatTarget.Label, pt, (XLPivotField)pivotField, (XLPivotStyleFormat)pivotField.StyleFormats.Label, pivotTableDefinition, context);
+                GeneratePivotFieldFormat(XLPivotStyleFormatTarget.Data, pt, (XLPivotField)pivotField, (XLPivotStyleFormat)pivotField.StyleFormats.DataValuesFormat, pivotTableDefinition, context);
+            }
+
+            if (pivotTableDefinition.Formats.Any())
+            {
+                pivotTableDefinition.Formats.Count = new UInt32Value((uint)pivotTableDefinition.Formats.Count());
+            }
+            else
+                pivotTableDefinition.Formats = null;
+
             #region Excel 2010 Features
 
             var pivotTableDefinitionExtensionList = new PivotTableDefinitionExtensionList();
@@ -2861,6 +2888,162 @@ namespace ClosedXML.Excel
             #endregion Excel 2010 Features
 
             pivotTablePart.PivotTableDefinition = pivotTableDefinition;
+        }
+
+        private static void GeneratePivotTableFormat(Boolean isRow, XLPivotStyleFormat styleFormat, PivotTableDefinition pivotTableDefinition, SaveContext context)
+        {
+            if (DefaultStyle.Equals(styleFormat.Style) || !context.DifferentialFormats.ContainsKey(((XLStyle)styleFormat.Style).Key))
+                return;
+
+            var format = new Format();
+
+            format.FormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[((XLStyle)styleFormat.Style).Key]));
+
+            var pivotArea = GenerateDefaultPivotArea(XLPivotStyleFormatTarget.GrandTotal);
+
+            pivotArea.LabelOnly = OpenXmlHelper.GetBooleanValue(styleFormat.AppliesTo == XLPivotStyleFormatElement.Label, false);
+            pivotArea.DataOnly = OpenXmlHelper.GetBooleanValue(styleFormat.AppliesTo == XLPivotStyleFormatElement.Data, true);
+
+            pivotArea.GrandColumn = OpenXmlHelper.GetBooleanValue(!isRow, false);
+            pivotArea.GrandRow = OpenXmlHelper.GetBooleanValue(isRow, false);
+            pivotArea.Axis = isRow ? PivotTableAxisValues.AxisRow : PivotTableAxisValues.AxisColumn;
+
+            format.PivotArea = pivotArea;
+
+            pivotTableDefinition.Formats.AppendChild(format);
+        }
+
+        private static void GeneratePivotFieldFormat(XLPivotStyleFormatTarget target, XLPivotTable pt, XLPivotField pivotField, XLPivotStyleFormat styleFormat, PivotTableDefinition pivotTableDefinition, SaveContext context)
+        {
+            if (target == XLPivotStyleFormatTarget.GrandTotal)
+                throw new ArgumentException($"Use {nameof(GeneratePivotTableFormat)} to populate grand total formats.");
+
+            if (DefaultStyle.Equals(styleFormat.Style) || !context.DifferentialFormats.ContainsKey(((XLStyle)styleFormat.Style).Key))
+                return;
+
+            var format = new Format();
+
+            format.FormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[((XLStyle)styleFormat.Style).Key]));
+
+            var pivotArea = GenerateDefaultPivotArea(target);
+
+            pivotArea.LabelOnly = OpenXmlHelper.GetBooleanValue(styleFormat.AppliesTo == XLPivotStyleFormatElement.Label, false);
+            pivotArea.DataOnly = OpenXmlHelper.GetBooleanValue(styleFormat.AppliesTo == XLPivotStyleFormatElement.Data, true);
+
+            pivotArea.CollapsedLevelsAreSubtotals = OpenXmlHelper.GetBooleanValue(styleFormat.CollapsedLevelsAreSubtotals, false);
+
+            if (target == XLPivotStyleFormatTarget.Header)
+            {
+                pivotArea.Field = pivotField.Offset;
+
+                if (pivotField.IsOnRowAxis)
+                    pivotArea.Axis = PivotTableAxisValues.AxisRow;
+                else if (pivotField.IsOnColumnAxis)
+                    pivotArea.Axis = PivotTableAxisValues.AxisColumn;
+                else if (pivotField.IsInFilterList)
+                    pivotArea.Axis = PivotTableAxisValues.AxisPage;
+                else
+                    throw new NotImplementedException();
+            }
+
+            //Ensure referenced pivot field is added to field references
+            if (new[]
+                {
+                    XLPivotStyleFormatTarget.Data, XLPivotStyleFormatTarget.Label, XLPivotStyleFormatTarget.Subtotal
+                }.Contains(target)
+                && !styleFormat.FieldReferences.OfType<PivotLabelFieldReference>().Select(fr => fr.PivotField).Contains(pivotField))
+            {
+                var fr = new PivotLabelFieldReference(pivotField);
+                fr.DefaultSubtotal = target == XLPivotStyleFormatTarget.Subtotal;
+                styleFormat.FieldReferences.Insert(0, fr);
+            }
+
+            if (pivotArea.PivotAreaReferences == null)
+                pivotArea.PivotAreaReferences = new PivotAreaReferences();
+            else
+                pivotArea.PivotAreaReferences.RemoveAllChildren();
+
+            foreach (var fr in styleFormat.FieldReferences)
+            {
+                GeneratePivotAreaReference(pt, pivotArea.PivotAreaReferences, fr, context);
+            }
+
+            if (pivotArea.PivotAreaReferences.Any())
+            {
+                pivotArea.PivotAreaReferences.Count = new UInt32Value((uint)pivotArea.PivotAreaReferences.Count());
+            }
+            else
+                pivotArea.PivotAreaReferences = null;
+
+            format.PivotArea = pivotArea;
+            pivotTableDefinition.Formats.AppendChild(format);
+        }
+
+        private static PivotArea GenerateDefaultPivotArea(XLPivotStyleFormatTarget target)
+        {
+            switch (target)
+            {
+                case XLPivotStyleFormatTarget.Header:
+                    return new PivotArea
+                    {
+                        Type = PivotAreaValues.Button,
+                        FieldPosition = 0,
+                        DataOnly = OpenXmlHelper.GetBooleanValue(false, true),
+                        LabelOnly = OpenXmlHelper.GetBooleanValue(true, false),
+                        Outline = OpenXmlHelper.GetBooleanValue(false, true),
+                    };
+
+                case XLPivotStyleFormatTarget.Subtotal:
+                    return new PivotArea
+                    {
+                        Type = PivotAreaValues.Normal,
+                        FieldPosition = 0,
+                    };
+
+                case XLPivotStyleFormatTarget.GrandTotal:
+                    return new PivotArea
+                    {
+                        Type = PivotAreaValues.Normal,
+                        FieldPosition = 0,
+                        DataOnly = OpenXmlHelper.GetBooleanValue(false, true),
+                        LabelOnly = OpenXmlHelper.GetBooleanValue(false, false),
+                    };
+
+                case XLPivotStyleFormatTarget.Label:
+                    return new PivotArea
+                    {
+                        Type = PivotAreaValues.Normal,
+                        FieldPosition = 0,
+                        DataOnly = OpenXmlHelper.GetBooleanValue(false, true),
+                        LabelOnly = OpenXmlHelper.GetBooleanValue(true, false),
+                    };
+
+                case XLPivotStyleFormatTarget.Data:
+                    return new PivotArea
+                    {
+                        Type = PivotAreaValues.Normal,
+                        FieldPosition = 0,
+                    };
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private static void GeneratePivotAreaReference(XLPivotTable pt, PivotAreaReferences pivotAreaReferences, AbstractPivotFieldReference fieldReference, SaveContext context)
+        {
+            var pivotAreaReference = new PivotAreaReference();
+
+            pivotAreaReference.DefaultSubtotal = OpenXmlHelper.GetBooleanValue(fieldReference.DefaultSubtotal, false);
+            pivotAreaReference.Field = fieldReference.GetFieldOffset();
+
+            var matchedOffsets = fieldReference.Match(context.PivotTables[pt.Guid], pt);
+            foreach (var o in matchedOffsets)
+            {
+                pivotAreaReference.AppendChild(new FieldItem { Val = UInt32Value.FromUInt32((uint)o) });
+            }
+
+            pivotAreaReferences.AppendChild(pivotAreaReference);
         }
 
         private static void GenerateWorksheetCommentsPartContent(WorksheetCommentsPart worksheetCommentsPart,
@@ -3531,6 +3714,16 @@ namespace ClosedXML.Excel
 
                         if (!style.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(style.Key))
                             AddStyleAsDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, style, context);
+                    }
+                }
+
+                foreach (var pt in ws.PivotTables.Cast<XLPivotTable>())
+                {
+                    foreach (var styleFormat in pt.AllStyleFormats)
+                    {
+                        var xlStyle = (XLStyle)styleFormat.Style;
+                        if (!xlStyle.Value.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(xlStyle.Key))
+                            AddStyleAsDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, xlStyle.Value, context);
                     }
                 }
             }

--- a/ClosedXML_Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/ClosedXML_Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -179,6 +179,90 @@ namespace ClosedXML_Tests
             }
         }
 
+        [Test]
+        public void PivotTableStyleFormatsTest()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
+                using (var wbSource = new XLWorkbook(stream))
+                using (var wbDestination = new XLWorkbook())
+                {
+                    var ws = wbSource.Worksheet("PastrySalesData");
+                    wbDestination.AddWorksheet(ws);
+                    ws = wbDestination.Worksheet("PastrySalesData");
+
+                    var table = ws.Table("PastrySalesData");
+                    var ptSheet = wbDestination.Worksheets.Add("PivotTableStyleFormats");
+                    var pt = ptSheet.PivotTables.Add("pvtStyleFormats", ptSheet.Cell(1, 1), table);
+                    pt.Layout = XLPivotLayout.Tabular;
+
+                    pt.SetSubtotals(XLPivotSubtotals.AtBottom);
+
+                    var monthPivotField = pt.ColumnLabels.Add("Month");
+
+                    var namePivotField = pt.RowLabels.Add("Name")
+                        .SetSubtotalCaption("Test caption")
+                        .SetCustomName("Test name")
+                        .AddSubtotal(XLSubtotalFunction.Sum);
+
+                    ptSheet.SetTabActive();
+
+                    var numberOfOrdersPivotValue = pt.Values.Add("NumberOfOrders")
+                        .SetSummaryFormula(XLPivotSummary.Sum);
+
+                    var qualityPivotValue = pt.Values.Add("Quality").SetSummaryFormula(XLPivotSummary.Sum);
+
+                    pt.StyleFormats.RowGrandTotalFormats.ForElement(XLPivotStyleFormatElement.All).Style.Font.FontColor = XLColor.VenetianRed;
+
+                    namePivotField.StyleFormats.Subtotal.Style.Fill.BackgroundColor = XLColor.Blue;
+                    monthPivotField.StyleFormats.Label.Style.Fill.BackgroundColor = XLColor.Amber;
+                    monthPivotField.StyleFormats.Header.Style.Font.FontColor = XLColor.Yellow;
+                    namePivotField.StyleFormats.DataValuesFormat
+                        .AndWith(monthPivotField, v => v.ToString() == "May")
+                        .ForValueField(numberOfOrdersPivotValue)
+                        .Style.Font.FontColor = XLColor.Green;
+
+                    wbDestination.SaveAs(ms);
+                }
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws = wb.Worksheet("PivotTableStyleFormats");
+                    var pt = ws.PivotTable("pvtStyleFormats").CastTo<XLPivotTable>();
+
+                    Assert.AreEqual(0, pt.StyleFormats.ColumnGrandTotalFormats.Count());
+
+                    Assert.NotNull(pt.StyleFormats.RowGrandTotalFormats);
+                    Assert.AreEqual(1, pt.StyleFormats.RowGrandTotalFormats.Count());
+                    Assert.AreEqual(XLPivotStyleFormatElement.All, pt.StyleFormats.RowGrandTotalFormats.First().AppliesTo);
+                    Assert.AreEqual(XLColor.VenetianRed, pt.StyleFormats.RowGrandTotalFormats.ForElement(XLPivotStyleFormatElement.All).Style.Font.FontColor);
+
+                    var namePivotField = pt.RowLabels.Get("Name");
+                    var monthPivotField = pt.ColumnLabels.Get("Month");
+                    var numberOfOrdersPivotValue = pt.Values.Get("NumberOfOrders");
+
+                    Assert.AreEqual(XLStyle.Default, namePivotField.StyleFormats.Label.Style);
+                    Assert.AreEqual(XLColor.Blue, namePivotField.StyleFormats.Subtotal.Style.Fill.BackgroundColor);
+
+                    Assert.AreEqual(XLStyle.Default, monthPivotField.StyleFormats.Subtotal.Style);
+                    Assert.AreEqual(XLColor.Amber, monthPivotField.StyleFormats.Label.Style.Fill.BackgroundColor);
+                    Assert.AreEqual(XLColor.Yellow, monthPivotField.StyleFormats.Header.Style.Font.FontColor);
+
+                    var nameDataValuesFormat = namePivotField.StyleFormats.DataValuesFormat as XLPivotValueStyleFormat;
+                    Assert.AreEqual(2, nameDataValuesFormat.FieldReferences.Count());
+
+                    Assert.AreEqual(monthPivotField, nameDataValuesFormat.FieldReferences.First().CastTo<PivotLabelFieldReference>().PivotField);
+
+                    Assert.AreEqual(numberOfOrdersPivotValue.CustomName, nameDataValuesFormat.FieldReferences.Last().CastTo<PivotValueFieldReference>().Value);
+
+                    wb.Save();
+                }
+            }
+        }
+
         private class Pastry
         {
             public Pastry(string name, int? code, int numberOfOrders, double quality, string month, DateTime? bakeDate)


### PR DESCRIPTION
@b0bi79 @Pankraty 

Here is my alternative implementation. It removes the need for lambda functions and "builders". I think this is a cleaner API, althought the internals are a bit more messy than your implementation. Some of the new enum's could be better named. We can finalise that later.

I made some changes to e.g. `XLPivotValues` that should probably be submitted in a separate PR.

What do you think of this? Look at the unit test to see how to use it.

Closes #895 