### PR TITLE
Fix issues with ranges indexing

### DIFF
--- a/ClosedXML/Excel/Ranges/Index/IXLRangeIndex.cs
+++ b/ClosedXML/Excel/Ranges/Index/IXLRangeIndex.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel.Ranges.Index
     {
         bool Add(IXLRangeBase range);
 
-        bool Remove(IXLRangeBase range);
+        bool Remove(IXLRangeAddress rangeAddress);
 
         int RemoveAll(Predicate<IXLRangeBase> predicate = null);
 
@@ -23,14 +23,14 @@ namespace ClosedXML.Excel.Ranges.Index
         bool Intersects(in XLRangeAddress rangeAddress);
 
         bool Contains(in XLAddress address);
+
+        bool MatchesType(XLRangeType rangeType);
     }
 
     internal interface IXLRangeIndex<T> : IXLRangeIndex
         where T : IXLRangeBase
     {
         bool Add(T range);
-
-        bool Remove(T range);
 
         int RemoveAll(Predicate<T> predicate = null);
 

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -1,7 +1,7 @@
+using ClosedXML.Excel.Ranges.Index;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using ClosedXML.Excel.Ranges.Index;
 
 namespace ClosedXML.Excel
 {
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel
 
         public void Remove(IXLRange range)
         {
-            if (GetRangeIndex(range.Worksheet).Remove(range))
+            if (GetRangeIndex(range.Worksheet).Remove(range.RangeAddress))
                 Count--;
         }
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1860,8 +1860,15 @@ namespace ClosedXML.Excel
 
             foreach (var rangeIndex in _rangeIndices)
             {
-                if (rangeIndex.Remove(range))
+                if (!rangeIndex.MatchesType(rangeType))
+                    continue;
+
+                if (rangeIndex.Remove(oldAddress) &&
+                    newAddress.IsValid &&
+                    range != null)
+                {
                     rangeIndex.Add(range);
+                }
             }
         }
 

--- a/ClosedXML_Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML_Tests/Excel/Ranges/RangeIndexTest.cs
@@ -104,9 +104,9 @@ namespace ClosedXML_Tests.Excel.Ranges
                 var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
                 var index = FillIndexWithTestData(ws);
 
-                ws.Column(3).InsertColumnsBefore(2);
+                ws.Column(1).InsertColumnsBefore(1000);
 
-                var address = new XLAddress(ws, 102, 6, false, false);
+                var address = new XLAddress(ws, 102, 1004, false, false);
 
                 Assert.True(index.Contains(in address));
             }
@@ -240,6 +240,21 @@ namespace ClosedXML_Tests.Excel.Ranges
 
                 Assert.AreEqual(ranges.Count, ranges.Count());
 
+                // Add many entries to activate QuadTree
+                for (int i = 1; i <= TEST_COUNT; i++)
+                {
+                    ranges.Add(ws.Range(i * 2, 2, i * 2, 4));
+                }
+
+                Assert.AreEqual(2 + TEST_COUNT, ranges.Count);
+
+                for (int i = 1; i <= TEST_COUNT; i++)
+                {
+                    ranges.Remove(ws.Range(i * 2, 2, i * 2, 4));
+                }
+
+                Assert.AreEqual(2, ranges.Count);
+
                 ranges.Remove(range3);
                 Assert.AreEqual(1, ranges.Count);
                 ranges.Remove(range2);
@@ -251,7 +266,7 @@ namespace ClosedXML_Tests.Excel.Ranges
 
         private IXLRangeIndex CreateRangeIndex(IXLWorksheet worksheet)
         {
-            return new XLRangeIndex((XLWorksheet)worksheet);
+            return new XLRangeIndex<XLRange>((XLWorksheet)worksheet);
         }
 
         private IXLRangeIndex FillIndexWithTestData(IXLWorksheet worksheet)


### PR DESCRIPTION
Description:
1. The method XLWorksheet.RegisterRangeIndex was never called so modified ranges did not change their positions in indices
2. Removing ranges from the index by passing IXLRangeBase instance is not possible as the instance may already change its address
(so it cannot be found in QuadTree). That is why the Remove method changed to accept IXLRangeAddress
3. Check range index type before adding a relocated range there to avoid typecast exception later on enumeration

See https://github.com/ClosedXML/ClosedXML/pull/1033#issuecomment-455412853
@sflanker you were absolutely right. I really made a serious bug. It took me 5 months to realize :(