### PR TITLE
Fix typo

### DIFF
--- a/ClosedXML_Tests/Utils/StreamHelper.cs
+++ b/ClosedXML_Tests/Utils/StreamHelper.cs
@@ -130,7 +130,7 @@ namespace ClosedXML_Tests
             {
                 throw new ArgumentException("Must be in position 0", "one");
             }
-            if (tuple1.Item2.Position != 0)
+            if (tuple2.Item2.Position != 0)
             {
                 throw new ArgumentException("Must be in position 0", "other");
             }


### PR DESCRIPTION
Seems like it is a typo, because there are two identical `if`s