### PR TITLE
Fix CONCATENATE for cell references

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -84,7 +84,20 @@ namespace ClosedXML.Excel.CalcEngine
             foreach (var x in p)
             {
                 if (x is XObjectExpression objectExpression)
-                    throw new CellValueException("This function does not accept cell ranges as parameters.");
+                {
+                    if (objectExpression.Value is CellRangeReference cellRangeReference)
+                    {
+                        if (!cellRangeReference.Range.RangeAddress.IsValid)
+                            throw new CellReferenceException();
+
+                        // Only single cell range references allows at this stage. See unit test for more details
+                        if (cellRangeReference.Range.RangeAddress.NumberOfCells > 1)
+                            throw new CellValueException("This function does not accept cell ranges as parameters.");
+                    }
+                    else
+                        // I'm unsure about what else objectExpression.Value could be, but let's throw CellReferenceException
+                        throw new CellReferenceException();
+                }
 
                 sb.Append((string)x);
             }
@@ -316,8 +329,8 @@ namespace ClosedXML.Excel.CalcEngine
             bool ignoreEmptyStrings;
             try
             {
-                delimiter = (string) p[0];
-                ignoreEmptyStrings = (bool) p[1];
+                delimiter = (string)p[0];
+                ignoreEmptyStrings = (bool)p[1];
             }
             catch (Exception e)
             {
@@ -385,7 +398,7 @@ namespace ClosedXML.Excel.CalcEngine
             numberFormatInfo.NumberGroupSeparator = p.Count > 2 ? p[2] : CultureInfo.InvariantCulture.NumberFormat.NumberGroupSeparator;
             numberFormatInfo.CurrencyGroupSeparator = numberFormatInfo.NumberGroupSeparator;
 
-            if(numberFormatInfo.NumberDecimalSeparator == numberFormatInfo.NumberGroupSeparator)
+            if (numberFormatInfo.NumberDecimalSeparator == numberFormatInfo.NumberGroupSeparator)
             {
                 throw new CellValueException("CurrencyDecimalSeparator and CurrencyGroupSeparator have to be different.");
             }

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -6,6 +6,11 @@ namespace ClosedXML.Excel
     public interface IXLRangeAddress
     {
         /// <summary>
+        /// Gets the number of columns in the area covered by the range address.
+        /// </summary>
+        int ColumnSpan { get; }
+
+        /// <summary>
         /// Gets or sets the first address in the range.
         /// </summary>
         /// <value>
@@ -28,6 +33,16 @@ namespace ClosedXML.Excel
         /// The last address.
         /// </value>
         IXLAddress LastAddress { get; }
+
+        /// <summary>
+        /// Gets the number of cells in the area covered by the range address.
+        /// </summary>
+        int NumberOfCells { get; }
+
+        /// <summary>
+        /// Gets the number of rows in the area covered by the range address.
+        /// </summary>
+        int RowSpan { get; }
 
         IXLWorksheet Worksheet { get; }
 

--- a/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeAddress.cs
@@ -1,3 +1,4 @@
+// Keep this file CodeMaid organised and cleaned
 using System;
 
 namespace ClosedXML.Excel
@@ -11,6 +12,38 @@ namespace ClosedXML.Excel
         /// The first address.
         /// </value>
         IXLAddress FirstAddress { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this range is valid.
+        /// </summary>
+        /// <value>
+        /// 	<c>true</c> if this instance is valid; otherwise, <c>false</c>.
+        /// </value>
+        Boolean IsValid { get; }
+
+        /// <summary>
+        /// Gets or sets the last address in the range.
+        /// </summary>
+        /// <value>
+        /// The last address.
+        /// </value>
+        IXLAddress LastAddress { get; }
+
+        IXLWorksheet Worksheet { get; }
+
+        /// <summary>Allocates the current range address in the internal range repository and returns it</summary>
+        IXLRange AsRange();
+
+        Boolean Contains(IXLAddress address);
+
+        /// <summary>
+        /// Returns the intersection of this range address with another range address on the same worksheet.
+        /// </summary>
+        /// <param name="otherRangeAddress">The other range address.</param>
+        /// <returns>The intersection's range address</returns>
+        IXLRangeAddress Intersection(IXLRangeAddress otherRangeAddress);
+
+        Boolean Intersects(IXLRangeAddress otherAddress);
 
         /// <summary>
         /// Determines whether range address spans the entire column.
@@ -37,22 +70,13 @@ namespace ClosedXML.Excel
         Boolean IsEntireSheet();
 
         /// <summary>
-        /// Gets or sets a value indicating whether this range is valid.
+        /// Returns a range address so that its offset from the target base address is equal to the offset of the current range address to the source base address.
+        /// For example, if the current range address is D4:E4, the source base address is A1:C3, then the relative address to the target base address B10:D13 is E14:F14
         /// </summary>
-        /// <value>
-        /// 	<c>true</c> if this instance is valid; otherwise, <c>false</c>.
-        /// </value>
-        Boolean IsValid { get; }
-
-        /// <summary>
-        /// Gets or sets the last address in the range.
-        /// </summary>
-        /// <value>
-        /// The last address.
-        /// </value>
-        IXLAddress LastAddress { get; }
-
-        IXLWorksheet Worksheet { get; }
+        /// <param name="sourceRangeAddress">The source base range address.</param>
+        /// <param name="targetRangeAddress">The target base range address.</param>
+        /// <returns>The relative range</returns>
+        IXLRangeAddress Relative(IXLRangeAddress sourceRangeAddress, IXLRangeAddress targetRangeAddress);
 
         String ToString(XLReferenceStyle referenceStyle);
 
@@ -67,28 +91,5 @@ namespace ClosedXML.Excel
         String ToStringRelative();
 
         String ToStringRelative(Boolean includeSheet);
-
-        Boolean Intersects(IXLRangeAddress otherAddress);
-
-        Boolean Contains(IXLAddress address);
-
-        /// <summary>
-        /// Returns the intersection of this range address with another range address on the same worksheet.
-        /// </summary>
-        /// <param name="otherRangeAddress">The other range address.</param>
-        /// <returns>The intersection's range address</returns>
-        IXLRangeAddress Intersection(IXLRangeAddress otherRangeAddress);
-
-        /// <summary>
-        /// Returns a range address so that its offset from the target base address is equal to the offset of the current range address to the source base address.
-        /// For example, if the current range address is D4:E4, the source base address is A1:C3, then the relative address to the target base address B10:D13 is E14:F14
-        /// </summary>
-        /// <param name="sourceRangeAddress">The source base range address.</param>
-        /// <param name="targetRangeAddress">The target base range address.</param>
-        /// <returns>The relative range</returns>
-        IXLRangeAddress Relative(IXLRangeAddress sourceRangeAddress, IXLRangeAddress targetRangeAddress);
-
-        /// <summary>Allocates the current range address in the internal range repository and returns it</summary>
-        IXLRange AsRange();
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -120,7 +120,7 @@ namespace ClosedXML.Excel
                 if (!IsValid)
                     throw new InvalidOperationException("Range address is invalid.");
 
-                return LastAddress.ColumnNumber - FirstAddress.ColumnNumber + 1;
+                return Math.Abs(LastAddress.ColumnNumber - FirstAddress.ColumnNumber) + 1;
             }
         }
 
@@ -133,7 +133,7 @@ namespace ClosedXML.Excel
                 if (!IsValid)
                     throw new InvalidOperationException("Range address is invalid.");
 
-                return LastAddress.RowNumber - FirstAddress.RowNumber + 1;
+                return Math.Abs(LastAddress.RowNumber - FirstAddress.RowNumber) + 1;
             }
         }
 

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -113,6 +113,30 @@ namespace ClosedXML.Excel
 
         public bool IsValid => FirstAddress.IsValid && LastAddress.IsValid;
 
+        public int ColumnSpan
+        {
+            get
+            {
+                if (!IsValid)
+                    throw new InvalidOperationException("Range address is invalid.");
+
+                return LastAddress.ColumnNumber - FirstAddress.ColumnNumber + 1;
+            }
+        }
+
+        public int NumberOfCells => ColumnSpan * RowSpan;
+
+        public int RowSpan
+        {
+            get
+            {
+                if (!IsValid)
+                    throw new InvalidOperationException("Range address is invalid.");
+
+                return LastAddress.RowNumber - FirstAddress.RowNumber + 1;
+            }
+        }
+
         private bool WorksheetIsDeleted => Worksheet?.IsDeleted == true;
 
         #endregion Public properties

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -289,6 +289,28 @@ namespace ClosedXML_Tests
             Assert.AreEqual("#REF!", rangeAddress.ToString());
         }
 
+        [Test]
+        public void TestSpanProperties()
+        {
+            var ws = new XLWorkbook().AddWorksheet() as XLWorksheet;
+
+            var range = ws.Range("B3:E5");
+            var rangeAddress = range.RangeAddress as IXLRangeAddress;
+            Assert.AreEqual(4, rangeAddress.ColumnSpan);
+            Assert.AreEqual(3, rangeAddress.RowSpan);
+            Assert.AreEqual(12, rangeAddress.NumberOfCells);
+
+            rangeAddress = ProduceAddressOnDeletedWorksheet();
+            Assert.AreEqual(2, rangeAddress.ColumnSpan);
+            Assert.AreEqual(2, rangeAddress.RowSpan);
+            Assert.AreEqual(4, rangeAddress.NumberOfCells);
+
+            rangeAddress = ProduceInvalidAddress();
+            Assert.Throws<InvalidOperationException>(() => { var x = rangeAddress.ColumnSpan; });
+            Assert.Throws<InvalidOperationException>(() => { var x = rangeAddress.RowSpan; });
+            Assert.Throws<InvalidOperationException>(() => { var x = rangeAddress.NumberOfCells; });
+        }
+
         #region Private Methods
 
         private IXLRangeAddress ProduceInvalidAddress()

--- a/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -300,6 +300,12 @@ namespace ClosedXML_Tests
             Assert.AreEqual(3, rangeAddress.RowSpan);
             Assert.AreEqual(12, rangeAddress.NumberOfCells);
 
+            range = ws.Range("E5:B3");
+            rangeAddress = range.RangeAddress as IXLRangeAddress;
+            Assert.AreEqual(4, rangeAddress.ColumnSpan);
+            Assert.AreEqual(3, rangeAddress.RowSpan);
+            Assert.AreEqual(12, rangeAddress.NumberOfCells);
+
             rangeAddress = ProduceAddressOnDeletedWorksheet();
             Assert.AreEqual(2, rangeAddress.ColumnSpan);
             Assert.AreEqual(2, rangeAddress.RowSpan);


### PR DESCRIPTION
CONCATENATE may accept cell range references as parameters, but its implementation is tricky and we can't support the full scope that Excel supports. See added code comments for clarification. This improves it though.

Fixes #1264 