### PR TITLE
Improvements for workbook saving (#1280)

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -232,7 +232,7 @@ namespace ClosedXML.Excel
             // because we are using SetValue<T> (typed).
             // Only in SetValue(object value) to we try to fall back to a value of a different type
             if (!parsed)
-                throw new ArgumentException($"Unable to set cell value to {value.ToInvariantString()}");
+                throw new ArgumentException($"Unable to set cell value to {value.ObjectToInvariantString()}");
 
             SetInternalCellValueString(parsedValue, validate: true, parseToCachedValue: false);
 
@@ -248,7 +248,7 @@ namespace ClosedXML.Excel
             bool parsed;
             if (value is String && acceptString || value is char || value is Guid || value is Enum)
             {
-                parsedValue = value.ToInvariantString();
+                parsedValue = value.ObjectToInvariantString();
                 _dataType = XLDataType.Text;
                 if (parsedValue.Contains(Environment.NewLine) && !style.Alignment.WrapText)
                     Style.Alignment.WrapText = true;
@@ -292,7 +292,7 @@ namespace ClosedXML.Excel
                 }
                 else
                 {
-                    parsedValue = value.ToInvariantString();
+                    parsedValue = value.ObjectToInvariantString();
                     _dataType = XLDataType.Number;
                 }
                 parsed = true;
@@ -1112,7 +1112,7 @@ namespace ClosedXML.Excel
                                 break;
 
                             default:
-                                _cellValue = v.ToInvariantString();
+                                _cellValue = v.ObjectToInvariantString();
                                 break;
                         }
                     }
@@ -1123,7 +1123,7 @@ namespace ClosedXML.Excel
                         if (!String.IsNullOrWhiteSpace(error))
                             throw new ArgumentException(error, nameof(value));
 
-                        _cellValue = v?.ToInvariantString() ?? "";
+                        _cellValue = v?.ObjectToInvariantString() ?? "";
 
                         var style = GetStyleForRead();
                         switch (v)
@@ -1917,7 +1917,7 @@ namespace ClosedXML.Excel
                     var field = table.Fields.First(f => f.Column.ColumnNumber() == cell.WorksheetColumn().ColumnNumber());
                     field.TotalsRowFunction = XLTotalsRowFunction.None;
 
-                    SetInternalCellValueString(value.ToInvariantString(), validate: true, parseToCachedValue: false);
+                    SetInternalCellValueString(value.ObjectToInvariantString(), validate: true, parseToCachedValue: false);
 
                     field.TotalsRowLabel = _cellValue;
                     this.DataType = XLDataType.Text;
@@ -2253,7 +2253,7 @@ namespace ClosedXML.Excel
             // This doesn't happen in the SetValue<T>() version
             if (style.NumberFormat.Format == "@")
             {
-                parsedValue = value.ToInvariantString();
+                parsedValue = value.ObjectToInvariantString();
 
                 _dataType = XLDataType.Text;
                 if (parsedValue.Contains(Environment.NewLine) && !style.Alignment.WrapText)

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1499,7 +1499,7 @@ namespace ClosedXML.Excel
 
             if (options.HasFlag(XLCellsUsedOptions.NormalFormats))
             {
-                if (Style.IncludeQuotePrefix)
+                if (StyleValue.IncludeQuotePrefix)
                     return false;
 
                 if (!StyleValue.Equals(Worksheet.StyleValue))

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.Operator = cf.Operator.ToOpenXml();
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFContainsConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFContainsConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.ContainsText;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFDatesOccuringConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFDatesOccuringConverter.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.TimePeriod = cf.TimePeriod.ToOpenXml();
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFEndsWithConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFEndsWithConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.EndsWith;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsBlankConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsBlankConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             var formula = new Formula { Text = "LEN(TRIM(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + "))=0" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsErrorConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsErrorConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             var formula = new Formula { Text = "ISERROR(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + ")" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotBlankConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotBlankConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             var formula = new Formula { Text = "LEN(TRIM(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + "))>0" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotContainsConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotContainsConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.NotContains;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotErrorConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotErrorConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             var formula = new Formula { Text = "NOT(ISERROR(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + "))" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFStartsWithConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFStartsWithConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.BeginsWith;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFTopConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFTopConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             conditionalFormattingRule.Percent = cf.Percent;
             conditionalFormattingRule.Rank = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFUniqueConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFUniqueConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = (cf.Style as XLStyle).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle.Key];
+                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
 
             return conditionalFormattingRule;
         }

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -343,45 +343,46 @@ namespace ClosedXML.Excel
                 }
 
                 var firstCell = FirstCell();
-                var firstCellStyle = (firstCell.Style as XLStyle).Key;
-                var defaultStyle = XLStyle.Default.Key;
+                var firstCellStyleKey = (firstCell.Style as XLStyle).Key;
+                var firstCellStyle = firstCell.Style;
+                var defaultStyleKey = XLStyle.Default.Key;
                 var cellsUsed =
                     CellsUsed(XLCellsUsedOptions.All & ~XLCellsUsedOptions.MergedRanges, c => c != firstCell).ToList();
                 cellsUsed.ForEach(c => c.Clear(XLClearOptions.All
                                                & ~XLClearOptions.MergedRanges
                                                & ~XLClearOptions.NormalFormats));
 
-                if (firstCellStyle.Alignment != defaultStyle.Alignment)
-                    asRange.Style.Alignment = firstCell.Style.Alignment;
+                if (firstCellStyleKey.Alignment != defaultStyleKey.Alignment)
+                    asRange.Style.Alignment = firstCellStyle.Alignment;
                 else
-                    cellsUsed.ForEach(c => c.Style.Alignment = firstCell.Style.Alignment);
+                    cellsUsed.ForEach(c => c.Style.Alignment = firstCellStyle.Alignment);
 
-                if (firstCellStyle.Fill != defaultStyle.Fill)
-                    asRange.Style.Fill = firstCell.Style.Fill;
+                if (firstCellStyleKey.Fill != defaultStyleKey.Fill)
+                    asRange.Style.Fill = firstCellStyle.Fill;
                 else
-                    cellsUsed.ForEach(c => c.Style.Fill = firstCell.Style.Fill);
+                    cellsUsed.ForEach(c => c.Style.Fill = firstCellStyle.Fill);
 
-                if (firstCellStyle.Font != defaultStyle.Font)
-                    asRange.Style.Font = firstCell.Style.Font;
+                if (firstCellStyleKey.Font != defaultStyleKey.Font)
+                    asRange.Style.Font = firstCellStyle.Font;
                 else
-                    cellsUsed.ForEach(c => c.Style.Font = firstCell.Style.Font);
+                    cellsUsed.ForEach(c => c.Style.Font = firstCellStyle.Font);
 
-                if (firstCellStyle.IncludeQuotePrefix != defaultStyle.IncludeQuotePrefix)
-                    asRange.Style.IncludeQuotePrefix = firstCell.Style.IncludeQuotePrefix;
+                if (firstCellStyleKey.IncludeQuotePrefix != defaultStyleKey.IncludeQuotePrefix)
+                    asRange.Style.IncludeQuotePrefix = firstCellStyle.IncludeQuotePrefix;
                 else
-                    cellsUsed.ForEach(c => c.Style.IncludeQuotePrefix = firstCell.Style.IncludeQuotePrefix);
+                    cellsUsed.ForEach(c => c.Style.IncludeQuotePrefix = firstCellStyle.IncludeQuotePrefix);
 
-                if (firstCellStyle.NumberFormat != defaultStyle.NumberFormat)
-                    asRange.Style.NumberFormat = firstCell.Style.NumberFormat;
+                if (firstCellStyleKey.NumberFormat != defaultStyleKey.NumberFormat)
+                    asRange.Style.NumberFormat = firstCellStyle.NumberFormat;
                 else
-                    cellsUsed.ForEach(c => c.Style.NumberFormat = firstCell.Style.NumberFormat);
+                    cellsUsed.ForEach(c => c.Style.NumberFormat = firstCellStyle.NumberFormat);
 
-                if (firstCellStyle.Protection != defaultStyle.Protection)
-                    asRange.Style.Protection = firstCell.Style.Protection;
+                if (firstCellStyleKey.Protection != defaultStyleKey.Protection)
+                    asRange.Style.Protection = firstCellStyle.Protection;
                 else
-                    cellsUsed.ForEach(c => c.Style.Protection = firstCell.Style.Protection);
+                    cellsUsed.ForEach(c => c.Style.Protection = firstCellStyle.Protection);
 
-                if (cellsUsed.Any(c => (c.Style as XLStyle).Key.Border != defaultStyle.Border))
+                if (cellsUsed.Any(c => (c.Style as XLStyle).Key.Border != defaultStyleKey.Border))
                     asRange.Style.Border.SetInsideBorder(XLBorderStyleValues.None);
             }
 

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -63,7 +63,11 @@ namespace ClosedXML.Excel
 
         public override int GetHashCode()
         {
-            return -280332839 + Key.GetHashCode();
+            if (_hashCode.HasValue)
+                return _hashCode.Value;
+
+            _hashCode = -280332839 + Key.GetHashCode();
+            return _hashCode.Value;
         }
 
         public static bool operator ==(XLStyleValue left, XLStyleValue right)
@@ -74,6 +78,9 @@ namespace ClosedXML.Excel
                 return true;
             if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
                 return false;
+            if (left._hashCode.HasValue && right._hashCode.HasValue &&
+                left._hashCode != right._hashCode)
+                return false;
             return left.Key.Equals(right.Key);
         }
 
@@ -81,5 +88,7 @@ namespace ClosedXML.Excel
         {
             return !(left == right);
         }
+
+        private int? _hashCode;
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -12,22 +12,22 @@ namespace ClosedXML.Excel
         {
             public SaveContext()
             {
-                DifferentialFormats = new Dictionary<XLStyleKey, int>();
+                DifferentialFormats = new Dictionary<XLStyleValue, int>();
                 PivotTables = new Dictionary<Guid, PivotTableInfo>();
                 RelIdGenerator = new RelIdGenerator();
                 SharedFonts = new Dictionary<XLFontValue, FontInfo>();
                 SharedNumberFormats = new Dictionary<int, NumberFormatInfo>();
-                SharedStyles = new Dictionary<XLStyleKey, StyleInfo>();
+                SharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
                 TableId = 0;
                 TableNames = new HashSet<String>();
             }
 
-            public Dictionary<XLStyleKey, Int32> DifferentialFormats { get; private set; }
+            public Dictionary<XLStyleValue, Int32> DifferentialFormats { get; private set; }
             public IDictionary<Guid, PivotTableInfo> PivotTables { get; private set; }
             public RelIdGenerator RelIdGenerator { get; private set; }
             public Dictionary<XLFontValue, FontInfo> SharedFonts { get; private set; }
             public Dictionary<Int32, NumberFormatInfo> SharedNumberFormats { get; private set; }
-            public Dictionary<XLStyleKey, StyleInfo> SharedStyles { get; private set; }
+            public Dictionary<XLStyleValue, StyleInfo> SharedStyles { get; private set; }
             public uint TableId { get; set; }
             public HashSet<string> TableNames { get; private set; }
         }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -956,7 +956,7 @@ namespace ClosedXML.Excel
             bool hasSharedString(IXLCell c)
             {
                 if (c.DataType == XLDataType.Text && c.ShareString || c.HasRichText)
-                    return c.Style.IncludeQuotePrefix || String.IsNullOrWhiteSpace(c.FormulaA1) && (c as XLCell).InnerText.Length > 0;
+                    return (c as XLCell).StyleValue.IncludeQuotePrefix || String.IsNullOrWhiteSpace(c.FormulaA1) && (c as XLCell).InnerText.Length > 0;
                 else
                     return false;
             }
@@ -6032,7 +6032,7 @@ namespace ClosedXML.Excel
 
             if (dataType == XLDataType.Text)
             {
-                if (!xlCell.Style.IncludeQuotePrefix && xlCell.InnerText.Length == 0)
+                if (!xlCell.StyleValue.IncludeQuotePrefix && xlCell.InnerText.Length == 0)
                     openXmlCell.CellValue = null;
                 else
                 {

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -1021,7 +1021,7 @@ namespace ClosedXML.Excel
                 }
                 else
                 {
-                    var value = c.Value.ToInvariantString();
+                    var value = c.Value.ObjectToInvariantString();
                     if (newStrings.ContainsKey(value))
                         c.SharedStringId = newStrings[value];
                     else
@@ -2136,7 +2136,7 @@ namespace ClosedXML.Excel
             foreach (var c in source.Columns())
             {
                 var columnNumber = c.ColumnNumber();
-                var columnName = c.FirstCell().Value.ToInvariantString();
+                var columnName = c.FirstCell().Value.ObjectToInvariantString();
 
                 CacheField cacheField = null;
 
@@ -2596,9 +2596,9 @@ namespace ClosedXML.Excel
                         if (ptfi.MixedDataType || ptfi.DataType == XLDataType.Text)
                         {
                             var values = ptfi.DistinctValues
-                                .Select(v => v.ToInvariantString().ToLower())
+                                .Select(v => v.ObjectToInvariantString().ToLower())
                                 .ToList();
-                            var selectedValue = labelOrFilterField.SelectedValues.Single().ToInvariantString().ToLower();
+                            var selectedValue = labelOrFilterField.SelectedValues.Single().ObjectToInvariantString().ToLower();
                             if (values.Contains(selectedValue))
                                 pageField.Item = Convert.ToUInt32(values.IndexOf(selectedValue));
                         }
@@ -2833,7 +2833,7 @@ namespace ClosedXML.Excel
             foreach (var value in pt.Values)
             {
                 var sourceColumn =
-                    pt.SourceRange.Columns().FirstOrDefault(c => c.Cell(1).Value.ToInvariantString() == value.SourceName);
+                    pt.SourceRange.Columns().FirstOrDefault(c => c.Cell(1).Value.ObjectToInvariantString() == value.SourceName);
                 if (sourceColumn == null) continue;
 
                 UInt32 numberFormatId = 0;
@@ -2853,7 +2853,7 @@ namespace ClosedXML.Excel
 
                 if (!String.IsNullOrEmpty(value.BaseField))
                 {
-                    var baseField = pt.SourceRange.Columns().FirstOrDefault(c => c.Cell(1).Value.ToInvariantString() == value.BaseField);
+                    var baseField = pt.SourceRange.Columns().FirstOrDefault(c => c.Cell(1).Value.ObjectToInvariantString() == value.BaseField);
                     if (baseField != null)
                     {
                         df.BaseField = baseField.ColumnNumber() - pt.SourceRange.RangeAddress.FirstAddress.ColumnNumber;
@@ -5991,7 +5991,7 @@ namespace ClosedXML.Excel
                 try
                 {
                     var v = xlCell.Value;
-                    cellValue.Text = v.ToInvariantString();
+                    cellValue.Text = v.ObjectToInvariantString();
                     switch (v)
                     {
                         case String s:
@@ -6104,7 +6104,7 @@ namespace ClosedXML.Excel
                         var customFilters = new CustomFilters();
                         foreach (var filter in kp.Value)
                         {
-                            var customFilter = new CustomFilter { Val = filter.Value.ToInvariantString() };
+                            var customFilter = new CustomFilter { Val = filter.Value.ObjectToInvariantString() };
 
                             if (filter.Operator != XLFilterOperator.Equal)
                                 customFilter.Operator = filter.Operator.ToOpenXml();
@@ -6164,7 +6164,7 @@ namespace ClosedXML.Excel
                         var filters = new Filters();
                         foreach (var filter in kp.Value)
                         {
-                            filters.Append(new Filter { Val = filter.Value.ToInvariantString() });
+                            filters.Append(new Filter { Val = filter.Value.ObjectToInvariantString() });
                         }
 
                         filterColumn.Append(filters);

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -1902,8 +1902,8 @@ namespace ClosedXML.Excel
                         .First()
                         .Style as XLStyle).Value;
 
-                    if (!DefaultStyleValue.Equals(style) && context.DifferentialFormats.ContainsKey(style.Key))
-                        tableColumn.DataFormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[style.Key]));
+                    if (!DefaultStyleValue.Equals(style) && context.DifferentialFormats.ContainsKey(style))
+                        tableColumn.DataFormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[style]));
                 }
                 else
                     tableColumn.DataFormatId = null;
@@ -2954,12 +2954,12 @@ namespace ClosedXML.Excel
 
         private static void GeneratePivotTableFormat(Boolean isRow, XLPivotStyleFormat styleFormat, PivotTableDefinition pivotTableDefinition, SaveContext context)
         {
-            if (DefaultStyle.Equals(styleFormat.Style) || !context.DifferentialFormats.ContainsKey(((XLStyle)styleFormat.Style).Key))
+            if (DefaultStyle.Equals(styleFormat.Style) || !context.DifferentialFormats.ContainsKey(((XLStyle)styleFormat.Style).Value))
                 return;
 
             var format = new Format();
 
-            format.FormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[((XLStyle)styleFormat.Style).Key]));
+            format.FormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[((XLStyle)styleFormat.Style).Value]));
 
             var pivotArea = GenerateDefaultPivotArea(XLPivotStyleFormatTarget.GrandTotal);
 
@@ -2980,12 +2980,12 @@ namespace ClosedXML.Excel
             if (target == XLPivotStyleFormatTarget.GrandTotal)
                 throw new ArgumentException($"Use {nameof(GeneratePivotTableFormat)} to populate grand total formats.");
 
-            if (DefaultStyle.Equals(styleFormat.Style) || !context.DifferentialFormats.ContainsKey(((XLStyle)styleFormat.Style).Key))
+            if (DefaultStyle.Equals(styleFormat.Style) || !context.DifferentialFormats.ContainsKey(((XLStyle)styleFormat.Style).Value))
                 return;
 
             var format = new Format();
 
-            format.FormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[((XLStyle)styleFormat.Style).Key]));
+            format.FormatId = UInt32Value.FromUInt32(Convert.ToUInt32(context.DifferentialFormats[((XLStyle)styleFormat.Style).Value]));
 
             var pivotArea = GenerateDefaultPivotArea(target);
 
@@ -3608,7 +3608,7 @@ namespace ClosedXML.Excel
             else
                 defaultFormatId = 0;
 
-            context.SharedStyles.Add(defaultStyle.Key,
+            context.SharedStyles.Add(defaultStyle,
                 new StyleInfo
                 {
                     StyleId = defaultFormatId,
@@ -3714,8 +3714,8 @@ namespace ClosedXML.Excel
                     ? xlStyle.NumberFormat.NumberFormatId
                     : allSharedNumberFormats[xlStyle.NumberFormat].NumberFormatId;
 
-                if (!context.SharedStyles.ContainsKey(xlStyle.Key))
-                    context.SharedStyles.Add(xlStyle.Key,
+                if (!context.SharedStyles.ContainsKey(xlStyle))
+                    context.SharedStyles.Add(xlStyle,
                         new StyleInfo
                         {
                             StyleId = styleCount++,
@@ -3736,7 +3736,7 @@ namespace ClosedXML.Excel
 
             workbookStylesPart.Stylesheet.CellStyles.Count = (UInt32)workbookStylesPart.Stylesheet.CellStyles.Count();
 
-            var newSharedStyles = new Dictionary<XLStyleKey, StyleInfo>();
+            var newSharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
             foreach (var ss in context.SharedStyles)
             {
                 var styleId = -1;
@@ -3777,7 +3777,7 @@ namespace ClosedXML.Excel
                 foreach (var cf in ws.ConditionalFormats)
                 {
                     var styleValue = (cf.Style as XLStyle).Value;
-                    if (!styleValue.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(styleValue.Key))
+                    if (!styleValue.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(styleValue))
                         AddConditionalDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, cf, context);
                 }
 
@@ -3790,7 +3790,7 @@ namespace ClosedXML.Excel
                             .First()
                             .Style as XLStyle).Value;
 
-                        if (!style.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(style.Key))
+                        if (!style.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(style))
                             AddStyleAsDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, style, context);
                     }
                 }
@@ -3800,7 +3800,7 @@ namespace ClosedXML.Excel
                     foreach (var styleFormat in pt.AllStyleFormats)
                     {
                         var xlStyle = (XLStyle)styleFormat.Style;
-                        if (!xlStyle.Value.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(xlStyle.Key))
+                        if (!xlStyle.Value.Equals(DefaultStyleValue) && !context.DifferentialFormats.ContainsKey(xlStyle.Value))
                             AddStyleAsDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, xlStyle.Value, context);
                     }
                 }
@@ -3812,7 +3812,7 @@ namespace ClosedXML.Excel
         }
 
         private void FillDifferentialFormatsCollection(DifferentialFormats differentialFormats,
-            Dictionary<XLStyleKey, int> dictionary)
+            Dictionary<XLStyleValue, int> dictionary)
         {
             dictionary.Clear();
             var id = 0;
@@ -3827,8 +3827,8 @@ namespace ClosedXML.Excel
                 LoadNumberFormat(df.NumberingFormat, emptyContainer.Style.NumberFormat);
                 LoadFill(df.Fill, emptyContainer.Style.Fill, differentialFillFormat: true);
 
-                if (!dictionary.ContainsKey(emptyContainer.StyleValue.Key))
-                    dictionary.Add(emptyContainer.StyleValue.Key, id++);
+                if (!dictionary.ContainsKey(emptyContainer.StyleValue))
+                    dictionary.Add(emptyContainer.StyleValue, id++);
             }
         }
 
@@ -3862,7 +3862,7 @@ namespace ClosedXML.Excel
 
             differentialFormats.Append(differentialFormat);
 
-            context.DifferentialFormats.Add(styleValue.Key, differentialFormats.Count() - 1);
+            context.DifferentialFormats.Add(styleValue, differentialFormats.Count() - 1);
         }
 
         private static void AddStyleAsDifferentialFormat(DifferentialFormats differentialFormats, XLStyleValue style,
@@ -3908,7 +3908,7 @@ namespace ClosedXML.Excel
 
             differentialFormats.Append(differentialFormat);
 
-            context.DifferentialFormats.Add(style.Key, differentialFormats.Count() - 1);
+            context.DifferentialFormats.Add(style, differentialFormats.Count() - 1);
         }
 
         private static void ResolveRest(WorkbookStylesPart workbookStylesPart, SaveContext context)
@@ -4837,7 +4837,7 @@ namespace ClosedXML.Excel
 
             #region Columns
 
-            var worksheetStyleId = context.SharedStyles[xlWorksheet.StyleValue.Key].StyleId;
+            var worksheetStyleId = context.SharedStyles[xlWorksheet.StyleValue].StyleId;
             if (xlWorksheet.Internals.CellsCollection.Count == 0 &&
                 xlWorksheet.Internals.ColumnsCollection.Count == 0
                 && worksheetStyleId == 0)
@@ -4898,7 +4898,7 @@ namespace ClosedXML.Excel
                     var outlineLevel = 0;
                     if (xlWorksheet.Internals.ColumnsCollection.ContainsKey(co))
                     {
-                        styleId = context.SharedStyles[xlWorksheet.Internals.ColumnsCollection[co].StyleValue.Key].StyleId;
+                        styleId = context.SharedStyles[xlWorksheet.Internals.ColumnsCollection[co].StyleValue].StyleId;
                         columnWidth = GetColumnWidth(xlWorksheet.Internals.ColumnsCollection[co].Width).SaveRound();
                         isHidden = xlWorksheet.Internals.ColumnsCollection[co].IsHidden;
                         collapsed = xlWorksheet.Internals.ColumnsCollection[co].Collapsed;
@@ -4906,7 +4906,7 @@ namespace ClosedXML.Excel
                     }
                     else
                     {
-                        styleId = context.SharedStyles[xlWorksheet.StyleValue.Key].StyleId;
+                        styleId = context.SharedStyles[xlWorksheet.StyleValue].StyleId;
                         columnWidth = worksheetColumnWidth;
                     }
 
@@ -5029,7 +5029,7 @@ namespace ClosedXML.Excel
 
                     if (thisRow.StyleValue != xlWorksheet.StyleValue)
                     {
-                        row.StyleIndex = context.SharedStyles[thisRow.StyleValue.Key].StyleId;
+                        row.StyleIndex = context.SharedStyles[thisRow.StyleValue].StyleId;
                         row.CustomFormat = true;
                     }
 
@@ -5077,7 +5077,7 @@ namespace ClosedXML.Excel
                     {
                         XLTableField field = null;
 
-                        var styleId = context.SharedStyles[xlCell.StyleValue.Key].StyleId;
+                        var styleId = context.SharedStyles[xlCell.StyleValue].StyleId;
                         var cellReference = (xlCell.Address).GetTrimmedAddress();
 
                         // For saving cells to file, ignore conditional formatting, data validation rules and merged

--- a/ClosedXML/Extensions.cs
+++ b/ClosedXML/Extensions.cs
@@ -349,7 +349,57 @@ namespace ClosedXML.Excel
                     || value is decimal;
         }
 
-        public static string ToInvariantString(this object value)
+        public static string ToInvariantString<T>(this T value) where T: struct
+        {
+            switch (value)
+            {
+                case sbyte v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case byte v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case short v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case ushort v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case int v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case uint v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case long v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case ulong v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case float v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case double v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case decimal v:
+                    return v.ToString(CultureInfo.InvariantCulture);
+
+                case TimeSpan ts:
+                    return ts.ToString("c", CultureInfo.InvariantCulture);
+
+                case DateTime d:
+                    return d.ToString(CultureInfo.InvariantCulture);
+
+                default:
+                    return value.ToString();
+            }
+        }
+
+        // This method may cause boxing of value types so it is better to replace its calls with
+        // the generic version, where applicable
+        public static string ObjectToInvariantString(this object value)
         {
             if (value == null)
                 return string.Empty;


### PR DESCRIPTION
Here I remove filling `cellsWithoutFormulas` collection which has not been used for last two years (from 56db35624eeaae2ec794e6b4b131f0a22f838a4c). This lowers the memory usage (~147 MB on the test file from #1280) and should speed up saving thanks to removing multiple `c.Address.ToStringRelative()` calls.

Better see the diff in "ignore spaces" mode.

**UPDATE**
Being unable to significantly reduce memory usage I managed to slightly speed up saving. Before the changes it took 63-64 seconds to open and save the workbook; now it takes 55-57 seconds.