### PR TITLE
Improve Merge operation performance

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
+++ b/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
@@ -24,10 +24,11 @@ namespace ClosedXML.Excel.CalcEngine
         // ** IEnumerable
         public IEnumerator GetEnumerator()
         {
-            var maxRow = Math.Min(Range.RangeAddress.LastAddress.RowNumber, Range.Worksheet.LastCellUsed().Address.RowNumber);
-            var maxCol = Math.Min(Range.RangeAddress.LastAddress.ColumnNumber, Range.Worksheet.LastCellUsed().Address.ColumnNumber);
+            var lastCellAddress = Range.Worksheet.LastCellUsed().Address;
+            var maxRow = Math.Min(Range.RangeAddress.LastAddress.RowNumber, lastCellAddress.RowNumber);
+            var maxColumn = Math.Min(Range.RangeAddress.LastAddress.ColumnNumber, lastCellAddress.ColumnNumber);
             var trimmedRange = (XLRangeBase)Range.Worksheet.Range(Range.FirstCell().Address,
-                new XLAddress(maxRow, maxCol, false, false));
+                new XLAddress(maxRow, maxColumn, fixedRow: false, fixedColumn: false));
             return trimmedRange.CellValues().GetEnumerator();
         }
 

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -357,7 +357,7 @@ namespace ClosedXML.Excel
             var firstCell = FirstCell();
             var firstCellStyle = (firstCell.Style as XLStyle).Key;
             var defaultStyle = XLStyle.Default.Key;
-            var cellsUsed = CellsUsed(XLCellsUsedOptions.All & ~XLCellsUsedOptions.MergedRanges, c => c != firstCell);
+            var cellsUsed = CellsUsed(XLCellsUsedOptions.All & ~XLCellsUsedOptions.MergedRanges, c => c != firstCell).ToList();
             cellsUsed.ForEach(c => c.Clear(XLClearOptions.All
                                         & ~XLClearOptions.MergedRanges
                                         & ~XLClearOptions.NormalFormats));


### PR DESCRIPTION
As @b0bi79 has discovered, `XLRangeBase.Merge()` is not quite efficient: `cellsUsed` is enumerated multiple times.

In addition, `LastCellUsed()` method is called in `CellRangeReference` twice so this part was also improved.

In my testing example, the execution time changes from 17 sec to 11 sec (>130K random merges).