### PR TITLE
Remove the dependency on FastMember. Improve performance of InsertData (#797)

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -51,6 +51,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
   </ItemGroup>
 
@@ -60,6 +61,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -75,11 +77,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)'=='Release.Signed'">
-    <PackageReference Include="FastMember.Signed" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)'!='Release.Signed'">
-    <PackageReference Include="FastMember" Version="1.3.0" />
-  </ItemGroup>
 </Project>

--- a/ClosedXML/Excel/XLTheme.cs
+++ b/ClosedXML/Excel/XLTheme.cs
@@ -1,4 +1,4 @@
-using FastMember;
+using System;
 using System.Linq;
 
 namespace ClosedXML.Excel
@@ -18,16 +18,49 @@ namespace ClosedXML.Excel
         public XLColor Hyperlink { get; set; }
         public XLColor FollowedHyperlink { get; set; }
 
-        private TypeAccessor accessor = TypeAccessor.Create(typeof(XLTheme));
-
         public XLColor ResolveThemeColor(XLThemeColor themeColor)
         {
-            var tc = themeColor.ToString();
-            var members = accessor.GetMembers();
-            if (members.Any(m => m.Name.Equals(tc)))
-                return accessor[this, tc] as XLColor;
-            else
-                return null;
+            switch (themeColor)
+            {
+                case XLThemeColor.Background1:
+                    return Background1;
+
+                case XLThemeColor.Text1:
+                    return Text1;
+
+                case XLThemeColor.Background2:
+                    return Background2;
+
+                case XLThemeColor.Text2:
+                    return Text2;
+
+                case XLThemeColor.Accent1:
+                    return Accent1;
+
+                case XLThemeColor.Accent2:
+                    return Accent2;
+
+                case XLThemeColor.Accent3:
+                    return Accent3;
+
+                case XLThemeColor.Accent4:
+                    return Accent4;
+                    
+                case XLThemeColor.Accent5:
+                    return Accent5;
+
+                case XLThemeColor.Accent6:
+                    return Accent6;
+
+                case XLThemeColor.Hyperlink:
+                    return Hyperlink;
+
+                case XLThemeColor.FollowedHyperlink:
+                    return FollowedHyperlink;
+
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/ClosedXML_Tests/Excel/Misc/StylesTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/StylesTests.cs
@@ -78,6 +78,14 @@ namespace ClosedXML_Tests.Excel.Misc
             }
         }
 
+        [Theory]
+        public void CanResolveAllThemeColors(XLThemeColor themeColor)
+        {
+            var theme = new XLWorkbook().Theme;
+            var color = theme.ResolveThemeColor(themeColor);
+            Assert.IsNotNull(color);
+        }
+
         [Test]
         public void SetStyleViaRowReference()
         {


### PR DESCRIPTION
(_edit Francois_) Addresses #797 , but does not completely close it. We should still provide a stripped down version of dumping data with minimal type checking, probably in a new `InsertXXX` method. 

