### PR TITLE
Avoid instantiation of cell properties on reading (#1184)

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -71,8 +71,6 @@ namespace ClosedXML.Excel
 
         Boolean HasSparkline { get; }
 
-        XLHyperlink Hyperlink { get; set; }
-
         /// <summary>
         /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
         /// </summary>
@@ -181,6 +179,11 @@ namespace ClosedXML.Excel
         IXLDataValidation CreateDataValidation();
 
         /// <summary>
+        /// Creates a new hyperlink replacing the existing one.
+        /// </summary>
+        XLHyperlink CreateHyperlink();
+
+        /// <summary>
         /// Replaces a value of the cell with a newly created rich text object.
         /// </summary>
         IXLRichText CreateRichText();
@@ -227,6 +230,9 @@ namespace ClosedXML.Excel
         /// </summary>
         String GetFormattedString();
 
+        /// <summary>
+        /// Returns a hyperlink for the cell, if any, or creates a new instance is there is no hyperlink.
+        /// </summary>
         XLHyperlink GetHyperlink();
 
         /// <summary>
@@ -392,6 +398,8 @@ namespace ClosedXML.Excel
         IXLCell SetFormulaA1(String formula);
 
         IXLCell SetFormulaR1C1(String formula);
+
+        void SetHyperlink(XLHyperlink hyperlink);
 
         /// <summary>
         /// Sets the cell's value.

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -84,8 +84,6 @@ namespace ClosedXML.Excel
 
         IXLDataValidation NewDataValidation { get; }
 
-        IXLRichText RichText { get; }
-
         /// <summary>
         /// Gets or sets a value indicating whether this cell's text should be shared or not.
         /// </summary>
@@ -179,6 +177,11 @@ namespace ClosedXML.Excel
         IXLCell CopyTo(String target);
 
         /// <summary>
+        /// Replaces a value of the cell with a newly created rich text object.
+        /// </summary>
+        IXLRichText CreateRichText();
+
+        /// <summary>
         /// Deletes the current cell and shifts the surrounding cells according to the shiftDeleteCells parameter.
         /// </summary>
         /// <param name="shiftDeleteCells">How to shift the surrounding cells.</param>
@@ -211,6 +214,11 @@ namespace ClosedXML.Excel
         String GetFormattedString();
 
         XLHyperlink GetHyperlink();
+
+        /// <summary>
+        /// Returns the value of the cell if it formatted as a rich text.
+        /// </summary>
+        IXLRichText GetRichText();
 
         /// <summary>
         /// Gets the cell's value converted to a String.

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -24,8 +24,6 @@ namespace ClosedXML.Excel
         /// </summary>
         Object CachedValue { get; }
 
-        IXLComment Comment { get; }
-
         /// <summary>
         /// Returns the current region. The current region is a range bounded by any combination of blank rows and blank columns
         /// </summary>
@@ -177,6 +175,11 @@ namespace ClosedXML.Excel
         IXLCell CopyTo(String target);
 
         /// <summary>
+        /// Creates a new comment for the cell, replacing the existing one.
+        /// </summary>
+        IXLComment CreateComment();
+
+        /// <summary>
         /// Replaces a value of the cell with a newly created rich text object.
         /// </summary>
         IXLRichText CreateRichText();
@@ -193,6 +196,11 @@ namespace ClosedXML.Excel
         /// <para>An exception will be thrown if the current value cannot be converted to Boolean.</para>
         /// </summary>
         Boolean GetBoolean();
+
+        /// <summary>
+        /// Returns the comment for the cell or create a new instance if there is no comment on the cell.
+        /// </summary>
+        IXLComment GetComment();
 
         /// <summary>
         /// Gets the cell's value converted to DateTime.

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -43,8 +43,6 @@ namespace ClosedXML.Excel
         /// <exception cref="ArgumentException"></exception>
         XLDataType DataType { get; set; }
 
-        IXLDataValidation DataValidation { get; }
-
         /// <summary>
         /// Gets or sets the cell's formula with A1 references.
         /// </summary>
@@ -79,8 +77,6 @@ namespace ClosedXML.Excel
         /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
         /// </summary>
         Boolean NeedsRecalculation { get; }
-
-        IXLDataValidation NewDataValidation { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this cell's text should be shared or not.
@@ -180,6 +176,11 @@ namespace ClosedXML.Excel
         IXLComment CreateComment();
 
         /// <summary>
+        /// Creates a new data validation rule for the cell, replacing the existing one.
+        /// </summary>
+        IXLDataValidation CreateDataValidation();
+
+        /// <summary>
         /// Replaces a value of the cell with a newly created rich text object.
         /// </summary>
         IXLRichText CreateRichText();
@@ -201,6 +202,11 @@ namespace ClosedXML.Excel
         /// Returns the comment for the cell or create a new instance if there is no comment on the cell.
         /// </summary>
         IXLComment GetComment();
+
+        /// <summary>
+        /// Returns a data validation rule assigned to the cell, if any, or creates a new instance of data validation rule if no rule exists.
+        /// </summary>
+        IXLDataValidation GetDataValidation();
 
         /// <summary>
         /// Gets the cell's value converted to DateTime.
@@ -380,6 +386,7 @@ namespace ClosedXML.Excel
         /// <returns></returns>
         IXLCell SetDataType(XLDataType dataType);
 
+        [Obsolete("Use GetDataValidation to access the existing rule, or CreateDataValidation() to create a new one.")]
         IXLDataValidation SetDataValidation();
 
         IXLCell SetFormulaA1(String formula);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1279,26 +1279,25 @@ namespace ClosedXML.Excel
             }
         }
 
-        public IXLRichText RichText
+        public IXLRichText GetRichText()
         {
-            get
+            return _richText ?? CreateRichText();
+        }
+
+        public bool HasRichText
             {
-                if (_richText == null)
+            get { return _richText != null; }
+        }
+
+        public IXLRichText CreateRichText()
                 {
                     var style = GetStyleForRead();
                     _richText = _cellValue.Length == 0
                                     ? new XLRichText(new XLFont(Style as XLStyle, style.Font))
                                     : new XLRichText(GetFormattedString(), new XLFont(Style as XLStyle, style.Font));
-                }
 
                 return _richText;
             }
-        }
-
-        public bool HasRichText
-        {
-            get { return _richText != null; }
-        }
 
         IXLComment IXLCell.Comment
         {
@@ -1651,7 +1650,7 @@ namespace ClosedXML.Excel
         {
             if (typeof(T) == typeof(IXLRichText))
             {
-                value = (T)RichText;
+                value = (T)GetRichText();
                 return true;
             }
             value = default;

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -154,17 +154,9 @@ namespace ClosedXML.Excel
             }
         }
 
-        internal XLComment Comment
+        internal XLComment GetComment()
         {
-            get
-            {
-                if (_comment == null)
-                {
-                    CreateComment();
-                }
-
-                return _comment;
-            }
+            return _comment ?? CreateComment();
         }
 
         internal XLComment CreateComment(int? shapeId = null)
@@ -1299,14 +1291,19 @@ namespace ClosedXML.Excel
                 return _richText;
             }
 
-        IXLComment IXLCell.Comment
+        IXLComment IXLCell.GetComment()
         {
-            get { return Comment; }
+            return GetComment();
         }
 
         public bool HasComment
         {
             get { return _comment != null; }
+        }
+
+        IXLComment IXLCell.CreateComment()
+        {
+            return CreateComment(shapeId: null);
         }
 
         public Boolean IsMerged()

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1145,8 +1145,7 @@ namespace ClosedXML.Excel
 
             set
             {
-                if (Worksheet.Hyperlinks.Any(hl => Address.Equals(hl.Cell.Address)))
-                    Worksheet.Hyperlinks.Delete(Address);
+                Worksheet.Hyperlinks.TryDelete(Address);
 
                 _hyperlink = value;
 

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -202,7 +202,7 @@ namespace ClosedXML.Excel
 
                     if (c.HasRichText)
                     {
-                        foreach (IXLRichString rt in c.RichText)
+                        foreach (IXLRichString rt in c.GetRichText())
                         {
                             String formattedString = rt.Text;
                             var arr = formattedString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);

--- a/ClosedXML/Excel/Hyperlinks/IXLHyperlinks.cs
+++ b/ClosedXML/Excel/Hyperlinks/IXLHyperlinks.cs
@@ -7,6 +7,8 @@ namespace ClosedXML.Excel
         void Add(XLHyperlink hyperlink);
         void Delete(XLHyperlink hyperlink);
         void Delete(IXLAddress address);
-        
+        bool TryDelete(IXLAddress address);
+        XLHyperlink Get(IXLAddress address);
+        bool TryGet(IXLAddress address, out XLHyperlink hyperlink);
     }
 }

--- a/ClosedXML/Excel/Hyperlinks/XLHyperlinks.cs
+++ b/ClosedXML/Excel/Hyperlinks/XLHyperlinks.cs
@@ -4,10 +4,11 @@ namespace ClosedXML.Excel
 {
     internal class XLHyperlinks: IXLHyperlinks
     {
-        private Dictionary<IXLAddress, XLHyperlink> hyperlinks = new Dictionary<IXLAddress, XLHyperlink>();
+        private readonly Dictionary<IXLAddress, XLHyperlink> _hyperlinks = new Dictionary<IXLAddress, XLHyperlink>();
+
         public IEnumerator<XLHyperlink> GetEnumerator()
         {
-            return hyperlinks.Values.GetEnumerator();
+            return _hyperlinks.Values.GetEnumerator();
         }
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
@@ -17,18 +18,38 @@ namespace ClosedXML.Excel
 
         public void Add(XLHyperlink hyperlink)
         {
-            hyperlinks.Add(hyperlink.Cell.Address, hyperlink);
+            _hyperlinks.Add(hyperlink.Cell.Address, hyperlink);
         }
 
         public void Delete(XLHyperlink hyperlink)
         {
-            hyperlinks.Remove(hyperlink.Cell.Address);
+            _hyperlinks.Remove(hyperlink.Cell.Address);
         }
 
         public void Delete(IXLAddress address)
         {
-            hyperlinks.Remove(address);
+            _hyperlinks.Remove(address);
         }
 
+        public bool TryDelete(IXLAddress address)
+        {
+            if (_hyperlinks.ContainsKey(address))
+            {
+                _hyperlinks.Remove(address);
+                return true;
+            }
+
+            return false;
+        }
+
+        public XLHyperlink Get(IXLAddress address)
+        {
+            return _hyperlinks[address];
+        }
+
+        public bool TryGet(IXLAddress address, out XLHyperlink hyperlink)
+        {
+            return _hyperlinks.TryGetValue(address, out hyperlink);
+        }
     }
 }

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -302,8 +302,19 @@ namespace ClosedXML.Excel
 
         IXLAutoFilter SetAutoFilter(Boolean value);
 
-        IXLDataValidation SetDataValidation();
+        /// <summary>
+        /// Returns a data validation rule assigned to the range, if any, or creates a new instance of data validation rule if no rule exists.
+        /// </summary>
+        IXLDataValidation GetDataValidation();
 
+        /// <summary>
+        /// Creates a new data validation rule for the range, replacing the existing one.
+        /// </summary>
+        IXLDataValidation CreateDataValidation();
+
+        [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
+        IXLDataValidation SetDataValidation();
+        
         IXLConditionalFormat AddConditionalFormat();
 
         void Select();

--- a/ClosedXML/Excel/Ranges/IXLRanges.cs
+++ b/ClosedXML/Excel/Ranges/IXLRanges.cs
@@ -53,6 +53,12 @@ namespace ClosedXML.Excel
 
         IXLStyle Style { get; set; }
 
+        /// <summary>
+        /// Creates a new data validation rule for the ranges collection, replacing the existing ones.
+        /// </summary>
+        IXLDataValidation CreateDataValidation();
+
+        [Obsolete("Use CreateDataValidation() instead.")]
         IXLDataValidation SetDataValidation();
 
         /// <summary>

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -64,29 +64,15 @@ namespace ClosedXML.Excel
             get { return RangeAddress.Worksheet; }
         }
 
-        public IXLDataValidation NewDataValidation
+        public IXLDataValidation CreateDataValidation()
         {
-            get
-            {
-                var newRange = AsRange();
-                var dataValidation = new XLDataValidation(newRange);
-                Worksheet.DataValidations.Add(dataValidation);
-                return dataValidation;
-            }
+            var newRange = AsRange();
+            var dataValidation = new XLDataValidation(newRange);
+            Worksheet.DataValidations.Add(dataValidation);
+            return dataValidation;
         }
 
-        /// <summary>
-        /// Get the data validation rule containing current range or create a new one if no rule was defined for range.
-        /// </summary>
-        public IXLDataValidation DataValidation
-        {
-            get
-            {
-                return SetDataValidation();
-            }
-        }
-
-        private IXLDataValidation GetDataValidation()
+        public IXLDataValidation GetDataValidation()
         {
             Worksheet.DataValidations.TryGet(RangeAddress, out var existingDataValidation);
             return existingDataValidation;
@@ -422,7 +408,7 @@ namespace ClosedXML.Excel
 
             if (clearOptions.HasFlag(XLClearOptions.DataValidation))
             {
-                var validation = NewDataValidation;
+                var validation = CreateDataValidation();
                 Worksheet.DataValidations.Delete(validation);
             }
 
@@ -2148,6 +2134,7 @@ namespace ClosedXML.Excel
             return Worksheet.RangeRow(new XLRangeAddress(firstCellAddress, lastCellAddress));
         }
 
+        [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
         public IXLDataValidation SetDataValidation()
         {
             var existingValidation = GetDataValidation();

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -139,7 +139,7 @@ namespace ClosedXML.Excel
             {
                 var hyperlinks = new XLHyperlinks();
                 var hls = from hl in Worksheet.Hyperlinks
-                          where Contains(hl.Cell.AsRange())
+                          where RangeAddress.Contains(hl.Cell.Address)
                           select hl;
                 hls.ForEach(hyperlinks.Add);
                 return hyperlinks;

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -159,7 +159,7 @@ namespace ClosedXML.Excel
 
         public IEnumerable<IXLDataValidation> DataValidation
         {
-            get { return Ranges.Select(range => range.DataValidation).Where(dv => dv != null); }
+            get { return Ranges.Select(range => range.GetDataValidation()).Where(dv => dv != null); }
         }
 
         public IXLRanges AddToNamed(String rangeName)
@@ -291,7 +291,7 @@ namespace ClosedXML.Excel
             return Ranges.Aggregate(0, (current, r) => current ^ r.GetHashCode());
         }
 
-        public IXLDataValidation SetDataValidation()
+        public IXLDataValidation CreateDataValidation()
         {
             var firstRange = Ranges.First();
             var dataValidation = new XLDataValidation(firstRange);
@@ -302,6 +302,12 @@ namespace ClosedXML.Excel
 
             firstRange.Worksheet.DataValidations.Add(dataValidation);
             return dataValidation;
+        }
+
+        [Obsolete("Use CreateDataValidation() instead.")]
+        public IXLDataValidation SetDataValidation()
+        {
+            return CreateDataValidation();
         }
 
         public void Select()

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -221,7 +221,7 @@ namespace ClosedXML.Excel
                     var kpList = new List<KeyValuePair<IXLFontBase, string>>();
                     if (c.HasRichText)
                     {
-                        foreach (IXLRichString rt in c.RichText)
+                        foreach (IXLRichString rt in c.GetRichText())
                         {
                             String formattedString = rt.Text;
                             var arr = formattedString.Split(new[] { Environment.NewLine }, StringSplitOptions.None);

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1908,10 +1908,10 @@ namespace ClosedXML.Excel
                 String text = run.Text.InnerText.FixNewLines();
 
                 if (runProperties == null)
-                    xlCell.RichText.AddText(text, xlCell.Style.Font);
+                    xlCell.GetRichText().AddText(text, xlCell.Style.Font);
                 else
                 {
-                    var rt = xlCell.RichText.AddText(text);
+                    var rt = xlCell.GetRichText().AddText(text);
                     LoadFont(runProperties, rt);
                 }
                 if (!hasRuns)
@@ -1927,11 +1927,11 @@ namespace ClosedXML.Excel
             if (pp != null)
             {
                 if (pp.Alignment != null)
-                    xlCell.RichText.Phonetics.Alignment = pp.Alignment.Value.ToClosedXml();
+                    xlCell.GetRichText().Phonetics.Alignment = pp.Alignment.Value.ToClosedXml();
                 if (pp.Type != null)
-                    xlCell.RichText.Phonetics.Type = pp.Type.Value.ToClosedXml();
+                    xlCell.GetRichText().Phonetics.Type = pp.Type.Value.ToClosedXml();
 
-                LoadFont(pp, xlCell.RichText.Phonetics);
+                LoadFont(pp, xlCell.GetRichText().Phonetics);
             }
 
             #endregion Load PhoneticProperties
@@ -1940,7 +1940,7 @@ namespace ClosedXML.Excel
 
             foreach (PhoneticRun pr in phoneticRuns)
             {
-                xlCell.RichText.Phonetics.Add(pr.Text.InnerText.FixNewLines(), (Int32)pr.BaseTextStartIndex.Value,
+                xlCell.GetRichText().Phonetics.Add(pr.Text.InnerText.FixNewLines(), (Int32)pr.BaseTextStartIndex.Value,
                                               (Int32)pr.EndingBaseIndex.Value);
             }
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2801,11 +2801,11 @@ namespace ClosedXML.Excel
                     xlCell.SettingHyperlink = true;
 
                     if (hl.Id != null)
-                        xlCell.Hyperlink = new XLHyperlink(hyperlinkDictionary[hl.Id], tooltip);
+                        xlCell.SetHyperlink(new XLHyperlink(hyperlinkDictionary[hl.Id], tooltip));
                     else if (hl.Location != null)
-                        xlCell.Hyperlink = new XLHyperlink(hl.Location.Value, tooltip);
+                        xlCell.SetHyperlink(new XLHyperlink(hl.Location.Value, tooltip));
                     else
-                        xlCell.Hyperlink = new XLHyperlink(hl.Reference.Value, tooltip);
+                        xlCell.SetHyperlink(new XLHyperlink(hl.Reference.Value, tooltip));
 
                     xlCell.SettingHyperlink = false;
                 }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -1001,7 +1001,7 @@ namespace ClosedXML.Excel
                 c.DataType = XLDataType.Text;
                 if (c.HasRichText)
                 {
-                    if (newRichStrings.TryGetValue(c.RichText, out int id))
+                    if (newRichStrings.TryGetValue(c.GetRichText(), out int id))
                         c.SharedStringId = id;
                     else
                     {
@@ -1012,7 +1012,7 @@ namespace ClosedXML.Excel
                         sharedStringTablePart.SharedStringTable.Count += 1;
                         sharedStringTablePart.SharedStringTable.UniqueCount += 1;
 
-                        newRichStrings.Add(c.RichText, stringId);
+                        newRichStrings.Add(c.GetRichText(), stringId);
                         c.SharedStringId = stringId;
 
                         stringId++;
@@ -1046,14 +1046,15 @@ namespace ClosedXML.Excel
 
         private static void PopulatedRichTextElements(RstType rstType, IXLCell cell, SaveContext context)
         {
-            foreach (var rt in cell.RichText.Where(r => !String.IsNullOrEmpty(r.Text)))
+            var richText = cell.GetRichText();
+            foreach (var rt in richText.Where(r => !String.IsNullOrEmpty(r.Text)))
             {
                 rstType.Append(GetRun(rt));
             }
 
-            if (cell.RichText.HasPhonetics)
+            if (richText.HasPhonetics)
             {
-                foreach (var p in cell.RichText.Phonetics)
+                foreach (var p in richText.Phonetics)
                 {
                     var phoneticRun = new PhoneticRun
                     {
@@ -1069,7 +1070,7 @@ namespace ClosedXML.Excel
                     rstType.Append(phoneticRun);
                 }
 
-                var fontKey = XLFont.GenerateKey(cell.RichText.Phonetics);
+                var fontKey = XLFont.GenerateKey(richText.Phonetics);
                 var f = XLFontValue.FromKey(ref fontKey);
 
                 if (!context.SharedFonts.TryGetValue(f, out FontInfo fi))
@@ -1083,10 +1084,11 @@ namespace ClosedXML.Excel
                     FontId = fi.FontId
                 };
 
-                if (cell.RichText.Phonetics.Alignment != XLPhoneticAlignment.Left)
-                    phoneticProperties.Alignment = cell.RichText.Phonetics.Alignment.ToOpenXml();
-                if (cell.RichText.Phonetics.Type != XLPhoneticType.FullWidthKatakana)
-                    phoneticProperties.Type = cell.RichText.Phonetics.Type.ToOpenXml();
+                if (richText.Phonetics.Alignment != XLPhoneticAlignment.Left)
+                    phoneticProperties.Alignment = richText.Phonetics.Alignment.ToOpenXml();
+
+                if (richText.Phonetics.Type != XLPhoneticType.FullWidthKatakana)
+                    phoneticProperties.Type = richText.Phonetics.Type.ToOpenXml();
 
                 rstType.Append(phoneticProperties);
             }

--- a/ClosedXML_Examples/Comments/AddingComments.cs
+++ b/ClosedXML_Examples/Comments/AddingComments.cs
@@ -32,7 +32,7 @@ namespace ClosedXML_Examples
         private void AddWeb(XLWorkbook wb)
         {
             var ws = wb.Worksheets.Add("Web");
-            ws.Cell("A1").Comment.Style.Web.AlternateText = "The alternate text in case you need it.";
+            ws.Cell("A1").GetComment().Style.Web.AlternateText = "The alternate text in case you need it.";
         }
 
         private void AddSize(XLWorkbook wb)
@@ -42,23 +42,23 @@ namespace ClosedXML_Examples
             // Automatic size is a copy of the property comment.Style.Alignment.AutomaticSize
             // I created the duplicate because it makes more sense for it to be in Size
             // but Excel has it under the Alignment tab.
-            ws.Cell("A2").Comment.AddText("Things are very tight around here.");
-            ws.Cell("A2").Comment.Style.Size.SetAutomaticSize();
+            ws.Cell("A2").GetComment().AddText("Things are very tight around here.");
+            ws.Cell("A2").GetComment().Style.Size.SetAutomaticSize();
 
-            ws.Cell("A4").Comment.AddText("Different size");
-            ws.Cell("A4").Comment.Style
+            ws.Cell("A4").GetComment().AddText("Different size");
+            ws.Cell("A4").GetComment().Style
                 .Size.SetHeight(30) // The height is set in the same units as row.Height
                 .Size.SetWidth(30); // The width is set in the same units as row.Width
 
             // Set all comments to visible
-            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.Comment.SetVisible());
+            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.GetComment().SetVisible());
         }
 
         private void AddProtection(XLWorkbook wb)
         {
             var ws = wb.Worksheets.Add("Protection");
 
-            ws.Cell("A1").Comment.Style
+            ws.Cell("A1").GetComment().Style
                 .Protection.SetLocked(false)
                 .Protection.SetLockText(false);
         }
@@ -67,22 +67,22 @@ namespace ClosedXML_Examples
         {
             var ws = wb.Worksheets.Add("Properties");
 
-            ws.Cell("A1").Comment.Style.Properties.Positioning = XLDrawingAnchor.Absolute;
-            ws.Cell("A2").Comment.Style.Properties.Positioning = XLDrawingAnchor.MoveAndSizeWithCells;
-            ws.Cell("A3").Comment.Style.Properties.Positioning = XLDrawingAnchor.MoveWithCells;
+            ws.Cell("A1").GetComment().Style.Properties.Positioning = XLDrawingAnchor.Absolute;
+            ws.Cell("A2").GetComment().Style.Properties.Positioning = XLDrawingAnchor.MoveAndSizeWithCells;
+            ws.Cell("A3").GetComment().Style.Properties.Positioning = XLDrawingAnchor.MoveWithCells;
         }
 
         private void AddMagins(XLWorkbook wb)
         {
             var ws = wb.Worksheets.Add("Margins");
 
-            ws.Cell("A2").Comment
+            ws.Cell("A2").GetComment()
                 .SetVisible()
                 .AddText("Lorem ipsum dolor sit amet, adipiscing elit. ").AddNewLine()
                 .AddText("Nunc elementum, sapien a ultrices, commodo nisl. ").AddNewLine()
                 .AddText("Consequat erat lectus a nisi. Aliquam facilisis.");
 
-            ws.Cell("A2").Comment.Style
+            ws.Cell("A2").GetComment().Style
                 .Margins.SetAll(0.25)
                 .Size.SetAutomaticSize();
         }
@@ -91,11 +91,11 @@ namespace ClosedXML_Examples
         {
             var ws = wb.Worksheets.Add("Colors and Lines");
 
-            ws.Cell("A2").Comment
+            ws.Cell("A2").GetComment()
                 .AddText("Now ")
                 .AddText("THIS").SetBold().SetFontColor(XLColor.Red)
                 .AddText(" is colorful!");
-            ws.Cell("A2").Comment.Style
+            ws.Cell("A2").GetComment().Style
                 .ColorsAndLines.SetFillColor(XLColor.RichCarmine)
                 .ColorsAndLines.SetFillTransparency(0.25) // 25% opaque
                 .ColorsAndLines.SetLineColor(XLColor.Blue)
@@ -105,7 +105,7 @@ namespace ClosedXML_Examples
                 .ColorsAndLines.SetLineWeight(7.5);
 
             // Set all comments to visible
-            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.Comment.SetVisible());
+            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.GetComment().SetVisible());
         }
 
         private void AddStyleAlignment(XLWorkbook wb)
@@ -113,82 +113,82 @@ namespace ClosedXML_Examples
             var ws = wb.Worksheets.Add("Alignment");
 
             // Automagically adjust the size of the comment to fit the contents
-            ws.Cell("A1").Comment.Style.Alignment.SetAutomaticSize();
-            ws.Cell("A1").Comment.AddText("Things are pretty tight around here");
+            ws.Cell("A1").GetComment().Style.Alignment.SetAutomaticSize();
+            ws.Cell("A1").GetComment().AddText("Things are pretty tight around here");
 
             // Default values
-            ws.Cell("A3").Comment
+            ws.Cell("A3").GetComment()
                 .AddText("Default Alignments:").AddNewLine()
                 .AddText("Vertical = Top").AddNewLine()
                 .AddText("Horizontal = Left").AddNewLine()
                 .AddText("Orientation = Left to Right");
 
             // Let's change the alignments
-            ws.Cell("A8").Comment
+            ws.Cell("A8").GetComment()
                 .AddText("Vertical = Bottom").AddNewLine()
                 .AddText("Horizontal = Right");
-            ws.Cell("A8").Comment.Style
+            ws.Cell("A8").GetComment().Style
                 .Alignment.SetVertical(XLDrawingVerticalAlignment.Bottom)
                 .Alignment.SetHorizontal(XLDrawingHorizontalAlignment.Right);
 
             // And now the orientation...
-            ws.Cell("D3").Comment.AddText("Orientation = Bottom to Top");
-            ws.Cell("D3").Comment.Style
+            ws.Cell("D3").GetComment().AddText("Orientation = Bottom to Top");
+            ws.Cell("D3").GetComment().Style
                 .Alignment.SetOrientation(XLDrawingTextOrientation.BottomToTop)
                 .Alignment.SetAutomaticSize();
 
-            ws.Cell("E3").Comment.AddText("Orientation = Top to Bottom");
-            ws.Cell("E3").Comment.Style
+            ws.Cell("E3").GetComment().AddText("Orientation = Top to Bottom");
+            ws.Cell("E3").GetComment().Style
                 .Alignment.SetOrientation(XLDrawingTextOrientation.TopToBottom)
                 .Alignment.SetAutomaticSize();
 
-            ws.Cell("F3").Comment.AddText("Orientation = Vertical");
-            ws.Cell("F3").Comment.Style
+            ws.Cell("F3").GetComment().AddText("Orientation = Vertical");
+            ws.Cell("F3").GetComment().Style
                 .Alignment.SetOrientation(XLDrawingTextOrientation.Vertical)
                 .Alignment.SetAutomaticSize();
 
 
             // Set all comments to visible
-            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.Comment.SetVisible());
+            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.GetComment().SetVisible());
         }
 
         private static void AddMiscComments(XLWorkbook wb)
         {
             var ws = wb.Worksheets.Add("Comments");
 
-            ws.Cell("A1").SetValue("Hidden").Comment.AddText("Hidden");
-            ws.Cell("A2").SetValue("Visible").Comment.AddText("Visible");
-            ws.Cell("A3").SetValue("On Top").Comment.AddText("On Top");
-            ws.Cell("A4").SetValue("Underneath").Comment.AddText("Underneath");
-            ws.Cell("A4").Comment.Style.Alignment.SetVertical(XLDrawingVerticalAlignment.Bottom);
-            ws.Cell("A3").Comment.SetZOrder(ws.Cell("A4").Comment.ZOrder + 1);
+            ws.Cell("A1").SetValue("Hidden").GetComment().AddText("Hidden");
+            ws.Cell("A2").SetValue("Visible").GetComment().AddText("Visible");
+            ws.Cell("A3").SetValue("On Top").GetComment().AddText("On Top");
+            ws.Cell("A4").SetValue("Underneath").GetComment().AddText("Underneath");
+            ws.Cell("A4").GetComment().Style.Alignment.SetVertical(XLDrawingVerticalAlignment.Bottom);
+            ws.Cell("A3").GetComment().SetZOrder(ws.Cell("A4").GetComment().ZOrder + 1);
 
-            ws.Cell("D9").Comment.AddText("Vertical");
-            ws.Cell("D9").Comment.Style.Alignment.Orientation = XLDrawingTextOrientation.Vertical;
-            ws.Cell("D9").Comment.Style.Size.SetAutomaticSize();
+            ws.Cell("D9").GetComment().AddText("Vertical");
+            ws.Cell("D9").GetComment().Style.Alignment.Orientation = XLDrawingTextOrientation.Vertical;
+            ws.Cell("D9").GetComment().Style.Size.SetAutomaticSize();
 
-            ws.Cell("E9").Comment.AddText("Top to Bottom");
-            ws.Cell("E9").Comment.Style.Alignment.Orientation = XLDrawingTextOrientation.TopToBottom;
-            ws.Cell("E9").Comment.Style.Size.SetAutomaticSize();
+            ws.Cell("E9").GetComment().AddText("Top to Bottom");
+            ws.Cell("E9").GetComment().Style.Alignment.Orientation = XLDrawingTextOrientation.TopToBottom;
+            ws.Cell("E9").GetComment().Style.Size.SetAutomaticSize();
 
-            ws.Cell("F9").Comment.AddText("Bottom to Top");
-            ws.Cell("F9").Comment.Style.Alignment.Orientation = XLDrawingTextOrientation.BottomToTop;
-            ws.Cell("F9").Comment.Style.Size.SetAutomaticSize();
+            ws.Cell("F9").GetComment().AddText("Bottom to Top");
+            ws.Cell("F9").GetComment().Style.Alignment.Orientation = XLDrawingTextOrientation.BottomToTop;
+            ws.Cell("F9").GetComment().Style.Size.SetAutomaticSize();
 
-            ws.Cell("E1").Comment.Position.SetColumn(5);
-            ws.Cell("E1").Comment.AddText("Start on Col E, on top border");
-            ws.Cell("E1").Comment.Style.Size.SetWidth(10);
-            var cE3 = ws.Cell("E3").Comment;
+            ws.Cell("E1").GetComment().Position.SetColumn(5);
+            ws.Cell("E1").GetComment().AddText("Start on Col E, on top border");
+            ws.Cell("E1").GetComment().Style.Size.SetWidth(10);
+            var cE3 = ws.Cell("E3").GetComment();
             cE3.AddText("Size and position");
             cE3.Position.SetColumn(5).SetRow(4).SetColumnOffset(7).SetRowOffset(10);
             cE3.Style.Size.SetHeight(25).Size.SetWidth(10);
-            var cE7 = ws.Cell("E7").Comment;
+            var cE7 = ws.Cell("E7").GetComment();
             cE7.Position.SetColumn(6).SetRow(7).SetColumnOffset(0).SetRowOffset(0);
             cE7.Style.Size.SetHeight(ws.Row(7).Height).Size.SetWidth(ws.Column(6).Width);
 
-            ws.Cell("G1").Comment.AddText("Automatic Size");
-            ws.Cell("G1").Comment.Style.Alignment.SetAutomaticSize();
-            var cG3 = ws.Cell("G3").Comment;
+            ws.Cell("G1").GetComment().AddText("Automatic Size");
+            ws.Cell("G1").GetComment().Style.Alignment.SetAutomaticSize();
+            var cG3 = ws.Cell("G3").GetComment();
             cG3.SetAuthor("MDeLeon");
             cG3.AddSignature();
             cG3.AddText("This is a test of the emergency broadcast system.");
@@ -216,10 +216,10 @@ namespace ClosedXML_Examples
                 .Protection.SetLockText(false)
                 .Web.SetAlternateText("This won't be released to the web");
 
-            ws.Cell("A9").Comment.SetAuthor("MDeLeon").AddSignature().AddText("Something");
-            ws.Cell("A9").Comment.SetBold().SetFontColor(XLColor.DarkBlue);
+            ws.Cell("A9").GetComment().SetAuthor("MDeLeon").AddSignature().AddText("Something");
+            ws.Cell("A9").GetComment().SetBold().SetFontColor(XLColor.DarkBlue);
 
-            ws.CellsUsed(XLCellsUsedOptions.All, c => !c.Address.ToStringRelative().Equals("A1") && c.HasComment).ForEach(c => c.Comment.SetVisible());
+            ws.CellsUsed(XLCellsUsedOptions.All, c => !c.Address.ToStringRelative().Equals("A1") && c.HasComment).ForEach(c => c.GetComment().SetVisible());
         }
 
         private static void AddVisibilityComments(XLWorkbook wb)
@@ -227,19 +227,19 @@ namespace ClosedXML_Examples
             var ws = wb.Worksheets.Add("Visibility");
 
             // By default comments are hidden
-            ws.Cell("A1").SetValue("I have a hidden comment").Comment.AddText("Hidden");
+            ws.Cell("A1").SetValue("I have a hidden comment").GetComment().AddText("Hidden");
             
             // Set the comment as visible
-            ws.Cell("A2").Comment.SetVisible().AddText("Visible");
+            ws.Cell("A2").GetComment().SetVisible().AddText("Visible");
 
             // The ZOrder on previous comments were 1 and 2 respectively
             // here we're explicit about the ZOrder
-            ws.Cell("A3").Comment.SetZOrder(5).SetVisible().AddText("On Top");
+            ws.Cell("A3").GetComment().SetZOrder(5).SetVisible().AddText("On Top");
 
             // We want this comment to appear underneath the one for A3
             // so we set the ZOrder to something lower
-            ws.Cell("A4").Comment.SetZOrder(4).SetVisible().AddText("Underneath");
-            ws.Cell("A4").Comment.Style.Alignment.SetVertical(XLDrawingVerticalAlignment.Bottom);
+            ws.Cell("A4").GetComment().SetZOrder(4).SetVisible().AddText("Underneath");
+            ws.Cell("A4").GetComment().Style.Alignment.SetVertical(XLDrawingVerticalAlignment.Bottom);
             
             // Alternatively you could set all comments to visible with the following line:
             // ws.CellsUsed(true, c => c.HasComment).ForEach(c => c.Comment.SetVisible());
@@ -253,15 +253,15 @@ namespace ClosedXML_Examples
             
             ws.Columns().Width = 10;
 
-            ws.Cell("A1").Comment.AddText("This is an unusual place for a comment...");
-            ws.Cell("A1").Comment.Position
+            ws.Cell("A1").GetComment().AddText("This is an unusual place for a comment...");
+            ws.Cell("A1").GetComment().Position
                 .SetColumn(3) // Starting from the third column
                 .SetColumnOffset(5) // The comment will start in the middle of the third column
                 .SetRow(5) // Starting from the fifth row
                 .SetRowOffset(7.5); // The comment will start in the middle of the fifth row
 
             // Set all comments to visible
-            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.Comment.SetVisible());
+            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.GetComment().SetVisible());
         }
 
         private void AddSignatures(XLWorkbook wb)
@@ -272,14 +272,14 @@ namespace ClosedXML_Examples
             // ws.Cell("A2").Comment.AddSignature().AddText("Hello World!");
 
             // You can override this by specifying the comment's author:
-            ws.Cell("A2").Comment
+            ws.Cell("A2").GetComment()
                 .SetAuthor("MDeLeon")
                 .AddSignature()
                 .AddText("Hello World!");
             
 
             // Set all comments to visible
-            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.Comment.SetVisible());
+            ws.CellsUsed(XLCellsUsedOptions.All, c => c.HasComment).ForEach(c => c.GetComment().SetVisible());
         }
     }
 }

--- a/ClosedXML_Examples/Comments/EditingComments.cs
+++ b/ClosedXML_Examples/Comments/EditingComments.cs
@@ -28,9 +28,9 @@ namespace ClosedXML_Examples
             // A1
 
             // edit existing comment
-            sheet.Cell("B3").Comment.AddNewLine();
-            sheet.Cell("B3").Comment.AddSignature();
-            sheet.Cell("B3").Comment.AddText("more comment");
+            sheet.Cell("B3").GetComment().AddNewLine();
+            sheet.Cell("B3").GetComment().AddSignature();
+            sheet.Cell("B3").GetComment().AddText("more comment");
 
             // delete
             //sheet.Cell("C1").DeleteComment();
@@ -39,11 +39,11 @@ namespace ClosedXML_Examples
             sheet.Cell("D3").Clear(XLClearOptions.Contents);
 
             // new basic
-            sheet.Cell("E1").Comment.AddText("non authored comment");
+            sheet.Cell("E1").GetComment().AddText("non authored comment");
 
             // new with author
-            sheet.Cell("F3").Comment.AddSignature();
-            sheet.Cell("F3").Comment.AddText("comment from author");
+            sheet.Cell("F3").GetComment().AddSignature();
+            sheet.Cell("F3").GetComment().AddText("comment from author");
 
             // TODO: merge with cells
             // TODO: resize with cells

--- a/ClosedXML_Examples/Misc/AdjustToContents.cs
+++ b/ClosedXML_Examples/Misc/AdjustToContents.cs
@@ -61,13 +61,13 @@ namespace ClosedXML_Examples.Misc
                 {
                     var c = ws4.Cell(1, (co / 5) + 2);
 
-                    c.RichText.AddText("Text to adjust - " + co).SetBold();
-                    c.RichText.AddText(Environment.NewLine);
-                    c.RichText.AddText("World!").SetBold().SetFontColor(XLColor.Blue).SetFontSize(25);
-                    c.RichText.AddText(Environment.NewLine);
-                    c.RichText.AddText("Hello Cruel and unsusual world").SetBold().SetFontSize(20);
-                    c.RichText.AddText(Environment.NewLine);
-                    c.RichText.AddText("Hello").SetBold();
+                    c.GetRichText().AddText("Text to adjust - " + co).SetBold();
+                    c.GetRichText().AddText(Environment.NewLine);
+                    c.GetRichText().AddText("World!").SetBold().SetFontColor(XLColor.Blue).SetFontSize(25);
+                    c.GetRichText().AddText(Environment.NewLine);
+                    c.GetRichText().AddText("Hello Cruel and unsusual world").SetBold().SetFontSize(20);
+                    c.GetRichText().AddText(Environment.NewLine);
+                    c.GetRichText().AddText("Hello").SetBold();
                     c.Style.Alignment.SetTextRotation(co);
                 }
                 ws4.Columns().AdjustToContents();
@@ -86,13 +86,13 @@ namespace ClosedXML_Examples.Misc
                 for (Int32 ro = 0; ro < 90; ro += 5)
                 {
                     var c = ws5.Cell((ro / 5) + 2, 1);
-                    c.RichText.AddText("Text to adjust - " + ro).SetBold();
-                    c.RichText.AddText(Environment.NewLine);
-                    c.RichText.AddText("World!").SetBold().SetFontColor(XLColor.Blue).SetFontSize(10);
-                    c.RichText.AddText(Environment.NewLine);
-                    c.RichText.AddText("Hello Cruel and unsusual world").SetBold().SetFontSize(15);
-                    c.RichText.AddText(Environment.NewLine);
-                    c.RichText.AddText("Hello").SetBold();
+                    c.GetRichText().AddText("Text to adjust - " + ro).SetBold();
+                    c.GetRichText().AddText(Environment.NewLine);
+                    c.GetRichText().AddText("World!").SetBold().SetFontColor(XLColor.Blue).SetFontSize(10);
+                    c.GetRichText().AddText(Environment.NewLine);
+                    c.GetRichText().AddText("Hello Cruel and unsusual world").SetBold().SetFontSize(15);
+                    c.GetRichText().AddText(Environment.NewLine);
+                    c.GetRichText().AddText("Hello").SetBold();
                     c.Style.Alignment.SetTextRotation(ro);
                 }
 

--- a/ClosedXML_Examples/Misc/DataValidation.cs
+++ b/ClosedXML_Examples/Misc/DataValidation.cs
@@ -48,10 +48,10 @@ namespace ClosedXML_Examples.Misc
             var ws = wb.Worksheets.Add("Data Validation");
 
             // Decimal between 1 and 5
-            ws.Cell(1, 1).SetDataValidation().Decimal.Between(1, 5);
+            ws.Cell(1, 1).CreateDataValidation().Decimal.Between(1, 5);
 
             // Whole number equals 2
-            var dv1 = ws.Range("A2:A3").SetDataValidation();
+            var dv1 = ws.Range("A2:A3").CreateDataValidation();
             dv1.WholeNumber.EqualTo(2);
             // Change the error message
             dv1.ErrorStyle = XLErrorStyle.Warning;
@@ -59,7 +59,7 @@ namespace ClosedXML_Examples.Misc
             dv1.ErrorMessage = "This cell only allows the number 2.";
 
             // Date after the millenium
-            var dv2 = ws.Cell("A4").SetDataValidation();
+            var dv2 = ws.Cell("A4").CreateDataValidation();
             dv2.Date.EqualOrGreaterThan(new DateTime(2000, 1, 1));
             // Change the input message
             dv2.InputTitle = "Can't party like it's 1999.";
@@ -68,63 +68,63 @@ namespace ClosedXML_Examples.Misc
             // From a list
             ws.Cell("C1").Value = "Yes";
             ws.Cell("C2").Value = "No";
-            ws.Cell("A5").SetDataValidation().List(ws.Range("C1:C2"));
+            ws.Cell("A5").CreateDataValidation().List(ws.Range("C1:C2"));
 
             ws.Range("C1:C2").AddToNamed("YesNo");
-            ws.Cell("A6").SetDataValidation().List("=YesNo");
+            ws.Cell("A6").CreateDataValidation().List("=YesNo");
 
             // Intersecting dataValidations
-            ws.Range("B1:B4").SetDataValidation().WholeNumber.EqualTo(1);
-            ws.Range("B3:B4").SetDataValidation().WholeNumber.EqualTo(2);
+            ws.Range("B1:B4").CreateDataValidation().WholeNumber.EqualTo(1);
+            ws.Range("B3:B4").CreateDataValidation().WholeNumber.EqualTo(2);
 
 
             // Validate with multiple ranges
             var ws2 = wb.Worksheets.Add("Validate Ranges");
             var rng1 = ws2.Ranges("A1:B2,B4:D7,F4:G5");
             rng1.Style.Fill.SetBackgroundColor(XLColor.YellowGreen);
-            var rng1Validation = rng1.SetDataValidation();
+            var rng1Validation = rng1.CreateDataValidation();
             rng1Validation.Decimal.EqualTo(1.1);
             rng1Validation.IgnoreBlanks = false;
 
             var rng2 = ws2.Range("A11:E14");
             rng2.Style.Fill.SetBackgroundColor(XLColor.Alizarin);
-            var rng2Validation = rng2.SetDataValidation();
+            var rng2Validation = rng2.CreateDataValidation();
             rng2Validation.Decimal.NotEqualTo(2.2);
             rng2Validation.IgnoreBlanks = false;
 
             var rng3 = ws2.Range("B2:B12");
             rng3.Style.Fill.SetBackgroundColor(XLColor.Almond);
-            var rng3Validation = rng3.SetDataValidation();
+            var rng3Validation = rng3.CreateDataValidation();
             rng3Validation.Decimal.GreaterThan(3.3);
             rng3Validation.IgnoreBlanks = true;
 
             var rng4 = ws2.Range("D5:D6");
             rng4.Style.Fill.SetBackgroundColor(XLColor.Amaranth);
-            var rng4Validation = rng4.SetDataValidation();
+            var rng4Validation = rng4.CreateDataValidation();
             rng4Validation.Decimal.LessThan(4.4);
             rng4Validation.IgnoreBlanks = true;
 
             var rng5 = ws2.Range("C13:C14");
             rng5.Style.Fill.SetBackgroundColor(XLColor.Amber);
-            var rng5Validation = rng5.SetDataValidation();
+            var rng5Validation = rng5.CreateDataValidation();
             rng5Validation.Decimal.EqualOrGreaterThan(5.5);
             rng5Validation.IgnoreBlanks = true;
 
             var rng6 = ws2.Range("D11:D12");
             rng6.Style.Fill.SetBackgroundColor(XLColor.Amethyst);
-            var rng6Validation = rng6.SetDataValidation();
+            var rng6Validation = rng6.CreateDataValidation();
             rng6Validation.Decimal.EqualOrLessThan(6.6);
             rng6Validation.IgnoreBlanks = true;
 
             var rng7 = ws2.Range("G4:G5");
             rng7.Style.Fill.SetBackgroundColor(XLColor.Apricot);
-            var rng7Validation = rng7.SetDataValidation();
+            var rng7Validation = rng7.CreateDataValidation();
             rng7Validation.Decimal.Between(7.7, 8.8);
             rng7Validation.IgnoreBlanks = true;
 
             var rng8 = ws2.Range("H1:H12");
             rng8.Style.Fill.SetBackgroundColor(XLColor.Aqua);
-            var rng8Validation = rng8.SetDataValidation();
+            var rng8Validation = rng8.CreateDataValidation();
             rng8Validation.Decimal.NotBetween(9.9, 10.1);
             rng8Validation.IgnoreBlanks = true;
 

--- a/ClosedXML_Examples/Misc/DataValidationDate.cs
+++ b/ClosedXML_Examples/Misc/DataValidationDate.cs
@@ -16,23 +16,23 @@ namespace ClosedXML_Examples.Misc
             c1.Value = date1;
             c2.Value = date2;
 
-            ws.Range("A2:A10").SetDataValidation().Date.EqualTo(date1);
-            ws.Range("B2:B10").SetDataValidation().Date.NotEqualTo(date1);
-            ws.Range("C2:C10").SetDataValidation().Date.GreaterThan(date1);
-            ws.Range("D2:D10").SetDataValidation().Date.LessThan(date1);
-            ws.Range("E2:E10").SetDataValidation().Date.EqualOrGreaterThan(date1);
-            ws.Range("F2:F10").SetDataValidation().Date.EqualOrLessThan(date1);
-            ws.Range("G2:G10").SetDataValidation().Date.Between(date1, date2);
-            ws.Range("H2:H10").SetDataValidation().Date.NotBetween(date1, date2);
+            ws.Range("A2:A10").CreateDataValidation().Date.EqualTo(date1);
+            ws.Range("B2:B10").CreateDataValidation().Date.NotEqualTo(date1);
+            ws.Range("C2:C10").CreateDataValidation().Date.GreaterThan(date1);
+            ws.Range("D2:D10").CreateDataValidation().Date.LessThan(date1);
+            ws.Range("E2:E10").CreateDataValidation().Date.EqualOrGreaterThan(date1);
+            ws.Range("F2:F10").CreateDataValidation().Date.EqualOrLessThan(date1);
+            ws.Range("G2:G10").CreateDataValidation().Date.Between(date1, date2);
+            ws.Range("H2:H10").CreateDataValidation().Date.NotBetween(date1, date2);
 
-            ws.Range("A11:A20").SetDataValidation().Date.EqualTo(c1);
-            ws.Range("B11:B20").SetDataValidation().Date.NotEqualTo(c1);
-            ws.Range("C11:C20").SetDataValidation().Date.GreaterThan(c1);
-            ws.Range("D11:D20").SetDataValidation().Date.LessThan(c1);
-            ws.Range("E11:E20").SetDataValidation().Date.EqualOrGreaterThan(c1);
-            ws.Range("F11:F20").SetDataValidation().Date.EqualOrLessThan(c1);
-            ws.Range("G11:G20").SetDataValidation().Date.Between(c1, c2);
-            ws.Range("H11:H20").SetDataValidation().Date.NotBetween(c1, c2);
+            ws.Range("A11:A20").CreateDataValidation().Date.EqualTo(c1);
+            ws.Range("B11:B20").CreateDataValidation().Date.NotEqualTo(c1);
+            ws.Range("C11:C20").CreateDataValidation().Date.GreaterThan(c1);
+            ws.Range("D11:D20").CreateDataValidation().Date.LessThan(c1);
+            ws.Range("E11:E20").CreateDataValidation().Date.EqualOrGreaterThan(c1);
+            ws.Range("F11:F20").CreateDataValidation().Date.EqualOrLessThan(c1);
+            ws.Range("G11:G20").CreateDataValidation().Date.Between(c1, c2);
+            ws.Range("H11:H20").CreateDataValidation().Date.NotBetween(c1, c2);
 
             wb.SaveAs(filePath);
         }

--- a/ClosedXML_Examples/Misc/DataValidationDecimal.cs
+++ b/ClosedXML_Examples/Misc/DataValidationDecimal.cs
@@ -15,23 +15,23 @@ namespace ClosedXML_Examples.Misc
             var r1 = ws.Range("A1:A10");
             var r2 = ws.Range("B1:B10");
 
-            ws.Range("A2:A10").SetDataValidation().Decimal.EqualTo(1.1);
-            ws.Range("B2:B10").SetDataValidation().Decimal.NotEqualTo(2.1);
-            ws.Range("C2:C10").SetDataValidation().Decimal.GreaterThan(3.1);
-            ws.Range("D2:D10").SetDataValidation().Decimal.LessThan(4.1);
-            ws.Range("E2:E10").SetDataValidation().Decimal.EqualOrGreaterThan(5.1);
-            ws.Range("F2:F10").SetDataValidation().Decimal.EqualOrLessThan(6.1);
-            ws.Range("G2:G10").SetDataValidation().Decimal.Between(7.1, 8.1);
-            ws.Range("H2:H10").SetDataValidation().Decimal.NotBetween(9.1, 10.1);
+            ws.Range("A2:A10").CreateDataValidation().Decimal.EqualTo(1.1);
+            ws.Range("B2:B10").CreateDataValidation().Decimal.NotEqualTo(2.1);
+            ws.Range("C2:C10").CreateDataValidation().Decimal.GreaterThan(3.1);
+            ws.Range("D2:D10").CreateDataValidation().Decimal.LessThan(4.1);
+            ws.Range("E2:E10").CreateDataValidation().Decimal.EqualOrGreaterThan(5.1);
+            ws.Range("F2:F10").CreateDataValidation().Decimal.EqualOrLessThan(6.1);
+            ws.Range("G2:G10").CreateDataValidation().Decimal.Between(7.1, 8.1);
+            ws.Range("H2:H10").CreateDataValidation().Decimal.NotBetween(9.1, 10.1);
 
-            ws.Range("A11:A20").SetDataValidation().Decimal.EqualTo(c1);
-            ws.Range("B11:B20").SetDataValidation().Decimal.NotEqualTo(c1);
-            ws.Range("C11:C20").SetDataValidation().Decimal.GreaterThan(c1);
-            ws.Range("D11:D20").SetDataValidation().Decimal.LessThan(c1);
-            ws.Range("E11:E20").SetDataValidation().Decimal.EqualOrGreaterThan(c1);
-            ws.Range("F11:F20").SetDataValidation().Decimal.EqualOrLessThan(c1);
-            ws.Range("G11:G20").SetDataValidation().Decimal.Between(c1, c2);
-            ws.Range("H11:H20").SetDataValidation().Decimal.NotBetween(c1, c2);
+            ws.Range("A11:A20").CreateDataValidation().Decimal.EqualTo(c1);
+            ws.Range("B11:B20").CreateDataValidation().Decimal.NotEqualTo(c1);
+            ws.Range("C11:C20").CreateDataValidation().Decimal.GreaterThan(c1);
+            ws.Range("D11:D20").CreateDataValidation().Decimal.LessThan(c1);
+            ws.Range("E11:E20").CreateDataValidation().Decimal.EqualOrGreaterThan(c1);
+            ws.Range("F11:F20").CreateDataValidation().Decimal.EqualOrLessThan(c1);
+            ws.Range("G11:G20").CreateDataValidation().Decimal.Between(c1, c2);
+            ws.Range("H11:H20").CreateDataValidation().Decimal.NotBetween(c1, c2);
 
             wb.SaveAs(filePath);
         }

--- a/ClosedXML_Examples/Misc/DataValidationTextLength.cs
+++ b/ClosedXML_Examples/Misc/DataValidationTextLength.cs
@@ -13,23 +13,23 @@ namespace ClosedXML_Examples.Misc
             c1.Value = 1;
             c2.Value = 2;
 
-            ws.Range("A2:A10").SetDataValidation().TextLength.EqualTo(1);
-            ws.Range("B2:B10").SetDataValidation().TextLength.NotEqualTo(2);
-            ws.Range("C2:C10").SetDataValidation().TextLength.GreaterThan(3);
-            ws.Range("D2:D10").SetDataValidation().TextLength.LessThan(4);
-            ws.Range("E2:E10").SetDataValidation().TextLength.EqualOrGreaterThan(5);
-            ws.Range("F2:F10").SetDataValidation().TextLength.EqualOrLessThan(6);
-            ws.Range("G2:G10").SetDataValidation().TextLength.Between(7, 8);
-            ws.Range("H2:H10").SetDataValidation().TextLength.NotBetween(9, 10);
+            ws.Range("A2:A10").CreateDataValidation().TextLength.EqualTo(1);
+            ws.Range("B2:B10").CreateDataValidation().TextLength.NotEqualTo(2);
+            ws.Range("C2:C10").CreateDataValidation().TextLength.GreaterThan(3);
+            ws.Range("D2:D10").CreateDataValidation().TextLength.LessThan(4);
+            ws.Range("E2:E10").CreateDataValidation().TextLength.EqualOrGreaterThan(5);
+            ws.Range("F2:F10").CreateDataValidation().TextLength.EqualOrLessThan(6);
+            ws.Range("G2:G10").CreateDataValidation().TextLength.Between(7, 8);
+            ws.Range("H2:H10").CreateDataValidation().TextLength.NotBetween(9, 10);
 
-            ws.Range("A11:A20").SetDataValidation().TextLength.EqualTo(c1);
-            ws.Range("B11:B20").SetDataValidation().TextLength.NotEqualTo(c1);
-            ws.Range("C11:C20").SetDataValidation().TextLength.GreaterThan(c1);
-            ws.Range("D11:D20").SetDataValidation().TextLength.LessThan(c1);
-            ws.Range("E11:E20").SetDataValidation().TextLength.EqualOrGreaterThan(c1);
-            ws.Range("F11:F20").SetDataValidation().TextLength.EqualOrLessThan(c1);
-            ws.Range("G11:G20").SetDataValidation().TextLength.Between(c1, c2);
-            ws.Range("H11:H20").SetDataValidation().TextLength.NotBetween(c1, c2);
+            ws.Range("A11:A20").CreateDataValidation().TextLength.EqualTo(c1);
+            ws.Range("B11:B20").CreateDataValidation().TextLength.NotEqualTo(c1);
+            ws.Range("C11:C20").CreateDataValidation().TextLength.GreaterThan(c1);
+            ws.Range("D11:D20").CreateDataValidation().TextLength.LessThan(c1);
+            ws.Range("E11:E20").CreateDataValidation().TextLength.EqualOrGreaterThan(c1);
+            ws.Range("F11:F20").CreateDataValidation().TextLength.EqualOrLessThan(c1);
+            ws.Range("G11:G20").CreateDataValidation().TextLength.Between(c1, c2);
+            ws.Range("H11:H20").CreateDataValidation().TextLength.NotBetween(c1, c2);
 
             wb.SaveAs(filePath);
         }

--- a/ClosedXML_Examples/Misc/DataValidationTime.cs
+++ b/ClosedXML_Examples/Misc/DataValidationTime.cs
@@ -16,23 +16,23 @@ namespace ClosedXML_Examples.Misc
             c1.Value = time1;
             c2.Value = time2;
 
-            ws.Range("A2:A10").SetDataValidation().Time.EqualTo(time1);
-            ws.Range("B2:B10").SetDataValidation().Time.NotEqualTo(time1);
-            ws.Range("C2:C10").SetDataValidation().Time.GreaterThan(time1);
-            ws.Range("D2:D10").SetDataValidation().Time.LessThan(time1);
-            ws.Range("E2:E10").SetDataValidation().Time.EqualOrGreaterThan(time1);
-            ws.Range("F2:F10").SetDataValidation().Time.EqualOrLessThan(time1);
-            ws.Range("G2:G10").SetDataValidation().Time.Between(time1, time2);
-            ws.Range("H2:H10").SetDataValidation().Time.NotBetween(time1, time2);
+            ws.Range("A2:A10").CreateDataValidation().Time.EqualTo(time1);
+            ws.Range("B2:B10").CreateDataValidation().Time.NotEqualTo(time1);
+            ws.Range("C2:C10").CreateDataValidation().Time.GreaterThan(time1);
+            ws.Range("D2:D10").CreateDataValidation().Time.LessThan(time1);
+            ws.Range("E2:E10").CreateDataValidation().Time.EqualOrGreaterThan(time1);
+            ws.Range("F2:F10").CreateDataValidation().Time.EqualOrLessThan(time1);
+            ws.Range("G2:G10").CreateDataValidation().Time.Between(time1, time2);
+            ws.Range("H2:H10").CreateDataValidation().Time.NotBetween(time1, time2);
 
-            ws.Range("A11:A20").SetDataValidation().Time.EqualTo(c1);
-            ws.Range("B11:B20").SetDataValidation().Time.NotEqualTo(c1);
-            ws.Range("C11:C20").SetDataValidation().Time.GreaterThan(c1);
-            ws.Range("D11:D20").SetDataValidation().Time.LessThan(c1);
-            ws.Range("E11:E20").SetDataValidation().Time.EqualOrGreaterThan(c1);
-            ws.Range("F11:F20").SetDataValidation().Time.EqualOrLessThan(c1);
-            ws.Range("G11:G20").SetDataValidation().Time.Between(c1, c2);
-            ws.Range("H11:H20").SetDataValidation().Time.NotBetween(c1, c2);
+            ws.Range("A11:A20").CreateDataValidation().Time.EqualTo(c1);
+            ws.Range("B11:B20").CreateDataValidation().Time.NotEqualTo(c1);
+            ws.Range("C11:C20").CreateDataValidation().Time.GreaterThan(c1);
+            ws.Range("D11:D20").CreateDataValidation().Time.LessThan(c1);
+            ws.Range("E11:E20").CreateDataValidation().Time.EqualOrGreaterThan(c1);
+            ws.Range("F11:F20").CreateDataValidation().Time.EqualOrLessThan(c1);
+            ws.Range("G11:G20").CreateDataValidation().Time.Between(c1, c2);
+            ws.Range("H11:H20").CreateDataValidation().Time.NotBetween(c1, c2);
 
             wb.SaveAs(filePath);
         }

--- a/ClosedXML_Examples/Misc/DataValidationWholeNumber.cs
+++ b/ClosedXML_Examples/Misc/DataValidationWholeNumber.cs
@@ -13,23 +13,23 @@ namespace ClosedXML_Examples.Misc
             c1.Value = 1;
             c2.Value = 2;
 
-            ws.Range("A2:A10").SetDataValidation().WholeNumber.EqualTo(1);
-            ws.Range("B2:B10").SetDataValidation().WholeNumber.NotEqualTo(2);
-            ws.Range("C2:C10").SetDataValidation().WholeNumber.GreaterThan(3);
-            ws.Range("D2:D10").SetDataValidation().WholeNumber.LessThan(4);
-            ws.Range("E2:E10").SetDataValidation().WholeNumber.EqualOrGreaterThan(5);
-            ws.Range("F2:F10").SetDataValidation().WholeNumber.EqualOrLessThan(6);
-            ws.Range("G2:G10").SetDataValidation().WholeNumber.Between(7, 8);
-            ws.Range("H2:H10").SetDataValidation().WholeNumber.NotBetween(9, 10);
+            ws.Range("A2:A10").CreateDataValidation().WholeNumber.EqualTo(1);
+            ws.Range("B2:B10").CreateDataValidation().WholeNumber.NotEqualTo(2);
+            ws.Range("C2:C10").CreateDataValidation().WholeNumber.GreaterThan(3);
+            ws.Range("D2:D10").CreateDataValidation().WholeNumber.LessThan(4);
+            ws.Range("E2:E10").CreateDataValidation().WholeNumber.EqualOrGreaterThan(5);
+            ws.Range("F2:F10").CreateDataValidation().WholeNumber.EqualOrLessThan(6);
+            ws.Range("G2:G10").CreateDataValidation().WholeNumber.Between(7, 8);
+            ws.Range("H2:H10").CreateDataValidation().WholeNumber.NotBetween(9, 10);
 
-            ws.Range("A11:A20").SetDataValidation().WholeNumber.EqualTo(c1);
-            ws.Range("B11:B20").SetDataValidation().WholeNumber.NotEqualTo(c1);
-            ws.Range("C11:C20").SetDataValidation().WholeNumber.GreaterThan(c1);
-            ws.Range("D11:D20").SetDataValidation().WholeNumber.LessThan(c1);
-            ws.Range("E11:E20").SetDataValidation().WholeNumber.EqualOrGreaterThan(c1);
-            ws.Range("F11:F20").SetDataValidation().WholeNumber.EqualOrLessThan(c1);
-            ws.Range("G11:G20").SetDataValidation().WholeNumber.Between(c1, c2);
-            ws.Range("H11:H20").SetDataValidation().WholeNumber.NotBetween(c1, c2);
+            ws.Range("A11:A20").CreateDataValidation().WholeNumber.EqualTo(c1);
+            ws.Range("B11:B20").CreateDataValidation().WholeNumber.NotEqualTo(c1);
+            ws.Range("C11:C20").CreateDataValidation().WholeNumber.GreaterThan(c1);
+            ws.Range("D11:D20").CreateDataValidation().WholeNumber.LessThan(c1);
+            ws.Range("E11:E20").CreateDataValidation().WholeNumber.EqualOrGreaterThan(c1);
+            ws.Range("F11:F20").CreateDataValidation().WholeNumber.EqualOrLessThan(c1);
+            ws.Range("G11:G20").CreateDataValidation().WholeNumber.Between(c1, c2);
+            ws.Range("H11:H20").CreateDataValidation().WholeNumber.NotBetween(c1, c2);
 
             wb.SaveAs(filePath);
         }

--- a/ClosedXML_Examples/Misc/Hyperlinks.cs
+++ b/ClosedXML_Examples/Misc/Hyperlinks.cs
@@ -52,50 +52,50 @@ namespace ClosedXML_Examples.Misc
             // browser: http, ftp, mailto, gopher, news, nntp, etc.
             
             ws.Cell(++ro, 1).Value = "Link to a web page, no tooltip - Yahoo!";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink(@"http://www.yahoo.com");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink(@"http://www.yahoo.com"));
 
             ws.Cell(++ro, 1).Value = "Link to a web page, with a tooltip - Yahoo!";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink(@"http://www.yahoo.com", "Click to go to Yahoo!");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink(@"http://www.yahoo.com", "Click to go to Yahoo!"));
 
             ws.Cell(++ro, 1).Value = "Link to a file - same folder";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink("Test.xlsx");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("Test.xlsx"));
 
             ws.Cell(++ro, 1).Value = "Link to a file - Absolute";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink(@"D:\Test.xlsx");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink(@"D:\Test.xlsx"));
 
             ws.Cell(++ro, 1).Value = "Link to a file - relative address";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink(@"../Test.xlsx");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink(@"../Test.xlsx"));
 
             ws.Cell(++ro, 1).Value = "Link to an address in this worksheet";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink("B1");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("B1"));
 
             ws.Cell(++ro, 1).Value = "Link to an address in another worksheet";
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink("'Second Sheet'!A1");
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink("'Second Sheet'!A1"));
 
             // You can also set the properties of a hyperlink directly:
 
             ws.Cell(++ro, 1).Value = "Link to a range in this worksheet";
-            ws.Cell(ro, 1).Hyperlink.InternalAddress = "B1:C2";
-            ws.Cell(ro, 1).Hyperlink.Tooltip = "SquareBox";
+            ws.Cell(ro, 1).GetHyperlink().InternalAddress = "B1:C2";
+            ws.Cell(ro, 1).GetHyperlink().Tooltip = "SquareBox";
 
             ws.Cell(++ro, 1).Value = "Link to an email message";
-            ws.Cell(ro, 1).Hyperlink.ExternalAddress = new Uri(@"mailto:SantaClaus@NorthPole.com?subject=Presents");
+            ws.Cell(ro, 1).GetHyperlink().ExternalAddress = new Uri(@"mailto:SantaClaus@NorthPole.com?subject=Presents");
 
             // Deleting a hyperlink
             ws.Cell(++ro, 1).Value = "This is no longer a link";
-            ws.Cell(ro, 1).Hyperlink.InternalAddress = "A1";
-            ws.Cell(ro, 1).Hyperlink.Delete();
+            ws.Cell(ro, 1).GetHyperlink().InternalAddress = "A1";
+            ws.Cell(ro, 1).GetHyperlink().Delete();
 
             // Setting a hyperlink preserves previous formatting:
             ws.Cell(++ro, 1).Value = "Odd looking link";
             ws.Cell(ro, 1).Style.Font.FontColor = XLColor.Red;
             ws.Cell(ro, 1).Style.Font.Underline = XLFontUnderlineValues.Double;
-            ws.Cell(ro, 1).Hyperlink = new XLHyperlink(ws.Range("B1:C2"));
+            ws.Cell(ro, 1).SetHyperlink(new XLHyperlink(ws.Range("B1:C2")));
             
             // Hyperlink via formula
             ws.Cell( ++ro, 1 ).SetValue( "Send Email" )
                 .SetFormulaA1( "=HYPERLINK(\"mailto:test@test.com\", \"Send Email\")" )
-                .Hyperlink = new XLHyperlink( "mailto:test@test.com", "'Send Email'" );
+                .SetHyperlink(new XLHyperlink( "mailto:test@test.com", "'Send Email'" ));
 
             // List all hyperlinks in a worksheet:
             var hyperlinksInWorksheet = ws.Hyperlinks;
@@ -105,12 +105,12 @@ namespace ClosedXML_Examples.Misc
 
             // Clearing a cell with a hyperlink
             ws.Cell(++ro, 1).Value = "ERROR!";
-            ws.Cell(ro, 1).Hyperlink.InternalAddress = "A1";
+            ws.Cell(ro, 1).GetHyperlink().InternalAddress = "A1";
             ws.Cell(ro, 1).Clear();
 
             // Deleting a cell with a hyperlink
             ws.Cell(++ro, 1).Value = "ERROR!";
-            ws.Cell(ro, 1).Hyperlink.InternalAddress = "A1";
+            ws.Cell(ro, 1).GetHyperlink().InternalAddress = "A1";
             ws.Cell(ro, 1).Clear();
 
             ws.Columns().AdjustToContents();

--- a/ClosedXML_Examples/Styles/UsingPhonetics.cs
+++ b/ClosedXML_Examples/Styles/UsingPhonetics.cs
@@ -19,12 +19,12 @@ namespace ClosedXML_Examples.Styles
 
             // Phonetics are implemented as part of the Rich Text functionality. For more information see [Using Rich Text]
             // First we add the text.
-            cell.RichText.AddText("みんなさんはお元気ですか。").SetFontSize(16);
+            cell.GetRichText().AddText("みんなさんはお元気ですか。").SetFontSize(16);
 
             // And then we add the phonetics
-            cell.RichText.Phonetics.SetFontSize(8);
-            cell.RichText.Phonetics.Add("げん", 7, 8);
-            cell.RichText.Phonetics.Add("き", 8, 9);
+            cell.GetRichText().Phonetics.SetFontSize(8);
+            cell.GetRichText().Phonetics.Add("げん", 7, 8);
+            cell.GetRichText().Phonetics.Add("き", 8, 9);
 
             //TODO: I'm looking for someone who understands Japanese to confirm the validity of the above code.
 

--- a/ClosedXML_Examples/Styles/UsingRichText.cs
+++ b/ClosedXML_Examples/Styles/UsingRichText.cs
@@ -61,7 +61,7 @@ namespace ClosedXML_Examples.Styles
             // We want everything in blue except the word show 
             // (which we want in red and with Courier Font)
             cell1.Style.Font.FontColor = XLColor.Blue; // Set the color for the entire cell
-            cell1.RichText.Substring(4, 4)
+            cell1.GetRichText().Substring(4, 4)
                 .SetFontColor(XLColor.Red)
                 .SetFontName("Courier"); // Set the color and font for the word "show"
 
@@ -69,13 +69,13 @@ namespace ClosedXML_Examples.Styles
             var cell = ws.Cell(3, 1);
 
             // Add the text parts
-            cell.RichText.AddText("Hello").SetFontColor(XLColor.Red);
-            cell.RichText.AddText(" BIG ").SetFontColor(XLColor.Blue).SetBold();
-            cell.RichText.AddText("World").SetFontColor(XLColor.Red);
+            cell.GetRichText().AddText("Hello").SetFontColor(XLColor.Red);
+            cell.GetRichText().AddText(" BIG ").SetFontColor(XLColor.Blue).SetBold();
+            cell.GetRichText().AddText("World").SetFontColor(XLColor.Red);
 
             // Here we're showing that even though we added three pieces of text
             // you can treat then like a single one.
-            cell.RichText.Substring(4, 7).SetUnderline();
+            cell.GetRichText().Substring(4, 7).SetUnderline();
 
             // Right now cell.RichText has the following 5 strings:
             // 
@@ -86,7 +86,7 @@ namespace ClosedXML_Examples.Styles
             // "orld"  -> Red
 
             // Of course you can loop through each piece of text and check its properties
-            foreach (var richText in cell.RichText)
+            foreach (var richText in cell.GetRichText())
             {
                 if(richText.Bold)
                     ws.Cell(3, 2).Value = String.Format("\"{0}\" is Bold.", richText.Text);
@@ -97,13 +97,13 @@ namespace ClosedXML_Examples.Styles
             cell = ws.Cell(5, 1);
 
             // Add the text parts
-            cell.RichText.AddText("Some").SetFontColor(XLColor.Green);
-            cell.RichText.AddText(" rich text ").SetFontColor(XLColor.Blue).SetBold();
-            cell.RichText.AddText("with a gray background").SetItalic();
+            cell.GetRichText().AddText("Some").SetFontColor(XLColor.Green);
+            cell.GetRichText().AddText(" rich text ").SetFontColor(XLColor.Blue).SetBold();
+            cell.GetRichText().AddText("with a gray background").SetItalic();
 
             cell.Style.Fill.SetBackgroundColor(XLColor.Gray);
 
-            ws.Cell(5, 2).Value = cell.RichText; // Should copy only rich text, but not background
+            ws.Cell(5, 2).Value = cell.GetRichText(); // Should copy only rich text, but not background
 
 
             ws.Columns().AdjustToContents();

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -394,7 +394,7 @@ namespace ClosedXML_Tests
             IXLCell cell = ws.Cell("A1").SetValue("Anything");
             bool success = cell.TryGetValue(out IXLRichText outValue);
             Assert.IsTrue(success);
-            Assert.AreEqual(cell.RichText, outValue);
+            Assert.AreEqual(cell.GetRichText(), outValue);
             Assert.AreEqual("Anything", outValue.ToString());
         }
 
@@ -403,10 +403,10 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1");
-            cell.RichText.AddText("Anything");
+            cell.GetRichText().AddText("Anything");
             bool success = cell.TryGetValue(out IXLRichText outValue);
             Assert.IsTrue(success);
-            Assert.AreEqual(cell.RichText, outValue);
+            Assert.AreEqual(cell.GetRichText(), outValue);
         }
 
         [Test]

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -520,7 +520,7 @@ namespace ClosedXML_Tests
 
                 var linkCell1 = ws1.Cell("A1");
                 linkCell1.Value = "Link to IXLCell";
-                linkCell1.Hyperlink = new XLHyperlink(targetCell);
+                linkCell1.SetHyperlink(new XLHyperlink(targetCell));
 
                 var success = linkCell1.TryGetValue(out XLHyperlink hyperlink);
                 Assert.IsTrue(success);

--- a/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
+++ b/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
@@ -20,7 +20,7 @@ namespace ClosedXML_Tests
             var c = ws.FirstCell()
                 .SetValue("Hello world!");
 
-            c.Comment.AddText("Some comment");
+            c.GetComment().AddText("Some comment");
 
             c.Style.Fill.BackgroundColor = backgroundColor;
             c.Style.Font.FontColor = foregroundColor;
@@ -32,7 +32,7 @@ namespace ClosedXML_Tests
                 .CellBelow()
                 .SetFormulaA1("=LEFT(A1,5)");
 
-            c.Comment.AddText("Another comment");
+            c.GetComment().AddText("Another comment");
 
             c.Style.Fill.BackgroundColor = backgroundColor;
             c.Style.Font.FontColor = foregroundColor;
@@ -43,7 +43,7 @@ namespace ClosedXML_Tests
                 .CellBelow(2)
                 .SetValue(new DateTime(2018, 1, 15));
 
-            c.Comment.AddText("A date");
+            c.GetComment().AddText("A date");
 
             c.Style.Fill.BackgroundColor = backgroundColor;
             c.Style.Font.FontColor = foregroundColor;

--- a/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
+++ b/ClosedXML_Tests/Excel/Clearing/ClearingTests.cs
@@ -24,7 +24,7 @@ namespace ClosedXML_Tests
 
             c.Style.Fill.BackgroundColor = backgroundColor;
             c.Style.Font.FontColor = foregroundColor;
-            c.SetDataValidation().Custom("B1");
+            c.CreateDataValidation().Custom("B1");
 
             ////
 
@@ -71,7 +71,7 @@ namespace ClosedXML_Tests
                 Assert.IsTrue(cell.HasComment);
             }
 
-            Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+            Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
 
             return wb;
         }
@@ -93,7 +93,7 @@ namespace ClosedXML_Tests
                     Assert.AreEqual(ws.Style.Font.FontColor, c.Style.Font.FontColor);
                     Assert.IsFalse(ws.ConditionalFormats.Any());
                     Assert.IsFalse(c.HasComment);
-                    Assert.AreEqual(String.Empty, c.DataValidation.Value);
+                    Assert.AreEqual(String.Empty, c.GetDataValidation().Value);
                 }
             }
         }
@@ -116,7 +116,7 @@ namespace ClosedXML_Tests
                     Assert.IsTrue(c.HasComment);
                 }
 
-                Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
 
                 Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
                 Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
@@ -143,7 +143,7 @@ namespace ClosedXML_Tests
                     Assert.IsTrue(c.HasComment);
                 }
 
-                Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
             }
         }
 
@@ -169,7 +169,7 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
                 Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
 
-                Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
             }
         }
 
@@ -195,7 +195,7 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
                 Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
 
-                Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
             }
         }
 
@@ -221,7 +221,7 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
                 Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
 
-                Assert.AreEqual("B1", ws.Cell("A1").DataValidation.Value);
+                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
             }
         }
 
@@ -247,7 +247,7 @@ namespace ClosedXML_Tests
                 Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
                 Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
 
-                Assert.AreEqual(string.Empty, ws.Cell("A1").DataValidation.Value);
+                Assert.AreEqual(string.Empty, ws.Cell("A1").GetDataValidation().Value);
             }
         }
 

--- a/ClosedXML_Tests/Excel/Comments/CommentsTests.cs
+++ b/ClosedXML_Tests/Excel/Comments/CommentsTests.cs
@@ -18,7 +18,7 @@ namespace ClosedXML_Tests.Excel.Comments
                 var ws = wb.Worksheets.First();
                 var c = ws.FirstCellUsed();
 
-                var xlColor = c.Comment.Style.ColorsAndLines.LineColor;
+                var xlColor = c.GetComment().Style.ColorsAndLines.LineColor;
                 Assert.AreEqual(XLColorType.Indexed, xlColor.ColorType);
                 Assert.AreEqual(81, xlColor.Indexed);
 
@@ -40,7 +40,7 @@ namespace ClosedXML_Tests.Excel.Comments
             Assert.AreEqual(2, ws.Internals.RowsCollection.Count);
             Assert.AreEqual(3, ws.Internals.CellsCollection.RowsCollection.SelectMany(r => r.Value.Values).Count());
 
-            ws.Cell("A4").Comment.AddText("Comment");
+            ws.Cell("A4").GetComment().AddText("Comment");
             Assert.AreEqual(2, ws.Internals.RowsCollection.Count);
             Assert.AreEqual(3, ws.Internals.CellsCollection.RowsCollection.SelectMany(r => r.Value.Values).Count());
 
@@ -69,16 +69,16 @@ namespace ClosedXML_Tests.Excel.Comments
 
                 var cell = ws.Cell(2, 2).SetValue("Comment 1");
 
-                cell.Comment
+                cell.GetComment()
                     .SetVisible(false)
                     .AddText(strExcelComment);
 
-                cell.Comment
+                cell.GetComment()
                     .Style
                     .Alignment
                     .SetAutomaticSize();
 
-                cell.Comment
+                cell.GetComment()
                     .Style
                     .ColorsAndLines
                     .SetFillColor(XLColor.Red);
@@ -87,8 +87,8 @@ namespace ClosedXML_Tests.Excel.Comments
 
                 Action<IXLCell> validate = c =>
                 {
-                    Assert.IsTrue(c.Comment.Style.Alignment.AutomaticSize);
-                    Assert.AreEqual(XLColor.Red, c.Comment.Style.ColorsAndLines.FillColor);
+                    Assert.IsTrue(c.GetComment().Style.Alignment.AutomaticSize);
+                    Assert.AreEqual(XLColor.Red, c.GetComment().Style.ColorsAndLines.FillColor);
                 };
 
                 validate(ws.Cell("B3"));
@@ -186,8 +186,8 @@ namespace ClosedXML_Tests.Excel.Comments
             {
                 var ws = workbook.Worksheets.First();
 
-                Assert.True(ws.Cell("A1").Comment.Visible);
-                Assert.False(ws.Cell("A4").Comment.Visible);
+                Assert.True(ws.Cell("A1").GetComment().Visible);
+                Assert.False(ws.Cell("A4").GetComment().Visible);
             }
         }
     }

--- a/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
+++ b/ClosedXML_Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
@@ -64,8 +64,8 @@ namespace ClosedXML_Tests.Excel.ConditionalFormats
 
             var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet");
-            ws.Range("C2:C5").SetDataValidation().Decimal.Between(1, 5);
-            ws.Range("D2:D5").SetDataValidation().Decimal.Between(1, 5);
+            ws.Range("C2:C5").CreateDataValidation().Decimal.Between(1, 5);
+            ws.Range("D2:D5").CreateDataValidation().Decimal.Between(1, 5);
 
             using (var ms = new MemoryStream())
             {

--- a/ClosedXML_Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML_Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -13,11 +13,11 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A2:B2").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A3:C3").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B4:B6").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C7:D7").SetDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
                 ws.Cells("A1:D7").Value = 1;
 
                 ws.Column(2).InsertColumnsAfter(2);
@@ -38,11 +38,11 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B1:B2").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C1:C3").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("D2:F2").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("G4:G5").SetDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
                 ws.Cells("A1:G5").Value = 1;
 
                 ws.Row(2).InsertRowsBelow(2);
@@ -63,11 +63,11 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A2:B2").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A3:C3").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B4:B6").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C7:D7").SetDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
                 ws.Cells("A1:D7").Value = 1;
 
                 ws.Column(2).Delete();
@@ -87,11 +87,11 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B1:B2").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C1:C3").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("D2:F2").SetDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("G4:G5").SetDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
                 ws.Cells("A1:G5").Value = 1;
 
                 ws.Row(2).Delete();
@@ -111,7 +111,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("DataValidationShift");
-                ws.AsRange().SetDataValidation().WholeNumber.Between(0, 1);
+                ws.AsRange().CreateDataValidation().WholeNumber.Between(0, 1);
                 var dv = ws.DataValidations.Single();
 
                 ws.Row(2).InsertRowsAbove(1);

--- a/ClosedXML_Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML_Tests/Excel/DataValidations/DataValidationTests.cs
@@ -25,36 +25,36 @@ namespace ClosedXML_Tests.Excel.DataValidations
 
             ws.Cell("A1").SetValue("Cell below has Validation Only.");
             cell = ws.Cell("A2");
-            cell.DataValidation.List(ws.Range("$E$1:$E$4"));
+            cell.GetDataValidation().List(ws.Range("$E$1:$E$4"));
 
             ws.Cell("B1").SetValue("Cell below has Validation with a title.");
             cell = ws.Cell("B2");
-            cell.DataValidation.List(ws.Range("$E$1:$E$4"));
-            cell.DataValidation.InputTitle = "Title for B2";
+            cell.GetDataValidation().List(ws.Range("$E$1:$E$4"));
+            cell.GetDataValidation().InputTitle = "Title for B2";
 
-            Assert.AreEqual(XLAllowedValues.List, cell.DataValidation.AllowedValues);
-            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.DataValidation.Value);
-            Assert.AreEqual("Title for B2", cell.DataValidation.InputTitle);
+            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
+            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.GetDataValidation().Value);
+            Assert.AreEqual("Title for B2", cell.GetDataValidation().InputTitle);
 
             ws.Cell("C1").SetValue("Cell below has Validation with a message.");
             cell = ws.Cell("C2");
-            cell.DataValidation.List(ws.Range("$E$1:$E$4"));
-            cell.DataValidation.InputMessage = "Message for C2";
+            cell.GetDataValidation().List(ws.Range("$E$1:$E$4"));
+            cell.GetDataValidation().InputMessage = "Message for C2";
 
-            Assert.AreEqual(XLAllowedValues.List, cell.DataValidation.AllowedValues);
-            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.DataValidation.Value);
-            Assert.AreEqual("Message for C2", cell.DataValidation.InputMessage);
+            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
+            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.GetDataValidation().Value);
+            Assert.AreEqual("Message for C2", cell.GetDataValidation().InputMessage);
 
             ws.Cell("D1").SetValue("Cell below has Validation with title and message.");
             cell = ws.Cell("D2");
-            cell.DataValidation.List(ws.Range("$E$1:$E$4"));
-            cell.DataValidation.InputTitle = "Title for D2";
-            cell.DataValidation.InputMessage = "Message for D2";
+            cell.GetDataValidation().List(ws.Range("$E$1:$E$4"));
+            cell.GetDataValidation().InputTitle = "Title for D2";
+            cell.GetDataValidation().InputMessage = "Message for D2";
 
-            Assert.AreEqual(XLAllowedValues.List, cell.DataValidation.AllowedValues);
-            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.DataValidation.Value);
-            Assert.AreEqual("Title for D2", cell.DataValidation.InputTitle);
-            Assert.AreEqual("Message for D2", cell.DataValidation.InputMessage);
+            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
+            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.GetDataValidation().Value);
+            Assert.AreEqual("Title for D2", cell.GetDataValidation().InputTitle);
+            Assert.AreEqual("Message for D2", cell.GetDataValidation().InputMessage);
         }
 
         [Test]
@@ -63,13 +63,13 @@ namespace ClosedXML_Tests.Excel.DataValidations
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell("A1").SetValue("A");
-            ws.Cell("B1").SetDataValidation().Custom("Sheet1!A1");
+            ws.Cell("B1").CreateDataValidation().Custom("Sheet1!A1");
 
             IXLWorksheet ws2 = wb.AddWorksheet("Sheet2");
             ws2.Cell("A1").SetValue("B");
             ws.Cell("B1").CopyTo(ws2.Cell("B1"));
 
-            Assert.AreEqual("Sheet1!A1", ws2.Cell("B1").DataValidation.Value);
+            Assert.AreEqual("Sheet1!A1", ws2.Cell("B1").GetDataValidation().Value);
         }
 
         [Test, Ignore("Wait for proper formula shifting (#686)")]
@@ -78,10 +78,10 @@ namespace ClosedXML_Tests.Excel.DataValidations
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell("A1").SetValue("A");
-            ws.Cell("B1").SetDataValidation().Custom("A1");
+            ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.FirstRow().InsertRowsAbove(1);
 
-            Assert.AreEqual("A2", ws.Cell("B2").DataValidation.Value);
+            Assert.AreEqual("A2", ws.Cell("B2").GetDataValidation().Value);
         }
 
         [Test]
@@ -90,9 +90,9 @@ namespace ClosedXML_Tests.Excel.DataValidations
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell("A1").SetValue("A");
-            ws.Cell("B1").SetDataValidation().Custom("A1");
+            ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.Cell("B1").CopyTo(ws.Cell("B2"));
-            Assert.AreEqual("A2", ws.Cell("B2").DataValidation.Value);
+            Assert.AreEqual("A2", ws.Cell("B2").GetDataValidation().Value);
         }
 
         [Test, Ignore("Wait for proper formula shifting (#686)")]
@@ -101,10 +101,10 @@ namespace ClosedXML_Tests.Excel.DataValidations
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell("A1").SetValue("A");
-            ws.Cell("B1").SetDataValidation().Custom("A1");
+            ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.FirstColumn().InsertColumnsBefore(1);
 
-            Assert.AreEqual("B1", ws.Cell("C1").DataValidation.Value);
+            Assert.AreEqual("B1", ws.Cell("C1").GetDataValidation().Value);
         }
 
         [Test]
@@ -113,9 +113,9 @@ namespace ClosedXML_Tests.Excel.DataValidations
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell("A1").SetValue("A");
-            ws.Cell("B1").SetDataValidation().Custom("A1");
+            ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.Cell("B1").CopyTo(ws.Cell("C1"));
-            Assert.AreEqual("B1", ws.Cell("C1").DataValidation.Value);
+            Assert.AreEqual("B1", ws.Cell("C1").GetDataValidation().Value);
         }
 
         [Test]
@@ -130,10 +130,10 @@ namespace ClosedXML_Tests.Excel.DataValidations
 
             IXLTable table = ws.RangeUsed().CreateTable();
 
-            IXLDataValidation dv = table.DataRange.SetDataValidation();
+            IXLDataValidation dv = table.DataRange.CreateDataValidation();
             dv.ErrorTitle = "Error";
 
-            Assert.AreEqual("Error", table.DataRange.FirstCell().DataValidation.ErrorTitle);
+            Assert.AreEqual("Error", table.DataRange.FirstCell().GetDataValidation().ErrorTitle);
         }
 
         [Test]
@@ -147,7 +147,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
 
             IXLTable table = ws.RangeUsed().CreateTable();
 
-            IXLDataValidation dv = table.DataRange.SetDataValidation();
+            IXLDataValidation dv = table.DataRange.CreateDataValidation();
             dv.ErrorTitle = "Error";
 
             Assert.AreEqual("Error", ws.DataValidations.Single().ErrorTitle);
@@ -165,7 +165,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
             //Arrange
             var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("DataValidation");
-            var validation = ws.Range(initialAddress).SetDataValidation();
+            var validation = ws.Range(initialAddress).CreateDataValidation();
             validation.WholeNumber.Between(0, 100);
             if (setValue)
                 ws.Range(initialAddress).Value = 50;
@@ -191,7 +191,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
             //Arrange
             var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("DataValidation");
-            var validation = ws.Range(initialAddress).SetDataValidation();
+            var validation = ws.Range(initialAddress).CreateDataValidation();
             validation.WholeNumber.Between(0, 100);
             if (setValue)
                 ws.Range(initialAddress).Value = 50;
@@ -211,7 +211,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("DataValidation");
-                var validation = ws.Range("A1:C3").SetDataValidation();
+                var validation = ws.Range("A1:C3").CreateDataValidation();
                 validation.WholeNumber.Between(0, 100);
 
                 //Act
@@ -229,17 +229,17 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("DataValidation");
-                var validation = ws.Range("A1:C3").SetDataValidation();
+                var validation = ws.Range("A1:C3").CreateDataValidation();
                 validation.WholeNumber.Between(10, 100);
 
                 //Act
-                ws.Cell("B2").NewDataValidation.WholeNumber.Between(-100, -0);
+                ws.Cell("B2").CreateDataValidation().WholeNumber.Between(-100, -0);
 
                 //Assert
-                Assert.AreEqual("-100", ws.Cell("B2").DataValidation.MinValue);
+                Assert.AreEqual("-100", ws.Cell("B2").GetDataValidation().MinValue);
                 Assert.IsTrue(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2").All(c => c.HasDataValidation));
                 Assert.IsTrue(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2")
-                                .All(c => c.DataValidation.MinValue == "10"));
+                                .All(c => c.GetDataValidation().MinValue == "10"));
             }
         }
 
@@ -253,7 +253,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
 
             using (var wb = new XLWorkbook())
             {
-                var dv = wb.AddWorksheet("Sheet 1").Cell(1, 1).DataValidation;
+                var dv = wb.AddWorksheet("Sheet 1").Cell(1, 1).GetDataValidation();
 
                 Assert.Throws<ArgumentOutOfRangeException>(() => dv.List(values));
                 Assert.Throws<ArgumentOutOfRangeException>(() =>

--- a/ClosedXML_Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/ClosedXML_Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -23,7 +23,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
                 var ws1 = wb.AddWorksheet();
                 var ws2 = wb.AddWorksheet();
 
-                var dv1 = ws1.Range("A1:A3").SetDataValidation();
+                var dv1 = ws1.Range("A1:A3").CreateDataValidation();
                 dv1.MinValue = "100";
 
                 var dv2 = ws2.DataValidations.Add(dv1);
@@ -49,7 +49,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet();
-                var dv = ws.Range("A1:A3").SetDataValidation();
+                var dv = ws.Range("A1:A3").CreateDataValidation();
                 dv.MinValue = "100";
                 dv.AddRange(ws.Range("C1:C3"));
 
@@ -77,11 +77,11 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet();
-                var dv1 = ws.Range("A1:A3").SetDataValidation();
+                var dv1 = ws.Range("A1:A3").CreateDataValidation();
                 dv1.MinValue = "100";
                 dv1.AddRange(ws.Range("C1:C3"));
 
-                var dv2 = ws.Range("E4:G6").SetDataValidation();
+                var dv2 = ws.Range("E4:G6").CreateDataValidation();
                 dv2.MinValue = "200";
 
                 var address = new XLRangeAddress(ws as XLWorksheet, searchAddress);
@@ -98,10 +98,10 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet();
-                var dv1 = ws.Ranges("B2:G7,C11:C13").SetDataValidation();
+                var dv1 = ws.Ranges("B2:G7,C11:C13").CreateDataValidation();
                 dv1.MinValue = "100";
 
-                var dv2 = ws.Range("E4:G6").SetDataValidation();
+                var dv2 = ws.Range("E4:G6").CreateDataValidation();
                 dv2.MinValue = "100";
 
                 Assert.AreEqual(4, dv1.Ranges.Count());
@@ -116,7 +116,7 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet();
-                var dv = ws.Range("A1:A3").SetDataValidation();
+                var dv = ws.Range("A1:A3").CreateDataValidation();
                 dv.MinValue = "100";
                 var range = ws.Range("C1:C3");
                 dv.AddRange(range);
@@ -135,9 +135,9 @@ namespace ClosedXML_Tests.Excel.DataValidations
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet();
-                var dv1 = ws.Range("A1:A3").SetDataValidation();
+                var dv1 = ws.Range("A1:A3").CreateDataValidation();
                 dv1.MinValue = "100";
-                var dv2 = ws.Range("B1:B3").SetDataValidation();
+                var dv2 = ws.Range("B1:B3").CreateDataValidation();
                 dv2.MinValue = "100";
 
                 (ws.DataValidations as XLDataValidations).Consolidate();

--- a/ClosedXML_Tests/Excel/Misc/HyperlinkTests.cs
+++ b/ClosedXML_Tests/Excel/Misc/HyperlinkTests.cs
@@ -19,13 +19,13 @@ namespace ClosedXML_Tests.Excel.Misc
 
                 var linkCell1 = ws1.Cell("A1");
                 linkCell1.Value = "Link to IXLCell";
-                linkCell1.Hyperlink = new XLHyperlink(targetCell);
-                Assert.AreEqual("Sheet2!A1", linkCell1.Hyperlink.InternalAddress);
+                linkCell1.SetHyperlink(new XLHyperlink(targetCell));
+                Assert.AreEqual("Sheet2!A1", linkCell1.GetHyperlink().InternalAddress);
 
                 var linkRange1 = ws1.Cell("A2");
                 linkRange1.Value = "Link to IXLRangeBase";
-                linkRange1.Hyperlink = new XLHyperlink(targetRange);
-                Assert.AreEqual("Sheet2!A1:B1", linkRange1.Hyperlink.InternalAddress);
+                linkRange1.SetHyperlink(new XLHyperlink(targetRange));
+                Assert.AreEqual("Sheet2!A1:B1", linkRange1.GetHyperlink().InternalAddress);
             }
         }
     }

--- a/ClosedXML_Tests/Excel/Ranges/InsertingRangesTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/InsertingRangesTests.cs
@@ -91,10 +91,10 @@ namespace ClosedXML_Tests
 
             ws.Cell("A1").SetValue("Insert Below");
             ws.Cell("A2").SetValue("Already existing cell");
-            ws.Cell("A3").SetValue("Cell with comment").Comment.AddText("Comment here");
+            ws.Cell("A3").SetValue("Cell with comment").GetComment().AddText("Comment here");
 
             ws.Row(1).InsertRowsBelow(2);
-            Assert.AreEqual("Comment here", ws.Cell("A5").Comment.Text);
+            Assert.AreEqual("Comment here", ws.Cell("A5").GetComment().Text);
         }
 
         [Test]
@@ -105,10 +105,10 @@ namespace ClosedXML_Tests
 
             ws.Cell("A1").SetValue("Insert to the right");
             ws.Cell("B1").SetValue("Already existing cell");
-            ws.Cell("C1").SetValue("Cell with comment").Comment.AddText("Comment here");
+            ws.Cell("C1").SetValue("Cell with comment").GetComment().AddText("Comment here");
 
             ws.Column(1).InsertColumnsAfter(2);
-            Assert.AreEqual("Comment here", ws.Cell("E1").Comment.Text);
+            Assert.AreEqual("Comment here", ws.Cell("E1").GetComment().Text);
         }
 
         [Test]

--- a/ClosedXML_Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/MergedRangesTests.cs
@@ -271,14 +271,14 @@ namespace ClosedXML_Tests
             using (XLWorkbook wb = new XLWorkbook())
             {
                 var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").NewDataValidation.WholeNumber.Between(1, 2);
-                ws.Cell("A2").NewDataValidation.Date.GreaterThan(new System.DateTime(2018, 1, 1));
+                ws.Cell("A1").CreateDataValidation().WholeNumber.Between(1, 2);
+                ws.Cell("A2").CreateDataValidation().Date.GreaterThan(new System.DateTime(2018, 1, 1));
 
                 ws.Range("A1:A2").Merge();
 
                 Assert.IsTrue(ws.Cell("A1").HasDataValidation);
-                Assert.AreEqual("1", ws.Cell("A1").DataValidation.MinValue);
-                Assert.AreEqual("2", ws.Cell("A1").DataValidation.MaxValue);
+                Assert.AreEqual("1", ws.Cell("A1").GetDataValidation().MinValue);
+                Assert.AreEqual("2", ws.Cell("A1").GetDataValidation().MaxValue);
                 Assert.IsFalse(ws.Cell("A2").HasDataValidation);
             }
         }

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -281,7 +281,7 @@ namespace ClosedXML_Tests.Excel.Ranges
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                ws.Range("B2:B12").SetDataValidation()
+                ws.Range("B2:B12").CreateDataValidation()
                     .Decimal.EqualOrGreaterThan(0);
 
                 var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
@@ -344,7 +344,7 @@ namespace ClosedXML_Tests.Excel.Ranges
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                ws.SetDataValidation().WholeNumber.GreaterThan(0);
+                ws.CreateDataValidation().WholeNumber.GreaterThan(0);
 
                 var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
 
@@ -359,7 +359,7 @@ namespace ClosedXML_Tests.Excel.Ranges
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                ws.SetDataValidation().WholeNumber.GreaterThan(0);
+                ws.CreateDataValidation().WholeNumber.GreaterThan(0);
 
                 var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
 

--- a/ClosedXML_Tests/Excel/RichText/XLRichStringTests.cs
+++ b/ClosedXML_Tests/Excel/RichText/XLRichStringTests.cs
@@ -18,12 +18,12 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            cell.RichText.AddText("12");
+            cell.CreateRichText().AddText("12");
             cell.DataType = XLDataType.Number;
 
             Assert.AreEqual(12.0, cell.GetDouble());
 
-            IXLRichText richText = cell.RichText;
+            IXLRichText richText = cell.GetRichText();
 
             Assert.AreEqual("12", richText.ToString());
 
@@ -44,14 +44,14 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            IXLRichText richString = cell.RichText;
+            IXLRichText richString = cell.CreateRichText();
 
             string text = "Hello";
             richString.AddText(text).SetBold().SetFontColor(XLColor.Red);
 
             Assert.AreEqual(cell.GetString(), text);
-            Assert.AreEqual(cell.RichText.First().Bold, true);
-            Assert.AreEqual(cell.RichText.First().FontColor, XLColor.Red);
+            Assert.AreEqual(cell.GetRichText().First().Bold, true);
+            Assert.AreEqual(cell.GetRichText().First().FontColor, XLColor.Red);
 
             Assert.AreEqual(1, richString.Count);
 
@@ -72,14 +72,14 @@ namespace ClosedXML_Tests
 
             string text = number.ToString();
 
-            Assert.AreEqual(cell.RichText.ToString(), text);
-            Assert.AreEqual(cell.RichText.First().Bold, true);
-            Assert.AreEqual(cell.RichText.First().FontColor, XLColor.Red);
+            Assert.AreEqual(cell.GetRichText().ToString(), text);
+            Assert.AreEqual(cell.GetRichText().First().Bold, true);
+            Assert.AreEqual(cell.GetRichText().First().FontColor, XLColor.Red);
 
-            Assert.AreEqual(1, cell.RichText.Count);
+            Assert.AreEqual(1, cell.GetRichText().Count);
 
-            cell.RichText.AddText("World");
-            Assert.AreEqual(cell.RichText.First().Text, text, "Item in collection is not the same as the one returned");
+            cell.GetRichText().AddText("World");
+            Assert.AreEqual(cell.GetRichText().First().Text, text, "Item in collection is not the same as the one returned");
         }
 
         [Test]
@@ -95,14 +95,14 @@ namespace ClosedXML_Tests
 
             string text = number.ToString();
 
-            Assert.AreEqual(cell.RichText.ToString(), text);
-            Assert.AreEqual(cell.RichText.First().Bold, true);
-            Assert.AreEqual(cell.RichText.First().FontColor, XLColor.Red);
+            Assert.AreEqual(cell.GetRichText().ToString(), text);
+            Assert.AreEqual(cell.GetRichText().First().Bold, true);
+            Assert.AreEqual(cell.GetRichText().First().FontColor, XLColor.Red);
 
-            Assert.AreEqual(1, cell.RichText.Count);
+            Assert.AreEqual(1, cell.GetRichText().Count);
 
-            cell.RichText.AddText("World");
-            Assert.AreEqual(cell.RichText.First().Text, text, "Item in collection is not the same as the one returned");
+            cell.GetRichText().AddText("World");
+            Assert.AreEqual(cell.GetRichText().First().Text, text, "Item in collection is not the same as the one returned");
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace ClosedXML_Tests
         public void ClearTest()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
             richString.AddText(" ");
@@ -130,7 +130,7 @@ namespace ClosedXML_Tests
         public void CountTest()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
             richString.AddText(" ");
@@ -144,7 +144,7 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            cell.RichText.AddText("123");
+            cell.GetRichText().AddText("123");
 
             Assert.AreEqual(true, cell.HasRichText);
 
@@ -156,7 +156,7 @@ namespace ClosedXML_Tests
 
             Assert.AreEqual(false, cell.HasRichText);
 
-            cell.RichText.AddText("123");
+            cell.GetRichText().AddText("123");
 
             Assert.AreEqual(true, cell.HasRichText);
 
@@ -164,7 +164,7 @@ namespace ClosedXML_Tests
 
             Assert.AreEqual(false, cell.HasRichText);
 
-            cell.RichText.AddText("123");
+            cell.GetRichText().AddText("123");
 
             Assert.AreEqual(true, cell.HasRichText);
 
@@ -180,7 +180,7 @@ namespace ClosedXML_Tests
         public void Substring_All_From_OneString()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
 
@@ -192,14 +192,14 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.First().Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().First().Bold);
         }
 
         [Test]
         public void Substring_All_From_ThreeStrings()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -216,16 +216,16 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.First().Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.Last().Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().First().Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().Last().Bold);
         }
 
         [Test]
         public void Substring_From_OneString_End()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
 
@@ -242,20 +242,20 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.First().Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.Last().Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Bold);
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.First().Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.Last().Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Italic);
 
             Assert.AreEqual(true, actual.First().Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.First().FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.Last().FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().First().FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().Last().FontSize);
 
             Assert.AreEqual(20, actual.First().FontSize);
         }
@@ -264,7 +264,7 @@ namespace ClosedXML_Tests
         public void Substring_From_OneString_Middle()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
 
@@ -282,23 +282,23 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.First().Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.Last().Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().Last().Bold);
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.First().Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.Last().Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Italic);
 
             Assert.AreEqual(false, actual.First().Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.First().FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.Last().FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().First().FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().Last().FontSize);
 
             Assert.AreEqual(20, actual.First().FontSize);
         }
@@ -307,7 +307,7 @@ namespace ClosedXML_Tests
         public void Substring_From_OneString_Start()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
 
@@ -324,20 +324,20 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.First().Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.Last().Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().First().Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().Last().Bold);
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.First().Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.Last().Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Italic);
 
             Assert.AreEqual(false, actual.First().Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.First().FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.Last().FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().First().FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().Last().FontSize);
 
             Assert.AreEqual(20, actual.First().FontSize);
         }
@@ -346,7 +346,7 @@ namespace ClosedXML_Tests
         public void Substring_From_ThreeStrings_End1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -367,26 +367,26 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(0).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(3).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(3).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
 
             Assert.AreEqual(true, actual.First().Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(3).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
 
             Assert.AreEqual(20, actual.First().FontSize);
         }
@@ -395,7 +395,7 @@ namespace ClosedXML_Tests
         public void Substring_From_ThreeStrings_End2()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -417,27 +417,27 @@ namespace ClosedXML_Tests
 
             actual.ElementAt(1).SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(0).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(3).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(3).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
 
             Assert.AreEqual(false, actual.ElementAt(0).Italic);
             Assert.AreEqual(true, actual.ElementAt(1).Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(3).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
 
             Assert.AreEqual(20, actual.ElementAt(0).FontSize);
             Assert.AreEqual(20, actual.ElementAt(1).FontSize);
@@ -447,7 +447,7 @@ namespace ClosedXML_Tests
         public void Substring_From_ThreeStrings_Mid1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -473,7 +473,7 @@ namespace ClosedXML_Tests
         public void Substring_From_ThreeStrings_Mid2()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -500,7 +500,7 @@ namespace ClosedXML_Tests
         public void Substring_From_ThreeStrings_Start1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -521,26 +521,26 @@ namespace ClosedXML_Tests
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(0).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(3).Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
 
             richString.First().SetItalic();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(3).Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
 
             Assert.AreEqual(true, actual.First().Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(3).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
 
             Assert.AreEqual(20, actual.First().FontSize);
         }
@@ -549,7 +549,7 @@ namespace ClosedXML_Tests
         public void Substring_From_ThreeStrings_Start2()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Good Morning");
             richString.AddText(" my ");
@@ -571,27 +571,27 @@ namespace ClosedXML_Tests
 
             actual.ElementAt(1).SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(0).Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(3).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
 
             richString.First().SetItalic();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).RichText.ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(2).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).RichText.ElementAt(3).Italic);
+            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
+            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
 
             Assert.AreEqual(true, actual.ElementAt(0).Italic);
             Assert.AreEqual(false, actual.ElementAt(1).Italic);
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).RichText.ElementAt(3).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
+            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
 
             Assert.AreEqual(20, actual.ElementAt(0).FontSize);
             Assert.AreEqual(20, actual.ElementAt(1).FontSize);
@@ -601,7 +601,7 @@ namespace ClosedXML_Tests
         public void Substring_IndexOutsideRange1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
 
@@ -612,7 +612,7 @@ namespace ClosedXML_Tests
         public void Substring_IndexOutsideRange2()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
             richString.AddText("World");
@@ -624,7 +624,7 @@ namespace ClosedXML_Tests
         public void Substring_IndexOutsideRange3()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
 
@@ -635,7 +635,7 @@ namespace ClosedXML_Tests
         public void Substring_IndexOutsideRange4()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
             richString.AddText("World");
@@ -650,7 +650,7 @@ namespace ClosedXML_Tests
         public void ToStringTest()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            IXLRichText richString = ws.Cell(1, 1).RichText;
+            IXLRichText richString = ws.Cell(1, 1).GetRichText();
 
             richString.AddText("Hello");
             richString.AddText(" ");
@@ -705,7 +705,7 @@ namespace ClosedXML_Tests
                 using (var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlinedRichText\ChangeRichText\inputfile.xlsx")))
                 using (var workbook = new XLWorkbook(inputStream))
                 {
-                    var richText = workbook.Worksheets.First().Cell("A1").RichText;
+                    var richText = workbook.Worksheets.First().Cell("A1").GetRichText();
                     testRichText(richText);
                     richText.AddText(" - changed");
                     workbook.SaveAs(outputStream);
@@ -716,7 +716,7 @@ namespace ClosedXML_Tests
                     var cell = wb.Worksheets.First().Cell("A1");
                     Assert.IsFalse(cell.ShareString);
                     Assert.IsTrue(cell.HasRichText);
-                    var rt = cell.RichText;
+                    var rt = cell.GetRichText();
                     Assert.AreEqual("Year (range: 3 yrs) - changed", rt.ToString());
                     testRichText(rt);
                 }
@@ -735,7 +735,7 @@ namespace ClosedXML_Tests
                         var ws = wb.AddWorksheet();
                         var cell = ws.FirstCell();
 
-                        cell.RichText.AddText("Bold").SetBold().AddText(" and red").SetBold().SetFontColor(XLColor.Red);
+                        cell.GetRichText().AddText("Bold").SetBold().AddText(" and red").SetBold().SetFontColor(XLColor.Red);
                         cell.ShareString = false;
 
                         //wb.SaveAs(ms);

--- a/ClosedXML_Tests/Excel/Rows/RowTests.cs
+++ b/ClosedXML_Tests/Excel/Rows/RowTests.cs
@@ -264,7 +264,7 @@ namespace ClosedXML_Tests.Excel
         public void DeleteRowOnWorksheetWithComment()
         {
             var ws = new XLWorkbook().AddWorksheet();
-            ws.Cell(4, 1).Comment.AddText("test");
+            ws.Cell(4, 1).GetComment().AddText("test");
             ws.Column(1).Width = 100;
             Assert.DoesNotThrow(() => ws.Row(1).Delete());
         }

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -37,7 +37,7 @@ namespace ClosedXML_Tests.Excel.Saving
                 var sheet = wb.Worksheets.Add("TestSheet");
 
                 // Comments might cause duplicate VmlDrawing Id's - ensure it's tested:
-                sheet.Cell(1, 1).Comment.AddText("abc");
+                sheet.Cell(1, 1).GetComment().AddText("abc");
 
                 wb.SaveAs(memoryStream, validate: true);
 
@@ -302,7 +302,7 @@ namespace ClosedXML_Tests.Excel.Saving
                     .MoveTo(50, 50)
                     .WithSize(200, 200);
 
-                ws.Cell("D4").Comment.SetVisible().AddText("This is a comment");
+                ws.Cell("D4").GetComment().SetVisible().AddText("This is a comment");
 
                 wb.SaveAs(ms);
             }
@@ -737,7 +737,7 @@ namespace ClosedXML_Tests.Excel.Saving
             using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\GoogleSheets\file1.xlsx"));
             using var wb = new XLWorkbook(stream);
             var ws = wb.Worksheets.First();
-            ws.Cell(1, 1).Comment.AddText("Test");
+            ws.Cell(1, 1).CreateComment().AddText("Test");
             Assert.DoesNotThrow(() => wb.SaveAs(ms));
         }
     }

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -711,7 +711,7 @@ namespace ClosedXML_Tests.Excel.Saving
             using (var ms = new MemoryStream())
             {
                 var ws = wb.AddWorksheet("WithDataValidation");
-                ws.Range("B4:B4").SetDataValidation().WholeNumber.Between(0, 1);
+                ws.Range("B4:B4").CreateDataValidation().WholeNumber.Between(0, 1);
 
                 ws.Row(1).InsertRowsAbove(1);
                 var dv = ws.DataValidations.ToArray();

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -670,19 +670,19 @@ namespace ClosedXML_Tests
             {
                 var ws1 = wb1.Worksheets.Add("Original");
 
-                var dv1 = ws1.Range("A:A").SetDataValidation();
+                var dv1 = ws1.Range("A:A").CreateDataValidation();
                 dv1.WholeNumber.EqualTo(2);
                 dv1.ErrorStyle = XLErrorStyle.Warning;
                 dv1.ErrorTitle = "Number out of range";
                 dv1.ErrorMessage = "This cell only allows the number 2.";
 
-                var dv2 = ws1.Ranges("B2:C3,D4:E5").SetDataValidation();
+                var dv2 = ws1.Ranges("B2:C3,D4:E5").CreateDataValidation();
                 dv2.Decimal.GreaterThan(5);
                 dv2.ErrorStyle = XLErrorStyle.Stop;
                 dv2.ErrorTitle = "Decimal number out of range";
                 dv2.ErrorMessage = "This cell only allows decimals greater than 5.";
 
-                var dv3 = ws1.Cell("D1").SetDataValidation();
+                var dv3 = ws1.Cell("D1").CreateDataValidation();
                 dv3.TextLength.EqualOrLessThan(10);
                 dv3.ErrorStyle = XLErrorStyle.Information;
                 dv3.ErrorTitle = "Text length out of range";


### PR DESCRIPTION
Fixes #1184

Historically, we had a few properties that were initialized on first access to them. It might be quite convenient to not have to initialize them manually but that also caused cells to change their state on simple inspection their properties via Watch window, or on outputting them in PowerShell.

There also were many nasty issues with data validation rules (#680), and with rich texts (#1271), so we [agreed](https://github.com/ClosedXML/ClosedXML/pull/1370#issuecomment-598219364) on introducing breaking changes that will let us avoid such issues all at once.

Initially, I was going to change the behavior of existing properties so that their getters would not change the object state, but then I realized that this will bring lots of `NullReferenceException`s in our users' code that can easily be missed before going to production. So I decided it will be safer to change the API in a way it won't even compile. Yes, it brings _some_ inconvenience in the upgrade process, but this is going to be a simple mechanical process - replace property accessors with corresponding methods - which is far better than getting unexpected exceptions in runtime.

**Breaking changes:**
* `IXLCell.Hyperlink` removed; use `GetHyperlink()` to get an existing hyperlink or to create a new one if it does not exist; instead of property setter, use `SetHyperlink()`; to replace the existing hyperlink with a fresh one, use `CreateHyperlink()`;
* `IXLCell.DataValidation` removed; use `GetDataValidation()`;
* `IXLCell.NewDataValidation` removed; use `CreateDataValidation()`;
* `IXLCell.Comment` removed; use `GetComment()` to access the existing comment or to create a new one if it does not exist; use `CreateComment()` to replace the existing comment with the fresh one;
* `IXLCell.RichText` removed; use `GetRichText()` to access the existing rich text or to create a new one if it does not exist; use `CreateRichText()` to replace the existing rich text with the fresh one.

**Obsolete members**
* `IXLCell.SetDataValidation()`
* `IXLRangeBase.SetDataValidation()`
* `IXLRanges.SetDataValidation()`

Their functionality is covered by `GetDataValidation()` and `CreateDataValidation()` so they will be removed in future.