### PR TITLE
Fix the incorrect FirstRowUsed method (#1443)

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -268,7 +268,7 @@ namespace ClosedXML.Excel
 
         IXLRow IXLWorksheet.FirstRowUsed(XLCellsUsedOptions options)
         {
-            return LastRowUsed(options);
+            return FirstRowUsed(options);
         }
 
         IXLRow IXLWorksheet.LastRowUsed()

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -60,6 +60,17 @@ namespace ClosedXML_Tests.Excel.Ranges
             Assert.AreEqual(0, i);
         }
 
+        [Test(Description = "See 1443")]
+        public void FirstRowUsedRegression()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Range("B3:F6").SetValue(100);
+
+            Assert.AreEqual(3, ws.FirstRowUsed(XLCellsUsedOptions.AllContents).RowNumber());
+        }
+
         [Test]
         public void CountAllCellsInRow()
         {


### PR DESCRIPTION
Fixes #1443 

This is not a true regression as in 0.94.2 it worked the same way, and before that there was no such method. But it is a nasty bag nonetheless.