### PR TITLE
Replace String.Compare with TryGetValue

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -443,10 +443,8 @@ namespace ClosedXML.Excel
                 cAddress = fA1;
             }
 
-            if (Worksheet.Workbook.WorksheetsInternal.Any<XLWorksheet>(
-                w => String.Compare(w.Name, sName, true) == 0)
-                && XLHelper.IsValidA1Address(cAddress)
-                )
+            if (Worksheet.Workbook.Worksheets.Contains(sName)
+                && XLHelper.IsValidA1Address(cAddress))
             {
                 var referenceCell = Worksheet.Workbook.Worksheet(sName).Cell(cAddress);
                 if (referenceCell.IsEmpty(XLCellsUsedOptions.AllContents))
@@ -460,10 +458,7 @@ namespace ClosedXML.Excel
             {
                 IsEvaluating = true;
 
-                if (Worksheet
-                        .Workbook
-                        .WorksheetsInternal
-                        .Any<XLWorksheet>(w => String.Compare(w.Name, sName, true) == 0)
+                if (Worksheet.Workbook.Worksheets.Contains(sName)
                     && XLHelper.IsValidA1Address(cAddress))
                 {
                     var referenceCell = Worksheet.Workbook.Worksheet(sName).Cell(cAddress);

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -80,7 +80,7 @@ namespace ClosedXML.Excel
             return Cell(rowNumber, 1);
         }
 
-        public new IXLCells Cells(String cellsInColumn)
+        public override IXLCells Cells(String cellsInColumn)
         {
             var retVal = new XLCells(false, XLCellsUsedOptions.All);
             var rangePairs = cellsInColumn.Split(',');
@@ -89,12 +89,12 @@ namespace ClosedXML.Excel
             return retVal;
         }
 
-        public new IXLCells Cells()
+        public override IXLCells Cells()
         {
             return Cells(true, XLCellsUsedOptions.All);
         }
 
-        public new IXLCells Cells(Boolean usedCellsOnly)
+        public override IXLCells Cells(Boolean usedCellsOnly)
         {
             if (usedCellsOnly)
                 return Cells(true, XLCellsUsedOptions.All);

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -590,13 +590,11 @@ namespace ClosedXML.Excel
                                   ? Worksheet.Workbook.NamedRanges
                                   : Worksheet.NamedRanges;
 
-            if (namedRanges.Any(nr => String.Compare(nr.Name, rangeName, true) == 0))
-            {
-                var namedRange = namedRanges.Single(nr => String.Compare(nr.Name, rangeName, true) == 0);
+            if (namedRanges.TryGetValue(rangeName, out IXLNamedRange namedRange))
                 namedRange.Add(Worksheet.Workbook, RangeAddress.ToStringFixed(XLReferenceStyle.A1, true));
-            }
             else
                 namedRanges.Add(rangeName, RangeAddress.ToStringFixed(XLReferenceStyle.A1, true), comment);
+
             return AsRange();
         }
 
@@ -851,7 +849,10 @@ namespace ClosedXML.Excel
             if (XLHelper.IsValidA1Address(cellAddressInRange))
                 return Cell(XLAddress.Create(Worksheet, cellAddressInRange));
 
-            return (XLCell)Worksheet.NamedRange(cellAddressInRange).Ranges.First().FirstCell();
+            if (Worksheet.NamedRanges.TryGetValue(cellAddressInRange, out IXLNamedRange namedRange))
+                return namedRange.Ranges.First().FirstCell().CastTo<XLCell>();
+
+            return null;
         }
 
         public XLCell Cell(Int32 row, String column)

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -270,12 +270,12 @@ namespace ClosedXML.Excel
             return LastCellUsed(options, predicate);
         }
 
-        public IXLCells Cells()
+        public virtual IXLCells Cells()
         {
             return Cells(false);
         }
 
-        public IXLCells Cells(Boolean usedCellsOnly)
+        public virtual IXLCells Cells(Boolean usedCellsOnly)
         {
             return Cells(usedCellsOnly, XLCellsUsedOptions.AllContents);
         }
@@ -295,7 +295,7 @@ namespace ClosedXML.Excel
             return cells;
         }
 
-        public IXLCells Cells(String cells)
+        public virtual IXLCells Cells(String cells)
         {
             return Ranges(cells).Cells();
         }
@@ -846,7 +846,7 @@ namespace ClosedXML.Excel
             return Cell(new XLAddress(Worksheet, row, column, false, false));
         }
 
-        public XLCell Cell(String cellAddressInRange)
+        public virtual XLCell Cell(String cellAddressInRange)
         {
             if (XLHelper.IsValidA1Address(cellAddressInRange))
                 return Cell(XLAddress.Create(Worksheet, cellAddressInRange));
@@ -1059,7 +1059,7 @@ namespace ClosedXML.Excel
             return GetRange(newFirstCellAddress, newLastCellAddress);
         }
 
-        public IXLRanges Ranges(String ranges)
+        public virtual IXLRanges Ranges(String ranges)
         {
             var retVal = new XLRanges();
             var rangePairs = ranges.Split(',');
@@ -1864,7 +1864,7 @@ namespace ClosedXML.Excel
             return (XLPivotTable)targetCell.Worksheet.PivotTables.Add(name, targetCell, AsRange());
         }
 
-        public IXLAutoFilter SetAutoFilter()
+        public virtual IXLAutoFilter SetAutoFilter()
         {
             return SetAutoFilter(true);
         }

--- a/ClosedXML/Excel/Ranges/XLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumn.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel
             return Cell(rowNumber);
         }
 
-        public new IXLCells Cells(string cellsInColumn)
+        public override IXLCells Cells(string cellsInColumn)
         {
             var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
             var rangePairs = cellsInColumn.Split(',');

--- a/ClosedXML/Excel/Ranges/XLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRow.cs
@@ -24,9 +24,14 @@ namespace ClosedXML.Excel
             return Cell(1, column);
         }
 
-        public new IXLCell Cell(string column)
+        public override XLCell Cell(string columnLetter)
         {
-            return Cell(1, column);
+            return Cell(1, columnLetter);
+        }
+
+        IXLCell IXLRangeRow.Cell(string columnLetter)
+        {
+            return Cell(columnLetter);
         }
 
         public void Delete()
@@ -54,7 +59,7 @@ namespace ClosedXML.Excel
             return InsertColumnsBefore(numberOfColumns, expandRange).Cells();
         }
 
-        public new IXLCells Cells(string cellsInRow)
+        public override IXLCells Cells(string cellsInRow)
         {
             var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
             var rangePairs = cellsInRow.Split(',');

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -144,17 +144,22 @@ namespace ClosedXML.Excel
             return Cell(1, columnNumber);
         }
 
-        public new IXLCell Cell(String columnLetter)
+        public override XLCell Cell(String columnLetter)
         {
             return Cell(1, columnLetter);
         }
 
-        public new IXLCells Cells()
+        IXLCell IXLRow.Cell(string columnLetter)
+        {
+            return Cell(columnLetter);
+        }
+
+        public override IXLCells Cells()
         {
             return Cells(true, XLCellsUsedOptions.All);
         }
 
-        public new IXLCells Cells(Boolean usedCellsOnly)
+        public override IXLCells Cells(Boolean usedCellsOnly)
         {
             if (usedCellsOnly)
                 return Cells(true, XLCellsUsedOptions.All);
@@ -162,7 +167,7 @@ namespace ClosedXML.Excel
                 return Cells(FirstCellUsed().Address.ColumnNumber, LastCellUsed().Address.ColumnNumber);
         }
 
-        public new IXLCells Cells(String cellsInRow)
+        public override IXLCells Cells(String cellsInRow)
         {
             var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
             var rangePairs = cellsInRow.Split(',');

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -180,7 +180,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        public new IXLAutoFilter SetAutoFilter()
+        public override IXLAutoFilter SetAutoFilter()
         {
             return AutoFilter;
         }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -916,7 +916,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public new IXLRanges Ranges(String ranges)
+        public override IXLRanges Ranges(String ranges)
         {
             var retVal = new XLRanges();
             foreach (string rangeAddressStr in ranges.Split(',').Select(s => s.Trim()))
@@ -1632,12 +1632,12 @@ namespace ClosedXML.Excel
             return (XLPivotTable)PivotTables.PivotTable(name);
         }
 
-        public new IXLCells Cells()
+        public override IXLCells Cells()
         {
             return Cells(true, XLCellsUsedOptions.All);
         }
 
-        public new IXLCells Cells(Boolean usedCellsOnly)
+        public override IXLCells Cells(Boolean usedCellsOnly)
         {
             if (usedCellsOnly)
                 return Cells(true, XLCellsUsedOptions.All);
@@ -1647,7 +1647,7 @@ namespace ClosedXML.Excel
                     .Cells(false, XLCellsUsedOptions.All);
         }
 
-        public new XLCell Cell(String cellAddressInRange)
+        public override XLCell Cell(String cellAddressInRange)
         {
             if (XLHelper.IsValidA1Address(cellAddressInRange))
                 return Cell(XLAddress.Create(this, cellAddressInRange));


### PR DESCRIPTION
First commit changes some inheritance behaviour. Some methods were marked as `new`. This is change to `override` and the base class methods are now `virtual`.

Then, where possible, use `TryGetValue` to retrieve worksheets and named ranges and remove manual case insensitive lookup.