### PR TITLE
Replace ContainsKey with TryGetValue

### DIFF
--- a/ClosedXML/Excel/Caching/XLRepositoryBase.cs
+++ b/ClosedXML/Excel/Caching/XLRepositoryBase.cs
@@ -43,7 +43,7 @@ namespace ClosedXML.Excel.Caching
             if (_storage.TryGetValue(key, out WeakReference cachedReference))
             {
                 value = cachedReference.Target as Tvalue;
-                return (value != null);
+                return value != null;
             }
             value = null;
             return false;
@@ -64,16 +64,14 @@ namespace ClosedXML.Excel.Caching
             if (value == null)
                 return null;
 
-            if (!_storage.ContainsKey(key))
+            if (!_storage.TryGetValue(key, out WeakReference cachedReference))
             {
                 _storage.TryAdd(key, new WeakReference(value));
                 return value;
             }
             else
             {
-                var cachedReference = _storage[key];
-                var storedValue = cachedReference.Target as Tvalue;
-                if (storedValue == null)
+                if (!(cachedReference.Target is Tvalue storedValue))
                 {
                     _storage.TryAdd(key, new WeakReference(value));
                     return value;
@@ -86,8 +84,7 @@ namespace ClosedXML.Excel.Caching
         {
             if (_storage.TryGetValue(key, out WeakReference cachedReference))
             {
-                var storedValue = cachedReference.Target as Tvalue;
-                if (storedValue != null)
+                if (cachedReference.Target is Tvalue storedValue)
                 {
                     return storedValue;
                 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -918,18 +918,16 @@ namespace ClosedXML.Excel
                             isDataTable |= type == typeof(DataRow);
                             isDataReader |= type == typeof(IDataRecord);
 
-                            if (!memberCache.ContainsKey(type))
+                            if (!memberCache.TryGetValue(type, out members))
                             {
-                                var _members = type.GetFields(bindingFlags).Cast<MemberInfo>()
+                                members = type.GetFields(bindingFlags).Cast<MemberInfo>()
                                      .Concat(type.GetProperties(bindingFlags))
                                      .Where(mi => !XLColumnAttribute.IgnoreMember(mi))
                                      .OrderBy(mi => XLColumnAttribute.GetOrder(mi))
                                      .ToArray();
 
-                                memberCache.Add(type, _members);
+                                memberCache.Add(type, members);
                             }
-
-                            members = memberCache[type];
                         }
 
                         if (isArray)
@@ -2049,17 +2047,17 @@ namespace ClosedXML.Excel
 
         private string GetFormat()
         {
-            var format = String.Empty;
             var style = GetStyleForRead();
             if (String.IsNullOrWhiteSpace(style.NumberFormat.Format))
             {
                 var formatCodes = XLPredefinedFormat.FormatCodes;
-                if (formatCodes.ContainsKey(style.NumberFormat.NumberFormatId))
-                    format = formatCodes[style.NumberFormat.NumberFormatId];
+                if (formatCodes.TryGetValue(style.NumberFormat.NumberFormatId, out string format))
+                    return format;
+                else
+                    return string.Empty;
             }
             else
-                format = style.NumberFormat.Format;
-            return format;
+                return style.NumberFormat.Format;
         }
 
         private bool SetRichText(object value)

--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -53,8 +53,8 @@ namespace ClosedXML.Excel
 
         private static void IncrementUsage(Dictionary<int, int> dictionary, Int32 key)
         {
-            if (dictionary.ContainsKey(key))
-                dictionary[key]++;
+            if (dictionary.TryGetValue(key, out Int32 value))
+                dictionary[key] = value + 1;
             else
                 dictionary.Add(key, 1);
         }

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -60,10 +60,13 @@ namespace ClosedXML.Excel
                 var toDelete = new Dictionary<IXLWorksheet, List<Int32>>();
                 foreach (XLColumn c in _columns)
                 {
-                    if (!toDelete.ContainsKey(c.Worksheet))
-                        toDelete.Add(c.Worksheet, new List<Int32>());
+                    if (!toDelete.TryGetValue(c.Worksheet, out List<Int32> list))
+                    {
+                        list = new List<Int32>();
+                        toDelete.Add(c.Worksheet, list);
+                    }
 
-                    toDelete[c.Worksheet].Add(c.ColumnNumber());
+                    list.Add(c.ColumnNumber());
                 }
 
                 foreach (KeyValuePair<IXLWorksheet, List<int>> kp in toDelete)

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFColorScaleConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFColorScaleConverter.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel
             for (Int32 i = 1; i <= cf.ContentTypes.Count; i++)
             {
                 var type = cf.ContentTypes[i].ToOpenXml();
-                var val = (cf.Values.ContainsKey(i) && cf.Values[i] != null) ? cf.Values[i].Value : null;
+                var val = cf.Values.TryGetValue(i, out XLFormula formula) ? formula?.Value : null;
 
                 var conditionalFormatValueObject = new ConditionalFormatValueObject { Type = type };
                 if (val != null)

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -68,7 +68,7 @@ namespace ClosedXML.Excel.Drawings
 
                 using (var bitmap = new Bitmap(ImageStream))
                 {
-                    if (FormatMap.ContainsKey(this.Format) && FormatMap[this.Format].Guid != bitmap.RawFormat.Guid)
+                    if (FormatMap.TryGetValue(this.Format, out ImageFormat imageFormat) && imageFormat.Guid != bitmap.RawFormat.Guid)
                         throw new ArgumentException("The picture format in the stream and the parameter don't match");
 
                     DeduceDimensionsFromBitmap(bitmap);

--- a/ClosedXML/Excel/PageSetup/XLHFItem.cs
+++ b/ClosedXML/Excel/PageSetup/XLHFItem.cs
@@ -20,9 +20,9 @@ namespace ClosedXML.Excel
         public String GetText(XLHFOccurrence occurrence)
         {
             var sb = new StringBuilder();
-            if(texts.ContainsKey(occurrence))
+            if(texts.TryGetValue(occurrence, out List<XLHFText> hfTexts))
             {
-                foreach (var hfText in texts[occurrence])
+                foreach (var hfText in hfTexts)
                     sb.Append(hfText.GetHFText(sb.ToString()));
             }
 
@@ -69,8 +69,8 @@ namespace ClosedXML.Excel
 
         private void AddTextToOccurrence(XLHFText hfText, XLHFOccurrence occurrence)
         {
-            if (texts.ContainsKey(occurrence))
-                texts[occurrence].Add(hfText);
+            if (texts.TryGetValue(occurrence, out List<XLHFText> hfTexts))
+                hfTexts.Add(hfText);
             else
                 texts.Add(occurrence, new List<XLHFText> { hfText });
 

--- a/ClosedXML/Excel/PageSetup/XLHeaderFooter.cs
+++ b/ClosedXML/Excel/PageSetup/XLHeaderFooter.cs
@@ -50,7 +50,7 @@ namespace ClosedXML.Excel
         }
 
         private Dictionary<XLHFOccurrence, String> innerTexts = new Dictionary<XLHFOccurrence, String>();
-        internal String SetInnerText(XLHFOccurrence occurrence, String text)
+        internal void SetInnerText(XLHFOccurrence occurrence, String text)
         {
             var parsedElements = ParseFormattedHeaderFooterText(text);
 
@@ -63,13 +63,7 @@ namespace ClosedXML.Excel
             if (parsedElements.Any(e => e.Position == 'R'))
                 this.Right.AddText(string.Join("\r\n", parsedElements.Where(e => e.Position == 'R').Select(e => e.Text).ToArray()), occurrence);
 
-
-            if (innerTexts.ContainsKey(occurrence))
-                innerTexts[occurrence] = text;
-            else
-                innerTexts.Add(occurrence, text);
-
-            return innerTexts[occurrence];
+            innerTexts[occurrence] = text;
         }
 
         private struct ParsedHeaderFooterElement

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormats.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormats.cs
@@ -26,10 +26,13 @@ namespace ClosedXML.Excel
             if (element == XLPivotStyleFormatElement.None)
                 throw new ArgumentException("Choose an enum value that represents an element", nameof(element));
 
-            if (!_styleFormats.ContainsKey(element))
-                _styleFormats.Add(element, new XLPivotStyleFormat(_pivotField) { AppliesTo = element });
+            if (!_styleFormats.TryGetValue(element, out IXLPivotStyleFormat pivotStyleFormat))
+            {
+                pivotStyleFormat = new XLPivotStyleFormat(_pivotField) { AppliesTo = element };
+                _styleFormats.Add(element, pivotStyleFormat);
+            }
 
-            return _styleFormats[element];
+            return pivotStyleFormat;
         }
 
         public IEnumerator<IXLPivotStyleFormat> GetEnumerator()

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1327,9 +1327,11 @@ namespace ClosedXML.Excel
                     Int32 lastRoReturned = lastRoUsed.RowNumber();
                     for (Int32 ro = 1; ro <= lastRoReturned; ro++)
                     {
-                        var styleToUse = Worksheet.Internals.RowsCollection.ContainsKey(ro)
-                                             ? Worksheet.Internals.RowsCollection[ro].Style
-                                             : Worksheet.Style;
+                        var styleToUse =
+                            Worksheet.Internals.RowsCollection.TryGetValue(ro, out XLRow row)
+                                ? row.Style
+                                : Worksheet.Style;
+
                         rangeToReturn.Row(ro).Style = styleToUse;
                     }
                 }
@@ -1543,9 +1545,11 @@ namespace ClosedXML.Excel
                     Int32 lastCoReturned = lastCoUsed.ColumnNumber();
                     for (Int32 co = 1; co <= lastCoReturned; co++)
                     {
-                        var styleToUse = Worksheet.Internals.ColumnsCollection.ContainsKey(co)
-                                             ? Worksheet.Internals.ColumnsCollection[co].Style
-                                             : Worksheet.Style;
+                        var styleToUse =
+                            Worksheet.Internals.ColumnsCollection.TryGetValue(co, out XLColumn column)
+                                ? column.Style
+                                : Worksheet.Style;
+
                         rangeToReturn.Style = styleToUse;
                     }
                 }

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -18,10 +18,13 @@ namespace ClosedXML.Excel
 
         private IXLRangeIndex<XLRange> GetRangeIndex(IXLWorksheet worksheet)
         {
-            if (!_indexes.ContainsKey(worksheet))
-                _indexes.Add(worksheet, new XLRangeIndex<XLRange>(worksheet));
+            if (!_indexes.TryGetValue(worksheet, out IXLRangeIndex<XLRange> rangeIndex))
+            {
+                rangeIndex = new XLRangeIndex<XLRange>(worksheet);
+                _indexes.Add(worksheet, rangeIndex);
+            }
 
-            return _indexes[worksheet];
+            return rangeIndex;
         }
 
         public XLRanges() : base(XLWorkbook.DefaultStyleValue)
@@ -79,7 +82,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="match">Criteria to filter ranges. Only those ranges that satisfy the criteria will be removed.
         /// Null means the entire collection should be cleared.</param>
-        /// <param name="releaseEventHandlers">Specify whether or not should removed ranges be unsubscribed from 
+        /// <param name="releaseEventHandlers">Specify whether or not should removed ranges be unsubscribed from
         /// row/column shifting events. Until ranges are unsubscribed they cannot be collected by GC.</param>
         public void RemoveAll(Predicate<IXLRange> match = null, bool releaseEventHandlers = true)
         {
@@ -139,7 +142,7 @@ namespace ClosedXML.Excel
         /// </summary>
         public IEnumerable<IXLRange> GetIntersectedRanges(IXLAddress address)
         {
-            var xlAddress = (XLAddress) address;
+            var xlAddress = (XLAddress)address;
             return GetIntersectedRanges(in xlAddress);
         }
 
@@ -203,7 +206,6 @@ namespace ClosedXML.Excel
         }
 
         [Obsolete("Use the overload with XLCellsUsedOptions")]
-
         public IXLCells CellsUsed(Boolean includeFormats)
         {
             return CellsUsed(includeFormats

--- a/ClosedXML/Excel/Rows/XLRowCollection.cs
+++ b/ClosedXML/Excel/Rows/XLRowCollection.cs
@@ -76,7 +76,7 @@ namespace ClosedXML.Excel
 
         public void Clear()
         {
-            foreach (KeyValuePair<int, XLRow> kp in _dictionary.Where(kp => !_deleted.ContainsKey(kp.Key)))
+            foreach (var kp in _dictionary.Where(kp => !_deleted.ContainsKey(kp.Key)))
             {
                 _deleted.Add(kp.Key, kp.Value);
             }
@@ -141,9 +141,9 @@ namespace ClosedXML.Excel
 
         public void RemoveAll(Func<XLRow, Boolean> predicate)
         {
-            foreach (XLRow kp in _dictionary.Values.Where(predicate).Select(c => c).Where(kp => !_deleted.ContainsKey(kp.RowNumber())))
+            foreach (var row in _dictionary.Values.Where(predicate).Where(row1 => !_deleted.ContainsKey(row1.RowNumber())))
             {
-                _deleted.Add(kp.RowNumber(), kp);
+                _deleted.Add(row.RowNumber(), row);
             }
 
             _dictionary.RemoveAll(predicate);

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -59,10 +59,13 @@ namespace ClosedXML.Excel
                 var toDelete = new Dictionary<IXLWorksheet, List<Int32>>();
                 foreach (XLRow r in _rows)
                 {
-                    if (!toDelete.ContainsKey(r.Worksheet))
-                        toDelete.Add(r.Worksheet, new List<Int32>());
+                    if (!toDelete.TryGetValue(r.Worksheet, out List<Int32> list))
+                    {
+                        list = new List<Int32>();
+                        toDelete.Add(r.Worksheet, list);
+                    }
 
-                    toDelete[r.Worksheet].Add(r.RowNumber());
+                    list.Add(r.RowNumber());
                 }
 
                 foreach (KeyValuePair<IXLWorksheet, List<int>> kp in toDelete)

--- a/ClosedXML/Excel/Sparkline/XLSparkLineGroup.cs
+++ b/ClosedXML/Excel/Sparkline/XLSparkLineGroup.cs
@@ -306,12 +306,7 @@ namespace ClosedXML.Excel
                 throw new ArgumentException("The specified sparkline belongs to the different worksheet");
 
             SparklineGroups.Remove(sparkline.Location);
-
-            if (_sparklines.ContainsKey(sparkline.Location))
-                _sparklines.Remove(sparkline.Location);
-
-            _sparklines.Add(sparkline.Location, sparkline);
-
+            _sparklines[sparkline.Location] = sparkline;
             return sparkline;
         }
 

--- a/ClosedXML/Excel/Sparkline/XLSparkLineGroup.cs
+++ b/ClosedXML/Excel/Sparkline/XLSparkLineGroup.cs
@@ -143,8 +143,7 @@ namespace ClosedXML.Excel
             if (location.Worksheet != Worksheet)
                 throw new ArgumentException("The specified sparkline belongs to the different worksheet");
 
-            var sparkline = new XLSparkline(this, location, sourceData);
-            return Add(sparkline);
+            return new XLSparkline(this, location, sourceData);
         }
 
         public IEnumerable<IXLSparkline> Add(string locationRangeAddress, string sourceDataAddress)

--- a/ClosedXML/Excel/Sparkline/XLSparkLineGroup.cs
+++ b/ClosedXML/Excel/Sparkline/XLSparkLineGroup.cs
@@ -212,9 +212,7 @@ namespace ClosedXML.Excel
 
         public IXLSparkline GetSparkline(IXLCell cell)
         {
-            return _sparklines.ContainsKey(cell)
-                ? _sparklines[cell]
-                : null;
+            return _sparklines.TryGetValue(cell, out IXLSparkline sparkline) ? sparkline : null;
         }
 
         public IEnumerable<IXLSparkline> GetSparklines(IXLRangeBase searchRange)

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -77,9 +77,9 @@ namespace ClosedXML.Excel
                 foreach (var cell in headersRow.Cells())
                 {
                     var name = cell.GetString();
-                    if (_fieldNames.ContainsKey(name) && _fieldNames[name].Column.ColumnNumber() == cell.Address.ColumnNumber)
+                    if (_fieldNames.TryGetValue(name, out IXLTableField tableField) && tableField.Column.ColumnNumber() == cell.Address.ColumnNumber)
                     {
-                        (_fieldNames[name] as XLTableField).Index = cellPos;
+                        (tableField as XLTableField).Index = cellPos;
                         detectedFieldNames.Add(name, _fieldNames[name]);
                         cellPos++;
                         continue;
@@ -132,10 +132,9 @@ namespace ClosedXML.Excel
 
         internal void RenameField(String oldName, String newName)
         {
-            if (!_fieldNames.ContainsKey(oldName))
+            if (!_fieldNames.TryGetValue(oldName, out IXLTableField field))
                 throw new ArgumentException("The field does not exist in this table", "oldName");
 
-            var field = _fieldNames[oldName];
             _fieldNames.Remove(oldName);
             _fieldNames.Add(newName, field);
         }
@@ -596,8 +595,8 @@ namespace ClosedXML.Excel
             // The entry in the table definition will contain \r\n
             // but the shared string value of the actual cell will contain only \n
             name = name.Replace("\r\n", "\n");
-            if (FieldNames.ContainsKey(name))
-                return FieldNames[name].Index;
+            if (FieldNames.TryGetValue(name, out IXLTableField tableField))
+                return tableField.Index;
 
             throw new ArgumentOutOfRangeException("The header row doesn't contain field name '" + name + "'.");
         }

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -779,10 +779,7 @@ namespace ClosedXML.Excel
                     var value = row.Cell(f.Index + 1).Value;
                     // ExpandoObject supports IDictionary so we can extend it like this
                     var expandoDict = expando as IDictionary<string, object>;
-                    if (expandoDict.ContainsKey(f.Name))
-                        expandoDict[f.Name] = value;
-                    else
-                        expandoDict.Add(f.Name, value);
+                    expandoDict[f.Name] = value;
                 }
 
                 yield return expando;

--- a/ClosedXML/Excel/Tables/XLTables.cs
+++ b/ClosedXML/Excel/Tables/XLTables.cs
@@ -54,13 +54,15 @@ namespace ClosedXML.Excel
 
         public void Remove(String name)
         {
-            if (!_tables.ContainsKey(name))
+            if (!_tables.TryGetValue(name, out IXLTable table))
                 throw new ArgumentOutOfRangeException(nameof(name), $"Unable to delete table because the table name {name} could not be found.");
 
-            var table = _tables[name] as XLTable;
             _tables.Remove(name);
 
-            if (table.RelId != null) Deleted.Add(table.RelId);
+            var relId = (table as XLTable)?.RelId;
+
+            if (relId != null)
+                Deleted.Add(relId);
         }
 
         public IXLTable Table(Int32 index)
@@ -78,13 +80,7 @@ namespace ClosedXML.Excel
 
         public bool TryGetTable(string tableName, out IXLTable table)
         {
-            if (_tables.ContainsKey(tableName))
-            {
-                table = _tables[tableName];
-                return true;
-            }
-            table = null;
-            return false;
+            return _tables.TryGetValue(tableName, out table);
         }
 
         #endregion IXLTables Members

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1685,9 +1685,9 @@ namespace ClosedXML.Excel
 
             var xlCell = ws.Cell(in cellAddress);
 
-            if (styleList.ContainsKey(styleIndex))
+            if (styleList.TryGetValue(styleIndex, out IXLStyle style))
             {
-                xlCell.InnerStyle = styleList[styleIndex];
+                xlCell.InnerStyle = style;
             }
             else
             {

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -51,11 +51,12 @@ namespace ClosedXML.Excel
 
             public void AddValues(IEnumerable<String> values, RelType relType)
             {
-                if (!_relIds.ContainsKey(relType))
+                if (!_relIds.TryGetValue(relType, out List<String> list))
                 {
-                    _relIds.Add(relType, new List<String>());
+                    list = new List<String>();
+                    _relIds.Add(relType, list);
                 }
-                _relIds[relType].AddRange(values.Where(v => !_relIds[relType].Contains(v)));
+                list.AddRange(values.Where(v => !list.Contains(v)));
             }
 
             public String GetNext()
@@ -65,18 +66,19 @@ namespace ClosedXML.Excel
 
             public String GetNext(RelType relType)
             {
-                if (!_relIds.ContainsKey(relType))
+                if (!_relIds.TryGetValue(relType, out List<String> list))
                 {
-                    _relIds.Add(relType, new List<String>());
+                    list = new List<String>();
+                    _relIds.Add(relType, list);
                 }
 
-                Int32 id = _relIds[relType].Count + 1;
+                Int32 id = list.Count + 1;
                 while (true)
                 {
                     String relId = String.Concat("rId", id);
-                    if (!_relIds[relType].Contains(relId))
+                    if (!list.Contains(relId))
                     {
-                        _relIds[relType].Add(relId);
+                        list.Add(relId);
                         return relId;
                     }
                     id++;

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1028,20 +1028,22 @@ namespace ClosedXML.Excel
         public void IncrementColumnOutline(Int32 level)
         {
             if (level <= 0) return;
-            if (!_columnOutlineCount.ContainsKey(level))
-                _columnOutlineCount.Add(level, 0);
-
-            _columnOutlineCount[level]++;
+            if (_columnOutlineCount.TryGetValue(level, out Int32 value))
+                _columnOutlineCount[level] = value + 1;
+            else
+                _columnOutlineCount.Add(level, 1);
         }
 
         public void DecrementColumnOutline(Int32 level)
         {
             if (level <= 0) return;
-            if (!_columnOutlineCount.ContainsKey(level))
+            if (_columnOutlineCount.TryGetValue(level, out Int32 value))
+            {
+                if (value > 0)
+                    _columnOutlineCount[level] = value - 1;
+            }
+            else
                 _columnOutlineCount.Add(level, 0);
-
-            if (_columnOutlineCount[level] > 0)
-                _columnOutlineCount[level]--;
         }
 
         public Int32 GetMaxColumnOutline()
@@ -1053,20 +1055,22 @@ namespace ClosedXML.Excel
         public void IncrementRowOutline(Int32 level)
         {
             if (level <= 0) return;
-            if (!_rowOutlineCount.ContainsKey(level))
+            if (_rowOutlineCount.TryGetValue(level, out Int32 value))
+                _rowOutlineCount[level] = value + 1;
+            else
                 _rowOutlineCount.Add(level, 0);
-
-            _rowOutlineCount[level]++;
         }
 
         public void DecrementRowOutline(Int32 level)
         {
             if (level <= 0) return;
-            if (!_rowOutlineCount.ContainsKey(level))
+            if (_rowOutlineCount.TryGetValue(level, out Int32 value))
+            {
+                if (value > 0)
+                    _rowOutlineCount[level] = level - 1;
+            }
+            else
                 _rowOutlineCount.Add(level, 0);
-
-            if (_rowOutlineCount[level] > 0)
-                _rowOutlineCount[level]--;
         }
 
         public Int32 GetMaxRowOutline()

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -1,4 +1,3 @@
-using ClosedXML.Extensions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -63,9 +62,6 @@ namespace ClosedXML.Excel
 
             if (_worksheets.TryGetValue(sheetName, out XLWorksheet w))
                 return w;
-
-            if (_worksheets.ContainsKey(sheetName))
-                return _worksheets[sheetName];
 
             throw new ArgumentException("There isn't a worksheet named '" + sheetName + "'.");
         }
@@ -180,13 +176,12 @@ namespace ClosedXML.Excel
 
         public void Rename(String oldSheetName, String newSheetName)
         {
-            if (String.IsNullOrWhiteSpace(oldSheetName) || !_worksheets.ContainsKey(oldSheetName)) return;
+            if (String.IsNullOrWhiteSpace(oldSheetName) || !_worksheets.TryGetValue(oldSheetName, out XLWorksheet ws)) return;
 
             if (!oldSheetName.Equals(newSheetName, StringComparison.OrdinalIgnoreCase)
                 && _worksheets.ContainsKey(newSheetName))
                 throw new ArgumentException(String.Format("A worksheet with the same name ({0}) has already been added.", newSheetName), nameof(newSheetName));
 
-            var ws = _worksheets[oldSheetName];
             _worksheets.Remove(oldSheetName);
             Add(newSheetName, ws);
         }

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -96,12 +96,7 @@ namespace ClosedXML.Utils
                 if (openXMLColor.Rgb != null)
                 {
                     String htmlColor = "#" + openXMLColor.Rgb.Value;
-                    Drawing.Color thisColor;
-                    if (colorCache?.ContainsKey(htmlColor) ?? false)
-                    {
-                        thisColor = colorCache[htmlColor];
-                    }
-                    else
+                    if (colorCache == null || !colorCache.TryGetValue(htmlColor, out Drawing.Color thisColor))
                     {
                         thisColor = ColorStringParser.ParseFromHtml(htmlColor);
                         colorCache?.Add(htmlColor, thisColor);


### PR DESCRIPTION
Hopefully this makes some small performance gain.
Firstly I remove a redundant `Add` call in `XLSparkLineGroup`
Then, I try to replace all `Dictionary.ContainsKey` + indexer with `TryGetValue`