### PR TITLE
Correctly throw DivisionByZeroException when denominator is zero.

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -354,12 +354,21 @@ namespace ClosedXML.Excel.CalcEngine
                     return (double)_lft * (double)_rgt;
 
                 case TKID.DIV:
+                    if (Math.Abs((double)_rgt) < double.Epsilon)
+                        throw new DivisionByZeroException();
+
                     return (double)_lft / (double)_rgt;
 
                 case TKID.DIVINT:
+                    if (Math.Abs((double)_rgt) < double.Epsilon)
+                        throw new DivisionByZeroException();
+
                     return (double)(int)((double)_lft / (double)_rgt);
 
                 case TKID.MOD:
+                    if (Math.Abs((double)_rgt) < double.Epsilon)
+                        throw new DivisionByZeroException();
+
                     return (double)(int)((double)_lft % (double)_rgt);
 
                 case TKID.POWER:

--- a/ClosedXML_Tests/Excel/CalcEngine/CalcEngineExceptionTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/CalcEngineExceptionTests.cs
@@ -1,11 +1,7 @@
 ﻿using ClosedXML.Excel;
 using ClosedXML.Excel.CalcEngine.Exceptions;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 using System.Threading;
 
 namespace ClosedXML_Tests.Excel.CalcEngine
@@ -24,6 +20,12 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         {
             Assert.Throws<CellValueException>(() => XLWorkbook.EvaluateExpr("CHAR(-2)"));
             Assert.Throws<CellValueException>(() => XLWorkbook.EvaluateExpr("CHAR(270)"));
+        }
+
+        [Test]
+        public void DivisionByZero()
+        {
+            Assert.Throws<DivisionByZeroException>(() => XLWorkbook.EvaluateExpr("0/0"));
         }
     }
 }


### PR DESCRIPTION
Fixes #1152 