### PR TITLE
 Avoid creation of new item in Internals.RowsCollection when adding comment

### DIFF
--- a/ClosedXML/Excel/Comments/XLComment.cs
+++ b/ClosedXML/Excel/Comments/XLComment.cs
@@ -45,7 +45,7 @@ namespace ClosedXML.Excel
             _cell.DeleteComment();
         }
 
-        #endregion
+        #endregion IXLComment Members
 
         #region IXLDrawing
 
@@ -151,7 +151,7 @@ namespace ClosedXML.Excel
             return Container;
         }
 
-        #endregion
+        #endregion IXLDrawing
 
         private void Initialize(XLCell cell)
         {
@@ -159,22 +159,26 @@ namespace ClosedXML.Excel
             Container = this;
             Anchor = XLDrawingAnchor.MoveAndSizeWithCells;
             Style = new XLDrawingStyle();
-            Int32 pRow = cell.Address.RowNumber;
-            Double pRowOffset = 0;
-            if (pRow > 1)
+            Int32 previousRowNumber = cell.Address.RowNumber;
+            Double previousRowOffset = 0;
+
+            if (previousRowNumber > 1)
             {
-                pRow--;
-                double prevHeight = cell.Worksheet.Row(pRow).Height;
-                if (prevHeight > 7)
-                    pRowOffset = prevHeight - 7;
+                previousRowNumber--;
+
+                if (cell.Worksheet.Internals.RowsCollection.TryGetValue(previousRowNumber, out XLRow previousRow))
+                    previousRowOffset = Math.Max(0, previousRow.Height - 7);
+                else
+                    previousRowOffset = Math.Max(0, cell.Worksheet.RowHeight - 7);
             }
+
             Position = new XLDrawingPosition
-                           {
-                               Column = cell.Address.ColumnNumber + 1,
-                               ColumnOffset = 2,
-                               Row = pRow,
-                               RowOffset = pRowOffset
-                           };
+            {
+                Column = cell.Address.ColumnNumber + 1,
+                ColumnOffset = 2,
+                Row = previousRowNumber,
+                RowOffset = previousRowOffset
+            };
 
             ZOrder = cell.Worksheet.ZOrder++;
             Style

--- a/ClosedXML_Tests/Excel/Comments/CommentsTests.cs
+++ b/ClosedXML_Tests/Excel/Comments/CommentsTests.cs
@@ -23,5 +23,27 @@ namespace ClosedXML_Tests.Excel.Comments
                 Assert.AreEqual("FF000000", color);
             }
         }
+
+        [Test]
+        public void AddingCommentDoesNotAffectCollections()
+        {
+            var ws = new XLWorkbook().AddWorksheet() as XLWorksheet;
+            ws.Cell("A1").SetValue(10);
+            ws.Cell("A4").SetValue(10);
+            ws.Cell("A5").SetValue(10);
+
+            ws.Rows("1,4").Height = 20;
+
+            Assert.AreEqual(2, ws.Internals.RowsCollection.Count);
+            Assert.AreEqual(3, ws.Internals.CellsCollection.RowsCollection.SelectMany(r => r.Value.Values).Count());
+
+            ws.Cell("A4").Comment.AddText("Comment");
+            Assert.AreEqual(2, ws.Internals.RowsCollection.Count);
+            Assert.AreEqual(3, ws.Internals.CellsCollection.RowsCollection.SelectMany(r => r.Value.Values).Count());
+
+            ws.Row(1).Delete();
+            Assert.AreEqual(1, ws.Internals.RowsCollection.Count);
+            Assert.AreEqual(2, ws.Internals.CellsCollection.RowsCollection.SelectMany(r => r.Value.Values).Count());
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/Rows/RowTests.cs
+++ b/ClosedXML_Tests/Excel/Rows/RowTests.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
+using System.Linq;
 
 namespace ClosedXML_Tests.Excel
 {
@@ -56,7 +56,6 @@ namespace ClosedXML_Tests.Excel
 
             Assert.AreEqual("X", ws.Row(3).Cell(2).GetString());
 
-
             Assert.AreEqual(ws.Style.Fill.BackgroundColor, rowIns.Cell(1).Style.Fill.BackgroundColor);
             Assert.AreEqual(ws.Style.Fill.BackgroundColor, rowIns.Cell(2).Style.Fill.BackgroundColor);
             Assert.AreEqual(ws.Style.Fill.BackgroundColor, rowIns.Cell(3).Style.Fill.BackgroundColor);
@@ -110,7 +109,6 @@ namespace ClosedXML_Tests.Excel
 
             Assert.AreEqual("X", ws.Row(3).Cell(2).GetString());
 
-
             Assert.AreEqual(XLColor.Red, rowIns.Cell(1).Style.Fill.BackgroundColor);
             Assert.AreEqual(XLColor.Red, rowIns.Cell(2).Style.Fill.BackgroundColor);
             Assert.AreEqual(XLColor.Red, rowIns.Cell(3).Style.Fill.BackgroundColor);
@@ -163,7 +161,6 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(3).Style.Fill.BackgroundColor);
 
             Assert.AreEqual("X", ws.Row(2).Cell(2).GetString());
-
 
             Assert.AreEqual(XLColor.Yellow, rowIns.Cell(1).Style.Fill.BackgroundColor);
             Assert.AreEqual(XLColor.Green, rowIns.Cell(2).Style.Fill.BackgroundColor);
@@ -245,7 +242,6 @@ namespace ClosedXML_Tests.Excel
             Assert.AreEqual("B1:C1", fromRange.RangeAddress.ToStringRelative());
         }
 
-
         [Test]
         public void UngroupFromAll()
         {
@@ -262,6 +258,15 @@ namespace ClosedXML_Tests.Excel
             var row = new XLRow(ws, -1);
 
             Assert.IsFalse(row.RangeAddress.IsValid);
+        }
+
+        [Test]
+        public void DeleteRowOnWorksheetWithComment()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            ws.Cell(4, 1).Comment.AddText("test");
+            ws.Column(1).Width = 100;
+            Assert.DoesNotThrow(() => ws.Row(1).Delete());
         }
     }
 }


### PR DESCRIPTION
In the `XLComment` constructor, the previous row's height is being looked up. If the row doesn't exist, we should avoid its creation in `RowsCollection`.

Also refactored `XLRangeBase.Delete` to make it more readable.

Fixes #1160 