### PR TITLE
Fix the incorrect FirstRowUsed method (#1443), RC branch

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -267,7 +267,7 @@ namespace ClosedXML.Excel
 
         IXLRow IXLWorksheet.FirstRowUsed(XLCellsUsedOptions options)
         {
-            return LastRowUsed(options);
+            return FirstRowUsed(options);
         }
 
         IXLRow IXLWorksheet.LastRowUsed()

--- a/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -60,6 +60,19 @@ namespace ClosedXML_Tests.Excel.Ranges
             Assert.AreEqual(0, i);
         }
 
+        [Test(Description = "See 1443")]
+        public void FirstRowUsedRegression()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet();
+
+                ws.Range("B3:F6").SetValue(100);
+
+                Assert.AreEqual(3, ws.FirstRowUsed(XLCellsUsedOptions.AllContents).RowNumber());
+            }
+        }
+
         [Test]
         public void CountAllCellsInRow()
         {


### PR DESCRIPTION
Same as #1445, targeting `release-candidate` branch

(cherry picked from commit 60a7903facd07a0618ea194ef86f2b97c86201e4)