### PR TITLE
WIP Refactor value comparison into its own IEqualityComparer

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
@@ -1,5 +1,6 @@
 // Keep this file CodeMaid organised and cleaned
 using ClosedXML.Excel.CalcEngine.Exceptions;
+using ClosedXML.Excel.Patterns;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -59,7 +60,8 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 throw new CellReferenceException("Row index has to be positive");
 
             IXLRangeColumn matching_column;
-            matching_column = range.FindColumn(c => !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) == 0);
+            matching_column = range.FindColumn(c => !c.Cell(1).IsEmpty()
+                                                    && ClosedXMLValueComparer.DefaultComparer.Compare(c.Cell(1).Value, lookup_value) == 0);
             if (range_lookup && matching_column == null)
             {
                 var first_column = range.FirstColumn().ColumnNumber();
@@ -68,9 +70,15 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 matching_column = range.FindColumn(c =>
                 {
                     var column_index_in_range = c.ColumnNumber() - first_column + 1;
-                    if (column_index_in_range < number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0 && !c.ColumnRight().Cell(1).IsEmpty() && new Expression(c.ColumnRight().Cell(1).Value).CompareTo(lookup_value) > 0)
+                    if (column_index_in_range < number_of_columns_in_range
+                        && !c.Cell(1).IsEmpty()
+                        && ClosedXMLValueComparer.DefaultComparer.Compare(c.Cell(1).Value, lookup_value) <= 0
+                        && !c.ColumnRight().Cell(1).IsEmpty()
+                        && ClosedXMLValueComparer.DefaultComparer.Compare(c.ColumnRight().Cell(1).Value, lookup_value) > 0)
                         return true;
-                    else if (column_index_in_range == number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0)
+                    else if (column_index_in_range == number_of_columns_in_range
+                             && !c.Cell(1).IsEmpty()
+                             && ClosedXMLValueComparer.DefaultComparer.Compare(c.Cell(1).Value, lookup_value) <= 0)
                         return true;
                     else
                         return false;
@@ -180,7 +188,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
             if (match_type == 0)
                 foundCell = range
-                    .CellsUsed(XLCellsUsedOptions.Contents, c => lookupPredicate.Invoke(new Expression(c.Value).CompareTo(lookup_value)))
+                    .CellsUsed(XLCellsUsedOptions.Contents, c => lookupPredicate.Invoke(ClosedXMLValueComparer.DefaultComparer.Compare(c.Value, lookup_value)))
                     .FirstOrDefault();
             else
             {
@@ -189,19 +197,18 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                     .CellsUsed(XLCellsUsedOptions.Contents)
                     .TakeWhile(c =>
                     {
-                        var currentCellExpression = new Expression(c.Value);
+                        var currentCellValue = c.Value;
 
                         if (previousValue != null)
                         {
                             // When match_type != 0, we have to assume that the order of the items being search is ascending or descending
-                            var previousValueExpression = new Expression(previousValue);
-                            if (!lookupPredicate.Invoke(previousValueExpression.CompareTo(currentCellExpression)))
+                            if (!lookupPredicate.Invoke(ClosedXMLValueComparer.DefaultComparer.Compare(previousValue, currentCellValue)))
                                 return false;
                         }
 
-                        previousValue = c.Value;
+                        previousValue = currentCellValue;
 
-                        return lookupPredicate.Invoke(currentCellExpression.CompareTo(lookup_value));
+                        return lookupPredicate.Invoke(ClosedXMLValueComparer.DefaultComparer.Compare(currentCellValue, lookup_value));
                     })
                     .LastOrDefault();
             }
@@ -232,7 +239,8 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             IXLRangeRow matching_row;
             try
             {
-                matching_row = range.FindRow(r => !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) == 0);
+                matching_row = range.FindRow(r => !r.Cell(1).IsEmpty()
+                                                  && ClosedXMLValueComparer.DefaultComparer.Compare(r.Cell(1).Value, lookup_value) == 0);
             }
             catch (Exception ex)
             {
@@ -246,9 +254,15 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 matching_row = range.FindRow(r =>
                 {
                     var row_index_in_range = r.RowNumber() - first_row + 1;
-                    if (row_index_in_range < number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0 && !r.RowBelow().Cell(1).IsEmpty() && new Expression(r.RowBelow().Cell(1).Value).CompareTo(lookup_value) > 0)
+                    if (row_index_in_range < number_of_rows_in_range
+                        && !r.Cell(1).IsEmpty()
+                        && ClosedXMLValueComparer.DefaultComparer.Compare(r.Cell(1).Value, lookup_value) <= 0
+                        && !r.RowBelow().Cell(1).IsEmpty()
+                        && ClosedXMLValueComparer.DefaultComparer.Compare(r.RowBelow().Cell(1).Value, lookup_value) > 0)
                         return true;
-                    else if (row_index_in_range == number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0)
+                    else if (row_index_in_range == number_of_rows_in_range
+                             && !r.Cell(1).IsEmpty()
+                             && ClosedXMLValueComparer.DefaultComparer.Compare(r.Cell(1).Value, lookup_value) <= 0)
                         return true;
                     else
                         return false;

--- a/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
@@ -63,12 +63,14 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (range_lookup && matching_column == null)
             {
                 var first_column = range.FirstColumn().ColumnNumber();
+                var number_of_columns_in_range = range.ColumnsUsed().Count();
+
                 matching_column = range.FindColumn(c =>
                 {
                     var column_index_in_range = c.ColumnNumber() - first_column + 1;
-                    if (column_index_in_range < range.ColumnsUsed().Count() && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0 && !c.ColumnRight().Cell(1).IsEmpty() && new Expression(c.ColumnRight().Cell(1).Value).CompareTo(lookup_value) > 0)
+                    if (column_index_in_range < number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0 && !c.ColumnRight().Cell(1).IsEmpty() && new Expression(c.ColumnRight().Cell(1).Value).CompareTo(lookup_value) > 0)
                         return true;
-                    else if (column_index_in_range == range.ColumnsUsed().Count() && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0)
+                    else if (column_index_in_range == number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0)
                         return true;
                     else
                         return false;
@@ -239,12 +241,14 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (range_lookup && matching_row == null)
             {
                 var first_row = range.FirstRow().RowNumber();
+                var number_of_rows_in_range = range.RowsUsed().Count();
+
                 matching_row = range.FindRow(r =>
                 {
                     var row_index_in_range = r.RowNumber() - first_row + 1;
-                    if (row_index_in_range < range.RowsUsed().Count() && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0 && !r.RowBelow().Cell(1).IsEmpty() && new Expression(r.RowBelow().Cell(1).Value).CompareTo(lookup_value) > 0)
+                    if (row_index_in_range < number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0 && !r.RowBelow().Cell(1).IsEmpty() && new Expression(r.RowBelow().Cell(1).Value).CompareTo(lookup_value) > 0)
                         return true;
-                    else if (row_index_in_range == range.RowsUsed().Count() && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0)
+                    else if (row_index_in_range == number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0)
                         return true;
                     else
                         return false;

--- a/ClosedXML/Excel/Patterns/ClosedXMLValueComparer.cs
+++ b/ClosedXML/Excel/Patterns/ClosedXMLValueComparer.cs
@@ -1,0 +1,100 @@
+﻿using ClosedXML.Excel.CalcEngine;
+using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.Patterns
+{
+    internal class ClosedXMLValueComparer : IEqualityComparer<object>, IComparer<object>
+    {
+        private static ClosedXMLValueComparer _defaultComparer = new ClosedXMLValueComparer(StringComparer.OrdinalIgnoreCase);
+        private readonly StringComparer _stringComparer;
+
+        private ClosedXMLValueComparer()
+            : this(StringComparer.OrdinalIgnoreCase)
+        { }
+
+        private ClosedXMLValueComparer(StringComparer stringComparer)
+        {
+            this._stringComparer = stringComparer;
+        }
+
+        public static ClosedXMLValueComparer DefaultComparer { get { return _defaultComparer; } }
+
+        public int Compare(object x, object y)
+        {
+            IComparable c1;
+            if (x is Expression e1)
+                c1 = e1.Evaluate() as IComparable;
+            else
+                c1 = x as IComparable;
+
+            IComparable c2;
+            if (y is Expression e2)
+                c2 = e2.Evaluate() as IComparable;
+            else
+                c2 = y as IComparable;
+
+            // handle nulls
+            if (c1 == null && c2 == null)
+                return 0;
+            if (c2 == null)
+                return -1;
+            if (c1 == null)
+                return +1;
+
+            // make sure types are the same
+            if (c1.GetType() != c2.GetType())
+                return CompareWithCoersion(c1, c2);
+            else
+                return CompareWithoutCoersion(c1, c2);
+        }
+
+        public new bool Equals(object x, object y)
+        {
+            if (x == null && y == null)
+                return true;
+
+            if (y == null || x == null)
+                return false;
+
+            if (ReferenceEquals(x, y))
+                return true;
+
+            return Compare(x, y) == 0;
+        }
+
+        public int GetHashCode(object obj)
+        {
+            if (obj is null)
+                return 0;
+
+            return obj.GetHashCode();
+        }
+
+        private int CompareWithCoersion(IComparable c1, IComparable c2)
+        {
+            try
+            {
+                if (c2 is DateTime dt2 && c1.IsNumber())
+                    c1 = Convert.ChangeType(new ConvertibleObject(c1), typeof(DateTime)) as IComparable;
+                else
+                    c2 = Convert.ChangeType(new ConvertibleObject(c2), c1.GetType()) as IComparable;
+
+                return CompareWithoutCoersion(c1, c2);
+            }
+            catch (InvalidCastException) { return -1; }
+            catch (FormatException) { return -1; }
+            catch (OverflowException) { return -1; }
+            catch (ArgumentNullException) { return -1; }
+        }
+
+        private int CompareWithoutCoersion<T>(T c1, T c2)
+            where T : IComparable
+        {
+            if (c1 is string s1 && c2 is string s2)
+                return _stringComparer.Compare(s1, s2);
+
+            return c1.CompareTo(c2);
+        }
+    }
+}

--- a/ClosedXML/Excel/Patterns/ConvertibleObject.cs
+++ b/ClosedXML/Excel/Patterns/ConvertibleObject.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Threading;
+
+namespace ClosedXML.Excel.Patterns
+{
+    internal class ConvertibleObject : IComparable, IConvertible
+    {
+        public ConvertibleObject(Object value)
+        {
+            Value = value;
+        }
+
+        public Object Value { get; }
+
+        public int CompareTo(object obj)
+        {
+            switch (this.Value)
+            {
+                case Double dbl:
+                    return dbl.CompareTo((Double)obj);
+
+                case DateTime dt:
+                    return dt.CompareTo((DateTime)obj);
+
+                case Boolean b:
+                    return b.CompareTo((Boolean)obj);
+
+                case TimeSpan ts:
+                    return ts.CompareTo((TimeSpan)obj);
+
+                case String s:
+                    return StringComparer.OrdinalIgnoreCase.Compare(s, (String)obj);
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        #region IConvertible interface
+
+        public TypeCode GetTypeCode()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ToBoolean(IFormatProvider provider)
+        {
+            return (bool)this;
+        }
+
+        public byte ToByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public char ToChar(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public DateTime ToDateTime(IFormatProvider provider)
+        {
+            return (DateTime)this;
+        }
+
+        public decimal ToDecimal(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public double ToDouble(IFormatProvider provider)
+        {
+            return (Double)this;
+        }
+
+        public short ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16((Double)this);
+        }
+
+        public int ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32((Double)this);
+        }
+
+        public long ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64((Double)this);
+        }
+
+        public sbyte ToSByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public float ToSingle(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            return (String)this;
+        }
+
+        public object ToType(Type conversionType, IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ushort ToUInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint ToUInt32(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ulong ToUInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion IConvertible interface
+
+        #region ** implicit converters
+
+        public static implicit operator bool(ConvertibleObject x)
+        {
+            // handle nulls
+            if (x.Value == null)
+                return false;
+
+            // handle booleans
+            if (x.Value is bool b)
+                return b;
+
+            // handle doubles
+            if (x.Value is double dbl)
+                return Math.Abs(dbl) > double.Epsilon;
+
+            // handle everything else
+            return (double)Convert.ChangeType(x.Value, typeof(double)) != 0;
+        }
+
+        public static implicit operator DateTime(ConvertibleObject x)
+        {
+            // handle dates
+            if (x.Value is DateTime dt)
+                return dt;
+
+            if (x.Value is TimeSpan ts)
+                return new DateTime().Add(ts);
+
+            // handle numbers
+            if (x.Value.IsNumber())
+                return DateTime.FromOADate(Convert.ToDouble(x.Value));
+
+            // handle everything else
+            var _ci = Thread.CurrentThread.CurrentCulture;
+            return (DateTime)Convert.ChangeType(x.Value, typeof(DateTime), _ci);
+        }
+
+        public static implicit operator double(ConvertibleObject x)
+        {
+            // handle doubles
+            if (x.Value is double dbl)
+                return dbl;
+
+            // handle booleans
+            if (x.Value is bool b)
+                return b ? 1 : 0;
+
+            // handle dates
+            if (x.Value is DateTime dt)
+                return dt.ToOADate();
+
+            if (x.Value is TimeSpan ts)
+                return ts.TotalDays;
+
+            // handle nulls
+            if (x.Value == null || x.Value is string)
+                return 0;
+
+            // handle everything else
+            var _ci = Thread.CurrentThread.CurrentCulture;
+            return (double)Convert.ChangeType(x.Value, typeof(double), _ci);
+        }
+
+        public static implicit operator string(ConvertibleObject x)
+        {
+            if (x.Value == null)
+                return string.Empty;
+
+            if (x.Value is bool b)
+                return b.ToString().ToUpper();
+
+            return x.Value.ToInvariantString();
+        }
+
+        #endregion ** implicit converters
+    }
+}

--- a/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValue.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValue.cs
@@ -1,10 +1,26 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ClosedXML.Excel
 {
+    public enum XLPivotCalculation
+    {
+        Normal,
+        DifferenceFrom,
+        PercentageOf,
+        PercentageDifferenceFrom,
+        RunningTotal,
+        PercentageOfRow,
+        PercentageOfColumn,
+        PercentageOfTotal,
+        Index
+    }
+
+    public enum XLPivotCalculationItem
+    {
+        Value, Previous, Next
+    }
+
     public enum XLPivotSummary
     {
         Sum,
@@ -20,52 +36,57 @@ namespace ClosedXML.Excel
         PopulationVariance,
     }
 
-    public enum XLPivotCalculation
-    {
-        Normal,
-        DifferenceFrom,
-        PercentageOf,
-        PercentageDifferenceFrom,
-        RunningTotal,
-        PercentageOfRow,
-        PercentageOfColumn,
-        PercentageOfTotal,
-        Index
-    }
-    public enum XLPivotCalculationItem
-    {
-        Value, Previous, Next
-    }
-
     public interface IXLPivotValue
     {
-        String SourceName { get; }
-        String CustomName { get; set; }
+        /// <summary>
+        /// Specifies the index to the base field when the ShowDataAs calculation is in use.
+        /// </summary>
+        /// <value>
+        /// The name of the column of the relevant base field.
+        /// </value>
+        String BaseFieldName { get; set; }
 
-        IXLPivotValueFormat NumberFormat { get; }
+        /// <summary>
+        /// Specifies the index to the base item when the ShowDataAs calculation is in use.
+        /// </summary>
+        /// <value>
+        /// The value of the referenced base field item.
+        /// </value>
+        Object BaseItemValue { get; set; }
 
-        XLPivotSummary SummaryFormula { get; set; }
         XLPivotCalculation Calculation { get; set; }
-        String BaseField { get; set; }
-        String BaseItem { get; set; }
         XLPivotCalculationItem CalculationItem { get; set; }
+        String CustomName { get; set; }
+        IXLPivotValueFormat NumberFormat { get; }
+        String SourceName { get; }
+        XLPivotSummary SummaryFormula { get; set; }
 
-        IXLPivotValue SetSummaryFormula(XLPivotSummary value);
+        IXLPivotValue SetBaseFieldName(String value);
+
+        IXLPivotValue SetBaseItemValue(Object value);
+
         IXLPivotValue SetCalculation(XLPivotCalculation value);
-        IXLPivotValue SetBaseField(String value);
-        IXLPivotValue SetBaseItem(String value);
+
         IXLPivotValue SetCalculationItem(XLPivotCalculationItem value);
 
+        IXLPivotValue SetSummaryFormula(XLPivotSummary value);
 
-        IXLPivotValue ShowAsNormal();
         IXLPivotValueCombination ShowAsDifferenceFrom(String fieldSourceName);
-        IXLPivotValueCombination ShowAsPercentageFrom(String fieldSourceName);
-        IXLPivotValueCombination ShowAsPercentageDifferenceFrom(String fieldSourceName);
-        IXLPivotValue ShowAsRunningTotalIn(String fieldSourceName);
-        IXLPivotValue ShowAsPercentageOfRow();
-        IXLPivotValue ShowAsPercentageOfColumn();
-        IXLPivotValue ShowAsPercentageOfTotal();
+
         IXLPivotValue ShowAsIndex();
 
+        IXLPivotValue ShowAsNormal();
+
+        IXLPivotValueCombination ShowAsPercentageDifferenceFrom(String fieldSourceName);
+
+        IXLPivotValueCombination ShowAsPercentageFrom(String fieldSourceName);
+
+        IXLPivotValue ShowAsPercentageOfColumn();
+
+        IXLPivotValue ShowAsPercentageOfRow();
+
+        IXLPivotValue ShowAsPercentageOfTotal();
+
+        IXLPivotValue ShowAsRunningTotalIn(String fieldSourceName);
     }
 }

--- a/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValueCombination.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValueCombination.cs
@@ -5,7 +5,7 @@ namespace ClosedXML.Excel
 {
     public interface IXLPivotValueCombination
     {
-        IXLPivotValue And(String item);
+        IXLPivotValue And(Object item);
 
         IXLPivotValue AndNext();
 

--- a/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValueCombination.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValueCombination.cs
@@ -1,14 +1,14 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ClosedXML.Excel
 {
     public interface IXLPivotValueCombination
     {
         IXLPivotValue And(String item);
-        IXLPivotValue AndPrevious();
+
         IXLPivotValue AndNext();
+
+        IXLPivotValue AndPrevious();
     }
 }

--- a/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValue.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValue.cs
@@ -1,11 +1,9 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ClosedXML.Excel
 {
-    internal class XLPivotValue: IXLPivotValue
+    internal class XLPivotValue : IXLPivotValue
     {
         public XLPivotValue(string sourceName)
         {
@@ -13,47 +11,56 @@ namespace ClosedXML.Excel
             NumberFormat = new XLPivotValueFormat(this);
         }
 
+        public String BaseFieldName { get; set; }
+        public Object BaseItemValue { get; set; }
+        public XLPivotCalculation Calculation { get; set; }
+        public XLPivotCalculationItem CalculationItem { get; set; }
+        public String CustomName { get; set; }
         public IXLPivotValueFormat NumberFormat { get; private set; }
         public String SourceName { get; private set; }
-        public String CustomName { get; set; }		public IXLPivotValue SetCustomName(String value) { CustomName = value; return this; }
+        public XLPivotSummary SummaryFormula { get; set; }
 
-        public XLPivotSummary SummaryFormula { get; set; }		public IXLPivotValue SetSummaryFormula(XLPivotSummary value) { SummaryFormula = value; return this; }
-        public XLPivotCalculation Calculation { get; set; }		public IXLPivotValue SetCalculation(XLPivotCalculation value) { Calculation = value; return this; }
-        public String BaseField { get; set; }		public IXLPivotValue SetBaseField(String value) { BaseField = value; return this; }
-        public String BaseItem { get; set; }		public IXLPivotValue SetBaseItem(String value) { BaseItem = value; return this; }
-        public XLPivotCalculationItem CalculationItem { get; set; }		public IXLPivotValue SetCalculationItem(XLPivotCalculationItem value) { CalculationItem = value; return this; }
+        public IXLPivotValue SetBaseFieldName(String value) { BaseFieldName = value; return this; }
 
+        public IXLPivotValue SetBaseItemValue(Object value) { BaseItemValue = value; return this; }
+
+        public IXLPivotValue SetCalculation(XLPivotCalculation value) { Calculation = value; return this; }
+
+        public IXLPivotValue SetCalculationItem(XLPivotCalculationItem value) { CalculationItem = value; return this; }
+
+        public IXLPivotValue SetCustomName(String value) { CustomName = value; return this; }
+
+        public IXLPivotValue SetSummaryFormula(XLPivotSummary value) { SummaryFormula = value; return this; }
+
+        public IXLPivotValueCombination ShowAsDifferenceFrom(String fieldSourceName)
+        {
+            BaseFieldName = fieldSourceName;
+            SetCalculation(XLPivotCalculation.DifferenceFrom);
+            return new XLPivotValueCombination(this);
+        }
+
+        public IXLPivotValue ShowAsIndex()
+        {
+            return SetCalculation(XLPivotCalculation.Index);
+        }
 
         public IXLPivotValue ShowAsNormal()
         {
             return SetCalculation(XLPivotCalculation.Normal);
         }
-        public IXLPivotValueCombination ShowAsDifferenceFrom(String fieldSourceName)
-        {
-            BaseField = fieldSourceName;
-            SetCalculation(XLPivotCalculation.DifferenceFrom);
-            return new XLPivotValueCombination(this);
-        }
-        public IXLPivotValueCombination ShowAsPercentageFrom(String fieldSourceName)
-        {
-            BaseField = fieldSourceName;
-            SetCalculation(XLPivotCalculation.PercentageOf);
-            return new XLPivotValueCombination(this);
-        }
+
         public IXLPivotValueCombination ShowAsPercentageDifferenceFrom(String fieldSourceName)
         {
-            BaseField = fieldSourceName;
+            BaseFieldName = fieldSourceName;
             SetCalculation(XLPivotCalculation.PercentageDifferenceFrom);
             return new XLPivotValueCombination(this);
         }
-        public IXLPivotValue ShowAsRunningTotalIn(String fieldSourceName)
+
+        public IXLPivotValueCombination ShowAsPercentageFrom(String fieldSourceName)
         {
-            BaseField = fieldSourceName;
-            return SetCalculation(XLPivotCalculation.RunningTotal);
-        }
-        public IXLPivotValue ShowAsPercentageOfRow()
-        {
-            return SetCalculation(XLPivotCalculation.PercentageOfRow);
+            BaseFieldName = fieldSourceName;
+            SetCalculation(XLPivotCalculation.PercentageOf);
+            return new XLPivotValueCombination(this);
         }
 
         public IXLPivotValue ShowAsPercentageOfColumn()
@@ -61,14 +68,20 @@ namespace ClosedXML.Excel
             return SetCalculation(XLPivotCalculation.PercentageOfColumn);
         }
 
+        public IXLPivotValue ShowAsPercentageOfRow()
+        {
+            return SetCalculation(XLPivotCalculation.PercentageOfRow);
+        }
+
         public IXLPivotValue ShowAsPercentageOfTotal()
         {
             return SetCalculation(XLPivotCalculation.PercentageOfTotal);
         }
 
-        public IXLPivotValue ShowAsIndex()
+        public IXLPivotValue ShowAsRunningTotalIn(String fieldSourceName)
         {
-            return SetCalculation(XLPivotCalculation.Index);
+            BaseFieldName = fieldSourceName;
+            return SetCalculation(XLPivotCalculation.RunningTotal);
         }
     }
 }

--- a/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValueCombination.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValueCombination.cs
@@ -1,31 +1,33 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace ClosedXML.Excel
 {
-    internal class XLPivotValueCombination: IXLPivotValueCombination
+    internal class XLPivotValueCombination : IXLPivotValueCombination
     {
         private readonly IXLPivotValue _pivotValue;
+
         public XLPivotValueCombination(IXLPivotValue pivotValue)
         {
             _pivotValue = pivotValue;
         }
+
         public IXLPivotValue And(String item)
         {
             _pivotValue.BaseItem = item;
             _pivotValue.CalculationItem = XLPivotCalculationItem.Value;
             return _pivotValue;
         }
-        public IXLPivotValue AndPrevious()
-        {
-            _pivotValue.CalculationItem = XLPivotCalculationItem.Previous;
-            return _pivotValue;
-        }
+
         public IXLPivotValue AndNext()
         {
             _pivotValue.CalculationItem = XLPivotCalculationItem.Next;
+            return _pivotValue;
+        }
+
+        public IXLPivotValue AndPrevious()
+        {
+            _pivotValue.CalculationItem = XLPivotCalculationItem.Previous;
             return _pivotValue;
         }
     }

--- a/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValueCombination.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/XLPivotValueCombination.cs
@@ -12,23 +12,23 @@ namespace ClosedXML.Excel
             _pivotValue = pivotValue;
         }
 
-        public IXLPivotValue And(String item)
+        public IXLPivotValue And(Object item)
         {
-            _pivotValue.BaseItem = item;
-            _pivotValue.CalculationItem = XLPivotCalculationItem.Value;
-            return _pivotValue;
+            return _pivotValue
+                .SetBaseItemValue(item)
+                .SetCalculationItem(XLPivotCalculationItem.Value);
         }
 
         public IXLPivotValue AndNext()
         {
-            _pivotValue.CalculationItem = XLPivotCalculationItem.Next;
-            return _pivotValue;
+            return _pivotValue
+                .SetCalculationItem(XLPivotCalculationItem.Next);
         }
 
         public IXLPivotValue AndPrevious()
         {
-            _pivotValue.CalculationItem = XLPivotCalculationItem.Previous;
-            return _pivotValue;
+            return _pivotValue
+                .SetCalculationItem(XLPivotCalculationItem.Previous);
         }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -766,13 +766,13 @@ namespace ClosedXML.Excel
                                                         .Skip(1) // Skip header column
                                                         .Distinct().ToList();
 
-                                            pivotValue.BaseField = col.FirstCell().GetValue<string>();
+                                            pivotValue.BaseFieldName = col.FirstCell().GetValue<string>();
 
                                             if (df.BaseItem?.Value != null)
                                             {
                                                 var bi = (int)df.BaseItem.Value;
                                                 if (bi.Between(0, items.Count - 1))
-                                                    pivotValue.BaseItem = items[(int)df.BaseItem.Value].ToString();
+                                                    pivotValue.BaseItemValue = items[(int)df.BaseItem.Value];
                                             }
                                         }
                                     }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -2853,9 +2853,9 @@ namespace ClosedXML.Excel
                     NumberFormatId = numberFormatId
                 };
 
-                if (!String.IsNullOrEmpty(value.BaseField))
+                if (!String.IsNullOrEmpty(value.BaseFieldName))
                 {
-                    var baseField = pt.SourceRange.Columns().FirstOrDefault(c => c.Cell(1).Value.ToInvariantString() == value.BaseField);
+                    var baseField = pt.SourceRange.Columns().FirstOrDefault(c => c.Cell(1).Value.ToInvariantString() == value.BaseFieldName);
                     if (baseField != null)
                     {
                         df.BaseField = baseField.ColumnNumber() - pt.SourceRange.RangeAddress.FirstAddress.ColumnNumber;
@@ -2865,8 +2865,8 @@ namespace ClosedXML.Excel
                             .Skip(1) // Skip header column
                             .Distinct().ToList();
 
-                        if (items.Any(i => i.Equals(value.BaseItem)))
-                            df.BaseItem = Convert.ToUInt32(items.IndexOf(value.BaseItem));
+                        if (items.Contains(value.BaseItemValue))
+                            df.BaseItem = Convert.ToUInt32(items.IndexOf(value.BaseItemValue));
                     }
                 }
                 else

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -1,5 +1,6 @@
 using ClosedXML.Excel.ContentManagers;
 using ClosedXML.Excel.Exceptions;
+using ClosedXML.Excel.Patterns;
 using ClosedXML.Extensions;
 using ClosedXML.Utils;
 using DocumentFormat.OpenXml;
@@ -2865,8 +2866,8 @@ namespace ClosedXML.Excel
                             .Skip(1) // Skip header column
                             .Distinct().ToList();
 
-                        if (items.Contains(value.BaseItemValue))
-                            df.BaseItem = Convert.ToUInt32(items.IndexOf(value.BaseItemValue));
+                        if (items.Contains(value.BaseItemValue, ClosedXMLValueComparer.DefaultComparer))
+                            df.BaseItem = Convert.ToUInt32(items.FindIndex(i => ClosedXMLValueComparer.DefaultComparer.Equals(i, value.BaseItemValue)));
                     }
                 }
                 else


### PR DESCRIPTION
Depends on #1237

As mentioned before to @pankraty.

Now we don't have to create a new `Expression` when comparing cell values in e.g. `VLOOKUP`.

The comparer can also be reused to calculate the `BaseItem` value for pivot tables.

@Pankraty , you're the master of computing patterns, so let me know if this can be improved.