### PR TITLE
Always treat "A1:B2" range strings as absolute

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -2105,7 +2105,7 @@ namespace ClosedXML.Excel
             {
                 var fmtRanges = cf.Ranges
                     .GetIntersectedRanges(fromRange.RangeAddress)
-                    .Select(r => Relative(r.Intersection(fromRange).AsRange(), fromRange, toRange) as XLRange)
+                    .Select(r => r.RangeAddress.Intersection(fromRange.RangeAddress).Relative(fromRange.RangeAddress, toRange.RangeAddress).AsRange() as XLRange)
                     .ToList();
 
                 var c = new XLConditionalFormat(fmtRanges, true);
@@ -2114,21 +2114,6 @@ namespace ClosedXML.Excel
 
                 Worksheet.ConditionalFormats.Add(c);
             }
-        }
-
-        private static IXLRange Relative(IXLRangeBase range, IXLRangeBase baseRange, IXLRangeBase targetBase)
-        {
-            var sheet = (XLWorksheet)targetBase.Worksheet;
-            var xlRangeAddress = new XLRangeAddress(
-                new XLAddress(sheet,
-                    range.RangeAddress.FirstAddress.RowNumber - baseRange.RangeAddress.FirstAddress.RowNumber + 1,
-                    range.RangeAddress.FirstAddress.ColumnNumber - baseRange.RangeAddress.FirstAddress.ColumnNumber + 1,
-                    false, false),
-                new XLAddress(sheet,
-                    range.RangeAddress.LastAddress.RowNumber - baseRange.RangeAddress.FirstAddress.RowNumber + 1,
-                    range.RangeAddress.LastAddress.ColumnNumber - baseRange.RangeAddress.FirstAddress.ColumnNumber + 1,
-                    false, false));
-            return ((XLRangeBase)targetBase).Range(xlRangeAddress);
         }
 
         private bool SetDataTable(object o)

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -477,8 +477,7 @@ namespace ClosedXML.Excel
                 IsEvaluating = false;
             }
 
-            var retValEnumerable = retVal as IEnumerable;
-            if (retValEnumerable != null && !(retVal is String))
+            if (retVal is IEnumerable retValEnumerable && !(retVal is String))
                 return retValEnumerable.Cast<object>().First();
 
             return retVal;
@@ -1901,62 +1900,67 @@ namespace ClosedXML.Excel
 
         private bool SetRangeColumns(object value)
         {
-            var columns = value as XLRangeColumns;
-            if (columns == null)
-                return SetColumns(value);
-
-            var cell = this;
-            foreach (var column in columns)
+            if (value is XLRangeColumns columns)
             {
-                cell.SetRange(column);
-                cell = cell.CellRight();
+                var cell = this;
+                foreach (var column in columns)
+                {
+                    cell.SetRange(column);
+                    cell = cell.CellRight();
+                }
+                return true;
             }
-            return true;
+            else
+
+                return SetColumns(value);
         }
 
         private bool SetColumns(object value)
         {
-            var columns = value as XLColumns;
-            if (columns == null)
-                return false;
-
-            var cell = this;
-            foreach (var column in columns)
+            if (value is XLColumns columns)
             {
-                cell.SetRange(column);
-                cell = cell.CellRight();
+                var cell = this;
+                foreach (var column in columns)
+                {
+                    cell.SetRange(column);
+                    cell = cell.CellRight();
+                }
+                return true;
             }
-            return true;
+            else
+                return false;
         }
 
         private bool SetRangeRows(object value)
         {
-            var rows = value as XLRangeRows;
-            if (rows == null)
-                return SetRows(value);
-
-            var cell = this;
-            foreach (var row in rows)
+            if (value is XLRangeRows rows)
             {
-                cell.SetRange(row);
-                cell = cell.CellBelow();
+                var cell = this;
+                foreach (var row in rows)
+                {
+                    cell.SetRange(row);
+                    cell = cell.CellBelow();
+                }
+                return true;
             }
-            return true;
+            else
+                return SetRows(value);
         }
 
         private bool SetRows(object value)
         {
-            var rows = value as XLRows;
-            if (rows == null)
-                return false;
-
-            var cell = this;
-            foreach (var row in rows)
+            if (value is XLRows rows)
             {
-                cell.SetRange(row);
-                cell = cell.CellBelow();
+                var cell = this;
+                foreach (var row in rows)
+                {
+                    cell.SetRange(row);
+                    cell = cell.CellBelow();
+                }
+                return true;
             }
-            return true;
+            else
+                return false;
         }
 
         public XLRange AsRange()
@@ -2016,14 +2020,14 @@ namespace ClosedXML.Excel
 
         private bool SetRichText(object value)
         {
-            var asRichString = value as XLRichText;
-
-            if (asRichString == null)
+            if (value is XLRichText asRichString)
+            {
+                _richText = asRichString;
+                _dataType = XLDataType.Text;
+                return true;
+            }
+            else
                 return false;
-
-            _richText = asRichString;
-            _dataType = XLDataType.Text;
-            return true;
         }
 
         private Boolean SetRange(Object rangeObject)
@@ -2110,7 +2114,7 @@ namespace ClosedXML.Excel
 
                 var c = new XLConditionalFormat(fmtRanges, true);
                 c.CopyFrom(cf);
-                c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), (XLCell)fmtRanges.First().FirstCell());
+                c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), fmtRanges.First().FirstCell());
 
                 Worksheet.ConditionalFormats.Add(c);
             }
@@ -2118,9 +2122,10 @@ namespace ClosedXML.Excel
 
         private bool SetDataTable(object o)
         {
-            var dataTable = o as DataTable;
-            if (dataTable == null) return false;
-            return InsertData(dataTable) != null;
+            if (o is DataTable dataTable)
+                return InsertData(dataTable) != null;
+            else
+                return false;
         }
 
         private bool SetEnumerable(object collectionObject)

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -2100,11 +2100,12 @@ namespace ClosedXML.Excel
             cCnt = Math.Min(cCnt, fromRange.ColumnCount());
             var toRange = Worksheet.Range(this, Worksheet.Cell(_rowNumber + rCnt - 1, _columnNumber + cCnt - 1));
             var formats = srcSheet.ConditionalFormats.Where(f => f.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any());
+
             foreach (var cf in formats.ToList())
             {
                 var fmtRanges = cf.Ranges
                     .GetIntersectedRanges(fromRange.RangeAddress)
-                    .Select(r => Relative(Intersection(r, fromRange), fromRange, toRange) as XLRange)
+                    .Select(r => Relative(r.Intersection(fromRange).AsRange(), fromRange, toRange) as XLRange)
                     .ToList();
 
                 var c = new XLConditionalFormat(fmtRanges, true);
@@ -2113,16 +2114,6 @@ namespace ClosedXML.Excel
 
                 Worksheet.ConditionalFormats.Add(c);
             }
-        }
-
-        private static IXLRangeBase Intersection(IXLRangeBase range, IXLRangeBase crop)
-        {
-            var sheet = range.Worksheet;
-            return sheet.Range(
-                Math.Max(range.RangeAddress.FirstAddress.RowNumber, crop.RangeAddress.FirstAddress.RowNumber),
-                Math.Max(range.RangeAddress.FirstAddress.ColumnNumber, crop.RangeAddress.FirstAddress.ColumnNumber),
-                Math.Min(range.RangeAddress.LastAddress.RowNumber, crop.RangeAddress.LastAddress.RowNumber),
-                Math.Min(range.RangeAddress.LastAddress.ColumnNumber, crop.RangeAddress.LastAddress.ColumnNumber));
         }
 
         private static IXLRange Relative(IXLRangeBase range, IXLRangeBase baseRange, IXLRangeBase targetBase)

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -68,8 +68,11 @@ namespace ClosedXML.Excel
 
         String ToStringRelative(Boolean includeSheet);
 
-        bool Intersects(IXLRangeAddress otherAddress);
+        Boolean Intersects(IXLRangeAddress otherAddress);
 
-        bool Contains(IXLAddress address);
+        Boolean Contains(IXLAddress address);
+
+        /// <summary>Allocates the current range address in the internal range repository and returns it</summary>
+        IXLRange AsRange();
     }
 }

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -72,6 +72,13 @@ namespace ClosedXML.Excel
 
         Boolean Contains(IXLAddress address);
 
+        /// <summary>
+        /// Returns the intersection of this range address with another range address on the same worksheet.
+        /// </summary>
+        /// <param name="otherRangeAddress">The other range address.</param>
+        /// <returns>The intersection's range address</returns>
+        IXLRangeAddress Intersection(IXLRangeAddress otherRangeAddress);
+
         /// <summary>Allocates the current range address in the internal range repository and returns it</summary>
         IXLRange AsRange();
     }

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -79,6 +79,15 @@ namespace ClosedXML.Excel
         /// <returns>The intersection's range address</returns>
         IXLRangeAddress Intersection(IXLRangeAddress otherRangeAddress);
 
+        /// <summary>
+        /// Returns a range address so that its offset from the target base address is equal to the offset of the current range address to the source base address.
+        /// For example, if the current range address is D4:E4, the source base address is A1:C3, then the relative address to the target base address B10:D13 is E14:F14
+        /// </summary>
+        /// <param name="sourceRangeAddress">The source base range address.</param>
+        /// <param name="targetRangeAddress">The target base range address.</param>
+        /// <returns>The relative range</returns>
+        IXLRangeAddress Relative(IXLRangeAddress sourceRangeAddress, IXLRangeAddress targetRangeAddress);
+
         /// <summary>Allocates the current range address in the internal range repository and returns it</summary>
         IXLRange AsRange();
     }

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -343,8 +343,8 @@ namespace ClosedXML.Excel
         /// <param name="otherRange">The other range.</param>
         /// <param name="thisRangePredicate">Predicate applied to this range's cells.</param>
         /// <param name="otherRangePredicate">Predicate applied to the other range's cells.</param>
-        /// <returns></returns>
-        IXLRangeBase Intersection(IXLRangeBase otherRange, Func<IXLCell, Boolean> thisRangePredicate = null, Func<IXLCell, Boolean> otherRangePredicate = null);
+        /// <returns>The range address of the intersection</returns>
+        IXLRangeAddress Intersection(IXLRangeBase otherRange, Func<IXLCell, Boolean> thisRangePredicate = null, Func<IXLCell, Boolean> otherRangePredicate = null);
 
         /// <summary>
         /// Returns the set of cells surrounding the current range.

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -371,5 +371,14 @@ namespace ClosedXML.Excel
         /// <param name="otherRangePredicate">Predicate applied to the other range's cells.</param>
         /// <returns></returns>
         IXLCells Difference(IXLRangeBase otherRange, Func<IXLCell, Boolean> thisRangePredicate = null, Func<IXLCell, Boolean> otherRangePredicate = null);
+
+        /// <summary>
+        /// Returns a range so that its offset from the target base range is equal to the offset of the current range to the source base range.
+        /// For example, if the current range is D4:E4, the source base range is A1:C3, then the relative range to the target base range B10:D13 is E14:F14
+        /// </summary>
+        /// <param name="sourceBaseRange">The source base range.</param>
+        /// <param name="targetBaseRange">The target base range.</param>
+        /// <returns>The relative range</returns>
+        IXLRangeBase Relative(IXLRangeBase sourceBaseRange, IXLRangeBase targetBaseRange);
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -114,6 +114,9 @@ namespace ClosedXML.Excel
 
         #region Public methods
 
+        public Boolean IsNormalized => LastAddress.RowNumber >= FirstAddress.RowNumber
+                                       && LastAddress.ColumnNumber >= FirstAddress.ColumnNumber;
+
         /// <summary>
         /// Lead a range address to a normal form - when <see cref="FirstAddress"/> points to the top-left address and
         /// <see cref="LastAddress"/> points to the bottom-right address.

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -367,6 +367,17 @@ namespace ClosedXML.Excel
             return IsValid && IsEntireColumn() && IsEntireRow();
         }
 
+        public IXLRange AsRange()
+        {
+            if (this.Worksheet == null)
+                throw new InvalidOperationException("The worksheet of the current range address has not been set.");
+
+            if (!this.IsValid)
+                return null;
+
+            return this.Worksheet.Range(this);
+        }
+
         #endregion Public methods
 
         #region Operators

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -24,6 +24,11 @@ namespace ClosedXML.Excel
                 new XLAddress(worksheet, row, XLHelper.MaxColumnNumber, false, false));
         }
 
+        public static readonly XLRangeAddress Invalid = new XLRangeAddress(
+            new XLAddress(-1, -1, fixedRow: true, fixedColumn: true),
+            new XLAddress(-1, -1, fixedRow: true, fixedColumn: true)
+        );
+
         #endregion Static members
 
         #region Constructor

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -372,6 +372,38 @@ namespace ClosedXML.Excel
             return IsValid && IsEntireColumn() && IsEntireRow();
         }
 
+        public IXLRangeAddress Intersection(IXLRangeAddress otherRangeAddress)
+        {
+            if (otherRangeAddress == null)
+                throw new ArgumentNullException(nameof(otherRangeAddress));
+
+            var xlOtherRangeAddress = (XLRangeAddress)otherRangeAddress;
+            return Intersection(in xlOtherRangeAddress);
+        }
+
+        internal XLRangeAddress Intersection(in XLRangeAddress otherRangeAddress)
+        {
+            if (!this.Worksheet.Equals(otherRangeAddress.Worksheet))
+                throw new ArgumentOutOfRangeException(nameof(otherRangeAddress), "The other range address is on a different worksheet");
+
+            var thisRangeAddressNormalized = this.Normalize();
+            var otherRangeAddressNormalized = otherRangeAddress.Normalize();
+
+            var firstRow = Math.Max(thisRangeAddressNormalized.FirstAddress.RowNumber, otherRangeAddressNormalized.FirstAddress.RowNumber);
+            var firstColumn = Math.Max(thisRangeAddressNormalized.FirstAddress.ColumnNumber, otherRangeAddressNormalized.FirstAddress.ColumnNumber);
+            var lastRow = Math.Min(thisRangeAddressNormalized.LastAddress.RowNumber, otherRangeAddressNormalized.LastAddress.RowNumber);
+            var lastColumn = Math.Min(thisRangeAddressNormalized.LastAddress.ColumnNumber, otherRangeAddressNormalized.LastAddress.ColumnNumber);
+
+            if (lastRow < firstRow || lastColumn < firstColumn)
+                return XLRangeAddress.Invalid;
+
+            return new XLRangeAddress
+            (
+                new XLAddress(this.Worksheet, firstRow, firstColumn, fixedRow: false, fixedColumn: false),
+                new XLAddress(this.Worksheet, lastRow, lastColumn, fixedRow: false, fixedColumn: false)
+            );
+        }
+
         public IXLRange AsRange()
         {
             if (this.Worksheet == null)

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -372,6 +372,39 @@ namespace ClosedXML.Excel
             return IsValid && IsEntireColumn() && IsEntireRow();
         }
 
+        public IXLRangeAddress Relative(IXLRangeAddress sourceRangeAddress, IXLRangeAddress targetRangeAddress)
+        {
+            var xlSourceRangeAddress = (XLRangeAddress)sourceRangeAddress;
+            var xlTargetRangeAddress = (XLRangeAddress)targetRangeAddress;
+
+            return Relative(in xlSourceRangeAddress, in xlTargetRangeAddress);
+        }
+
+        internal XLRangeAddress Relative(in XLRangeAddress sourceRangeAddress, in XLRangeAddress targetRangeAddress)
+        {
+            var sheet = targetRangeAddress.Worksheet;
+
+            return new XLRangeAddress
+            (
+                new XLAddress
+                (
+                    sheet,
+                    this.FirstAddress.RowNumber - sourceRangeAddress.FirstAddress.RowNumber + targetRangeAddress.FirstAddress.RowNumber,
+                    this.FirstAddress.ColumnNumber - sourceRangeAddress.FirstAddress.ColumnNumber + targetRangeAddress.FirstAddress.ColumnNumber,
+                    fixedRow: false,
+                    fixedColumn: false
+                ),
+                new XLAddress
+                (
+                    sheet,
+                    this.LastAddress.RowNumber - sourceRangeAddress.FirstAddress.RowNumber + targetRangeAddress.FirstAddress.RowNumber,
+                    this.LastAddress.ColumnNumber - sourceRangeAddress.FirstAddress.ColumnNumber + targetRangeAddress.FirstAddress.ColumnNumber,
+                    fixedRow: false,
+                    fixedColumn: false
+                )
+            );
+        }
+
         public IXLRangeAddress Intersection(IXLRangeAddress otherRangeAddress)
         {
             if (otherRangeAddress == null)

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -440,7 +440,7 @@ namespace ClosedXML.Excel
             var xlTargetBaseRangeAddress = (XLRangeAddress)targetBaseRange.RangeAddress;
             var xlRangeAddress = this.RangeAddress.Relative(in xlSourceBaseRangeAddress, in xlTargetBaseRangeAddress);
 
-            return ((XLRangeBase)targetBaseRange).Range(xlRangeAddress);
+            return ((XLRangeBase)targetBaseRange).Range(in xlRangeAddress);
         }
 
         internal void RemoveConditionalFormatting()
@@ -1003,9 +1003,16 @@ namespace ClosedXML.Excel
 
         public XLRange Range(IXLRangeAddress rangeAddress)
         {
-            var ws = (XLWorksheet)rangeAddress.FirstAddress.Worksheet ??
-                     (XLWorksheet)rangeAddress.LastAddress.Worksheet ??
+            var xlRangeAddress = (XLRangeAddress)rangeAddress;
+            return Range(in xlRangeAddress);
+        }
+
+        internal XLRange Range(in XLRangeAddress rangeAddress)
+        {
+            var ws = rangeAddress.FirstAddress.Worksheet ??
+                     rangeAddress.LastAddress.Worksheet ??
                      Worksheet;
+
             var newFirstCellAddress = new XLAddress(ws,
                                  rangeAddress.FirstAddress.RowNumber + RangeAddress.FirstAddress.RowNumber - 1,
                                  rangeAddress.FirstAddress.ColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1,

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -550,7 +550,7 @@ namespace ClosedXML.Excel
 
         public virtual XLRange AsRange()
         {
-            return Worksheet.Range(RangeAddress.FirstAddress, RangeAddress.LastAddress);
+            return Worksheet.Range(RangeAddress);
         }
 
         public IXLRange AddToNamed(String rangeName)

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -990,8 +990,25 @@ namespace ClosedXML.Excel
 
         public XLRange Range(Int32 firstCellRow, Int32 firstCellColumn, Int32 lastCellRow, Int32 lastCellColumn)
         {
-            var rangeAddress = new XLRangeAddress(new XLAddress(Worksheet, firstCellRow, firstCellColumn, false, false),
-                                                  new XLAddress(Worksheet, lastCellRow, lastCellColumn, false, false));
+            var rangeAddress = new XLRangeAddress
+            (
+                new XLAddress
+                (
+                    Worksheet,
+                    firstCellRow + RangeAddress.FirstAddress.RowNumber - 1,
+                    firstCellColumn + RangeAddress.FirstAddress.ColumnNumber - 1,
+                    fixedRow: false,
+                    fixedColumn: false
+                ),
+                new XLAddress
+                (
+                    Worksheet,
+                    lastCellRow + RangeAddress.FirstAddress.RowNumber - 1,
+                    lastCellColumn + RangeAddress.FirstAddress.ColumnNumber - 1,
+                    fixedRow: false,
+                    fixedColumn: false
+                )
+            );
             return Range(rangeAddress);
         }
 
@@ -1014,14 +1031,14 @@ namespace ClosedXML.Excel
                      Worksheet;
 
             var newFirstCellAddress = new XLAddress(ws,
-                                 rangeAddress.FirstAddress.RowNumber + RangeAddress.FirstAddress.RowNumber - 1,
-                                 rangeAddress.FirstAddress.ColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1,
+                                 rangeAddress.FirstAddress.RowNumber,
+                                 rangeAddress.FirstAddress.ColumnNumber,
                                  rangeAddress.FirstAddress.FixedRow,
                                  rangeAddress.FirstAddress.FixedColumn);
 
             var newLastCellAddress = new XLAddress(ws,
-                                rangeAddress.LastAddress.RowNumber + RangeAddress.FirstAddress.RowNumber - 1,
-                                rangeAddress.LastAddress.ColumnNumber + RangeAddress.FirstAddress.ColumnNumber - 1,
+                                rangeAddress.LastAddress.RowNumber,
+                                rangeAddress.LastAddress.ColumnNumber,
                                 rangeAddress.LastAddress.FixedRow,
                                 rangeAddress.LastAddress.FixedColumn);
 
@@ -1047,15 +1064,15 @@ namespace ClosedXML.Excel
 
         protected String FixColumnAddress(String address)
         {
-            if (Int32.TryParse(address, out Int32 test))
-                return "A" + address;
+            if (Int32.TryParse(address, out Int32 rowNumber))
+                return RangeAddress.FirstAddress.ColumnLetter + (rowNumber + RangeAddress.FirstAddress.RowNumber - 1).ToInvariantString();
             return address;
         }
 
         protected String FixRowAddress(String address)
         {
-            if (Int32.TryParse(address, out Int32 test))
-                return XLHelper.GetColumnLetterFromNumber(test) + "1";
+            if (Int32.TryParse(address, out Int32 columnNumber))
+                return XLHelper.GetColumnLetterFromNumber(columnNumber + RangeAddress.FirstAddress.ColumnNumber - 1) + RangeAddress.FirstAddress.RowNumber.ToInvariantString();
             return address;
         }
 

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -434,6 +434,15 @@ namespace ClosedXML.Excel
             return this;
         }
 
+        public IXLRangeBase Relative(IXLRangeBase sourceBaseRange, IXLRangeBase targetBaseRange)
+        {
+            var xlSourceBaseRangeAddress = (XLRangeAddress)sourceBaseRange.RangeAddress;
+            var xlTargetBaseRangeAddress = (XLRangeAddress)targetBaseRange.RangeAddress;
+            var xlRangeAddress = this.RangeAddress.Relative(in xlSourceBaseRangeAddress, in xlTargetBaseRangeAddress);
+
+            return ((XLRangeBase)targetBaseRange).Range(xlRangeAddress);
+        }
+
         internal void RemoveConditionalFormatting()
         {
             var mf = RangeAddress.FirstAddress;

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -2092,11 +2092,6 @@ namespace ClosedXML.Excel
             return Worksheet.RangeRow(new XLRangeAddress(firstCellAddress, lastCellAddress));
         }
 
-        /*public void Dispose()
-        {
-            // Dispose does nothing but left for not breaking the existing code
-        }*/
-
         public IXLDataValidation SetDataValidation()
         {
             var existingValidation = GetDataValidation();

--- a/ClosedXML_Examples/BasicTable.cs
+++ b/ClosedXML_Examples/BasicTable.cs
@@ -1,6 +1,5 @@
-using System;
 using ClosedXML.Excel;
-
+using System;
 
 namespace ClosedXML_Examples
 {
@@ -49,8 +48,8 @@ namespace ClosedXML_Examples
             //From worksheet
             var rngTable = ws.Range("B2:F6");
             //From another range
-            var rngDates = rngTable.Range("D3:D5"); // The address is relative to rngTable (NOT the worksheet)
-            var rngNumbers = rngTable.Range("E3:E5"); // The address is relative to rngTable (NOT the worksheet)
+            var rngDates = rngTable.Range("E4:E6");
+            var rngNumbers = rngTable.Range("F4:F6");
 
             //Formatting dates and numbers
             //Using a OpenXML's predefined formats
@@ -59,7 +58,7 @@ namespace ClosedXML_Examples
             rngNumbers.Style.NumberFormat.Format = "$ #,##0";
 
             //Formatting headers
-            var rngHeaders = rngTable.Range("A2:E2"); // The address is relative to rngTable (NOT the worksheet)
+            var rngHeaders = rngTable.Range("B3:F3");
             rngHeaders.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
             rngHeaders.Style.Font.Bold = true;
             rngHeaders.Style.Fill.BackgroundColor = XLColor.Aqua;
@@ -74,7 +73,7 @@ namespace ClosedXML_Examples
 
             //Merge title cells
             rngTable.Row(1).Merge(); // We could've also used: rngTable.Range("A1:E1").Merge()
-            
+
             //Add thick borders
             rngTable.Style.Border.OutsideBorder = XLBorderStyleValues.Thick;
 

--- a/ClosedXML_Examples/Misc/ShowCase.cs
+++ b/ClosedXML_Examples/Misc/ShowCase.cs
@@ -1,6 +1,5 @@
-using System;
 using ClosedXML.Excel;
-
+using System;
 
 namespace ClosedXML_Examples
 {
@@ -49,8 +48,8 @@ namespace ClosedXML_Examples
             //From worksheet
             var rngTable = ws.Range("B2:F6");
             //From another range
-            var rngDates = rngTable.Range("D3:D5"); // The address is relative to rngTable (NOT the worksheet)
-            var rngNumbers = rngTable.Range("E3:E5"); // The address is relative to rngTable (NOT the worksheet)
+            var rngDates = rngTable.Range("E4:E6");
+            var rngNumbers = rngTable.Range("F4:F6");
 
             //Formatting dates and numbers
             //Using a OpenXML's predefined formats
@@ -68,7 +67,7 @@ namespace ClosedXML_Examples
             rngTable.FirstRow().Merge(); // We could've also used: rngTable.Range("A1:E1").Merge() or rngTable.Row(1).Merge()
 
             //Formatting headers
-            var rngHeaders = rngTable.Range("A2:E2"); // The address is relative to rngTable (NOT the worksheet)
+            var rngHeaders = rngTable.Range("B3:F3");
             rngHeaders.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
             rngHeaders.Style.Font.Bold = true;
             rngHeaders.Style.Font.FontColor = XLColor.DarkBlue;
@@ -85,7 +84,7 @@ namespace ClosedXML_Examples
             excelTable.Field("Income").TotalsRowFunction = XLTotalsRowFunction.Average;
             // Put a label on the totals cell of the field "DOB"
             excelTable.Field("DOB").TotalsRowLabel = "Average:";
-            
+
             //Add thick borders to the contents of our spreadsheet
             ws.RangeUsed().Style.Border.OutsideBorder = XLBorderStyleValues.Thick;
 

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -261,6 +261,34 @@ namespace ClosedXML_Tests
             Assert.DoesNotThrow(() => rangeAddress.AsRange());
         }
 
+        [Test]
+        public void RelativeRanges()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+
+            IXLRangeAddress rangeAddress;
+
+            rangeAddress = ws.Range("D4:E4").RangeAddress.Relative(ws.Range("A1:E4").RangeAddress, ws.Range("B10:F14").RangeAddress);
+            Assert.IsTrue(rangeAddress.IsValid);
+            Assert.AreEqual("E13:F13", rangeAddress.ToString());
+
+            rangeAddress = ws.Range("D4:E4").RangeAddress.Relative(ws.Range("B10:F14").RangeAddress, ws.Range("A1:E4").RangeAddress);
+            Assert.IsFalse(rangeAddress.IsValid);
+            Assert.AreEqual("#REF!", rangeAddress.ToString());
+
+            rangeAddress = ws.Range("C3").RangeAddress.Relative(ws.Range("A1:B2").RangeAddress, ws.Range("C3").RangeAddress);
+            Assert.IsTrue(rangeAddress.IsValid);
+            Assert.AreEqual("E5:E5", rangeAddress.ToString());
+
+            rangeAddress = ws.Range("B2").RangeAddress.Relative(ws.Range("A1").RangeAddress, ws.Range("C3").RangeAddress);
+            Assert.IsTrue(rangeAddress.IsValid);
+            Assert.AreEqual("D4:D4", rangeAddress.ToString());
+
+            rangeAddress = ws.Range("A1").RangeAddress.Relative(ws.Range("B2").RangeAddress, ws.Range("A1").RangeAddress);
+            Assert.IsFalse(rangeAddress.IsValid);
+            Assert.AreEqual("#REF!", rangeAddress.ToString());
+        }
+
         #region Private Methods
 
         private IXLRangeAddress ProduceInvalidAddress()

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -1,5 +1,6 @@
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
 
 namespace ClosedXML_Tests
 {
@@ -232,6 +233,32 @@ namespace ClosedXML_Tests
 
             rangeAddress = (XLRangeAddress)ws.RangeAddress;
             Assert.IsTrue(rangeAddress.IsNormalized);
+        }
+
+        [Test]
+        public void AsRangeTests()
+        {
+            XLRangeAddress rangeAddress;
+            rangeAddress = new XLRangeAddress
+            (
+                new XLAddress(1, 1, false, false),
+                new XLAddress(5, 5, false, false)
+            );
+
+            Assert.IsTrue(rangeAddress.IsValid);
+            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.Throws<InvalidOperationException>(() => rangeAddress.AsRange());
+
+            var ws = new XLWorkbook().AddWorksheet() as XLWorksheet;
+            rangeAddress = new XLRangeAddress
+            (
+                new XLAddress(ws, 1, 1, false, false),
+                new XLAddress(ws, 5, 5, false, false)
+            );
+
+            Assert.IsTrue(rangeAddress.IsValid);
+            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.DoesNotThrow(() => rangeAddress.AsRange());
         }
 
         #region Private Methods

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -205,6 +205,35 @@ namespace ClosedXML_Tests
             }
         }
 
+        [Test]
+        public void RangeAddressIsNormalized()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+
+            XLRangeAddress rangeAddress;
+
+            rangeAddress = (XLRangeAddress)ws.Range(ws.Cell("A1"), ws.Cell("C3")).RangeAddress;
+            Assert.IsTrue(rangeAddress.IsNormalized);
+
+            rangeAddress = (XLRangeAddress)ws.Range(ws.Cell("C3"), ws.Cell("A1")).RangeAddress;
+            Assert.IsFalse(rangeAddress.IsNormalized);
+
+            rangeAddress = (XLRangeAddress)ws.Range("B2:B1").RangeAddress;
+            Assert.IsFalse(rangeAddress.IsNormalized);
+
+            rangeAddress = (XLRangeAddress)ws.Range("B2:B10").RangeAddress;
+            Assert.IsTrue(rangeAddress.IsNormalized);
+
+            rangeAddress = (XLRangeAddress)ws.Range("B:B").RangeAddress;
+            Assert.IsTrue(rangeAddress.IsNormalized);
+
+            rangeAddress = (XLRangeAddress)ws.Range("2:2").RangeAddress;
+            Assert.IsTrue(rangeAddress.IsNormalized);
+
+            rangeAddress = (XLRangeAddress)ws.RangeAddress;
+            Assert.IsTrue(rangeAddress.IsNormalized);
+        }
+
         #region Private Methods
 
         private IXLRangeAddress ProduceInvalidAddress()

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -226,12 +226,18 @@ namespace ClosedXML_Tests
             {
                 var ws = wb.AddWorksheet("Sheet1");
 
-                Assert.AreEqual("D9:G11", ws.Range("B9:I11").Intersection(ws.Range("D4:G16")).RangeAddress.ToString());
-                Assert.AreEqual("E9:G11", ws.Range("E9:I11").Intersection(ws.Range("D4:G16")).RangeAddress.ToString());
-                Assert.AreEqual("E9:E9", ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16")).RangeAddress.ToString());
-                Assert.AreEqual("E9:E9", ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange()).RangeAddress.ToString());
+                Assert.AreEqual("D9:G11", ws.Range("B9:I11").Intersection(ws.Range("D4:G16")).ToString());
+                Assert.AreEqual("E9:G11", ws.Range("E9:I11").Intersection(ws.Range("D4:G16")).ToString());
+                Assert.AreEqual("E9:E9", ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16")).ToString());
+                Assert.AreEqual("E9:E9", ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange()).ToString());
 
-                Assert.Null(ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange()));
+                XLRangeAddress rangeAddress;
+
+                rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange());
+                Assert.IsFalse(rangeAddress.IsValid);
+
+                rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange());
+                Assert.IsFalse(rangeAddress.IsValid);
 
                 Assert.Null(ws.Range("A1:C3").Intersection(null));
 


### PR DESCRIPTION
Previously, as commented in https://github.com/ClosedXML/ClosedXML/pull/1159/files#diff-03a6bc67d4fe134e5578c84c9fc4e29fL52 :

```c#
ws.Range("B2:F10").Range("B2").Address.ToString()
```
would return `C3` because the `B2` was treated as relative to the first range.

This PR breaks this and ensures that range strings are always treated as absolute, i.e. relative to the entire worksheet.

Range strings like `"1-3, 4, 7"` are still treated as relative.

The first few commits of this PR does some reorganising of methods: `Intersection()` is consolidated and `Relative` is moved to `IXLRangeBase` and made public.
