### PR TITLE
[WIP] Do not consider cell as having RichText unless it has been explicitly modified (#1271)

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1457,7 +1457,11 @@ namespace ClosedXML.Excel
 
         public bool HasRichText
         {
-            get { return _richText != null; }
+            get
+            {
+                return _richText is XLRichText richText &&
+                       !richText.IsDefault;
+            }
         }
 
         IXLComment IXLCell.Comment

--- a/ClosedXML/Excel/RichText/XLFormattedText.cs
+++ b/ClosedXML/Excel/RichText/XLFormattedText.cs
@@ -11,10 +11,12 @@ namespace ClosedXML.Excel
 
         protected T Container;
         readonly IXLFontBase _defaultFont;
+
         public XLFormattedText(IXLFontBase defaultFont)
         {
             Length = 0;
             _defaultFont = defaultFont;
+            _isDefault = true;
         }
 
         public XLFormattedText(IXLFormattedText<T> defaultRichText, IXLFontBase defaultFont)
@@ -26,13 +28,24 @@ namespace ClosedXML.Excel
             {
                 _phonetics = new XLPhonetics(defaultRichText.Phonetics, defaultFont);
             }
+
+            _isDefault = _richTexts.Count <= 1;
         }
 
         public XLFormattedText(String text, IXLFontBase defaultFont)
             :this(defaultFont)
         {
             AddText(text);
+            _isDefault = true;
         }
+
+        private bool _isDefault;
+
+        /// <summary>
+        /// Flag showing that the formatted text was constructed from a simple string and has not change since then.
+        /// When IsDefault is true a rich text can be converted to an ordinary text without information loss.
+        /// </summary>
+        internal bool IsDefault => _isDefault && !HasPhonetics;
 
         public Int32 Count { get { return _richTexts.Count; } }
         public int Length { get; private set; }
@@ -51,6 +64,7 @@ namespace ClosedXML.Excel
         {
             _richTexts.Add(richText);
             Length += richText.Text.Length;
+            _isDefault = false;
             return richText;
         }
 
@@ -63,6 +77,7 @@ namespace ClosedXML.Excel
         {
             _richTexts.Clear();
             Length = 0;
+            _isDefault = true;
             return this;
         }
         public IXLFormattedText<T> ClearFont()
@@ -70,6 +85,7 @@ namespace ClosedXML.Excel
             String text = Text;
             ClearText();
             AddText(text);
+            _isDefault = true;
             return this;
         }
 
@@ -126,6 +142,7 @@ namespace ClosedXML.Excel
                 lastPosition += rt.Text.Length;
             }
             _richTexts = newRichTexts;
+            _isDefault = false;
             return retVal;
         }
 
@@ -139,16 +156,95 @@ namespace ClosedXML.Excel
             return GetEnumerator();
         }
 
-        public Boolean Bold { set { _richTexts.ForEach(rt => rt.Bold = value); } }
-        public Boolean Italic { set { _richTexts.ForEach(rt => rt.Italic = value); } }
-        public XLFontUnderlineValues Underline { set { _richTexts.ForEach(rt => rt.Underline = value); } }
-        public Boolean Strikethrough { set { _richTexts.ForEach(rt => rt.Strikethrough = value); } }
-        public XLFontVerticalTextAlignmentValues VerticalAlignment { set { _richTexts.ForEach(rt => rt.VerticalAlignment = value); } }
-        public Boolean Shadow { set { _richTexts.ForEach(rt => rt.Shadow = value); } }
-        public Double FontSize { set { _richTexts.ForEach(rt => rt.FontSize = value); } }
-        public XLColor FontColor { set { _richTexts.ForEach(rt => rt.FontColor = value); } }
-        public String FontName { set { _richTexts.ForEach(rt => rt.FontName = value); } }
-        public XLFontFamilyNumberingValues FontFamilyNumbering { set { _richTexts.ForEach(rt => rt.FontFamilyNumbering = value); } }
+        public Boolean Bold
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.Bold = value);
+                _isDefault = false;
+            }
+        }
+
+        public Boolean Italic
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.Italic = value);
+                _isDefault = false;
+            }
+        }
+
+        public XLFontUnderlineValues Underline
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.Underline = value);
+                _isDefault = false;
+            }
+        }
+
+        public Boolean Strikethrough
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.Strikethrough = value);
+                _isDefault = false;
+            }
+        }
+
+        public XLFontVerticalTextAlignmentValues VerticalAlignment
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.VerticalAlignment = value);
+                _isDefault = false;
+            }
+        }
+
+        public Boolean Shadow
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.Shadow = value);
+                _isDefault = false;
+            }
+        }
+
+        public Double FontSize
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.FontSize = value);
+                _isDefault = false;
+            }
+        }
+
+        public XLColor FontColor
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.FontColor = value);
+                _isDefault = false;
+            }
+        }
+
+        public String FontName
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.FontName = value);
+                _isDefault = false;
+            }
+        }
+
+        public XLFontFamilyNumberingValues FontFamilyNumbering
+        {
+            set
+            {
+                _richTexts.ForEach(rt => rt.FontFamilyNumbering = value);
+                _isDefault = false;
+            }
+        }
 
         public IXLFormattedText<T> SetBold() { Bold = true; return this; }	public IXLFormattedText<T> SetBold(Boolean value) { Bold = value; return this; }
         public IXLFormattedText<T> SetItalic() { Italic = true; return this; }	public IXLFormattedText<T> SetItalic(Boolean value) { Italic = value; return this; }

--- a/ClosedXML_Tests/Excel/RichText/XLRichStringTests.cs
+++ b/ClosedXML_Tests/Excel/RichText/XLRichStringTests.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
+using System.Linq;
 
 namespace ClosedXML_Tests
 {
@@ -667,6 +667,97 @@ namespace ClosedXML_Tests
             expected = String.Empty;
             actual = richString.ToString();
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ConstructDefaultRichText()
+        {
+            var richText = new XLRichText(XLFont.DefaultCommentFont);
+            Assert.IsTrue(richText.IsDefault);
+
+            richText = new XLRichText("Test", XLFont.DefaultCommentFont);
+            Assert.IsTrue(richText.IsDefault);
+
+            richText = new XLRichText(richText, XLFont.DefaultCommentFont);
+            Assert.IsTrue(richText.IsDefault);
+        }
+
+        [Test]
+        public void RichTextEditMakesItNonDefault()
+        {
+            var richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Bold = true;
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.FontColor = XLColor.CosmicLatte;
+            Assert.IsFalse(richText.IsDefault);
+            
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.FontFamilyNumbering = XLFontFamilyNumberingValues.Script;
+            Assert.IsFalse(richText.IsDefault);
+            
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.FontName = "Times";
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.FontSize = 20;
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Italic = true;
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Phonetics.Add("abc", 0, 1);
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Shadow = true;
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Strikethrough = true;
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.AddNewLine();
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.AddText("Custom");
+            Assert.IsFalse(richText.IsDefault);
+
+            richText = new XLRichText("Test", XLFont.DefaultCommentFont);
+            richText.Substring(0);
+            Assert.IsFalse(richText.IsDefault);
+        }
+
+        [Test]
+        public void ClearRichTextMakesItDefault()
+        {
+            var richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Bold = true;
+            richText.ClearFont();
+            Assert.IsTrue(richText.IsDefault);
+
+            richText = new XLRichText(XLFont.DefaultCommentFont);
+            richText.Bold = true;
+            richText.ClearText();
+            Assert.IsTrue(richText.IsDefault);
+        }
+
+        [Test(Description = "See #1271")]
+        public void DefaultRichTextDoesNotAffectValue()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            var cell = ws.Cell("A1");
+            cell.Value = 123.45;
+            cell.Style.NumberFormat.Format = "$ 0.00";
+
+            Assert.AreEqual("$ 123.45", cell.RichText.ToString());
+            Assert.AreEqual(123.45, cell.GetValue<double>(), XLHelper.Epsilon);
         }
     }
 }


### PR DESCRIPTION
Fixes #1271 

I think this can be tricky for the user to avoid unnecessary RichText initialization with a 100% guarantee and this may lead to errors. At the same time, we have to preserve existing behavior: `XLCell.RichText` should create a new instance of `XLRichText` when accessed if it did not exist.

So I tried to find a balance between two: `XLCell.RichText` does create a new instance but it is considered "default" and does not affect `Value` property until that rich text is modified in some way.