### PR TITLE
Clear all RelId's if workbook is loaded from template.

### DIFF
--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -110,7 +110,7 @@ namespace ClosedXML.Excel
 
         public static XLWorkbook OpenFromTemplate(String path)
         {
-            return new XLWorkbook(path, true);
+            return new XLWorkbook(path, asTemplate: true);
         }
 
         #endregion Static

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -52,6 +52,33 @@ namespace ClosedXML.Excel
         {
             using (var dSpreadsheet = SpreadsheetDocument.CreateFromTemplate(fileName))
                 LoadSpreadsheetDocument(dSpreadsheet);
+
+            // If we load a workbook as a template, we have to treat it as a "new" workbook.
+            // The original file will NOT be copied into place before changes are applied
+            // Hence all loaded RelIds have to be cleared
+            ResetAllRelIds();
+        }
+
+        private void ResetAllRelIds()
+        {
+            foreach (var ws in Worksheets.Cast<XLWorksheet>())
+            {
+                ws.SheetId = 0;
+                ws.RelId = null;
+
+                foreach (var pt in ws.PivotTables.Cast<XLPivotTable>())
+                {
+                    pt.WorkbookCacheRelId = null;
+                    pt.CacheDefinitionRelId = null;
+                    pt.RelId = null;
+                }
+
+                foreach (var picture in ws.Pictures.Cast<XLPicture>())
+                    picture.RelId = null;
+
+                foreach (var table in ws.Tables.Cast<XLTable>())
+                    table.RelId = null;
+            }
         }
 
         private void LoadSpreadsheetDocument(SpreadsheetDocument dSpreadsheet)

--- a/ClosedXML_Tests/TestHelper.cs
+++ b/ClosedXML_Tests/TestHelper.cs
@@ -72,10 +72,17 @@ namespace ClosedXML_Tests
 
             filePath1 = Path.Combine(directory, "z" + fileName);
             var filePath2 = Path.Combine(directory, fileName);
+
             //Run test
             example.Create(filePath1);
             using (var wb = new XLWorkbook(filePath1))
-                wb.SaveAs(filePath2, true, evaluateFormulae);
+                wb.SaveAs(filePath2, validate: true, evaluateFormulae);
+
+            // Also load from template and save it again - but not necessary to test against reference file
+            // We're just testing that it can save.
+            using (var ms = new MemoryStream())
+            using (var wb = XLWorkbook.OpenFromTemplate(filePath1))
+                wb.SaveAs(ms, validate: true, evaluateFormulae);
 
             if (CompareWithResources)
             {


### PR DESCRIPTION
If a workbook is loaded with `XLWorkbook.OpenFromTemplate()`, it should be treated as brand new, i.e. no RelId's should be prepopulated.