### PR TITLE
Ignore _X (capital X) as XML escaping char

### DIFF
--- a/ClosedXML/Utils/XmlEncoder.cs
+++ b/ClosedXML/Utils/XmlEncoder.cs
@@ -8,20 +8,6 @@ namespace ClosedXML.Utils
     {
         private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-F]{4})_", RegexOptions.Compiled);
 
-        /// <summary>
-        /// Checks if a character is not allowed to the XML Spec http://www.w3.org/TR/REC-xml/#charsets
-        /// </summary>
-        /// <param name="ch">Input Character</param>
-        /// <returns>Returns false if the character is invalid according to the XML specification, and will not be
-        /// escaped by an XmlWriter.</returns>
-        public static bool IsXmlChar(char ch)
-        {
-            return (((ch >= 0x0020 && ch <= 0xD7FF) ||
-                      (ch >= 0xE000 && ch <= 0xFFFD) ||
-                      ch == 0x0009 || ch == 0x000A ||
-                      ch == 0x000D));
-        }
-
         public static string EncodeString(string encodeStr)
         {
             if (encodeStr == null) return null;
@@ -32,7 +18,7 @@ namespace ClosedXML.Utils
 
             foreach (var ch in encodeStr)
             {
-                if (IsXmlChar(ch)) //this method is new in .NET 4
+                if (XmlConvert.IsXmlChar(ch))
                 {
                     sb.Append(ch);
                 }

--- a/ClosedXML/Utils/XmlEncoder.cs
+++ b/ClosedXML/Utils/XmlEncoder.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Utils
 {
     public static class XmlEncoder
     {
-        private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-F]{4})_", RegexOptions.Compiled);
+        private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
 
         public static string EncodeString(string encodeStr)
         {

--- a/ClosedXML/Utils/XmlEncoder.cs
+++ b/ClosedXML/Utils/XmlEncoder.cs
@@ -7,6 +7,7 @@ namespace ClosedXML.Utils
     public static class XmlEncoder
     {
         private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
+        private static readonly Regex Uppercase_X_HHHHRegex = new Regex("_(X[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
 
         public static string EncodeString(string encodeStr)
         {
@@ -33,6 +34,13 @@ namespace ClosedXML.Utils
 
         public static string DecodeString(string decodeStr)
         {
+            if (string.IsNullOrEmpty(decodeStr)) return string.Empty;
+
+            // Strings "escaped" with _X (capital X) should not be treated as escaped
+            // Example: _Xceed_Something
+            // https://github.com/ClosedXML/ClosedXML/issues/1154
+            decodeStr = Uppercase_X_HHHHRegex.Replace(decodeStr, "_x005F_$1_");
+
             return XmlConvert.DecodeName(decodeStr);
         }
     }

--- a/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
@@ -14,20 +14,5 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual("\u0001 \u0002 \u0003 \u0004", XmlEncoder.DecodeString("_x0001_ _x0002_ _x0003_ _x0004_"));
             Assert.AreEqual("\u0005 \u0006 \u0007 \u0008", XmlEncoder.DecodeString("_x0005_ _x0006_ _x0007_ _x0008_"));
         }
-
-        [Test]
-        public void TestIsXmlChar()
-        {
-            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0001'));
-            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0005'));
-            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0007'));
-            Assert.AreEqual(false, XmlEncoder.IsXmlChar('\u0008'));
-            Assert.AreEqual(true, XmlEncoder.IsXmlChar('J'));
-            Assert.AreEqual(true, XmlEncoder.IsXmlChar('+'));
-            Assert.AreEqual(true, XmlEncoder.IsXmlChar('S'));
-            Assert.AreEqual(true, XmlEncoder.IsXmlChar('4'));
-            Assert.AreEqual(true, XmlEncoder.IsXmlChar('!'));
-            Assert.AreEqual(true, XmlEncoder.IsXmlChar('$'));
-        }
     }
 }

--- a/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
@@ -15,6 +15,9 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual("\u0001 \u0002 \u0003 \u0004", XmlEncoder.DecodeString("_x0001_ _x0002_ _x0003_ _x0004_"));
             Assert.AreEqual("\u0005 \u0006 \u0007 \u0008", XmlEncoder.DecodeString("_x0005_ _x0006_ _x0007_ _x0008_"));
             Assert.AreEqual("\uAABB \uAABB", XmlEncoder.DecodeString("_xaaBB_ _xAAbb_"));
+
+            // https://github.com/ClosedXML/ClosedXML/issues/1154
+            Assert.AreEqual("_Xceed_Something", XmlEncoder.DecodeString("_Xceed_Something"));
         }
     }
 }

--- a/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/XmlEncoderTests.cs
@@ -11,8 +11,10 @@ namespace ClosedXML_Tests.Excel
         {
             Assert.AreEqual("_x0001_ _x0002_ _x0003_ _x0004_", XmlEncoder.EncodeString("\u0001 \u0002 \u0003 \u0004"));
             Assert.AreEqual("_x0005_ _x0006_ _x0007_ _x0008_", XmlEncoder.EncodeString("\u0005 \u0006 \u0007 \u0008"));
+
             Assert.AreEqual("\u0001 \u0002 \u0003 \u0004", XmlEncoder.DecodeString("_x0001_ _x0002_ _x0003_ _x0004_"));
             Assert.AreEqual("\u0005 \u0006 \u0007 \u0008", XmlEncoder.DecodeString("_x0005_ _x0006_ _x0007_ _x0008_"));
+            Assert.AreEqual("\uAABB \uAABB", XmlEncoder.DecodeString("_xaaBB_ _xAAbb_"));
         }
     }
 }


### PR DESCRIPTION
Remove own implementation of `IsXmlChar`
Case-insensitive decoding of hex strings
Ignore _X (capital X) as XML escaping char for decoding. Fixes #1154 