### PR TITLE
<c> elements with missing r attribute: XLAddress constructor had parameters swapped

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1397,7 +1397,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        private Int32 lastCell;
+        private Int32 lastColumnNumber;
 
         private void LoadCells(SharedStringItem[] sharedStrings, Stylesheet s, NumberingFormats numberingFormats,
                                Fills fills, Borders borders, Fonts fonts, Dictionary<uint, string> sharedFormulasR1C1,
@@ -1405,9 +1405,16 @@ namespace ClosedXML.Excel
         {
             Int32 styleIndex = cell.StyleIndex != null ? Int32.Parse(cell.StyleIndex.InnerText) : 0;
 
-            var cellAddress = cell.CellReference == null
-                                       ? new XLAddress(ws, ++lastCell, rowIndex, false, false)
-                                       : XLAddress.Create(ws, cell.CellReference.Value);
+            XLAddress cellAddress;
+            if (cell.CellReference == null)
+            {
+                cellAddress = new XLAddress(ws, rowIndex, ++lastColumnNumber, false, false);
+            }
+            else
+            {
+                cellAddress = XLAddress.Create(ws, cell.CellReference.Value);
+                lastColumnNumber = cellAddress.ColumnNumber;
+            }
 
             var xlCell = ws.Cell(in cellAddress);
 
@@ -1458,7 +1465,6 @@ namespace ClosedXML.Excel
                             break;
                     }
                 }
-
             }
             else if (cell.CellFormula != null)
             {
@@ -1854,7 +1860,7 @@ namespace ClosedXML.Excel
                 }
             }
 
-            lastCell = 0;
+            lastColumnNumber = 0;
             foreach (Cell cell in row.Elements<Cell>())
                 LoadCells(sharedStrings, s, numberingFormats, fills, borders, fonts, sharedFormulasR1C1, ws, styleList,
                           cell, rowIndex);

--- a/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
@@ -436,5 +436,30 @@ namespace ClosedXML_Tests.Excel
                 Assert.AreEqual("B2:C2", ws.SelectedRanges.Last().RangeAddress.ToString());
             }
         }
+
+        [Test]
+        public void CanLoadCellsWithoutReferencesCorrectly()
+        {
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Misc\LO\xlsx\row-index-1-based.xlsx")))
+            using (var wb = new XLWorkbook(stream))
+            {
+                var ws = wb.Worksheet(1);
+
+                Assert.AreEqual("Page 1", ws.Name);
+
+                var expected = new Dictionary<string, string>()
+                {
+                    ["A1"] = "Action Plan.Name",
+                    ["B1"] = "Action Plan.Description",
+                    ["A2"] = "Jerry",
+                    ["B2"] = "This is a longer Text.\nSecond line.\nThird line.",
+                    ["A3"] = "",
+                    ["B3"] = ""
+                };
+
+                foreach (var pair in expected)
+                    Assert.AreEqual(pair.Value, ws.Cell(pair.Key).GetString(), pair.Key);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1131 