### PR TITLE
Fix null DateTime in XLCell.InsertDataInternal with IEnumerable

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -880,6 +880,13 @@ namespace ClosedXML.Excel
                 {
                     resetRecordPosition();
 
+                    if (m == null)
+                    {
+                        Worksheet.SetValue(String.Empty, currentRowNumber, currentColumnNumber);
+                        incrementRecordPosition();
+                        continue;
+                    }
+
                     if (m.GetType().IsSimpleType())
                     {
                         if (addHeadings && !hasHeadings)

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -157,6 +157,26 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void InsertData_with_Nulls_IEnumerable()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+
+            var dateTimeList = new List<DateTime?>()
+            {
+                new DateTime(2000, 1, 1),
+                new DateTime(2000, 1, 2),
+                new DateTime(2000, 1, 3),
+                new DateTime(2000, 1, 4),
+                null
+            };
+
+            ws.FirstCell().InsertData(dateTimeList);
+
+            Assert.AreEqual(new DateTime(2000, 1, 1), ws.Cell("A1").GetDateTime());
+            Assert.AreEqual(String.Empty, ws.Cell("A5").Value);
+        }
+
+        [Test]
         public void IsEmpty1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");


### PR DESCRIPTION
Fixed an issue where an IEnumerable<DateTime?> with a null value would throw an error due to no null checking. It will now instead insert an empty Cell value.