### PR TITLE
Fix issues occurred when running tests on .Net Core 3.0

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -68,7 +68,7 @@
 
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
-    <PackageReference Include="ExcelNumberFormat" Version="1.0.3" />
+    <PackageReference Include="ExcelNumberFormat" Version="1.0.10" />
 
     <!-- SourceLink , see https://github.com/ctaggart/SourceLink -->
     <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -547,14 +547,14 @@ namespace ClosedXML.Excel
                 if (this.DataType == XLDataType.DateTime && d.IsValidOADateNumber())
                     CachedValue = DateTime.FromOADate(d);
                 else if (this.DataType == XLDataType.TimeSpan)
-                    CachedValue = TimeSpan.FromDays(d);
+                    CachedValue = XLHelper.GetTimeSpan(d);
             }
             else if (CachedValue is DateTime dt)
             {
                 if (this.DataType == XLDataType.Number)
                     CachedValue = dt.ToOADate();
                 else if (this.DataType == XLDataType.TimeSpan)
-                    CachedValue = TimeSpan.FromDays(dt.ToOADate());
+                    CachedValue = XLHelper.GetTimeSpan(dt.ToOADate());
             }
             else if (CachedValue is TimeSpan ts)
             {
@@ -634,7 +634,7 @@ namespace ClosedXML.Excel
                 if (TimeSpan.TryParse(cellValue, out TimeSpan ts))
                     return ts;
                 else if (Double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out Double d))
-                    return TimeSpan.FromDays(d);
+                    return XLHelper.GetTimeSpan(d);
                 else
                 {
                     error = string.Format("Cannot set data type to TimeSpan because '{0}' is not recognized as a TimeSpan.", cellValue);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -328,7 +328,8 @@ namespace ClosedXML.Excel
 
                 this.Style.SetIncludeQuotePrefix();
             }
-            else if (value.Trim() != "NaN" && Double.TryParse(value, XLHelper.NumberStyle, XLHelper.ParseCulture, out Double _))
+            else if (!string.Equals(value.Trim(), "NaN", StringComparison.OrdinalIgnoreCase) &&
+                     Double.TryParse(value, XLHelper.NumberStyle, XLHelper.ParseCulture, out Double _))
                 _dataType = XLDataType.Number;
             else if (TimeSpan.TryParse(value, out TimeSpan ts))
             {

--- a/ClosedXML/Extensions/ObjectExtensions.cs
+++ b/ClosedXML/Extensions/ObjectExtensions.cs
@@ -55,10 +55,12 @@ namespace ClosedXML.Excel
                     return v.ToString(CultureInfo.InvariantCulture);
 
                 case float v:
-                    return v.ToString(CultureInfo.InvariantCulture);
+                    // Specify precision explicitly for backward compatibility
+                    return v.ToString("G7", CultureInfo.InvariantCulture);
 
                 case double v:
-                    return v.ToString(CultureInfo.InvariantCulture);
+                    // Specify precision explicitly for backward compatibility
+                    return v.ToString("G15", CultureInfo.InvariantCulture);
 
                 case decimal v:
                     return v.ToString(CultureInfo.InvariantCulture);
@@ -108,10 +110,12 @@ namespace ClosedXML.Excel
                     return v.ToString(CultureInfo.InvariantCulture);
 
                 case float v:
-                    return v.ToString(CultureInfo.InvariantCulture);
+                    // Specify precision explicitly for backward compatibility
+                    return v.ToString("G7", CultureInfo.InvariantCulture);
 
                 case double v:
-                    return v.ToString(CultureInfo.InvariantCulture);
+                    // Specify precision explicitly for backward compatibility
+                    return v.ToString("G15", CultureInfo.InvariantCulture);
 
                 case decimal v:
                     return v.ToString(CultureInfo.InvariantCulture);

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -330,6 +330,18 @@ namespace ClosedXML.Excel
             return -657435 <= d && d < 2958466;
         }
 
+        /// <summary>
+        /// A backward compatible version of <see cref="TimeSpan.FromDays(double)"/> that returns a value
+        /// rounded to milliseconds. In .Net Core 3.0 the behavior has changed and timespan includes microseconds
+        /// as well. As a result, the value 1:12:30 saved on one machine could become 1:12:29.999999 on another.
+        /// </summary>
+        internal static TimeSpan GetTimeSpan(double totalDays)
+        {
+            var timeSpan = TimeSpan.FromDays(totalDays);
+            var roundedMilliseconds = (int)Math.Round(timeSpan.TotalMilliseconds);
+            return new TimeSpan(0, 0, 0, 0, roundedMilliseconds);
+        }
+
         public static Boolean ValidateName(String objectType, String newName, String oldName, IEnumerable<String> existingNames, out String message)
         {
             message = "";

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net40;net46</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
     <Version>0.95.0</Version>
     <IsPackable>false</IsPackable>
@@ -21,7 +21,7 @@
     <DefineConstants>$(DefineConstants);RELEASE;STRONGNAME</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
   </PropertyGroup>
 
@@ -40,7 +40,7 @@
     <EmbeddedResource Include="Resource\Images\*.jpg" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
   </ItemGroup>

--- a/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -364,7 +364,7 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             {
                 var ws = wb.AddWorksheet("Test");
                 ws.Cell(1, 1).Value = new DateTime(2019, 1, 1, 14, 0, 0);
-                ws.Cell(1, 2).Value = new DateTime(2019, 1, 1, 17, 48, 0);
+                ws.Cell(1, 2).Value = new DateTime(2019, 1, 1, 17, 45, 0);
                 var cell = ws.Cell(1, 3);
                 cell.FormulaA1 = "=B1-A1";
                 cell.Style.DateFormat.Format = "hh:mm";
@@ -376,15 +376,15 @@ namespace ClosedXML_Tests.Excel.CalcEngine
 
                 cell.DataType = XLDataType.DateTime;
                 Assert.AreEqual(DateTime.FromOADate(value), cell.CachedValue);
-                Assert.AreEqual("03:48", cell.GetFormattedString());
+                Assert.AreEqual("03:45", cell.GetFormattedString());
 
                 cell.DataType = XLDataType.Number;
                 Assert.AreEqual(value, (double)cell.CachedValue, 1e-10);
-                Assert.AreEqual("0.158333333333333", cell.GetFormattedString());
+                Assert.AreEqual("0.15625", cell.GetFormattedString());
 
                 cell.DataType = XLDataType.TimeSpan;
                 Assert.AreEqual(TimeSpan.FromDays(value), (TimeSpan)cell.CachedValue);
-                Assert.AreEqual("03:48:00", cell.GetFormattedString()); // I think the seconds in this string is due to a shortcoming in the ExcelNumberFormat library
+                Assert.AreEqual("03:45:00", cell.GetFormattedString()); // I think the seconds in this string is due to a shortcoming in the ExcelNumberFormat library
             }
         }
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.95.0.{build}
 
-os: Visual Studio 2017
-image: Visual Studio 2017
+os: Visual Studio 2019
+image: Visual Studio 2019
 
 environment:
   AppVeyor: APPVEYOR


### PR DESCRIPTION
Fixes #1318

Fixes #1273

Fixes #1274 

One test is still failing due to andersnm/ExcelNumberFormat#23.

@igitur should we switch to `netcoreapp3.0` in tests or add it as a new target (the 4th one)?