### PR TITLE
Fixes in GetHashCode functions (1073)

### DIFF
--- a/ClosedXML/Excel/Style/XLFontKey.cs
+++ b/ClosedXML/Excel/Style/XLFontKey.cs
@@ -60,7 +60,7 @@ namespace ClosedXML.Excel
             hashCode = hashCode * -1521134295 + Shadow.GetHashCode();
             hashCode = hashCode * -1521134295 + FontSize.GetHashCode();
             hashCode = hashCode * -1521134295 + FontColor.GetHashCode();
-            hashCode = hashCode * -1521134295 + FontName.ToUpperInvariant().GetHashCode();
+            hashCode = hashCode * -1521134295 + StringComparer.InvariantCultureIgnoreCase.GetHashCode(FontName);
             hashCode = hashCode * -1521134295 + FontFamilyNumbering.GetHashCode();
             hashCode = hashCode * -1521134295 + FontCharSet.GetHashCode();
             return hashCode;

--- a/ClosedXML/Excel/Style/XLNumberFormatKey.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormatKey.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Excel
         {
             var hashCode = -759193072;
             hashCode = hashCode * -1521134295 + NumberFormatId.GetHashCode();
-            hashCode = hashCode * -1521134295 + (Format == null ? 0 : Format.ToUpperInvariant().GetHashCode());
+            hashCode = hashCode * -1521134295 + (Format == null ? 0 : Format.GetHashCode());
             return hashCode;
         }
 
@@ -20,7 +20,7 @@ namespace ClosedXML.Excel
         {
             return
                 NumberFormatId == other.NumberFormatId
-             && string.Equals(Format, other.Format, StringComparison.InvariantCultureIgnoreCase);
+             && string.Equals(Format, other.Format);
         }
 
         public override bool Equals(object obj)

--- a/ClosedXML_Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML_Tests/Excel/Styles/FontTests.cs
@@ -1,0 +1,30 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML_Tests.Excel.Styles
+{
+    public class FontTests
+    {
+        [Test]
+        public void XLFontKey_GetHashCode_IsCaseInsensitive()
+        {
+            var fontKey1 = new XLFontKey { FontName = "Arial" };
+            var fontKey2 = new XLFontKey { FontName = "Times New Roman" };
+            var fontKey3 = new XLFontKey { FontName = "TIMES NEW ROMAN" };
+
+            Assert.AreNotEqual(fontKey1.GetHashCode(), fontKey2.GetHashCode());
+            Assert.AreEqual(fontKey2.GetHashCode(), fontKey3.GetHashCode());
+        }
+
+        [Test]
+        public void XLFontKey_Equals_IsCaseInsensitive()
+        {
+            var fontKey1 = new XLFontKey { FontName = "Arial" };
+            var fontKey2 = new XLFontKey { FontName = "Times New Roman" };
+            var fontKey3 = new XLFontKey { FontName = "TIMES NEW ROMAN" };
+
+            Assert.IsFalse(fontKey1.Equals(fontKey2));
+            Assert.IsTrue(fontKey2.Equals(fontKey3));
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/Styles/NumberFormatTests.cs
+++ b/ClosedXML_Tests/Excel/Styles/NumberFormatTests.cs
@@ -72,5 +72,23 @@ namespace ClosedXML_Tests.Excel
                 }
             }
         }
+
+        [Test]
+        public void XLNumberFormatKey_GetHashCode_IsCaseSensitive()
+        {
+            var numberFormatKey1 = new XLNumberFormatKey { Format = "MM" };
+            var numberFormatKey2 = new XLNumberFormatKey { Format = "mm" };
+
+            Assert.AreNotEqual(numberFormatKey1.GetHashCode(), numberFormatKey2.GetHashCode());
+        }
+
+        [Test]
+        public void XLNumberFormatKey_Equals_IsCaseSensitive()
+        {
+            var numberFormatKey1 = new XLNumberFormatKey { Format = "MM" };
+            var numberFormatKey2 = new XLNumberFormatKey { Format = "mm" };
+
+            Assert.IsFalse(numberFormatKey1.Equals(numberFormatKey2));
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the bug in `XLNumberFormatKey` equality check: the comparison was case-insensitive while it should be case-sensitive as, for example, `mm` stands for minutes while `MM` - for months.

Besides, it improves `XLFontKey.GetHashCode` in order to reduce memory allocations.

Closes #1073