### PR TITLE
Update OpenXmlHelper.cs

### DIFF
--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -88,7 +88,47 @@ namespace ClosedXML.Utils
         /// Since these types do not implement a common interface we use dynamic.</param>
         /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
         /// <returns>The color in ClosedXML format.</returns>
-        private static XLColor ConvertToClosedXMLColor(dynamic openXMLColor, IDictionary<string, Drawing.Color> colorCache )
+        private static XLColor ConvertToClosedXMLColor(this X14.ColorType openXMLColor, IDictionary<string, Drawing.Color> colorCache )
+        {
+            XLColor retVal = null;
+            if (openXMLColor != null)
+            {
+                if (openXMLColor.Rgb != null)
+                {
+                    String htmlColor = "#" + openXMLColor.Rgb.Value;
+                    Drawing.Color thisColor;
+                    if (colorCache?.ContainsKey(htmlColor) ?? false)
+                    {
+                        thisColor = colorCache[htmlColor];
+                    }
+                    else
+                    {
+                        thisColor = ColorStringParser.ParseFromHtml(htmlColor);
+                        colorCache?.Add(htmlColor, thisColor);
+                    }
+
+                    retVal = XLColor.FromColor(thisColor);
+                }
+                else if (openXMLColor.Indexed != null && openXMLColor.Indexed <= 64)
+                    retVal = XLColor.FromIndex((Int32)openXMLColor.Indexed.Value);
+                else if (openXMLColor.Theme != null)
+                {
+                    retVal = openXMLColor.Tint != null
+                        ? XLColor.FromTheme((XLThemeColor)openXMLColor.Theme.Value, openXMLColor.Tint.Value)
+                        : XLColor.FromTheme((XLThemeColor)openXMLColor.Theme.Value);
+                }
+            }
+            return retVal ?? XLColor.NoColor;
+        }
+        
+        /// <summary>
+        /// Here we perform the actual convertion from OpenXML color to ClosedXML color.
+        /// </summary>
+        /// <param name="openXMLColor">OpenXML color. Must be either <see cref="ColorType"/> or <see cref="X14.ColorType"/>. 
+        /// Since these types do not implement a common interface we use dynamic.</param>
+        /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
+        /// <returns>The color in ClosedXML format.</returns>
+        private static XLColor ConvertToClosedXMLColor(this ColorType openXMLColor, IDictionary<string, Drawing.Color> colorCache )
         {
             XLColor retVal = null;
             if (openXMLColor != null)
@@ -130,7 +170,7 @@ namespace ClosedXML.Utils
         /// <param name="xlColor">Color in ClosedXML format.</param>
         /// <param name="isDifferential">Flag specifiying that the color should be saved in
         /// differential format (affects the transparent color processing).</param>
-        private static void FillFromClosedXMLColor(dynamic openXMLColor, XLColor xlColor, bool isDifferential)
+        private static void FillFromClosedXMLColor(this ColorType openXMLColor, XLColor xlColor, bool isDifferential)
         {
             if (openXMLColor == null)
                 throw new ArgumentNullException(nameof(openXMLColor));
@@ -158,6 +198,45 @@ namespace ClosedXML.Utils
                     break;
             }
         }
+        
+        /// <summary>
+        /// Initialize properties of the existing instance of the color in OpenXML format basing on properties of the color 
+        /// in ClosedXML format.
+        /// </summary>
+        /// <param name="openXMLColor">OpenXML color. Must be either <see cref="ColorType"/> or <see cref="X14.ColorType"/>. 
+        /// Since these types do not implement a common interface we use dynamic.</param>
+        /// <param name="xlColor">Color in ClosedXML format.</param>
+        /// <param name="isDifferential">Flag specifiying that the color should be saved in
+        /// differential format (affects the transparent color processing).</param>
+        private static void FillFromClosedXMLColor(this X14.ColorType openXMLColor, XLColor xlColor, bool isDifferential)
+        {
+            if (openXMLColor == null)
+                throw new ArgumentNullException(nameof(openXMLColor));
+
+            if (xlColor == null)
+                throw new ArgumentNullException(nameof(xlColor));
+
+            switch (xlColor.ColorType)
+            {
+                case XLColorType.Color:
+                    openXMLColor.Rgb = xlColor.Color.ToHex();
+                    break;
+
+                case XLColorType.Indexed:
+                    // 64 is 'transparent' and should be ignored for differential formats
+                    if (!isDifferential || xlColor.Indexed != 64)
+                        openXMLColor.Indexed = (UInt32)xlColor.Indexed;
+                    break;
+
+                case XLColorType.Theme:
+                    openXMLColor.Theme = (UInt32)xlColor.ThemeColor;
+
+                    if (xlColor.ThemeTint != 0)
+                        openXMLColor.Tint = xlColor.ThemeTint;
+                    break;
+            }
+        }
+
 
         #endregion Private Methods
     }


### PR DESCRIPTION
use of dynamic gives RuntimeInternal compiler exception while binding dynamic operation as c# is type safe language so use of dynamic must be exceptional.
