### PR TITLE
Clear CellsCollection on WorksheetInternals disposal (#1276)

### DIFF
--- a/ClosedXML/Excel/XLWorksheetInternals.cs
+++ b/ClosedXML/Excel/XLWorksheetInternals.cs
@@ -24,6 +24,7 @@ namespace ClosedXML.Excel
 
         public void Dispose()
         {
+            CellsCollection.Clear();
             ColumnsCollection.Clear();
             RowsCollection.Clear();
             MergedRanges.RemoveAll();


### PR DESCRIPTION
Fixes #1276 

Interestingly, GC could not correctly collect all instances after WorksheetsInternal disposal. Maybe because of too many cycle references, it could not traverse all roots in a reasonable time.

With this fix, it works as intended (19 iterations of opening the workbook, Release mode):

![image](https://user-images.githubusercontent.com/19576939/63512142-1d0d8380-c4f4-11e9-93f6-304993812cb7.png)
