### PR TITLE
Grow method now uses default value

### DIFF
--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -308,17 +308,14 @@ namespace ClosedXML.Excel
 
         void Select();
 
-        /// <summary>
-        /// Grows this the current range by one cell to each side
-        /// </summary>
-        IXLRangeBase Grow();
+      
 
         /// <summary>
         /// Grows this the current range by the specified number of cells to each side.
         /// </summary>
         /// <param name="growCount">The grow count.</param>
         /// <returns></returns>
-        IXLRangeBase Grow(Int32 growCount);
+        IXLRangeBase Grow(Int32 growCount = 1);
 
         /// <summary>
         /// Shrinks this current range by one cell.

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -2170,12 +2170,7 @@ namespace ClosedXML.Excel
             Worksheet.SelectedRanges.Add(AsRange());
         }
 
-        public IXLRangeBase Grow()
-        {
-            return Grow(1);
-        }
-
-        public IXLRangeBase Grow(int growCount)
+        public IXLRangeBase Grow(int growCount = 1)
         {
             var firstRow = Math.Max(1, this.RangeAddress.FirstAddress.RowNumber - growCount);
             var firstColumn = Math.Max(1, this.RangeAddress.FirstAddress.ColumnNumber - growCount);


### PR DESCRIPTION
I removed the Grow Method with no parameters, that returned a call to an overload of Grow with a Int parameter. Now there is only one grow method that takes an optional parameter.