### PR TITLE
Fix number of columns when loading a LibreOffice file

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2100,8 +2100,10 @@ namespace ClosedXML.Excel
         {
             if (columns == null) return;
 
-            var wsDefaultColumn =
-                columns.Elements<Column>().FirstOrDefault(c => c.Max == XLHelper.MaxColumnNumber);
+            var wsDefaultColumn = columns.Elements<Column>()
+                .Where(c => c.Max == XLHelper.MaxColumnNumber || c.Max == XLHelper.MaxLOColumnNumber)
+                .OrderByDescending(c => c.Max)
+                .FirstOrDefault();
 
             if (wsDefaultColumn != null && wsDefaultColumn.Width != null)
                 ws.ColumnWidth = wsDefaultColumn.Width - ColumnWidthOffset;
@@ -2115,7 +2117,7 @@ namespace ClosedXML.Excel
             foreach (Column col in columns.Elements<Column>())
             {
                 //IXLStylized toApply;
-                if (col.Max == XLHelper.MaxColumnNumber) continue;
+                if (col == wsDefaultColumn) continue;
 
                 var xlColumns = (XLColumns)ws.Columns(col.Min, col.Max);
                 if (col.Width != null)

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -16,6 +16,7 @@ namespace ClosedXML.Excel
         public const int MinColumnNumber = 1;
         public const int MaxRowNumber = 1048576;
         public const int MaxColumnNumber = 16384;
+        public const int MaxLOColumnNumber = 1025;
         public const String MaxColumnLetter = "XFD";
         public const Double Epsilon = 1e-10;
 

--- a/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML_Tests/Excel/Loading/LoadingTests.cs
@@ -494,6 +494,16 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
+        public void CorrectlyLoadLibreOfficeFileColumns()
+        {
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LibreOfficeFileWithDates.xlsx")))
+            using (var wb = new XLWorkbook(stream))
+            {
+                Assert.AreEqual(2, wb.Worksheets.First().Columns().Count()); // Column "A" with data and column "E" with cursor
+            }
+        }
+
+        [Test]
         public void EmptyNumberFormatIdTreatedAsGeneral()
         {
             using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyNumberFormatId.xlsx")))


### PR DESCRIPTION
**What is it:**
Fix of the problem with incorrect number of columns when loading a LibreOffice file.

**Description of the problem:**
LibreOffice and possibly OpenOffice supports a maximum of 1024 columns. Because the algorithm supported only 16,384 columns, ALL 1024 columns were loaded for LibreOffice files. This is the reason for the decline in performance.