### PR TITLE
Refactoring of InsertData logic (#797)

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -205,19 +205,21 @@ namespace ClosedXML.Excel
                 return this;
             }
             else
-                return SetValue(value, true);
+                return SetValue(value, setTableHeader: true, checkMergedRanges: true);
         }
 
-        internal IXLCell SetValue<T>(T value, bool setTableHeader)
+        internal IXLCell SetValue<T>(T value, bool setTableHeader, bool checkMergedRanges)
         {
-            if (IsInferiorMergedCell())
+            if (checkMergedRanges && IsInferiorMergedCell())
                 return this;
 
             if (value == null)
                 return this.Clear(XLClearOptions.Contents);
 
-            FormulaA1 = String.Empty;
             _richText = null;
+            _formulaA1 = String.Empty;
+            _formulaR1C1 = null;
+            cachedValue = null;
 
             if (setTableHeader)
             {
@@ -226,14 +228,12 @@ namespace ClosedXML.Excel
             }
 
             var style = GetStyleForRead();
-            Boolean parsed;
-            string parsedValue;
 
             // For SetValue<T> we set the cell value directly to the parameter
             // as opposed to the other SetValue(object value) where we parse the string and try to decude the value
             var tuple = SetKnownTypedValue(value, style, acceptString: true);
-            parsedValue = tuple.Item1;
-            parsed = tuple.Item2;
+            var parsedValue = tuple.Item1;
+            var parsed = tuple.Item2;
 
             // If parsing was unsuccessful, we throw an ArgumentException
             // because we are using SetValue<T> (typed).
@@ -242,8 +242,6 @@ namespace ClosedXML.Excel
                 throw new ArgumentException($"Unable to set cell value to {value.ObjectToInvariantString()}");
 
             SetInternalCellValueString(parsedValue, validate: true, parseToCachedValue: false);
-
-            CachedValue = null;
 
             return this;
         }

--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -63,7 +63,7 @@ namespace ClosedXML.Excel
 
             if (count > 1)
             {
-                dictionary[key]--;
+                dictionary[key] = count - 1;
                 return false;
             }
             else

--- a/ClosedXML/Excel/InsertData/ArrayReader.cs
+++ b/ClosedXML/Excel/InsertData/ArrayReader.cs
@@ -1,0 +1,41 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class ArrayReader : IInsertDataReader
+    {
+        private readonly IEnumerable<IEnumerable> _data;
+
+        public ArrayReader(IEnumerable<IEnumerable> data)
+        {
+            _data = data ?? throw new ArgumentNullException(nameof(data));
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            return _data.Select(item => item.Cast<object>());
+        }
+
+        public int GetPropertiesCount()
+        {
+            if (!_data.Any())
+                return 0;
+
+            return _data.First().Cast<object>().Count();
+        }
+
+        public string GetPropertyName(int propertyIndex)
+        {
+            return null;
+        }
+
+        public int GetRecordsCount()
+        {
+            return _data.Count();
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/DataRecordReader.cs
+++ b/ClosedXML/Excel/InsertData/DataRecordReader.cs
@@ -1,0 +1,76 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class DataRecordReader : IInsertDataReader
+    {
+        private readonly IEnumerable<object>[] _inMemoryData;
+        private string[] _columns;
+
+        public DataRecordReader(IEnumerable<IDataRecord> data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            _inMemoryData = ReadToEnd(data).ToArray();
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            return _inMemoryData;
+        }
+
+        public int GetPropertiesCount()
+        {
+            return _columns.Length;
+        }
+
+        public string GetPropertyName(int propertyIndex)
+        {
+            if (propertyIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(propertyIndex), "Property index must be non-negative");
+
+            if (_columns == null)
+                return null;
+
+            if (propertyIndex >= _columns.Length)
+                throw new ArgumentOutOfRangeException($"{propertyIndex} exceeds the number of the table columns");
+
+            return _columns[propertyIndex];
+        }
+
+        public int GetRecordsCount()
+        {
+            return _inMemoryData.Length;
+        }
+
+        private IEnumerable<IEnumerable<object>> ReadToEnd(IEnumerable<IDataRecord> data)
+        {
+            foreach (var dataRecord in data)
+            {
+                yield return ToEnumerable(dataRecord).ToArray();
+            }
+        }
+
+        private IEnumerable<object> ToEnumerable(IDataRecord dataRecord)
+        {
+            var firstRow = false;
+            if (_columns == null)
+            {
+                firstRow = true;
+                _columns = new string[dataRecord.FieldCount];
+            }
+
+            for (int i = 0; i < dataRecord.FieldCount; i++)
+            {
+                if (firstRow)
+                    _columns[i] = dataRecord.GetName(i);
+
+                yield return dataRecord[i];
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/DataTableReader.cs
+++ b/ClosedXML/Excel/InsertData/DataTableReader.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class DataTableReader : IInsertDataReader
+    {
+        private readonly IEnumerable<DataRow> _dataRows;
+        private readonly DataTable _dataTable;
+
+        public DataTableReader(DataTable dataTable)
+        {
+            _dataTable = dataTable ?? throw new ArgumentNullException(nameof(dataTable));
+            _dataRows = _dataTable.Rows.Cast<DataRow>();
+        }
+
+        public DataTableReader(IEnumerable<DataRow> dataRows)
+        {
+            _dataRows = dataRows ?? throw new ArgumentNullException(nameof(dataRows));
+            _dataTable = _dataRows.FirstOrDefault()?.Table;
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            return _dataRows.Select(r => r.ItemArray);
+        }
+
+        public int GetPropertiesCount()
+        {
+            if (_dataTable != null)
+                return _dataTable.Columns.Count;
+
+            if (_dataRows.Any())
+                return _dataRows.First().ItemArray.Length;
+
+            return 0;
+        }
+
+        public string GetPropertyName(int propertyIndex)
+        {
+            if (propertyIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(propertyIndex), "Property index must be non-negative");
+
+            if (_dataTable == null)
+                return null;
+
+            if (propertyIndex >= _dataTable.Columns.Count)
+                throw new ArgumentOutOfRangeException($"{propertyIndex} exceeds the number of the table columns");
+
+            return _dataTable.Columns[propertyIndex].Caption;
+        }
+
+        public int GetRecordsCount()
+        {
+            return _dataRows.Count();
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/IInsertDataReader.cs
+++ b/ClosedXML/Excel/InsertData/IInsertDataReader.cs
@@ -1,0 +1,33 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.InsertData
+{
+    /// <summary>
+    /// A universal interface for different data readers used in InsertData logic.
+    /// </summary>
+    internal interface IInsertDataReader
+    {
+        /// <summary>
+        /// Get a collection of records, each as a collection of values, extracted from a source.
+        /// </summary>
+        IEnumerable<IEnumerable<object>> GetData();
+
+        /// <summary>
+        /// Get the number of properties to use as a table with.
+        /// Actual number of may vary in different records.
+        /// </summary>
+        int GetPropertiesCount();
+
+        /// <summary>
+        /// Get the title of the property with the specified index.
+        /// </summary>
+        string GetPropertyName(int propertyIndex);
+
+        /// <summary>
+        /// Get the total number of records.
+        /// </summary>
+        /// <returns></returns>
+        int GetRecordsCount();
+    }
+}

--- a/ClosedXML/Excel/InsertData/InsertDataReaderFactory.cs
+++ b/ClosedXML/Excel/InsertData/InsertDataReaderFactory.cs
@@ -1,0 +1,63 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class InsertDataReaderFactory
+    {
+        private static readonly Lazy<InsertDataReaderFactory> _instance =
+            new Lazy<InsertDataReaderFactory>(() => new InsertDataReaderFactory());
+
+        public static InsertDataReaderFactory Instance => _instance.Value;
+
+        public IInsertDataReader CreateReader(IEnumerable data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            var itemType = data.GetItemType();
+
+            if (itemType == null || itemType == typeof(Object))
+                return new UntypedObjectReader(data);
+            else if (itemType.IsNullableType() && itemType.GetUnderlyingType().IsSimpleType())
+                return new SimpleNullableTypeReader(data);
+            else if (itemType.IsSimpleType())
+                return new SimpleTypeReader(data);
+            else if (typeof(IDataRecord).IsAssignableFrom(itemType))
+                return new DataRecordReader(data.OfType<IDataRecord>());
+            else if (itemType.IsArray || typeof(IEnumerable).IsAssignableFrom(itemType))
+                return new ArrayReader(data.Cast<IEnumerable>());
+            else if (itemType == typeof(DataRow))
+                return new DataTableReader(data.Cast<DataRow>());
+
+            return new ObjectReader(data);
+        }
+
+        public IInsertDataReader CreateReader<T>(IEnumerable<T[]> data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            return new ArrayReader(data);
+        }
+
+        public IInsertDataReader CreateReader(IEnumerable<IEnumerable> data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            if (data?.GetType().GetElementType() == typeof(String))
+                return new SimpleTypeReader(data);
+
+            return new ArrayReader(data);
+        }
+
+        public IInsertDataReader CreateReader(DataTable dataTable)
+        {
+            if (dataTable == null) throw new ArgumentNullException(nameof(dataTable));
+
+            return new DataTableReader(dataTable);
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/NullDataReader.cs
+++ b/ClosedXML/Excel/InsertData/NullDataReader.cs
@@ -1,0 +1,40 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class NullDataReader : IInsertDataReader
+    {
+        private readonly int _count;
+
+        public NullDataReader(IEnumerable<object> nulls)
+        {
+            _count = nulls.Count();
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            var res = new object[] { null }.AsEnumerable();
+            for (int i = 0; i < _count; i++)
+            {
+                yield return res;
+            }
+        }
+
+        public int GetPropertiesCount()
+        {
+            return 0;
+        }
+
+        public string GetPropertyName(int propertyIndex)
+        {
+            return null;
+        }
+
+        public int GetRecordsCount()
+        {
+            return _count;
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/ObjectReader.cs
+++ b/ClosedXML/Excel/InsertData/ObjectReader.cs
@@ -1,0 +1,102 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using ClosedXML.Attributes;
+using ClosedXML.Extensions;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class ObjectReader : IInsertDataReader
+    {
+        private const BindingFlags bindingFlags = BindingFlags.Public
+                                                  | BindingFlags.Instance
+                                                  | BindingFlags.Static;
+
+        private readonly IEnumerable<object> _data;
+        private readonly MemberInfo[] _members;
+        private readonly bool[] _staticMembers;
+
+        public ObjectReader(IEnumerable data)
+        {
+            _data = data?.Cast<object>() ?? throw new ArgumentNullException(nameof(data));
+
+            var itemType = data.GetItemType();
+            if (itemType.IsNullableType())
+                itemType = itemType.GetUnderlyingType();
+
+            _members = itemType.GetFields(bindingFlags).Cast<MemberInfo>()
+                .Concat(itemType.GetProperties(bindingFlags))
+                .Where(mi => !XLColumnAttribute.IgnoreMember(mi))
+                .OrderBy(mi => XLColumnAttribute.GetOrder(mi))
+                .ToArray();
+
+            _staticMembers = _members.Select(ReflectionExtensions.IsStatic).ToArray();
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            return _data.Select(GetItemData);
+        }
+
+        public int GetPropertiesCount()
+        {
+            return _members.Length;
+        }
+
+        public string GetPropertyName(int propertyIndex)
+        {
+            if (propertyIndex < 0)
+                throw new ArgumentOutOfRangeException(nameof(propertyIndex), "Property index must be non-negative");
+
+            if (propertyIndex >= GetPropertiesCount())
+                throw new ArgumentOutOfRangeException($"{propertyIndex} exceeds the number of the object properties");
+
+            var memberInfo = _members[propertyIndex];
+            var fieldName = XLColumnAttribute.GetHeader(memberInfo);
+            if (String.IsNullOrWhiteSpace(fieldName))
+                fieldName = memberInfo.Name;
+
+            return fieldName;
+        }
+
+        public int GetRecordsCount()
+        {
+            return _data.Count();
+        }
+
+        private IEnumerable<object> GetItemData(object item)
+        {
+            for (int i = 0; i < _members.Length; i++)
+            {
+                if (item == null)
+                {
+                    yield return null;
+                    continue;
+                }
+
+                var memberInfo = _members[i];
+                switch (memberInfo)
+                {
+                    case PropertyInfo propertyInfo when _staticMembers[i]:
+                        yield return propertyInfo.GetValue(null, null);
+                        break;
+
+                    case PropertyInfo propertyInfo:
+                        yield return propertyInfo.GetValue(item, null);
+                        break;
+
+                    case FieldInfo fieldInfo when _staticMembers[i]:
+                        yield return fieldInfo.GetValue(null);
+                        break;
+
+                    case FieldInfo fieldInfo:
+                        yield return fieldInfo.GetValue(item);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/SimpleNullableTypeReader.cs
+++ b/ClosedXML/Excel/InsertData/SimpleNullableTypeReader.cs
@@ -1,0 +1,43 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class SimpleNullableTypeReader : IInsertDataReader
+    {
+        private readonly IEnumerable<object> _data;
+        private readonly Type _itemType;
+
+        public SimpleNullableTypeReader(IEnumerable data)
+        {
+            _data = data?.Cast<object>() ?? throw new ArgumentNullException(nameof(data));
+            _itemType = data.GetItemType().GetUnderlyingType();
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            return _data.Select(item => new[] { item }.Cast<object>());
+        }
+
+        public int GetPropertiesCount()
+        {
+            return 1;
+        }
+
+        public string GetPropertyName(int propertyIndex = 0)
+        {
+            if (propertyIndex != 0)
+                throw new ArgumentException("SimpleNullableTypeReader supports only a single property");
+
+            return _itemType.Name;
+        }
+
+        public int GetRecordsCount()
+        {
+            return _data.Count();
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/SimpleTypeReader.cs
+++ b/ClosedXML/Excel/InsertData/SimpleTypeReader.cs
@@ -1,0 +1,43 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class SimpleTypeReader : IInsertDataReader
+    {
+        private readonly IEnumerable<object> _data;
+        private readonly Type _itemType;
+
+        public SimpleTypeReader(IEnumerable data)
+        {
+            _data = data?.Cast<object>() ?? throw new ArgumentNullException(nameof(data));
+            _itemType = data.GetItemType();
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            return _data.Select(item => new[] { item }.Cast<object>());
+        }
+
+        public int GetPropertiesCount()
+        {
+            return 1;
+        }
+
+        public string GetPropertyName(int propertyIndex = 0)
+        {
+            if (propertyIndex != 0)
+                throw new ArgumentException("SimpleTypeReader supports only a single property");
+
+            return _itemType.Name;
+        }
+
+        public int GetRecordsCount()
+        {
+            return _data.Count();
+        }
+    }
+}

--- a/ClosedXML/Excel/InsertData/UntypedObjectReader.cs
+++ b/ClosedXML/Excel/InsertData/UntypedObjectReader.cs
@@ -1,0 +1,89 @@
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.InsertData
+{
+    internal class UntypedObjectReader : IInsertDataReader
+    {
+        private readonly IEnumerable<object> _data;
+        private readonly IEnumerable<IInsertDataReader> _readers;
+
+        public UntypedObjectReader(IEnumerable data)
+        {
+            _data = (data ?? new object[0]).Cast<object>();
+            _readers = CreateReaders().ToList();
+
+            IEnumerable<IInsertDataReader> CreateReaders()
+            {
+                if (!_data.Any())
+                    yield break;
+
+                List<object> itemsOfSameType = new List<object>();
+                Type previousType = null;
+
+                foreach (var item in _data)
+                {
+                    var currentType = item?.GetType();
+
+                    if (previousType != currentType && itemsOfSameType.Count > 0)
+                    {
+                        yield return CreateReader(itemsOfSameType, previousType);
+                        itemsOfSameType.Clear();
+                    }
+                    itemsOfSameType.Add(item);
+                    previousType = currentType;
+                }
+
+                if (itemsOfSameType.Count > 0)
+                {
+                    yield return CreateReader(itemsOfSameType, previousType);
+                }
+            }
+
+            IInsertDataReader CreateReader(List<object> itemsOfSameType, Type itemType)
+            {
+                if (itemType == null)
+                    return new NullDataReader(itemsOfSameType);
+
+                var items = Array.CreateInstance(itemType, itemsOfSameType.Count);
+                Array.Copy(itemsOfSameType.ToArray(), items, items.Length);
+
+                return InsertDataReaderFactory.Instance.CreateReader(items);
+            }
+        }
+
+        public IEnumerable<IEnumerable<object>> GetData()
+        {
+            foreach (var reader in _readers)
+            {
+                foreach (var item in reader.GetData())
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        public int GetPropertiesCount()
+        {
+            return GetFirstNonNullReader()?.GetPropertiesCount() ?? 0;
+        }
+
+        public string GetPropertyName(int propertyIndex)
+        {
+            return GetFirstNonNullReader()?.GetPropertyName(propertyIndex);
+        }
+
+        public int GetRecordsCount()
+        {
+            return _data.Count();
+        }
+
+        private IInsertDataReader GetFirstNonNullReader()
+        {
+            return _readers.FirstOrDefault(r => !(r is NullDataReader));
+        }
+    }
+}

--- a/ClosedXML/Excel/Tables/XLTableField.cs
+++ b/ClosedXML/Excel/Tables/XLTableField.cs
@@ -86,7 +86,7 @@ namespace ClosedXML.Excel
                 if (name == value) return;
 
                 if (table.ShowHeaderRow)
-                    (table.HeadersRow(false).Cell(Index + 1) as XLCell).SetValue(value, false);
+                    (table.HeadersRow(false).Cell(Index + 1) as XLCell).SetValue(value, setTableHeader: false, checkMergedRanges: true);
 
                 table.RenameField(name, value);
                 name = value;
@@ -142,7 +142,7 @@ namespace ClosedXML.Excel
             set
             {
                 totalsRowFunction = XLTotalsRowFunction.None;
-                (table.TotalsRow().Cell(Index + 1) as XLCell).SetValue(value, false);
+                (table.TotalsRow().Cell(Index + 1) as XLCell).SetValue(value, setTableHeader: false, checkMergedRanges:true);
                 totalsRowLabel = value;
             }
         }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1831,11 +1831,11 @@ namespace ClosedXML.Excel
         internal void SetValue<T>(T value, int ro, int co) where T : class
         {
             if (value == null)
-                this.Cell(ro, co).SetValue(String.Empty);
+                this.Cell(ro, co).SetValue(String.Empty, setTableHeader: true, checkMergedRanges: false);
             else if (value is IConvertible)
-                this.Cell(ro, co).SetValue((T)Convert.ChangeType(value, typeof(T)));
+                this.Cell(ro, co).SetValue((T)Convert.ChangeType(value, typeof(T)), setTableHeader: true, checkMergedRanges: false);
             else
-                this.Cell(ro, co).SetValue(value);
+                this.Cell(ro, co).SetValue(value, setTableHeader: true, checkMergedRanges: false);
         }
 
         /// <summary>

--- a/ClosedXML/Extensions/EnumerableExtensions.cs
+++ b/ClosedXML/Extensions/EnumerableExtensions.cs
@@ -1,5 +1,6 @@
 // Keep this file CodeMaid organised and cleaned
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,9 +14,9 @@ namespace ClosedXML.Excel
                 action(item);
         }
 
-        public static Type GetItemType<T>(this IEnumerable<T> source)
+        public static Type GetItemType(this IEnumerable source)
         {
-            return GetGenericArgument(source?.GetType()) ?? typeof(T);
+            return GetGenericArgument(source?.GetType());
 
             Type GetGenericArgument(Type collectionType)
             {

--- a/ClosedXML/Extensions/EnumerableExtensions.cs
+++ b/ClosedXML/Extensions/EnumerableExtensions.cs
@@ -1,6 +1,7 @@
 // Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ClosedXML.Excel
 {
@@ -14,7 +15,19 @@ namespace ClosedXML.Excel
 
         public static Type GetItemType<T>(this IEnumerable<T> source)
         {
-            return typeof(T);
+            return GetGenericArgument(source?.GetType()) ?? typeof(T);
+
+            Type GetGenericArgument(Type collectionType)
+            {
+                if (collectionType == null)
+                    return null;
+
+                var ienumerable = collectionType.GetInterfaces()
+                    .SingleOrDefault(i => i.GetGenericArguments().Length == 1 &&
+                                          i.Name == "IEnumerable`1");
+
+                return ienumerable?.GetGenericArguments()?.FirstOrDefault();
+            }
         }
 
         public static Boolean HasDuplicates<T>(this IEnumerable<T> source)

--- a/ClosedXML/Extensions/ReflectionExtensions.cs
+++ b/ClosedXML/Extensions/ReflectionExtensions.cs
@@ -1,0 +1,19 @@
+// Keep this file CodeMaid organised and cleaned
+using System.Reflection;
+
+namespace ClosedXML.Extensions
+{
+    internal static class ReflectionExtensions
+    {
+        public static bool IsStatic(this MemberInfo memberInfo) =>
+            memberInfo switch
+            {
+                ConstructorInfo constructorInfo => constructorInfo.IsStatic,
+                EventInfo eventInfo => eventInfo.GetAddMethod().IsStatic,
+                FieldInfo fieldInfo => fieldInfo.IsStatic,
+                MethodInfo methodInfo => methodInfo.IsStatic,
+                PropertyInfo propertyInfo => propertyInfo.GetGetMethod().IsStatic,
+                _ => false
+            };
+    }
+}

--- a/ClosedXML_Tests/ClosedXML_Tests.csproj
+++ b/ClosedXML_Tests/ClosedXML_Tests.csproj
@@ -37,6 +37,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClosedXML_Tests/Excel/InsertData/ArrayTypeReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/ArrayTypeReaderTests.cs
@@ -1,0 +1,48 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class ArrayTypeReaderTests
+    {
+        private readonly int[][] _data = new int[][]
+        {
+            new[] {1, 2, 3},
+            new[] {4, 5, 6}
+        };
+
+        [Test]
+        public void GetPropertyNameReturnsNull()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.IsNull(reader.GetPropertyName(0));
+        }
+
+        [Test]
+        public void CanGetPropertiesCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(3, reader.GetPropertiesCount());
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(2, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanReadValues()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            var result = reader.GetData();
+
+            Assert.AreEqual(1, result.First().First());
+            Assert.AreEqual(3, result.First().Last());
+            Assert.AreEqual(4, result.Last().First());
+            Assert.AreEqual(6, result.Last().Last());
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/DataRecordReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/DataRecordReaderTests.cs
@@ -1,0 +1,79 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class DataRecordReaderTests
+    {
+        private readonly string _connectionString = @"Data Source=(localdb)\MSSQLLocalDB;Integrated Security=True;Connect Timeout=1";
+
+        private IEnumerable<IDataRecord> GetData()
+        {
+            const string queryString = @"
+            select 'Value 1' as StringValue, 100 as NumericValue
+            union all
+            select 'Value 2', 200
+            union all
+            select 'Value 3', 300";
+
+            using (var connection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(queryString, connection))
+            {
+                try
+                {
+                    connection.Open();
+                }
+                catch
+                {
+                    Assert.Ignore("Could not connect to localdb");
+                }
+
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        yield return reader;
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public void CanGetPropertyName()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+            Assert.AreEqual("StringValue", reader.GetPropertyName(0));
+            Assert.AreEqual("NumericValue", reader.GetPropertyName(1));
+        }
+
+        [Test]
+        public void CanGetPropertiesCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+            Assert.AreEqual(2, reader.GetPropertiesCount());
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+            Assert.AreEqual(3, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanGetData()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
+            var result = reader.GetData().ToArray();
+
+            Assert.AreEqual("Value 1", result.First().First());
+            Assert.AreEqual(100, result.First().Last());
+            Assert.AreEqual("Value 3", result.Last().First());
+            Assert.AreEqual(300, result.Last().Last());
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/DataRowReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/DataRowReaderTests.cs
@@ -1,0 +1,58 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System.Data;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class DataRowReaderTests
+    {
+        private readonly DataTable _data;
+
+        public DataRowReaderTests()
+        {
+            _data = new DataTable();
+            _data.Columns.Add("Last name");
+            _data.Columns.Add("First name");
+            _data.Columns.Add("Age", typeof(int));
+
+            _data.Rows.Add("Smith", "John", 33);
+            _data.Rows.Add("Ivanova", "Olga", 25);
+        }
+
+        [Test]
+        public void CanGetPropertyName()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual("Last name", reader.GetPropertyName(0));
+            Assert.AreEqual("First name", reader.GetPropertyName(1));
+            Assert.AreEqual("Age", reader.GetPropertyName(2));
+        }
+
+        [Test]
+        public void CanGetPropertiesCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(3, reader.GetPropertiesCount());
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(2, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanReadValue()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            var result = reader.GetData();
+
+            Assert.AreEqual("Smith", result.First().First());
+            Assert.AreEqual(33, result.First().Last());
+            Assert.AreEqual("Ivanova", result.Last().First());
+            Assert.AreEqual(25, result.Last().Last());
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
@@ -1,0 +1,167 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class InsertDataReaderFactoryTests
+    {
+        [Test]
+        public void CanInstantiateFactory()
+        {
+            var factory = InsertDataReaderFactory.Instance;
+
+            Assert.IsNotNull(factory);
+            Assert.AreSame(factory, InsertDataReaderFactory.Instance);
+        }
+
+        [TestCaseSource(nameof(SimpleSources))]
+        public void CanCreateSimpleReader(IEnumerable data)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+
+            Assert.IsInstanceOf<SimpleTypeReader>(reader);
+        }
+
+        private static IEnumerable<object> SimpleSources
+        {
+            get
+            {
+                yield return new[] { 1, 2, 3 };
+                yield return new List<double> { 1.0, 2.0, 3.0 };
+                yield return new[] { "A", "B", "C" };
+                yield return new[] { "A", "B", "C" }.Cast<object>();
+                yield return new[] { 'A', 'B', 'C' };
+            }
+        }
+
+        [TestCaseSource(nameof(SimpleNullableSources))]
+        public void CanCreateSimpleNullableReader(IEnumerable data)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+
+            Assert.IsInstanceOf<SimpleNullableTypeReader>(reader);
+        }
+
+        private static IEnumerable<object> SimpleNullableSources
+        {
+            get
+            {
+                yield return new int?[] { 1, 2, null };
+                yield return new List<double?> { 1.0, 2.0, null };
+                yield return new char?[] { 'A', 'B', null };
+                yield return new DateTime?[] { DateTime.MinValue, DateTime.MaxValue, null };
+            }
+        }
+
+        [TestCaseSource(nameof(ArraySources))]
+        public void CanCreateArrayReader<T>(IEnumerable<T> data)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+
+            Assert.IsInstanceOf<ArrayReader>(reader);
+        }
+
+        private static IEnumerable<object> ArraySources
+        {
+            get
+            {
+                yield return new int[][]
+                {
+                    new[] {1, 2, 3},
+                    new[] {4, 5, 6}
+                };
+                yield return new List<List<double>> { new List<double> { 1.0, 2.0, 3.0 } };
+                yield return (new int[][]
+                {
+                    new[] {1, 2, 3},
+                    new[] {4, 5, 6}
+                }).AsEnumerable();
+                yield return new Array[]
+                {
+                    Array.CreateInstance(typeof(decimal), 5),
+                    Array.CreateInstance(typeof(decimal), 5),
+                };
+            }
+        }
+
+        [Test]
+        public void CanCreateArrayReaderFromIEnumerableOfIEnumerables()
+        {
+            IEnumerable<IEnumerable> data = new List<IEnumerable>
+            {
+                new[] {1, 2, 3}.AsEnumerable(),
+                new[] {1.0, 2.0, 3.0}.AsEnumerable(),
+            };
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+
+            Assert.IsInstanceOf<ArrayReader>(reader);
+        }
+
+        [Test]
+        public void CanCreateSimpleReaderFromIEnumerableOfString()
+        {
+            IEnumerable<string> data = new []
+            {
+                "String 1",
+                "String 2",
+            };
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+
+            Assert.IsInstanceOf<SimpleTypeReader>(reader);
+        }
+
+        [Test]
+        public void CanCreateDataTableReader()
+        {
+            var dt = new DataTable();
+            var reader = InsertDataReaderFactory.Instance.CreateReader(dt);
+
+            Assert.IsInstanceOf<ClosedXML.Excel.InsertData.DataTableReader>(reader);
+        }
+
+        [Test]
+        public void CanCreateDataRecordReader()
+        {
+            var dataRecords = new IDataRecord[0];
+            var reader = InsertDataReaderFactory.Instance.CreateReader(dataRecords);
+            Assert.IsInstanceOf<DataRecordReader>(reader);
+        }
+
+        [Test]
+        public void CanCreateObjectReader()
+        {
+            var entities = new TestEntity[0];
+            var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
+            Assert.IsInstanceOf<ObjectReader>(reader);
+        }
+
+        [Test]
+        public void CanCreateObjectReaderForStruct()
+        {
+            var entities = new TestStruct[0];
+            var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
+            Assert.IsInstanceOf<ObjectReader>(reader);
+        }
+
+        [Test]
+        public void CanCreateUntypedObjectReader()
+        {
+            var entities = new ArrayList(new object[]
+            {
+                new TestEntity(),
+                "123",
+            });
+            var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
+            Assert.IsInstanceOf<UntypedObjectReader>(reader);
+        }
+
+        private class TestEntity { }
+
+        private struct TestStruct { }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/ObjectReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/ObjectReaderTests.cs
@@ -1,0 +1,194 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class ObjectReaderTests
+    {
+        private static readonly TablesTests.TestObjectWithAttributes[] ObjectWithAttributes =
+        {
+            new TablesTests.TestObjectWithAttributes
+            {
+                Column1 = "Value 1",
+                Column2 = "Value 2",
+                UnOrderedColumn = 3,
+                MyField = 4,
+            },
+            new TablesTests.TestObjectWithAttributes
+            {
+                Column1 = "Value 5",
+                Column2 = "Value 6",
+                UnOrderedColumn = 7,
+                MyField = 8,
+            }
+        };
+
+        private static readonly TablesTests.TestObjectWithoutAttributes[] ObjectWithoutAttributes =
+        {
+            new TablesTests.TestObjectWithoutAttributes
+            {
+                Column1 = "Value 9",
+                Column2 = "Value 10"
+            },
+            new TablesTests.TestObjectWithoutAttributes
+            {
+                Column1 = "Value 11",
+                Column2 = "Value 12"
+            }
+        };
+
+        private static readonly TestPoint[] Structs =
+        {
+            new TestPoint
+            {
+                X = 1,
+                Y = 2,
+                Z = 3
+            },
+            new TestPoint(),
+        };
+
+        private static readonly TestPoint?[] NullableStructs =
+        {
+            new TestPoint
+            {
+                X = 1,
+                Y = 2,
+                Z = 3
+            },
+            new TestPoint(),
+            null
+        };
+
+        [TestCaseSource(nameof(ObjectSourceNames))]
+        public string CanGetPropertyName<T>(IEnumerable<T> data, int propertyIndex)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+            return reader.GetPropertyName(propertyIndex);
+        }
+
+        private static IEnumerable<TestCaseData> ObjectSourceNames
+        {
+            get
+            {
+                IEnumerable data = ObjectWithoutAttributes;
+                yield return new TestCaseData(data, 0).Returns("Column1");
+                yield return new TestCaseData(data, 1).Returns("Column2");
+
+                data = ObjectWithAttributes;
+                yield return new TestCaseData(data, 0).Returns("FirstColumn");
+                yield return new TestCaseData(data, 1).Returns("SecondColumn");
+                yield return new TestCaseData(data, 2).Returns("SomeFieldNotProperty");
+                yield return new TestCaseData(data, 3).Returns("UnOrderedColumn");
+
+                data = Structs;
+                yield return new TestCaseData(data, 0).Returns("X");
+                yield return new TestCaseData(data, 1).Returns("Y");
+                yield return new TestCaseData(data, 2).Returns("Z");
+
+                data = NullableStructs;
+                yield return new TestCaseData(data, 0).Returns("X");
+                yield return new TestCaseData(data, 1).Returns("Y");
+                yield return new TestCaseData(data, 2).Returns("Z");
+            }
+        }
+
+        [TestCaseSource(nameof(PropertyCounts))]
+        public int CanGetPropertiesCount(IEnumerable data)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+            return reader.GetPropertiesCount();
+        }
+        
+        private static IEnumerable<TestCaseData> PropertyCounts
+        {
+            get
+            {
+                IEnumerable data = ObjectWithoutAttributes;
+                yield return new TestCaseData(data).Returns(2);
+
+                data = ObjectWithAttributes;
+                yield return new TestCaseData(data).Returns(4);
+
+                data = Structs;
+                yield return new TestCaseData(data).Returns(3);
+
+                data = NullableStructs;
+                yield return new TestCaseData(data).Returns(3);
+            }
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
+            Assert.AreEqual(2, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanReadValues_FromObject()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
+            var result = reader.GetData();
+
+            var firstRecord = result.First().ToArray();
+            var lastRecord = result.Last().ToArray();
+
+            Assert.AreEqual("Value 2", firstRecord[0]);
+            Assert.AreEqual("Value 1", firstRecord[1]);
+            Assert.AreEqual(4, firstRecord[2]);
+            Assert.AreEqual(3, firstRecord[3]);
+
+            Assert.AreEqual("Value 6", lastRecord[0]);
+            Assert.AreEqual("Value 5", lastRecord[1]);
+            Assert.AreEqual(8, lastRecord[2]);
+            Assert.AreEqual(7, lastRecord[3]);
+        }
+
+        [Test]
+        public void CanReadValues_FromStruct()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(Structs);
+            var result = reader.GetData();
+
+            var firstRecord = result.First().ToArray();
+            var lastRecord = result.Last().ToArray();
+
+            Assert.AreEqual(1, firstRecord[0]);
+            Assert.AreEqual(2, firstRecord[1]);
+            Assert.AreEqual(3, firstRecord[2]);
+
+            Assert.AreEqual(0, lastRecord[0]);
+            Assert.AreEqual(0, lastRecord[1]);
+            Assert.AreEqual(null, lastRecord[2]);
+        }
+
+        [Test]
+        public void CanReadValues_FromNullableStruct()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(NullableStructs);
+            var result = reader.GetData();
+
+            var firstRecord = result.First().ToArray();
+            var lastRecord = result.Last().ToArray();
+
+            Assert.AreEqual(1, firstRecord[0]);
+            Assert.AreEqual(2, firstRecord[1]);
+            Assert.AreEqual(3, firstRecord[2]);
+
+            Assert.AreEqual(null, lastRecord[0]);
+            Assert.AreEqual(null, lastRecord[1]);
+            Assert.AreEqual(null, lastRecord[2]);
+        }
+
+        private struct TestPoint
+        {
+            public double X { get; set; }
+            public double Y { get; set; }
+            public double? Z { get; set; }
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
@@ -1,0 +1,56 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class SimpleNullableTypeReaderTests
+    {
+        private readonly int?[] _data = { 1, 2, null };
+
+        [TestCaseSource(nameof(SimpleNullableSourceNames))]
+        public string CanGetPropertyName<T>(IEnumerable<T> data)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+            return reader.GetPropertyName(0);
+        }
+
+        private static IEnumerable<TestCaseData> SimpleNullableSourceNames
+        {
+            get
+            {
+                yield return new TestCaseData(new int?[] { 1, 2, null }).Returns("Int32");
+                yield return new TestCaseData(new List<double?> { 1.0, 2.0, null }).Returns("Double");
+                yield return new TestCaseData(new decimal?[] { 1.0m, 2.0m, null }).Returns("Decimal");
+                yield return new TestCaseData(new char?[] { 'A', 'B', null }).Returns("Char");
+                yield return new TestCaseData(new DateTime?[] { new DateTime(2020, 1, 1), null }).Returns("DateTime");
+            }
+        }
+
+        [Test]
+        public void CanGetPropertiesCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(1, reader.GetPropertiesCount());
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(3, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanReadValues()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            var result = reader.GetData();
+
+            Assert.AreEqual(1, result.First().Single());
+            Assert.AreEqual(null, result.Last().Single());
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/SimpleTypeReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/SimpleTypeReaderTests.cs
@@ -1,0 +1,57 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class SimpleTypeReaderTests
+    {
+        private readonly int[] _data = { 1, 2, 3 };
+
+        [TestCaseSource(nameof(SimpleSourceNames))]
+        public string CanGetPropertyName<T>(IEnumerable<T> data)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(data);
+            return reader.GetPropertyName(0);
+        }
+
+        private static IEnumerable<TestCaseData> SimpleSourceNames
+        {
+            get
+            {
+                yield return new TestCaseData(new[] { 1, 2, 3 }).Returns("Int32");
+                yield return new TestCaseData(new List<double> { 1.0, 2.0, 3.0 }).Returns("Double");
+                yield return new TestCaseData(new [] { 1.0m, 2.0m, 3.0m }).Returns("Decimal");
+                yield return new TestCaseData(arg: new [] { "A", "B", "C" }).Returns("String");
+                yield return new TestCaseData(new[] { 'A', 'B', 'C' }).Returns("Char");
+                yield return new TestCaseData(new [] { new DateTime(2020, 1, 1) }).Returns("DateTime");
+            }
+        }
+
+        [Test]
+        public void CanGetPropertiesCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(1, reader.GetPropertiesCount());
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(3, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanReadValues()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            var result = reader.GetData();
+
+            Assert.AreEqual(1, result.First().Single());
+            Assert.AreEqual(3, result.Last().Single());
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/InsertData/UntypedObjectReaderTests.cs
+++ b/ClosedXML_Tests/Excel/InsertData/UntypedObjectReaderTests.cs
@@ -1,0 +1,78 @@
+﻿using ClosedXML.Excel.InsertData;
+using NUnit.Framework;
+using System.Collections;
+using System.Linq;
+
+namespace ClosedXML_Tests.Excel.InsertData
+{
+    public class UntypedObjectReaderTests
+    {
+        private readonly ArrayList _data = new ArrayList(new object[]
+            {
+                null,
+                new TablesTests.TestObjectWithAttributes
+                {
+                    Column1 = "Value 1",
+                    Column2 = "Value 2",
+                    UnOrderedColumn = 3,
+                    MyField = 4,
+                },
+                null,
+                null,
+                null,
+                new int[]{ 1, 2, 3},
+                new int[]{ 4, 5, 6, 7},
+                "Separator",
+
+                new TablesTests.TestObjectWithoutAttributes
+                {
+                    Column1 = "Value 9",
+                    Column2 = "Value 10"
+                },
+            });
+
+        [TestCase(0, "FirstColumn")]
+        [TestCase(1, "SecondColumn")]
+        [TestCase(2, "SomeFieldNotProperty")]
+        [TestCase(3, "UnOrderedColumn")]
+        public void CanGetPropertyName(int propertyIndex, string expectedPropertyName)
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            var actualPropertyName = reader.GetPropertyName(propertyIndex);
+            Assert.AreEqual(expectedPropertyName, actualPropertyName);
+        }
+
+        [Test]
+        public void CanGetPropertiesCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(4, reader.GetPropertiesCount());
+        }
+
+        [Test]
+        public void CanGetRecordsCount()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+            Assert.AreEqual(9, reader.GetRecordsCount());
+        }
+
+        [Test]
+        public void CanGetData()
+        {
+            var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
+
+            var result = reader.GetData().ToArray();
+
+            Assert.AreEqual(new object [] { null }, result[0]);
+            Assert.AreEqual(new object[] { "Value 2", "Value 1", 4, 3 }, result[1]);
+            Assert.AreEqual(new object[] { null }, result[2]);
+            Assert.AreEqual(new object[] { null }, result[3]);
+            Assert.AreEqual(new object[] { null }, result[4]);
+            Assert.AreEqual(new object[] { 1, 2, 3 }, result[5]);
+            Assert.AreEqual(new object[] { 4, 5, 6, 7 }, result[6]);
+            Assert.AreEqual(new object[] { "Separator" }, result[7]);
+            Assert.AreEqual(new object[] { "Value 9", "Value 10" }, result[8]);
+        }
+    }
+}
+

--- a/ClosedXML_Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML_Tests/Excel/Tables/TablesTests.cs
@@ -248,6 +248,23 @@ namespace ClosedXML_Tests.Excel
         }
 
         [Test]
+        public void EmptyTableCreatedFromListOfObjectWithPropertyAttributes()
+        {
+            var l = new List<TestObjectWithAttributes>();
+
+            using (var wb = new XLWorkbook())
+            {
+                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+                ws.FirstCell().InsertTable(l);
+                Assert.AreEqual(4, ws.Tables.First().ColumnCount());
+                Assert.AreEqual("FirstColumn", ws.FirstCell().Value);
+                Assert.AreEqual("SecondColumn", ws.FirstCell().CellRight().Value);
+                Assert.AreEqual("SomeFieldNotProperty", ws.FirstCell().CellRight().CellRight().Value);
+                Assert.AreEqual("UnOrderedColumn", ws.FirstCell().CellRight().CellRight().CellRight().Value);
+            }
+        }
+
+        [Test]
         public void TableInsertAboveFromData()
         {
             using (var wb = new XLWorkbook())

--- a/ClosedXML_Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/ClosedXML_Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,0 +1,49 @@
+﻿using ClosedXML.Excel;
+using ClosedXML_Tests.Excel;
+using NUnit.Framework;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML_Tests.Extensions
+{
+    public class EnumerableExtensionsTests
+    {
+        [Test]
+        public void CanGetItemType()
+        {
+            var array = new int[0];
+            Assert.AreEqual(typeof(int), array.GetItemType());
+
+            var list = new List<double>();
+            Assert.AreEqual(typeof(double), list.GetItemType());
+            Assert.AreEqual(typeof(double), list.AsEnumerable().GetItemType());
+
+            IEnumerable<IEnumerable> enumerable = new List<string>();
+            Assert.AreEqual(typeof(string), enumerable.GetItemType());
+
+            enumerable = new List<List<string>>();
+            Assert.AreEqual(typeof(List<string>), enumerable.GetItemType());
+
+            enumerable = new List<int[]>();
+            Assert.AreEqual(typeof(int[]), enumerable.GetItemType());
+            
+            var anonymousIterator = new List<TablesTests.TestObjectWithoutAttributes>()
+                .Select(o => new { FirstName = o.Column1, LastName = o.Column2});
+
+            //expectedType can be something like <>f__AnonymousType9`2[System.String,System.String]
+            //but since that `9` may differ with new anonymous types declare in the assembly
+            //check the beginning and the ending of the actual type
+            var expectedTypeStart = "<>f__AnonymousType";
+            var expectedTypeEnd = "`2[System.String,System.String]";
+            var actualType = anonymousIterator.GetItemType().ToString();
+            Assert.True(actualType.StartsWith(expectedTypeStart));
+            Assert.True(actualType.EndsWith(expectedTypeEnd));
+
+            IEnumerable<object> obj = anonymousIterator;
+            actualType = obj.GetItemType().ToString();
+            Assert.True(actualType.StartsWith(expectedTypeStart));
+            Assert.True(actualType.EndsWith(expectedTypeEnd));
+        }
+    }
+}

--- a/ClosedXML_Tests/Extensions/ReflectionExtensionTests.cs
+++ b/ClosedXML_Tests/Extensions/ReflectionExtensionTests.cs
@@ -1,0 +1,65 @@
+using ClosedXML.Extensions;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ClosedXML_Tests.Extensions
+{
+    public class ReflectionExtensionTests
+    {
+        private class TestClass
+        {
+            static TestClass()
+            {
+            }
+
+            public static int StaticProperty { get; set; }
+            public static int StaticField;
+
+            public static event EventHandler<EventArgs> StaticEvent;
+
+            public static void StaticMethod()
+            {
+            }
+
+            public const int Const = 100;
+
+            public TestClass()
+            {
+            }
+
+            public int InstanceProperty { get; set; }
+            public int InstanceField;
+
+            public event EventHandler<EventArgs> InstanceEvent;
+
+            public void InstanceMethod()
+            {
+            }
+        }
+
+        [TestCase(nameof(TestClass.StaticProperty), true)]
+        [TestCase(nameof(TestClass.StaticField), true)]
+        [TestCase(nameof(TestClass.StaticEvent), true)]
+        [TestCase(nameof(TestClass.StaticMethod), true)]
+        [TestCase(nameof(TestClass.Const), true)]
+        [TestCase(nameof(TestClass.InstanceProperty), false)]
+        [TestCase(nameof(TestClass.InstanceField), false)]
+        [TestCase(nameof(TestClass.InstanceEvent), false)]
+        [TestCase(nameof(TestClass.InstanceMethod), false)]
+        public void IsStatic(string memberName, bool expectedIsStatic)
+        {
+            var member = typeof(TestClass).GetMember(memberName).Single();
+            Assert.AreEqual(expectedIsStatic, member.IsStatic());
+        }
+
+        [TestCase(BindingFlags.Static | BindingFlags.NonPublic, true)]
+        [TestCase(BindingFlags.Instance | BindingFlags.Public, false)]
+        public void ConstructorIsStatic(BindingFlags flag, bool expectedIsStatic)
+        {
+            var constructors = typeof(TestClass).GetConstructors(flag);
+            Assert.AreEqual(expectedIsStatic, constructors.Single().IsStatic());
+        }
+    }
+}


### PR DESCRIPTION
It is a continuation of #1388. It does not improve performance very much but, in my opinion, makes `InsertDataInternal` method much easier to understand and to extend, if we need it in the future.

Also, it fixes #1479 and adds support for collections of nullable structs as a table source.