### PR TITLE
Fix treatment of SUMIF and COUNTIF for mixed data

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -6,21 +6,21 @@ using System.Text.RegularExpressions;
 
 namespace ClosedXML.Excel.CalcEngine
 {
-    internal class CalcEngineHelpers
+    internal static class CalcEngineHelpers
     {
         private static Lazy<Dictionary<string, Tuple<string, string>>> patternReplacements =
             new Lazy<Dictionary<string, Tuple<string, string>>>(() =>
             {
-                var patternReplacements = new Dictionary<string, Tuple<string, string>>();
                 // key: the literal string to match
                 // value: a tuple: first item: the search pattern, second item: the replacement
-                patternReplacements.Add(@"~~", new Tuple<string, string>(@"~~", "~"));
-                patternReplacements.Add(@"~*", new Tuple<string, string>(@"~\*", @"\*"));
-                patternReplacements.Add(@"~?", new Tuple<string, string>(@"~\?", @"\?"));
-                patternReplacements.Add(@"?", new Tuple<string, string>(@"\?", ".?"));
-                patternReplacements.Add(@"*", new Tuple<string, string>(@"\*", ".*"));
-
-                return patternReplacements;
+                return new Dictionary<string, Tuple<string, string>>()
+                {
+                    [@"~~"] = new Tuple<string, string>(@"~~", "~"),
+                    [@"~*"] = new Tuple<string, string>(@"~\*", @"\*"),
+                    [@"~?"] = new Tuple<string, string>(@"~\?", @"\?"),
+                    [@"?"] = new Tuple<string, string>(@"\?", ".?"),
+                    [@"*"] = new Tuple<string, string>(@"\*", ".*"),
+                };
             });
 
         internal static bool ValueSatisfiesCriteria(object value, object criteria, CalcEngine ce)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -361,17 +361,8 @@ namespace ClosedXML.Excel.CalcEngine
                 p[2] as XObjectExpression;   // range of values to sum up
             var criteria = p[1].Evaluate();                             // the criteria to evaluate
 
-            // build list of values in range and sumRange
-            var rangeValues = new List<object>();
-            foreach (var value in range)
-            {
-                rangeValues.Add(value);
-            }
-            var sumRangeValues = new List<object>();
-            foreach (var value in sumRange)
-            {
-                sumRangeValues.Add(value);
-            }
+            var rangeValues = range.Cast<object>().ToList();
+            var sumRangeValues = sumRange.Cast<object>().ToList();
 
             // compute total
             var ce = new CalcEngine();

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -138,11 +138,10 @@ namespace ClosedXML.Excel.CalcEngine
             CalcEngine ce = new CalcEngine();
             var cnt = 0.0;
             long processedCount = 0;
-            var ienum = p[0] as XObjectExpression;
-            if (ienum != null)
+            if (p[0] is XObjectExpression ienum)
             {
                 long totalCount = CalcEngineHelpers.GetTotalCellsCount(ienum);
-                var criteria = (string)p[1].Evaluate();
+                var criteria = p[1].Evaluate();
                 foreach (var value in ienum)
                 {
                     if (CalcEngineHelpers.ValueSatisfiesCriteria(value, criteria, ce))

--- a/ClosedXML_Sandbox/PerformanceRunner.cs
+++ b/ClosedXML_Sandbox/PerformanceRunner.cs
@@ -44,6 +44,7 @@ namespace ClosedXML_Sandbox
         {
             using (var wb = new XLWorkbook("test.xlsx"))
             {
+                wb.RecalculateAllFormulas();
                 var ws = wb.Worksheets.First();
                 var cell = ws.FirstCellUsed();
                 Console.WriteLine(cell.Value);

--- a/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -1,9 +1,10 @@
+// Keep this file CodeMaid organised and cleaned
 using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine;
+using ClosedXML.Excel.CalcEngine.Exceptions;
 using NUnit.Framework;
 using System;
 using System.Linq;
-using ClosedXML.Excel.CalcEngine;
-using ClosedXML.Excel.CalcEngine.Exceptions;
 
 namespace ClosedXML_Tests.Excel.CalcEngine
 {
@@ -119,8 +120,8 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         [TestCase("x", @"=COUNTIF(A1:A1, ""?"")", 1)]
         [TestCase("x", @"=COUNTIF(A1:A1, ""~?"")", 0)]
         [TestCase("?", @"=COUNTIF(A1:A1, ""~?"")", 1)]
-        [TestCase("~?", @"=COUNTIF(A1:A1, ""~?"")", 0)] 
-        [TestCase("~?", @"=COUNTIF(A1:A1, ""~~~?"")", 1)] 
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~?"")", 0)]
+        [TestCase("~?", @"=COUNTIF(A1:A1, ""~~~?"")", 1)]
         [TestCase("?", @"=COUNTIF(A1:A1, ""~~?"")", 0)]
         [TestCase("~?", @"=COUNTIF(A1:A1, ""~~?"")", 1)]
         [TestCase("~x", @"=COUNTIF(A1:A1, ""~~?"")", 1)]
@@ -296,6 +297,36 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         }
 
         [Test]
+        [TestCase("COUNT(G:I,G:G,H:I)", 258d, Description = "COUNT overlapping columns")]
+        [TestCase("COUNT(6:8,6:6,7:8)", 30d, Description = "COUNT overlapping rows")]
+        [TestCase("COUNTBLANK(H:J)", 3145640d, Description = "COUNTBLANK columns")]
+        [TestCase("COUNTBLANK(7:9)", 49128d, Description = "COUNTBLANK rows")]
+        [TestCase("COUNT(1:1048576)", 216d, Description = "COUNT worksheet")]
+        [TestCase("COUNTBLANK(1:1048576)", 17179868831d, Description = "COUNTBLANK worksheet")]
+        [TestCase("SUM(H:J)", 20501.15d, Description = "SUM columns")]
+        [TestCase("SUM(4:5)", 85366.12d, Description = "SUM rows")]
+        [TestCase("SUMIF(G:G,50,H:H)", 24.98d, Description = "SUMIF columns")]
+        [TestCase("SUMIF(G23:G52,\"\",H3:H32)", 53.24d, Description = "SUMIF ranges")]
+        [TestCase("SUMIFS(H:H,G:G,50,I:I,\">900\")", 19.99d, Description = "SUMIFS columns")]
+        public void TallySkipsEmptyCells(string formulaA1, double expectedResult)
+        {
+            using (var wb = SetupWorkbook())
+            {
+                var ws = wb.Worksheets.First();
+                //Let's pre-initialize cells we need so they didn't affect the result
+                ws.Range("A1:J45").Style.Fill.BackgroundColor = XLColor.Amber;
+                ws.Cell("ZZ1000").Value = 1;
+                int initialCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
+
+                var actualResult = (double)ws.Evaluate(formulaA1);
+                int cellsCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
+
+                Assert.AreEqual(expectedResult, actualResult, tolerance);
+                Assert.AreEqual(initialCount, cellsCount);
+            }
+        }
+
+        [Test]
         public void Var()
         {
             var ws = workbook.Worksheets.First();
@@ -328,37 +359,6 @@ namespace ClosedXML_Tests.Excel.CalcEngine
             value = workbook.Evaluate(@"=VARP(Data!H:H)").CastTo<double>();
             Assert.AreEqual(2189.430863, value, tolerance);
         }
-
-        [Test]
-        [TestCase("COUNT(G:I,G:G,H:I)", 258d, Description = "COUNT overlapping columns")]
-        [TestCase("COUNT(6:8,6:6,7:8)", 30d, Description = "COUNT overlapping rows")]
-        [TestCase("COUNTBLANK(H:J)", 3145640d, Description = "COUNTBLANK columns")]
-        [TestCase("COUNTBLANK(7:9)", 49128d, Description = "COUNTBLANK rows")]
-        [TestCase("COUNT(1:1048576)", 216d, Description = "COUNT worksheet")]
-        [TestCase("COUNTBLANK(1:1048576)", 17179868831d, Description = "COUNTBLANK worksheet")]
-        [TestCase("SUM(H:J)", 20501.15d, Description = "SUM columns")]
-        [TestCase("SUM(4:5)", 85366.12d, Description = "SUM rows")]
-        [TestCase("SUMIF(G:G,50,H:H)", 24.98d, Description = "SUMIF columns")]
-        [TestCase("SUMIF(G23:G52,\"\",H3:H32)", 53.24d, Description = "SUMIF ranges")]
-        [TestCase("SUMIFS(H:H,G:G,50,I:I,\">900\")", 19.99d, Description = "SUMIFS columns")]
-        public void TallySkipsEmptyCells(string formulaA1, double expectedResult)
-        {
-            using (var wb = SetupWorkbook())
-            {
-                var ws = wb.Worksheets.First();
-                //Let's pre-initialize cells we need so they didn't affect the result
-                ws.Range("A1:J45").Style.Fill.BackgroundColor = XLColor.Amber;
-                ws.Cell("ZZ1000").Value = 1;
-                int initialCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
-
-                var actualResult = (double)ws.Evaluate(formulaA1);
-                int cellsCount = (ws as XLWorksheet).Internals.CellsCollection.Count;
-
-                Assert.AreEqual(expectedResult, actualResult, tolerance);
-                Assert.AreEqual(initialCount, cellsCount);
-            }
-        }
-
         private XLWorkbook SetupWorkbook()
         {
             var wb = new XLWorkbook();


### PR DESCRIPTION
Fixes #1431 

Follow Excel's convention of equality, i.e.  `1 != true`, but `3 == "3"`. LibreOffice treats them the alternative way.