### PR TITLE
CEILING and FLOOR fixes

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -26,7 +26,8 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ATAN2", 2, Atan2);
             ce.RegisterFunction("ATANH", 1, Atanh);
             ce.RegisterFunction("BASE", 2, 3, Base);
-            ce.RegisterFunction("CEILING", 1, Ceiling);
+            ce.RegisterFunction("CEILING", 2, Ceiling);
+            ce.RegisterFunction("CEILING.MATH", 1, 3, CeilingMath);
             ce.RegisterFunction("COMBIN", 2, Combin);
             ce.RegisterFunction("COMBINA", 2, CombinA);
             ce.RegisterFunction("COS", 1, Cos);
@@ -129,7 +130,34 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static object Ceiling(List<Expression> p)
         {
-            return Math.Ceiling(p[0]);
+            double number = p[0];
+            double significance = 1;
+            if (p.Count > 1)
+                significance = p[1];
+
+            if (significance < 0 && number > 0)
+                throw new NumberException();
+            else if (significance < 0)
+                return -Math.Ceiling(-number / -significance) * -significance;
+            else
+                return Math.Ceiling(number / significance) * significance;
+        }
+
+        private static object CeilingMath(List<Expression> p)
+        {
+            double number = p[0];
+            double significance = 1;
+            if (p.Count > 1) significance = p[1];
+
+            double mode = 0;
+            if (p.Count > 2) mode = p[2];
+
+            if (number >= 0)
+                return Math.Ceiling(number / Math.Abs(significance)) * Math.Abs(significance);
+            else if (mode == 0)
+                return Math.Ceiling(number / Math.Abs(significance)) * Math.Abs(significance);
+            else
+                return -Math.Ceiling(-number / Math.Abs(significance)) * Math.Abs(significance);
         }
 
         private static object Cos(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -131,9 +131,7 @@ namespace ClosedXML.Excel.CalcEngine
         private static object Ceiling(List<Expression> p)
         {
             double number = p[0];
-            double significance = 1;
-            if (p.Count > 1)
-                significance = p[1];
+            double significance = p[1];
 
             if (significance < 0 && number > 0)
                 throw new NumberException();
@@ -248,9 +246,7 @@ namespace ClosedXML.Excel.CalcEngine
         private static object Floor(List<Expression> p)
         {
             double number = p[0];
-            double significance = 1;
-            if (p.Count > 1)
-                significance = p[1];
+            double significance = p[1];
 
             if (significance < 0 && number > 0)
                 throw new NumberException();

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("EXP", 1, Exp);
             ce.RegisterFunction("FACT", 1, Fact);
             ce.RegisterFunction("FACTDOUBLE", 1, FactDouble);
-            ce.RegisterFunction("FLOOR", 1, 2, Floor);
+            ce.RegisterFunction("FLOOR", 2, Floor);
             ce.RegisterFunction("FLOOR.MATH", 1, 3, FloorMath);
             ce.RegisterFunction("GCD", 1, 255, Gcd);
             ce.RegisterFunction("INT", 1, Int);
@@ -252,15 +252,10 @@ namespace ClosedXML.Excel.CalcEngine
             if (p.Count > 1)
                 significance = p[1];
 
-            if (significance < 0)
-            {
-                number = -number;
-                significance = -significance;
-
-                return -Math.Floor(number / significance) * significance;
-            }
-            else if (significance == 1)
-                return Math.Floor(number);
+            if (significance < 0 && number > 0)
+                throw new NumberException();
+            else if (significance < 0)
+                return -Math.Floor(-number / -significance) * -significance;
             else
                 return Math.Floor(number / significance) * significance;
         }
@@ -276,7 +271,7 @@ namespace ClosedXML.Excel.CalcEngine
 
             if (number >= 0)
                 return Math.Floor(number / Math.Abs(significance)) * Math.Abs(significance);
-            else if (mode >= 0)
+            else if (mode == 0)
                 return Math.Floor(number / Math.Abs(significance)) * Math.Abs(significance);
             else
                 return -Math.Floor(-number / Math.Abs(significance)) * Math.Abs(significance);

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -133,7 +133,9 @@ namespace ClosedXML.Excel.CalcEngine
             double number = p[0];
             double significance = p[1];
 
-            if (significance < 0 && number > 0)
+            if (significance == 0)
+                return 0d;
+            else if (significance < 0 && number > 0)
                 throw new NumberException();
             else if (significance < 0)
                 return -Math.Ceiling(-number / -significance) * -significance;
@@ -150,7 +152,9 @@ namespace ClosedXML.Excel.CalcEngine
             double mode = 0;
             if (p.Count > 2) mode = p[2];
 
-            if (number >= 0)
+            if (significance == 0)
+                return 0d;
+            else if (number >= 0)
                 return Math.Ceiling(number / Math.Abs(significance)) * Math.Abs(significance);
             else if (mode == 0)
                 return Math.Ceiling(number / Math.Abs(significance)) * Math.Abs(significance);
@@ -248,7 +252,9 @@ namespace ClosedXML.Excel.CalcEngine
             double number = p[0];
             double significance = p[1];
 
-            if (significance < 0 && number > 0)
+            if (significance == 0)
+                throw new DivisionByZeroException();
+            else if (significance < 0 && number > 0)
                 throw new NumberException();
             else if (significance < 0)
                 return -Math.Floor(-number / -significance) * -significance;
@@ -265,7 +271,9 @@ namespace ClosedXML.Excel.CalcEngine
             double mode = 0;
             if (p.Count > 2) mode = p[2];
 
-            if (number >= 0)
+            if (significance == 0)
+                return 0d;
+            else if (number >= 0)
                 return Math.Floor(number / Math.Abs(significance)) * Math.Abs(significance);
             else if (mode == 0)
                 return Math.Floor(number / Math.Abs(significance)) * Math.Abs(significance);

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -454,8 +454,10 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase(6.7, 1, 7)]
         [TestCase(-8.1, 2, -8)]
         [TestCase(5.5, 2.1, 6.3)]
+        [TestCase(5.5, 0, 0)]
         [TestCase(-5.5, 2.1, -4.2)]
         [TestCase(-5.5, -2.1, -6.3)]
+        [TestCase(-5.5, 0, 0)]
         public void Ceiling(double input, double significance, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})");
@@ -473,16 +475,22 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase(-8.1, 2, null, -8)]
         [TestCase(5.5, 2.1, 0, 6.3)]
         [TestCase(5.5, -2.1, 0, 6.3)]
+        [TestCase(5.5, 0, 0, 0)]
         [TestCase(5.5, 2.1, -1, 6.3)]
         [TestCase(5.5, -2.1, -1, 6.3)]
+        [TestCase(5.5, 0, -1, 0)]
         [TestCase(5.5, 2.1, 10, 6.3)]
         [TestCase(5.5, -2.1, 10, 6.3)]
+        [TestCase(5.5, 0, 10, 0)]
         [TestCase(-5.5, 2.1, 0, -4.2)]
         [TestCase(-5.5, -2.1, 0, -4.2)]
+        [TestCase(-5.5, 0, 0, 0)]
         [TestCase(-5.5, 2.1, -1, -6.3)]
         [TestCase(-5.5, -2.1, -1, -6.3)]
+        [TestCase(-5.5, 0, -1, 0)]
         [TestCase(-5.5, 2.1, 10, -6.3)]
         [TestCase(-5.5, -2.1, 10, -6.3)]
+        [TestCase(-5.5, 0, 10, 0)]
 
         public void CeilingMath(double input, double? step, int? mode, double expectedResult)
         {
@@ -953,6 +961,13 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.Throws<NumberException>(() => XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
         }
 
+        [TestCase(6.7, 0)]
+        [TestCase(-6.7, 0)]
+        public void Floor_ThrowsDivisionByZeroOnZeroSignificance(object input, object significance)
+        {
+            Assert.Throws<DivisionByZeroException>(() => XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
+        }
+
         [Test]
         // Functions have to support a period first before we can implement this
         [TestCase(24.3, 5, null, 20)]
@@ -960,17 +975,22 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase(-8.1, 2, null, -10)]
         [TestCase(5.5, 2.1, 0, 4.2)]
         [TestCase(5.5, -2.1, 0, 4.2)]
+        [TestCase(5.5, 0, 0, 0)]
         [TestCase(5.5, 2.1, -1, 4.2)]
         [TestCase(5.5, -2.1, -1, 4.2)]
+        [TestCase(5.5, 0, -2, 0)]
         [TestCase(5.5, 2.1, 10, 4.2)]
         [TestCase(5.5, -2.1, 10, 4.2)]
+        [TestCase(5.5, 0, 10, 0)]
         [TestCase(-5.5, 2.1, 0, -6.3)]
         [TestCase(-5.5, -2.1, 0, -6.3)]
+        [TestCase(-5.5, 0, 0, 0)]
         [TestCase(-5.5, 2.1, -1, -4.2)]
         [TestCase(-5.5, -2.1, -1, -4.2)]
+        [TestCase(-5.5, 0, -1, 0)]
         [TestCase(-5.5, 2.1, 10, -4.2)]
         [TestCase(-5.5, -2.1, 10, -4.2)]
-
+        [TestCase(-5.5, 0, 0, 0)]
         public void FloorMath(double input, double? step, int? mode, double expectedResult)
         {
             string parameters = input.ToString(CultureInfo.InvariantCulture);

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -450,6 +450,54 @@ namespace ClosedXML_Tests.Excel.CalcEngine
                     minLength)));
         }
 
+        [TestCase(24.3, 5, 25)]
+        [TestCase(6.7, 1, 7)]
+        [TestCase(-8.1, 2, -8)]
+        [TestCase(5.5, 2.1, 6.3)]
+        [TestCase(-5.5, 2.1, -4.2)]
+        [TestCase(-5.5, -2.1, -6.3)]
+        public void Ceiling(double input, double significance, double expectedResult)
+        {
+            var actual = (double)XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})");
+            Assert.AreEqual(expectedResult, actual, tolerance);
+        }
+
+        [TestCase(6.7, -1)]
+        public void Ceiling_ThrowsNumberExceptionOnInvalidInput(object input, object significance)
+        {
+            Assert.Throws<NumberException>(() => XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})"));
+        }
+
+        [TestCase(24.3, 5, null, 25)]
+        [TestCase(6.7, null, null, 7)]
+        [TestCase(-8.1, 2, null, -8)]
+        [TestCase(5.5, 2.1, 0, 6.3)]
+        [TestCase(5.5, -2.1, 0, 6.3)]
+        [TestCase(5.5, 2.1, -1, 6.3)]
+        [TestCase(5.5, -2.1, -1, 6.3)]
+        [TestCase(5.5, 2.1, 10, 6.3)]
+        [TestCase(5.5, -2.1, 10, 6.3)]
+        [TestCase(-5.5, 2.1, 0, -4.2)]
+        [TestCase(-5.5, -2.1, 0, -4.2)]
+        [TestCase(-5.5, 2.1, -1, -6.3)]
+        [TestCase(-5.5, -2.1, -1, -6.3)]
+        [TestCase(-5.5, 2.1, 10, -6.3)]
+        [TestCase(-5.5, -2.1, 10, -6.3)]
+
+        public void CeilingMath(double input, double? step, int? mode, double expectedResult)
+        {
+            string parameters = input.ToString(CultureInfo.InvariantCulture);
+            if (step != null)
+            {
+                parameters = parameters + ", " + step?.ToString(CultureInfo.InvariantCulture);
+                if (mode != null)
+                    parameters = parameters + ", " + mode?.ToString(CultureInfo.InvariantCulture);
+            }
+
+            var actual = (double)XLWorkbook.EvaluateExpr($"CEILING.MATH({parameters})");
+            Assert.AreEqual(expectedResult, actual, tolerance);
+        }
+
         [Theory]
         public void Combin_Returns1ForKis0OrKEqualsN([Range(0, 10)] int n)
         {

--- a/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -935,40 +935,22 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             Assert.Throws<CellValueException>(() => XLWorkbook.EvaluateExpr(string.Format(@"FACTDOUBLE(""x"")")));
         }
 
-        [Test]
-        public void Floor()
+        [TestCase(24.3, 5, 20)]
+        [TestCase(6.7, 1, 6)]
+        [TestCase(-8.1, 2, -10)]
+        [TestCase(5.5, 2.1, 4.2)]
+        [TestCase(-5.5, 2.1, -6.3)]
+        [TestCase(-5.5, -2.1, -4.2)]
+        public void Floor(double input, double significance, double expectedResult)
         {
-            Object actual;
+            var actual = (double)XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})");
+            Assert.AreEqual(expectedResult, actual, tolerance);
+        }
 
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(1.2)");
-            Assert.AreEqual(1, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(1.7)");
-            Assert.AreEqual(1, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(-1.7)");
-            Assert.AreEqual(-2, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(1.2, 1)");
-            Assert.AreEqual(1, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(1.7, 1)");
-            Assert.AreEqual(1, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(-1.7, 1)");
-            Assert.AreEqual(-2, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(0.4, 2)");
-            Assert.AreEqual(0, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(2.7, 2)");
-            Assert.AreEqual(2, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(7.8, 2)");
-            Assert.AreEqual(6, actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"FLOOR(-5.5, -2)");
-            Assert.AreEqual(-4, actual);
+        [TestCase(6.7, -1)]
+        public void Floor_ThrowsNumberExceptionOnInvalidInput(object input, object significance)
+        {
+            Assert.Throws<NumberException>(() => XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
         }
 
         [Test]
@@ -980,10 +962,15 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase(5.5, -2.1, 0, 4.2)]
         [TestCase(5.5, 2.1, -1, 4.2)]
         [TestCase(5.5, -2.1, -1, 4.2)]
+        [TestCase(5.5, 2.1, 10, 4.2)]
+        [TestCase(5.5, -2.1, 10, 4.2)]
         [TestCase(-5.5, 2.1, 0, -6.3)]
         [TestCase(-5.5, -2.1, 0, -6.3)]
         [TestCase(-5.5, 2.1, -1, -4.2)]
         [TestCase(-5.5, -2.1, -1, -4.2)]
+        [TestCase(-5.5, 2.1, 10, -4.2)]
+        [TestCase(-5.5, -2.1, 10, -4.2)]
+
         public void FloorMath(double input, double? step, int? mode, double expectedResult)
         {
             string parameters = input.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
- Change the signature of CEILING and FLOOR to accept only 2 arguments, matching Excel behavior
- Invalid arguments to the CEILING and FLOOR (positive number and negative significance) throw NumberException, matching Excel behavior
- Fixed the mode argument behavior in FLOOR.MATH to match Excel behavior
- Implemented CEILING.MATH

Fixes #1366 