### PR TITLE
Implement % operator and correctly parse expressions with multiple unary operators (--, ++)

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -403,11 +403,19 @@ namespace ClosedXML.Excel.CalcEngine
         private Expression ParseUnary()
         {
             // unary plus and minus
-            if (_token.ID == TKID.ADD || _token.ID == TKID.SUB)
+            if (_token.Type == TKTYPE.ADDSUB)
             {
-                var t = _token;
-                GetToken();
+                var sign = 1;
+                do
+                {
+                    if (_token.ID == TKID.SUB)
+                        sign = -sign;
+                    GetToken();
+                } while (_token.Type == TKTYPE.ADDSUB);
                 var a = ParseAtom();
+                var t = (sign == 1)
+                    ? _tkTbl['+']
+                    : _tkTbl['-'];
                 return new UnaryExpression(t, a);
             }
 

--- a/ClosedXML/Excel/CalcEngine/Token.cs
+++ b/ClosedXML/Excel/CalcEngine/Token.cs
@@ -29,6 +29,7 @@ namespace ClosedXML.Excel.CalcEngine
         ADDSUB,      // + -
         MULDIV,      // * /
         POWER,       // ^
+        MULDIV_UNARY,// %
         GROUP,       // ( ) , .
         LITERAL,     // 123.32, "Hello", etc.
         IDENTIFIER,  // functions, external objects, bindings
@@ -44,6 +45,7 @@ namespace ClosedXML.Excel.CalcEngine
         ADD, SUB, // ADDSUB
         MUL, DIV, DIVINT, MOD, // MULDIV
         POWER, // POWER
+        DIV100, // MULTIV_UNARY
         OPEN, CLOSE, END, COMMA, PERIOD, // GROUP
         ATOM, // LITERAL, IDENTIFIER
         CONCAT

--- a/ClosedXML_Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -667,5 +667,20 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("_xlfn.TODAY()"));
             Assert.IsTrue((bool)XLWorkbook.EvaluateExpr("_xlfn.TODAY() = TODAY()"));
         }
+
+        [TestCase("=1234%", 12.34)]
+        [TestCase("=1234%%", 0.1234)]
+        [TestCase("=100+200%", 102.0)]
+        [TestCase("=100%+200", 201.0)]
+        [TestCase("=(100+200)%", 3.0)]
+        [TestCase("=200%^5", 32.0)]
+        [TestCase("=200%^400%", 16.0)]
+        [TestCase("=SUM(100,200,300)%", 6.0)]
+        public void PercentOperator(string formula, double expectedResult)
+        {
+            var res = (double)XLWorkbook.EvaluateExpr(formula);
+
+            Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
+        }
     }
 }

--- a/ClosedXML_Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -682,5 +682,16 @@ namespace ClosedXML_Tests.Excel.CalcEngine
 
             Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
         }
+
+        [TestCase("=--1", 1)]
+        [TestCase("=++1", 1)]
+        [TestCase("=-+-+-1", -1)]
+        [TestCase("=2^---2", 0.25)]
+        public void MultipleUnaryOperators(string formula, double expectedResult)
+        {
+            var res = (double)XLWorkbook.EvaluateExpr(formula);
+
+            Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1324 

Previously, we parsed % sign only as a part of a numeric literal, but in fact, % in formulas is equivalent to /100 and such expressions as `(100+300)%` or `123%%` are perfectly valid.

I've also noticed that we do not parse expressions with multiple unary operators (e.g. `=---12`) correctly. This is also fixed.