### PR TITLE
replaced usage of invariant culture with current culture

### DIFF
--- a/ClosedXML/Extensions/FormatExtensions.cs
+++ b/ClosedXML/Extensions/FormatExtensions.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Extensions
             if (!nf.IsValid)
                 return format;
 
-            return nf.Format(o, CultureInfo.InvariantCulture);
+            return nf.Format(o, CultureInfo.CurrentCulture);
         }
     }
 }


### PR DESCRIPTION
Different cultures have different formats for numbers/dates and etc. E.g. thousand separator in english ',' but in russian it's ' '.
I need covert excel file to xml as it is (with culture specified on user machine).