### PR TITLE
Prevent copying of deleted worksheets.

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -624,6 +624,9 @@ namespace ClosedXML.Excel
 
         public IXLWorksheet CopyTo(XLWorkbook workbook, String newSheetName, Int32 position)
         {
+            if (this.IsDeleted)
+                throw new InvalidOperationException($"`{this.Name}` has been deleted and cannot be copied.");
+
             var targetSheet = (XLWorksheet)workbook.WorksheetsInternal.Add(newSheetName, position);
             Internals.ColumnsCollection.ForEach(kp => kp.Value.CopyTo(targetSheet.Column(kp.Key)));
             Internals.RowsCollection.ForEach(kp => kp.Value.CopyTo(targetSheet.Row(kp.Key)));

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -287,6 +287,19 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void CannotCopyDeletedWorksheet()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                wb.AddWorksheet("Sheet1");
+                var ws = wb.AddWorksheet("Sheet2");
+
+                ws.Delete();
+                Assert.Throws<InvalidOperationException>(() => ws.CopyTo("Copy of Sheet2"));
+            }
+        }
+
+        [Test]
         public void WorksheetNameCannotStartWithApostrophe()
         {
             var title = "'StartsWithApostrophe";


### PR DESCRIPTION
Deleted worksheets should not be allowed to be copied.