### PR TITLE
Improve performance of operations involving intensive style edits (#1416)

### DIFF
--- a/ClosedXML/Excel/Caching/IXLRepository.cs
+++ b/ClosedXML/Excel/Caching/IXLRepository.cs
@@ -26,6 +26,6 @@ namespace ClosedXML.Excel.Caching
         /// <param name="value">Value to put into the repository if key does not exist.</param>
         /// <returns>Value stored in the repository under the specified <paramref name="key"/>. If key already existed
         /// returned value may differ from the input one.</returns>
-        Tvalue Store(Tkey key, Tvalue value);
+        Tvalue Store(ref Tkey key, Tvalue value);
     }
 }

--- a/ClosedXML/Excel/Caching/XLRepositoryBase.cs
+++ b/ClosedXML/Excel/Caching/XLRepositoryBase.cs
@@ -39,7 +39,7 @@ namespace ClosedXML.Excel.Caching
         /// <param name="value">Value from the repository stored under specified key or null if key does
         /// not exist or the entry under this key has already bee GCed.</param>
         /// <returns>True if entry exists and alive, false otherwise.</returns>
-        public bool ContainsKey(Tkey key, out Tvalue value)
+        public bool ContainsKey(ref Tkey key, out Tvalue value)
         {
             if (_storage.TryGetValue(key, out WeakReference cachedReference))
             {
@@ -59,7 +59,7 @@ namespace ClosedXML.Excel.Caching
         /// <returns>Entity that is stored in the repository under the specified key
         /// (it can be either the <paramref name="value"/> or another entity that has been added to
         /// the repository before.)</returns>
-        public Tvalue Store(Tkey key, Tvalue value)
+        public Tvalue Store(ref Tkey key, Tvalue value)
         {
             if (value == null)
                 return null;
@@ -76,7 +76,7 @@ namespace ClosedXML.Excel.Caching
             return value;
         }
 
-        public Tvalue GetOrCreate(Tkey key)
+        public Tvalue GetOrCreate(ref Tkey key)
         {
             if (_storage.TryGetValue(key, out WeakReference cachedReference) &&
                 cachedReference.Target is Tvalue storedValue)
@@ -86,21 +86,21 @@ namespace ClosedXML.Excel.Caching
 
             _storage.TryRemove(key, out WeakReference _);
             var value = _createNew(key);
-            return Store(key, value);
+            return Store(ref key, value);
         }
 
-        public Tvalue Replace(Tkey oldKey, Tkey newKey)
+        public Tvalue Replace(ref Tkey oldKey, ref Tkey newKey)
         {
             if (_storage.TryRemove(oldKey, out WeakReference cachedReference) && cachedReference != null)
             {
                 _storage.TryAdd(newKey, cachedReference);
-                return GetOrCreate(newKey);
+                return GetOrCreate(ref newKey);
             }
 
             return null;
         }
 
-        public void Remove(Tkey key)
+        public void Remove(ref Tkey key)
         {
             _storage.TryRemove(key, out WeakReference _);
         }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1878,6 +1878,13 @@ namespace ClosedXML.Excel
             }
         }
 
+        void IXLStylized.ModifyStyle(Func<XLStyleKey, XLStyleKey> modification)
+        {
+            //XLCell cannot have children so the base method may be optimized
+            var styleKey = modification(StyleValue.Key);
+            StyleValue = XLStyleValue.FromKey(ref styleKey);
+        }
+
         protected override IEnumerable<XLStylizedBase> Children
         {
             get { yield break; }

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -13,18 +13,19 @@ namespace ClosedXML.Excel
         private static readonly Dictionary<Color, XLColor> ByColor = new Dictionary<Color, XLColor>();
         private static readonly Object ByColorLock = new Object();
 
-        internal static XLColor FromKey(XLColorKey key)
+        internal static XLColor FromKey(ref XLColorKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
         public static XLColor FromColor(Color color)
         {
-            return FromKey(new XLColorKey
+            var key = new XLColorKey
             {
                 ColorType = XLColorType.Color,
                 Color = color
-            });
+            };
+            return FromKey(ref key);
         }
 
         public static XLColor FromArgb(Int32 argb)
@@ -61,30 +62,33 @@ namespace ClosedXML.Excel
 
         public static XLColor FromIndex(Int32 index)
         {
-            return FromKey(new XLColorKey
+            var key = new XLColorKey
             {
                 ColorType = XLColorType.Indexed,
                 Indexed = index
-            });
+            };
+            return FromKey(ref key);
         }
 
         public static XLColor FromTheme(XLThemeColor themeColor)
         {
-            return FromKey(new XLColorKey
+            var key = new XLColorKey
             {
                 ColorType = XLColorType.Theme,
                 ThemeColor = themeColor
-            });
+            };
+            return FromKey(ref key);
         }
 
         public static XLColor FromTheme(XLThemeColor themeColor, Double themeTint)
         {
-            return FromKey(new XLColorKey
+            var key = new XLColorKey
             {
                 ColorType = XLColorType.Theme,
                 ThemeColor = themeColor,
                 ThemeTint = themeTint
-            });
+            };
+            return FromKey(ref key);
         }
 
         private static Dictionary<Int32, XLColor> _indexedColors;

--- a/ClosedXML/Excel/Style/XLAlignment.cs
+++ b/ClosedXML/Excel/Style/XLAlignment.cs
@@ -50,7 +50,7 @@ namespace ClosedXML.Excel
         internal XLAlignmentKey Key
         {
             get { return _value.Key; }
-            private set { _value = XLAlignmentValue.FromKey(value); }
+            private set { _value = XLAlignmentValue.FromKey(ref value); }
         }
 
         #endregion Properties
@@ -68,7 +68,7 @@ namespace ClosedXML.Excel
             _value = value;
         }
 
-        public XLAlignment(XLStyle style, XLAlignmentKey key) : this(style, XLAlignmentValue.FromKey(key))
+        public XLAlignment(XLStyle style, XLAlignmentKey key) : this(style, XLAlignmentValue.FromKey(ref key))
         {
         }
 

--- a/ClosedXML/Excel/Style/XLAlignmentKey.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentKey.cs
@@ -49,14 +49,14 @@ namespace ClosedXML.Excel
         public override int GetHashCode()
         {
             var hashCode = -596887160;
-            hashCode = hashCode * -1521134295 + Horizontal.GetHashCode();
-            hashCode = hashCode * -1521134295 + Vertical.GetHashCode();
-            hashCode = hashCode * -1521134295 + Indent.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)Horizontal;
+            hashCode = hashCode * -1521134295 + (int)Vertical;
+            hashCode = hashCode * -1521134295 + Indent;
             hashCode = hashCode * -1521134295 + JustifyLastLine.GetHashCode();
-            hashCode = hashCode * -1521134295 + ReadingOrder.GetHashCode();
-            hashCode = hashCode * -1521134295 + RelativeIndent.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)ReadingOrder;
+            hashCode = hashCode * -1521134295 + RelativeIndent;
             hashCode = hashCode * -1521134295 + ShrinkToFit.GetHashCode();
-            hashCode = hashCode * -1521134295 + TextRotation.GetHashCode();
+            hashCode = hashCode * -1521134295 + TextRotation;
             hashCode = hashCode * -1521134295 + WrapText.GetHashCode();
             hashCode = hashCode * -1521134295 + TopToBottom.GetHashCode();
             return hashCode;

--- a/ClosedXML/Excel/Style/XLAlignmentValue.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentValue.cs
@@ -6,12 +6,12 @@ namespace ClosedXML.Excel
     {
         private static readonly XLAlignmentRepository Repository = new XLAlignmentRepository(key => new XLAlignmentValue(key));
 
-        public static XLAlignmentValue FromKey(XLAlignmentKey key)
+        public static XLAlignmentValue FromKey(ref XLAlignmentKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLAlignmentValue Default = FromKey(new XLAlignmentKey
+        private static readonly XLAlignmentKey DefaultKey = new XLAlignmentKey
         {
             Indent = 0,
             Horizontal = XLAlignmentHorizontalValues.General,
@@ -22,7 +22,9 @@ namespace ClosedXML.Excel
             TextRotation = 0,
             Vertical = XLAlignmentVerticalValues.Bottom,
             WrapText = false
-        });
+        };
+
+        internal static readonly XLAlignmentValue Default = FromKey(ref DefaultKey);
 
         public XLAlignmentKey Key { get; private set; }
 

--- a/ClosedXML/Excel/Style/XLBorder.cs
+++ b/ClosedXML/Excel/Style/XLBorder.cs
@@ -52,7 +52,7 @@ namespace ClosedXML.Excel
         internal XLBorderKey Key
         {
             get { return _value.Key; }
-            private set { _value = XLBorderValue.FromKey(value); }
+            private set { _value = XLBorderValue.FromKey(ref value); }
         }
 
         #region Constructors
@@ -70,7 +70,7 @@ namespace ClosedXML.Excel
             _value = value;
         }
 
-        public XLBorder(IXLStylized container, XLStyle style, XLBorderKey key) : this(container, style, XLBorderValue.FromKey(key))
+        public XLBorder(IXLStylized container, XLStyle style, XLBorderKey key) : this(container, style, XLBorderValue.FromKey(ref key))
         {
         }
 
@@ -92,9 +92,9 @@ namespace ClosedXML.Excel
                 {
                     Modify(k =>
                     {
-                        k.TopBorder = value;
-                        k.BottomBorder = value;
-                        k.LeftBorder = value;
+                        k.TopBorder =
+                        k.BottomBorder =
+                        k.LeftBorder =
                         k.RightBorder = value;
                         return k;
                     });
@@ -122,9 +122,9 @@ namespace ClosedXML.Excel
                 {
                     Modify(k =>
                     {
-                        k.TopBorderColor = value.Key;
-                        k.BottomBorderColor = value.Key;
-                        k.LeftBorderColor = value.Key;
+                        k.TopBorderColor =
+                        k.BottomBorderColor =
+                        k.LeftBorderColor =
                         k.RightBorderColor = value.Key;
                         return k;
                     });
@@ -153,9 +153,9 @@ namespace ClosedXML.Excel
                 {
                     Modify(k =>
                     {
-                        k.TopBorder = value;
-                        k.BottomBorder = value;
-                        k.LeftBorder = value;
+                        k.TopBorder =
+                        k.BottomBorder =
+                        k.LeftBorder =
                         k.RightBorder = value;
                         return k;
                     });
@@ -235,7 +235,11 @@ namespace ClosedXML.Excel
 
         public XLColor LeftBorderColor
         {
-            get { return XLColor.FromKey(Key.LeftBorderColor); }
+            get
+            {
+                var colorKey = Key.LeftBorderColor;
+                return XLColor.FromKey(ref colorKey);
+            }
             set
             {
                 if (value == null)
@@ -253,7 +257,11 @@ namespace ClosedXML.Excel
 
         public XLColor RightBorderColor
         {
-            get { return XLColor.FromKey(Key.RightBorderColor); }
+            get
+            {
+                var colorKey = Key.RightBorderColor;
+                return XLColor.FromKey(ref colorKey);
+            }
             set
             {
                 if (value == null)
@@ -271,7 +279,11 @@ namespace ClosedXML.Excel
 
         public XLColor TopBorderColor
         {
-            get { return XLColor.FromKey(Key.TopBorderColor); }
+            get
+            {
+                var colorKey = Key.TopBorderColor;
+                return XLColor.FromKey(ref colorKey);
+            }
             set
             {
                 if (value == null)
@@ -289,7 +301,11 @@ namespace ClosedXML.Excel
 
         public XLColor BottomBorderColor
         {
-            get { return XLColor.FromKey(Key.BottomBorderColor); }
+            get
+            {
+                var colorKey = Key.BottomBorderColor;
+                return XLColor.FromKey(ref colorKey);
+            }
             set
             {
                 if (value == null)
@@ -307,7 +323,11 @@ namespace ClosedXML.Excel
 
         public XLColor DiagonalBorderColor
         {
-            get { return XLColor.FromKey(Key.DiagonalBorderColor); }
+            get
+            {
+                var colorKey = Key.DiagonalBorderColor;
+                return XLColor.FromKey(ref colorKey);
+            }
             set
             {
                 if (value == null)
@@ -540,18 +560,34 @@ namespace ClosedXML.Excel
 
             public void Dispose()
             {
-                _topBorders.ForEach(kp => _range.FirstRow().Cell(kp.Key).Style
-                    .Border.SetTopBorder(kp.Value.TopBorder)
-                    .Border.SetTopBorderColor(XLColor.FromKey(kp.Value.TopBorderColor)));
-                _bottomBorders.ForEach(kp => _range.LastRow().Cell(kp.Key).Style
-                    .Border.SetBottomBorder(kp.Value.BottomBorder)
-                    .Border.SetBottomBorderColor(XLColor.FromKey(kp.Value.BottomBorderColor)));
-                _leftBorders.ForEach(kp => _range.FirstColumn().Cell(kp.Key).Style
-                    .Border.SetLeftBorder(kp.Value.LeftBorder)
-                    .Border.SetLeftBorderColor(XLColor.FromKey(kp.Value.LeftBorderColor)));
-                _rightBorders.ForEach(kp => _range.LastColumn().Cell(kp.Key).Style
-                    .Border.SetRightBorder(kp.Value.RightBorder)
-                    .Border.SetRightBorderColor(XLColor.FromKey(kp.Value.RightBorderColor)));
+                _topBorders.ForEach(kp => (_range.FirstRow().Cell(kp.Key).Style
+                    .Border as XLBorder).Modify(k =>
+                    {
+                        k.TopBorder = kp.Value.TopBorder;
+                        k.TopBorderColor = kp.Value.TopBorderColor;
+                        return k;
+                    }));
+                _bottomBorders.ForEach(kp => (_range.LastRow().Cell(kp.Key).Style
+                    .Border as XLBorder).Modify(k =>
+                    {
+                        k.BottomBorder = kp.Value.BottomBorder;
+                        k.BottomBorderColor = kp.Value.BottomBorderColor;
+                        return k;
+                    }));
+                _leftBorders.ForEach(kp => (_range.FirstColumn().Cell(kp.Key).Style
+                    .Border as XLBorder).Modify(k =>
+                    {
+                        k.LeftBorder = kp.Value.LeftBorder;
+                        k.LeftBorderColor = kp.Value.LeftBorderColor;
+                        return k;
+                    }));
+                _rightBorders.ForEach(kp => (_range.LastColumn().Cell(kp.Key).Style
+                    .Border as XLBorder).Modify(k =>
+                    {
+                        k.RightBorder = kp.Value.RightBorder;
+                        k.RightBorderColor = kp.Value.RightBorderColor;
+                        return k;
+                    }));
             }
         }
     }

--- a/ClosedXML/Excel/Style/XLBorder.cs
+++ b/ClosedXML/Excel/Style/XLBorder.cs
@@ -166,7 +166,18 @@ namespace ClosedXML.Excel
                     {
                         using (new RestoreOutsideBorder(r))
                         {
-                            r.Cells().Style.Border.OutsideBorder = value;
+                            foreach (var cell in r.Cells())
+                            {
+                                (cell.Style.Border as XLBorder)
+                                    .Modify(k =>
+                                    {
+                                        k.TopBorder =
+                                        k.BottomBorder =
+                                        k.LeftBorder =
+                                        k.RightBorder = value;
+                                        return k;
+                                    });
+                            }
                         }
                     }
                 }
@@ -184,9 +195,9 @@ namespace ClosedXML.Excel
                 {
                     Modify(k =>
                     {
-                        k.TopBorderColor = value.Key;
-                        k.BottomBorderColor = value.Key;
-                        k.LeftBorderColor = value.Key;
+                        k.TopBorderColor =
+                        k.BottomBorderColor =
+                        k.LeftBorderColor =
                         k.RightBorderColor = value.Key;
                         return k;
                     });
@@ -197,7 +208,19 @@ namespace ClosedXML.Excel
                     {
                         using (new RestoreOutsideBorder(r))
                         {
-                            r.Cells().Style.Border.OutsideBorderColor = value;
+                            foreach (var cell in r.Cells())
+                            {
+                                (cell.Style.Border as XLBorder)
+                                    .Modify(k =>
+                                    {
+                                        k.TopBorderColor = 
+                                        k.BottomBorderColor = 
+                                        k.LeftBorderColor = 
+                                        k.RightBorderColor = value.Key;
+                                        return k;
+                                    });
+                            }
+
                         }
                     }
                 }

--- a/ClosedXML/Excel/Style/XLBorderKey.cs
+++ b/ClosedXML/Excel/Style/XLBorderKey.cs
@@ -31,11 +31,11 @@ namespace ClosedXML.Excel
         public override int GetHashCode()
         {
             var hashCode = -198124310;
-            hashCode = hashCode * -1521134295 + LeftBorder.GetHashCode();
-            hashCode = hashCode * -1521134295 + RightBorder.GetHashCode();
-            hashCode = hashCode * -1521134295 + TopBorder.GetHashCode();
-            hashCode = hashCode * -1521134295 + BottomBorder.GetHashCode();
-            hashCode = hashCode * -1521134295 + DiagonalBorder.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)LeftBorder;
+            hashCode = hashCode * -1521134295 + (int)RightBorder;
+            hashCode = hashCode * -1521134295 + (int)TopBorder;
+            hashCode = hashCode * -1521134295 + (int)BottomBorder;
+            hashCode = hashCode * -1521134295 + (int)DiagonalBorder;
             hashCode = hashCode * -1521134295 + DiagonalUp.GetHashCode();
             hashCode = hashCode * -1521134295 + DiagonalDown.GetHashCode();
 

--- a/ClosedXML/Excel/Style/XLBorderValue.cs
+++ b/ClosedXML/Excel/Style/XLBorderValue.cs
@@ -6,12 +6,12 @@ namespace ClosedXML.Excel
     {
         private static readonly XLBorderRepository Repository = new XLBorderRepository(key => new XLBorderValue(key));
 
-        public static XLBorderValue FromKey(XLBorderKey key)
+        public static XLBorderValue FromKey(ref XLBorderKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLBorderValue Default = FromKey(new XLBorderKey
+        private static readonly XLBorderKey DefaultKey = new XLBorderKey
         {
             BottomBorder = XLBorderStyleValues.None,
             DiagonalBorder = XLBorderStyleValues.None,
@@ -25,7 +25,9 @@ namespace ClosedXML.Excel
             LeftBorderColor = XLColor.Black.Key,
             RightBorderColor = XLColor.Black.Key,
             TopBorderColor = XLColor.Black.Key
-        });
+        };
+
+        internal static readonly XLBorderValue Default = FromKey(ref DefaultKey);
 
         public XLBorderKey Key { get; private set; }
 
@@ -56,12 +58,16 @@ namespace ClosedXML.Excel
         private XLBorderValue(XLBorderKey key)
         {
             Key = key;
-
-            LeftBorderColor = XLColor.FromKey(Key.LeftBorderColor);
-            RightBorderColor = XLColor.FromKey(Key.RightBorderColor);
-            TopBorderColor = XLColor.FromKey(Key.TopBorderColor);
-            BottomBorderColor = XLColor.FromKey(Key.BottomBorderColor);
-            DiagonalBorderColor = XLColor.FromKey(Key.DiagonalBorderColor);
+            var leftBorderColor = Key.LeftBorderColor;
+            var rightBorderColor = Key.RightBorderColor;
+            var topBorderColor = Key.TopBorderColor;
+            var bottomBorderColor = Key.BottomBorderColor;
+            var diagonalBorderColor = Key.DiagonalBorderColor;
+            LeftBorderColor = XLColor.FromKey(ref leftBorderColor);
+            RightBorderColor = XLColor.FromKey(ref rightBorderColor);
+            TopBorderColor = XLColor.FromKey(ref topBorderColor);
+            BottomBorderColor = XLColor.FromKey(ref bottomBorderColor);
+            DiagonalBorderColor = XLColor.FromKey(ref diagonalBorderColor);
         }
 
         public override bool Equals(object obj)

--- a/ClosedXML/Excel/Style/XLColorKey.cs
+++ b/ClosedXML/Excel/Style/XLColorKey.cs
@@ -17,11 +17,11 @@ namespace ClosedXML.Excel
         public override int GetHashCode()
         {
             var hashCode = -331517974;
-            hashCode = hashCode * -1521134295 + ColorType.GetHashCode();
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Indexed ? Indexed.GetHashCode() : 0);
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? ThemeColor.GetHashCode() : 0);
+            hashCode = hashCode * -1521134295 + (int)ColorType;
+            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Indexed ? Indexed : 0);
+            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? (int)ThemeColor : 0);
             hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? ThemeTint.GetHashCode() : 0);
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Color ? Color.ToArgb().GetHashCode() : 0);
+            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Color ? Color.ToArgb() : 0);
             return hashCode;
         }
 

--- a/ClosedXML/Excel/Style/XLFill.cs
+++ b/ClosedXML/Excel/Style/XLFill.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Excel
         internal XLFillKey Key
         {
             get { return _value.Key; }
-            private set { _value = XLFillValue.FromKey(value); }
+            private set { _value = XLFillValue.FromKey(ref value); }
         }
 
         #endregion Properties
@@ -59,7 +59,7 @@ namespace ClosedXML.Excel
             _value = value;
         }
 
-        public XLFill(XLStyle style, XLFillKey key) : this(style, XLFillValue.FromKey(key))
+        public XLFill(XLStyle style, XLFillKey key) : this(style, XLFillValue.FromKey(ref key))
         {
         }
 
@@ -85,7 +85,11 @@ namespace ClosedXML.Excel
 
         public XLColor BackgroundColor
         {
-            get { return XLColor.FromKey(Key.BackgroundColor); }
+            get
+            {
+                var backgroundColorKey = Key.BackgroundColor;
+                return XLColor.FromKey(ref backgroundColorKey);
+            }
             set
             {
                 if (value == null)
@@ -110,7 +114,11 @@ namespace ClosedXML.Excel
 
         public XLColor PatternColor
         {
-            get { return XLColor.FromKey(Key.PatternColor); }
+            get
+            {
+                var patternColorKey = Key.PatternColor;
+                return XLColor.FromKey(ref patternColorKey);
+            }
             set
             {
                 if (value == null)

--- a/ClosedXML/Excel/Style/XLFillKey.cs
+++ b/ClosedXML/Excel/Style/XLFillKey.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Excel
 
             if (HasNoFill()) return hashCode;
 
-            hashCode = hashCode * -1521134295 + PatternType.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)PatternType;
             hashCode = hashCode * -1521134295 + BackgroundColor.GetHashCode();
 
             if (HasNoForeground()) return hashCode;

--- a/ClosedXML/Excel/Style/XLFillValue.cs
+++ b/ClosedXML/Excel/Style/XLFillValue.cs
@@ -6,17 +6,19 @@ namespace ClosedXML.Excel
     {
         private static readonly XLFillRepository Repository = new XLFillRepository(key => new XLFillValue(key));
 
-        public static XLFillValue FromKey(XLFillKey key)
+        public static XLFillValue FromKey(ref XLFillKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLFillValue Default = FromKey(new XLFillKey
+        private static readonly XLFillKey DefaultKey = new XLFillKey
         {
             BackgroundColor = XLColor.FromIndex(64).Key,
             PatternType = XLFillPatternValues.None,
             PatternColor = XLColor.FromIndex(64).Key
-        });
+        };
+
+        internal static readonly XLFillValue Default = FromKey(ref DefaultKey);
 
         public XLFillKey Key { get; private set; }
 
@@ -29,8 +31,10 @@ namespace ClosedXML.Excel
         private XLFillValue(XLFillKey key)
         {
             Key = key;
-            BackgroundColor = XLColor.FromKey(Key.BackgroundColor);
-            PatternColor = XLColor.FromKey(Key.PatternColor);
+            var backgroundColorKey = Key.BackgroundColor;
+            var patternColorKey = Key.PatternColor;
+            BackgroundColor = XLColor.FromKey(ref backgroundColorKey);
+            PatternColor = XLColor.FromKey(ref patternColorKey);
         }
 
         public override bool Equals(object obj)

--- a/ClosedXML/Excel/Style/XLFont.cs
+++ b/ClosedXML/Excel/Style/XLFont.cs
@@ -61,7 +61,7 @@ namespace ClosedXML.Excel
         internal XLFontKey Key
         {
             get { return _value.Key; }
-            private set { _value = XLFontValue.FromKey(value); }
+            private set { _value = XLFontValue.FromKey(ref value); }
         }
 
         #region Constructors
@@ -77,7 +77,7 @@ namespace ClosedXML.Excel
             _value = value;
         }
 
-        public XLFont(XLStyle style, XLFontKey key) : this(style, XLFontValue.FromKey(key))
+        public XLFont(XLStyle style, XLFontKey key) : this(style, XLFontValue.FromKey(ref key))
         {
         }
 
@@ -166,7 +166,11 @@ namespace ClosedXML.Excel
 
         public XLColor FontColor
         {
-            get { return XLColor.FromKey(Key.FontColor); }
+            get
+            {
+                var fontColorKey = Key.FontColor;
+                return XLColor.FromKey(ref fontColorKey);
+            }
             set
             {
                 if (value == null)

--- a/ClosedXML/Excel/Style/XLFontKey.cs
+++ b/ClosedXML/Excel/Style/XLFontKey.cs
@@ -54,15 +54,15 @@ namespace ClosedXML.Excel
             var hashCode = 1158783753;
             hashCode = hashCode * -1521134295 + Bold.GetHashCode();
             hashCode = hashCode * -1521134295 + Italic.GetHashCode();
-            hashCode = hashCode * -1521134295 + Underline.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)Underline;
             hashCode = hashCode * -1521134295 + Strikethrough.GetHashCode();
-            hashCode = hashCode * -1521134295 + VerticalAlignment.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)VerticalAlignment;
             hashCode = hashCode * -1521134295 + Shadow.GetHashCode();
             hashCode = hashCode * -1521134295 + FontSize.GetHashCode();
             hashCode = hashCode * -1521134295 + FontColor.GetHashCode();
             hashCode = hashCode * -1521134295 + StringComparer.InvariantCultureIgnoreCase.GetHashCode(FontName);
-            hashCode = hashCode * -1521134295 + FontFamilyNumbering.GetHashCode();
-            hashCode = hashCode * -1521134295 + FontCharSet.GetHashCode();
+            hashCode = hashCode * -1521134295 + (int)FontFamilyNumbering;
+            hashCode = hashCode * -1521134295 + (int)FontCharSet;
             return hashCode;
         }
 

--- a/ClosedXML/Excel/Style/XLFontValue.cs
+++ b/ClosedXML/Excel/Style/XLFontValue.cs
@@ -7,12 +7,12 @@ namespace ClosedXML.Excel
     {
         private static readonly XLFontRepository Repository = new XLFontRepository(key => new XLFontValue(key));
 
-        public static XLFontValue FromKey(XLFontKey key)
+        public static XLFontValue FromKey(ref XLFontKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLFontValue Default = FromKey(new XLFontKey
+        private static readonly XLFontKey DefaultKey = new XLFontKey
         {
             Bold = false,
             Italic = false,
@@ -24,7 +24,8 @@ namespace ClosedXML.Excel
             FontName = "Calibri",
             FontFamilyNumbering = XLFontFamilyNumberingValues.Swiss,
             FontCharSet = XLFontCharSet.Default
-        });
+        };
+        internal static readonly XLFontValue Default = FromKey(ref DefaultKey);
 
         public XLFontKey Key { get; private set; }
 
@@ -53,8 +54,8 @@ namespace ClosedXML.Excel
         private XLFontValue(XLFontKey key)
         {
             Key = key;
-
-            FontColor = XLColor.FromKey(Key.FontColor);
+            var fontColorKey = Key.FontColor;
+            FontColor = XLColor.FromKey(ref fontColorKey);
         }
 
         public override bool Equals(object obj)

--- a/ClosedXML/Excel/Style/XLNumberFormat.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormat.cs
@@ -32,7 +32,7 @@ namespace ClosedXML.Excel
         internal XLNumberFormatKey Key
         {
             get { return _value.Key; }
-            private set { _value = XLNumberFormatValue.FromKey(value); }
+            private set { _value = XLNumberFormatValue.FromKey(ref value); }
         }
 
         #endregion Properties
@@ -50,7 +50,7 @@ namespace ClosedXML.Excel
             _value = value;
         }
 
-        public XLNumberFormat(XLStyle style, XLNumberFormatKey key) : this(style, XLNumberFormatValue.FromKey(key))
+        public XLNumberFormat(XLStyle style, XLNumberFormatKey key) : this(style, XLNumberFormatValue.FromKey(ref key))
         {
         }
 

--- a/ClosedXML/Excel/Style/XLNumberFormatKey.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormatKey.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
         public override int GetHashCode()
         {
             var hashCode = -759193072;
-            hashCode = hashCode * -1521134295 + NumberFormatId.GetHashCode();
+            hashCode = hashCode * -1521134295 + NumberFormatId;
             hashCode = hashCode * -1521134295 + (Format == null ? 0 : Format.GetHashCode());
             return hashCode;
         }

--- a/ClosedXML/Excel/Style/XLNumberFormatValue.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormatValue.cs
@@ -6,16 +6,18 @@ namespace ClosedXML.Excel
     {
         private static readonly XLNumberFormatRepository Repository = new XLNumberFormatRepository(key => new XLNumberFormatValue(key));
 
-        public static XLNumberFormatValue FromKey(XLNumberFormatKey key)
+        public static XLNumberFormatValue FromKey(ref XLNumberFormatKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLNumberFormatValue Default = FromKey(new XLNumberFormatKey
+        private static readonly XLNumberFormatKey DefaultKey = new XLNumberFormatKey
         {
             NumberFormatId = 0,
             Format = string.Empty
-        });
+        };
+
+        internal static readonly XLNumberFormatValue Default = FromKey(ref DefaultKey);
 
         public XLNumberFormatKey Key { get; private set; }
 

--- a/ClosedXML/Excel/Style/XLProtection.cs
+++ b/ClosedXML/Excel/Style/XLProtection.cs
@@ -31,7 +31,7 @@ namespace ClosedXML.Excel
         internal XLProtectionKey Key
         {
             get { return _value.Key; }
-            private set { _value = XLProtectionValue.FromKey(value); }
+            private set { _value = XLProtectionValue.FromKey(ref value); }
         }
 
         #endregion Properties
@@ -49,7 +49,7 @@ namespace ClosedXML.Excel
             _value = value;
         }
 
-        public XLProtection(XLStyle style, XLProtectionKey key) : this(style, XLProtectionValue.FromKey(key))
+        public XLProtection(XLStyle style, XLProtectionKey key) : this(style, XLProtectionValue.FromKey(ref key))
         {
         }
 

--- a/ClosedXML/Excel/Style/XLProtectionValue.cs
+++ b/ClosedXML/Excel/Style/XLProtectionValue.cs
@@ -6,16 +6,18 @@ namespace ClosedXML.Excel
     {
         private static readonly XLProtectionRepository Repository = new XLProtectionRepository(key => new XLProtectionValue(key));
 
-        public static XLProtectionValue FromKey(XLProtectionKey key)
+        public static XLProtectionValue FromKey(ref XLProtectionKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLProtectionValue Default = FromKey(new XLProtectionKey
+        private static readonly XLProtectionKey DefaultKey = new XLProtectionKey
         {
             Locked = true,
             Hidden = false
-        });
+        };
+
+        internal static readonly XLProtectionValue Default = FromKey(ref DefaultKey);
 
         public XLProtectionKey Key { get; private set; }
 

--- a/ClosedXML/Excel/Style/XLStyle.cs
+++ b/ClosedXML/Excel/Style/XLStyle.cs
@@ -45,7 +45,7 @@ namespace ClosedXML.Excel
             get { return Value.Key; }
             private set
             {
-                Value = XLStyleValue.FromKey(value);
+                Value = XLStyleValue.FromKey(ref value);
             }
         }
 
@@ -57,7 +57,7 @@ namespace ClosedXML.Excel
         {
         }
 
-        public XLStyle(IXLStylized container, XLStyleKey key) : this(container, XLStyleValue.FromKey(key))
+        public XLStyle(IXLStylized container, XLStyleKey key) : this(container, XLStyleValue.FromKey(ref key))
         {
         }
 

--- a/ClosedXML/Excel/Style/XLStyleKey.cs
+++ b/ClosedXML/Excel/Style/XLStyleKey.cs
@@ -66,5 +66,23 @@ namespace ClosedXML.Excel
         public static bool operator ==(XLStyleKey left, XLStyleKey right) => left.Equals(right);
 
         public static bool operator !=(XLStyleKey left, XLStyleKey right) => !(left.Equals(right));
+
+        public void Deconstruct(
+            out XLAlignmentKey alignment,
+            out XLBorderKey border,
+            out XLFillKey fill,
+            out XLFontKey font,
+            out Boolean includeQuotePrefix,
+            out XLNumberFormatKey numberFormat,
+            out XLProtectionKey protection)
+        {
+            alignment = Alignment;
+            border = Border;
+            fill = Fill;
+            font = Font;
+            includeQuotePrefix = IncludeQuotePrefix;
+            numberFormat = NumberFormat;
+            protection = Protection;
+        }
     }
 }

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -7,12 +7,12 @@ namespace ClosedXML.Excel
     {
         private static readonly XLStyleRepository Repository = new XLStyleRepository(key => new XLStyleValue(key));
 
-        public static XLStyleValue FromKey(XLStyleKey key)
+        public static XLStyleValue FromKey(ref XLStyleKey key)
         {
-            return Repository.GetOrCreate(key);
+            return Repository.GetOrCreate(ref key);
         }
 
-        internal static readonly XLStyleValue Default = FromKey(new XLStyleKey
+        private static readonly XLStyleKey DefaultKey = new XLStyleKey
         {
             Alignment = XLAlignmentValue.Default.Key,
             Border = XLBorderValue.Default.Key,
@@ -21,7 +21,9 @@ namespace ClosedXML.Excel
             IncludeQuotePrefix = false,
             NumberFormat = XLNumberFormatValue.Default.Key,
             Protection = XLProtectionValue.Default.Key
-        });
+        };
+
+        internal static readonly XLStyleValue Default = FromKey(ref DefaultKey);
 
         public XLStyleKey Key { get; private set; }
 
@@ -42,13 +44,14 @@ namespace ClosedXML.Excel
         internal XLStyleValue(XLStyleKey key)
         {
             Key = key;
-            Alignment = XLAlignmentValue.FromKey(Key.Alignment);
-            Border = XLBorderValue.FromKey(Key.Border);
-            Fill = XLFillValue.FromKey(Key.Fill);
-            Font = XLFontValue.FromKey(Key.Font);
+            var (alignment, border, fill, font, _, numberFormat, protection) = Key;
+            Alignment = XLAlignmentValue.FromKey(ref alignment);
+            Border = XLBorderValue.FromKey(ref border);
+            Fill = XLFillValue.FromKey(ref fill);
+            Font = XLFontValue.FromKey(ref font);
             IncludeQuotePrefix = key.IncludeQuotePrefix;
-            NumberFormat = XLNumberFormatValue.FromKey(Key.NumberFormat);
-            Protection = XLProtectionValue.FromKey(Key.Protection);
+            NumberFormat = XLNumberFormatValue.FromKey(ref numberFormat);
+            Protection = XLProtectionValue.FromKey(ref protection);
         }
 
         public override bool Equals(object obj)

--- a/ClosedXML/Excel/Style/XLStylizedBase.cs
+++ b/ClosedXML/Excel/Style/XLStylizedBase.cs
@@ -66,7 +66,10 @@ namespace ClosedXML.Excel
             if (style is XLStyle xlStyle)
                 SetStyle(xlStyle.Value, propagate);
             else
-                SetStyle(XLStyleValue.FromKey(XLStyle.GenerateKey(style)), propagate);
+            {
+                var styleKey = XLStyle.GenerateKey(style);
+                SetStyle(XLStyleValue.FromKey(ref styleKey), propagate);
+            }
         }
 
         /// <summary>
@@ -93,7 +96,7 @@ namespace ClosedXML.Excel
             foreach (var group in children)
             {
                 var styleKey = modification(group.Key.Key);
-                var styleValue = XLStyleValue.FromKey(styleKey);
+                var styleValue = XLStyleValue.FromKey(ref styleKey);
                 foreach (var child in group)
                 {
                     child.StyleValue = styleValue;

--- a/ClosedXML/Excel/Style/XLStylizedBase.cs
+++ b/ClosedXML/Excel/Style/XLStylizedBase.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Read-only style property.
         /// </summary>
-        internal XLStyleValue StyleValue { get; private set; }
+        internal XLStyleValue StyleValue { get; private protected set; }
         XLStyleValue IXLStylized.StyleValue
         {
             get { return StyleValue; }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -1046,7 +1046,9 @@ namespace ClosedXML.Excel
                     phoneticRun.Append(text);
                     rstType.Append(phoneticRun);
                 }
-                var f = XLFontValue.FromKey(XLFont.GenerateKey(cell.RichText.Phonetics));
+
+                var fontKey = XLFont.GenerateKey(cell.RichText.Phonetics);
+                var f = XLFontValue.FromKey(ref fontKey);
 
                 if (!context.SharedFonts.TryGetValue(f, out FontInfo fi))
                 {
@@ -3707,11 +3709,12 @@ namespace ClosedXML.Excel
 
             foreach (var pivotNumberFormat in pivotTableNumberFormats.Where(nf => nf.NumberFormatId == -1))
             {
-                var numberFormat = XLNumberFormatValue.FromKey(new XLNumberFormatKey
+                var numberFormatKey = new XLNumberFormatKey
                 {
                     NumberFormatId = -1,
                     Format = pivotNumberFormat.Format
-                });
+                };
+                var numberFormat = XLNumberFormatValue.FromKey(ref numberFormatKey);
 
                 if (sharedNumberFormats.ContainsKey(numberFormat))
                     continue;

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1574,7 +1574,8 @@ namespace ClosedXML.Excel
             else
                 rangeAddress = range.RangeAddress;
 
-            var table = (XLTable)_rangeRepository.GetOrCreate(new XLRangeKey(XLRangeType.Table, rangeAddress));
+            var rangeKey = new XLRangeKey(XLRangeType.Table, rangeAddress);
+            var table = (XLTable)_rangeRepository.GetOrCreate(ref rangeKey);
 
             if (table.Name != name)
                 table.Name = name;
@@ -1839,7 +1840,8 @@ namespace ClosedXML.Excel
 
         public XLRange GetOrCreateRange(XLRangeParameters xlRangeParameters)
         {
-            var range = _rangeRepository.GetOrCreate(new XLRangeKey(XLRangeType.Range, xlRangeParameters.RangeAddress));
+            var rangeKey = new XLRangeKey(XLRangeType.Range, xlRangeParameters.RangeAddress);
+            var range = _rangeRepository.GetOrCreate(ref rangeKey);
             if (xlRangeParameters.DefaultStyle != null && range.StyleValue == StyleValue)
                 range.InnerStyle = xlRangeParameters.DefaultStyle;
 
@@ -1854,7 +1856,8 @@ namespace ClosedXML.Excel
         /// <returns>Range row with the specified address.</returns>
         public XLRangeRow RangeRow(XLRangeAddress address, IXLStyle defaultStyle = null)
         {
-            var rangeRow = (XLRangeRow)_rangeRepository.GetOrCreate(new XLRangeKey(XLRangeType.RangeRow, address));
+            var rangeKey = new XLRangeKey(XLRangeType.RangeRow, address);
+            var rangeRow = (XLRangeRow)_rangeRepository.GetOrCreate(ref rangeKey);
 
             if (defaultStyle != null && rangeRow.StyleValue == StyleValue)
                 rangeRow.InnerStyle = defaultStyle;
@@ -1870,7 +1873,8 @@ namespace ClosedXML.Excel
         /// <returns>Range column with the specified address.</returns>
         public XLRangeColumn RangeColumn(XLRangeAddress address, IXLStyle defaultStyle = null)
         {
-            var rangeColumn = (XLRangeColumn)_rangeRepository.GetOrCreate(new XLRangeKey(XLRangeType.RangeColumn, address));
+            var rangeKey = new XLRangeKey(XLRangeType.RangeColumn, address);
+            var rangeColumn = (XLRangeColumn)_rangeRepository.GetOrCreate(ref rangeKey);
 
             if (defaultStyle != null && rangeColumn.StyleValue == StyleValue)
                 rangeColumn.InnerStyle = defaultStyle;
@@ -1887,8 +1891,9 @@ namespace ClosedXML.Excel
             if (_rangeRepository == null)
                 return;
 
-            var range = _rangeRepository.Replace(new XLRangeKey(rangeType, oldAddress),
-                                                 new XLRangeKey(rangeType, newAddress));
+            var oldKey = new XLRangeKey(rangeType, oldAddress);
+            var newKey = new XLRangeKey(rangeType, newAddress);
+            var range = _rangeRepository.Replace(ref oldKey, ref newKey);
 
             foreach (var rangeIndex in _rangeIndices)
             {
@@ -1937,7 +1942,8 @@ namespace ClosedXML.Excel
 
         internal void DeleteRange(XLRangeAddress rangeAddress)
         {
-            _rangeRepository.Remove(new XLRangeKey(XLRangeType.Range, rangeAddress));
+            var rangeKey = new XLRangeKey(XLRangeType.Range, rangeAddress);
+            _rangeRepository.Remove(ref rangeKey);
         }
     }
 }


### PR DESCRIPTION
Fixes #1416

I suggest reviewing per commit.

1) Commit 1 - improvement from 2:33 to ~30
2) Commit 2 - from ~30 to ~12
3) Commit 3 - the effect is negligible
4) Commit 4 - from ~12 to ~9 (and reduced memory traffic)

Besides, I was experimenting with preserving the last obtained element in `XLRepositoryBase` - on intensive style edits high chances are that the next queried element is the same as was fetched before and we don't have to go to the dictionary. It saves another 2 seconds but I did not include this in PR as it will make our repositories non-thread safe. I know, we generally do not support multi-threading, but our repositories are shared globally, therefore they must be thread-safe; otherwise, concurrent requests in, say, ASP.Net application will skrew everything up. 