### PR TITLE
Correctly propagate worksheet style to cells from a worksheet

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -124,10 +124,21 @@ namespace ClosedXML.Excel
         {
             get
             {
-                foreach (var col in ColumnsUsed(XLCellsUsedOptions.All).OfType<XLColumn>())
-                    yield return col;
-                foreach (var row in RowsUsed(XLCellsUsedOptions.All).OfType<XLRow>())
-                    yield return row;
+                var columnsUsed = Internals.ColumnsCollection.Keys
+                    .Union(Internals.CellsCollection.ColumnsUsed.Keys)
+                    .Distinct()
+                    .OrderBy(c => c)
+                    .ToList();
+                foreach (var col in columnsUsed)
+                    yield return Column(col);
+
+                var rowsUsed = Internals.RowsCollection.Keys
+                    .Union(Internals.CellsCollection.RowsUsed.Keys)
+                    .Distinct()
+                    .OrderBy(r => r)
+                    .ToList();
+                foreach (var row in rowsUsed)
+                    yield return Row(row);
             }
         }
 

--- a/ClosedXML_Tests/Excel/Styles/StyleTests.cs
+++ b/ClosedXML_Tests/Excel/Styles/StyleTests.cs
@@ -41,5 +41,27 @@ namespace ClosedXML_Tests.Excel
                 }
             }
         }
+
+        [TestCase("A1", TestName = "First cell")]
+        [TestCase("A2", TestName = "Cell from initialized row")]
+        [TestCase("B1", TestName = "Cell from initialized column")]
+        [TestCase("D4", TestName = "Initialized cell")]
+        [TestCase("F6", TestName = "Non-initialized cell")]
+        public void CellTakesWorksheetStyle(string cellAddress)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Column(2);
+                ws.Row(2);
+                ws.Cell("D4").Value = "Non empty";
+                ws.Style.Font.SetFontName("Arial");
+                ws.Style.Font.SetFontSize(9);
+
+                var cell = ws.Cell(cellAddress);
+                Assert.AreEqual("Arial", cell.Style.Font.FontName);
+                Assert.AreEqual(9, cell.Style.Font.FontSize);
+            }
+        }
     }
 }


### PR DESCRIPTION
As @b0bi79 has discovered, ClosedXML does not assign the worksheet style to empty cells that belong to columns or rows which had been initialized before the worksheet style was set.

```
        [TestCase("A1", TestName = "First cell")] // OK
        [TestCase("A2", TestName = "Cell from initialized row")]  // Fails
        [TestCase("B1", TestName = "Cell from initialized column")]  // Fails
        [TestCase("D4", TestName = "Initialized cell")]  // OK
        [TestCase("F6", TestName = "Non-initialized cell")]  // OK
        public void CellTakesWorksheetStyle(string cellAddress)
        {
            using (var wb = new XLWorkbook())
            {
                var ws = wb.AddWorksheet("Sheet1");
                ws.Column(2);
                ws.Row(2);
                ws.Cell("D4").Value = "Non empty";
                ws.Style.Font.SetFontName("Arial");
                ws.Style.Font.SetFontSize(9);

                var cell = ws.Cell(cellAddress);
                Assert.AreEqual("Arial", cell.Style.Font.FontName);
                Assert.AreEqual(9, cell.Style.Font.FontSize);
            }
        }
```