### PR TITLE
When saving, mark the first selected tab as active if no active tabs exist (#1383)

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -773,14 +773,25 @@ namespace ClosedXML.Excel
 
             if (activeTab == 0)
             {
-                activeTab = firstSheetVisible;
+                UInt32? firstActiveTab = null;
+                UInt32? firstSelectedTab = null;
                 foreach (var ws in worksheets)
                 {
-                    if (!ws.TabActive) continue;
+                    if (ws.TabActive)
+                    {
+                        firstActiveTab = (UInt32)(ws.Position - 1);
+                        break;
+                    }
 
-                    activeTab = (UInt32)(ws.Position - 1);
-                    break;
+                    if (ws.TabSelected)
+                    {
+                        firstSelectedTab = (UInt32)(ws.Position - 1);
+                    }
                 }
+
+                activeTab = firstActiveTab
+                         ?? firstSelectedTab
+                         ?? firstSheetVisible;
             }
 
             if (workbookView == null)

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1142,5 +1142,31 @@ namespace ClosedXML_Tests
                 Assert.IsTrue(ws.Cell("B2").Style.Font.Italic);
             }
         }
+
+        [Test]
+        public void SelectedTabIsActive_WhenInsertBefore()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    var ws1 = wb.AddWorksheet();
+                    ws1.TabSelected = true;
+                    var ws2 = wb.Worksheets.Add(1);
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws1 = wb.Worksheets.First();
+                    var ws2 = wb.Worksheets.Last();
+
+                    Assert.IsFalse(ws1.TabActive);
+                    Assert.IsFalse(ws1.TabSelected);
+                    Assert.IsTrue(ws2.TabActive);
+                    Assert.IsTrue(ws2.TabSelected);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1383 

The issue occurred when there was no tab explicitly marked as active but there was a selected tab different than the first visible tab. On saving, we chose the first visible tab to become active while the selected tab remained selected. Excel showed it correspondingly.