### PR TITLE
Avoid creating new XLCell instances during range shifting

### DIFF
--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1248,10 +1248,8 @@ namespace ClosedXML.Excel
                             var oldCell = Worksheet.Internals.CellsCollection.GetCell(ro, co) ??
                                           Worksheet.Cell(oldKey);
 
-                            var newCell = new XLCell(Worksheet, newKey, oldCell.StyleValue);
-                            newCell.CopyValuesFrom(oldCell);
-                            newCell.FormulaA1 = oldCell.FormulaA1;
-                            cellsToInsert.Add(newKey, newCell);
+                            oldCell.Address = newKey;
+                            cellsToInsert.Add(newKey, oldCell);
                             cellsToDelete.Add(oldKey);
                         }
 
@@ -1271,11 +1269,10 @@ namespace ClosedXML.Excel
                 {
                     int newColumn = c.Address.ColumnNumber + numberOfColumns;
                     var newKey = new XLAddress(Worksheet, c.Address.RowNumber, newColumn, false, false);
-                    var newCell = new XLCell(Worksheet, newKey, c.StyleValue);
-                    newCell.CopyValuesFrom(c);
-                    newCell.FormulaA1 = c.FormulaA1;
-                    cellsToInsert.Add(newKey, newCell);
+
                     cellsToDelete.Add(c.Address);
+                    c.Address = newKey;
+                    cellsToInsert.Add(newKey, c);
                 }
             }
 
@@ -1465,10 +1462,8 @@ namespace ClosedXML.Excel
                             var oldCell = Worksheet.Internals.CellsCollection.GetCell(ro, co);
                             if (oldCell != null)
                             {
-                                var newCell = new XLCell(Worksheet, newKey, oldCell.StyleValue);
-                                newCell.CopyValuesFrom(oldCell);
-                                newCell.FormulaA1 = oldCell.FormulaA1;
-                                cellsToInsert.Add(newKey, newCell);
+                                oldCell.Address = newKey;
+                                cellsToInsert.Add(newKey, oldCell);
                                 cellsToDelete.Add(oldKey);
                             }
                         }
@@ -1489,11 +1484,9 @@ namespace ClosedXML.Excel
                 {
                     int newRow = c.Address.RowNumber + numberOfRows;
                     var newKey = new XLAddress(Worksheet, newRow, c.Address.ColumnNumber, false, false);
-                    var newCell = new XLCell(Worksheet, newKey, c.StyleValue);
-                    newCell.CopyValuesFrom(c);
-                    newCell.FormulaA1 = c.FormulaA1;
-                    cellsToInsert.Add(newKey, newCell);
                     cellsToDelete.Add(c.Address);
+                    c.Address = newKey;
+                    cellsToInsert.Add(newKey, c);
                 }
             }
 
@@ -1654,16 +1647,14 @@ namespace ClosedXML.Excel
 
                 if (newCellAddress.IsValid)
                 {
-                    var newCell = new XLCell(Worksheet, newCellAddress, c.StyleValue);
-                    newCell.CopyValuesFrom(c);
-                    newCell.FormulaA1 = c.FormulaA1;
-
                     bool canInsert = shiftDeleteCells == XLShiftDeletedCells.ShiftCellsLeft
                                          ? c.Address.ColumnNumber > RangeAddress.LastAddress.ColumnNumber
                                          : c.Address.RowNumber > RangeAddress.LastAddress.RowNumber;
 
+                    c.Address = newCellAddress;
+
                     if (canInsert)
-                        cellsToInsert.Add(newCellAddress, newCell);
+                        cellsToInsert.Add(newCellAddress, c);
                 }
             }
 

--- a/ClosedXML_Tests/Excel/Ranges/RangeShiftingTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/RangeShiftingTests.cs
@@ -1,0 +1,82 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML_Tests.Excel.Ranges
+{
+    public class RangeShiftingTests
+    {
+        [Test]
+        public void CellReferenceRemainAfterColumnDeleted()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet();
+                var d4 = ws.Cell("D4");
+
+                ws.Column("C").Delete();
+
+                Assert.AreSame(d4, ws.Cell("C4"));
+            }
+        }
+
+        [Test]
+        public void CellReferenceRemainAfterRowDeleted()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet();
+                var d4 = ws.Cell("D4");
+
+                ws.Row(3).Delete();
+
+                Assert.AreSame(d4, ws.Cell("D3"));
+            }
+        }
+
+        [Test]
+        public void CellReferenceRemainAfterColumnInserted()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet();
+                var d4 = ws.Cell("D4");
+
+                ws.Column("C").InsertColumnsBefore(1);
+
+                Assert.AreSame(d4, ws.Cell("E4"));
+            }
+        }
+
+        [Test]
+        public void CellReferenceRemainAfterRowInserted()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet();
+                var d4 = ws.Cell("D4");
+
+                ws.Row(3).InsertRowsAbove(1);
+
+                Assert.AreSame(d4, ws.Cell("D5"));
+            }
+        }
+
+        [Test]
+        public void CellReferenceRemainAfterRangeDeleted()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet();
+                var d4 = ws.Cell("D4");
+                var f8 = ws.Cell("F8");
+
+                ws.Range("B2:C5").Delete(XLShiftDeletedCells.ShiftCellsLeft);
+                ws.Range("E5:F7").Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+                Assert.AreSame(d4, ws.Cell("B4"));
+                Assert.AreSame(f8, ws.Cell("F5"));
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This PR addresses the performance issues of #1162.

I've created a small benchmark that fills the worksheet with some random data (2000 * 2000) and then removes the first row or column.

Before this PR it took 9.6-12.1 sec to fill the table and 5.8-7.0 sec to remove a row or a column (6 test runs).
With these chanegs it takes 9.1-12.3 sec to fill and 4.1-5.0 to remove (6 test runs).

I hoped the effect would be more significant.