### PR TITLE
Better nullable and enum support

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1724,6 +1724,17 @@ namespace ClosedXML.Excel
             if (underlyingType == typeof(double)) return TryGetBasicValue<T, double>(strValue, double.TryParse, out value);
             if (underlyingType == typeof(decimal)) return TryGetBasicValue<T, decimal>(strValue, decimal.TryParse, out value);
 
+            if (underlyingType.IsEnum)
+            {
+                if (Enum.IsDefined(underlyingType, strValue))
+                {
+                    value = (T)Enum.Parse(underlyingType, strValue, ignoreCase: false);
+                    return true;
+                }
+                value = default;
+                return false;
+            }
+
             try
             {
                 value = (T)Convert.ChangeType(currentValue, targetType);

--- a/ClosedXML/Extensions/TypeExtensions.cs
+++ b/ClosedXML/Extensions/TypeExtensions.cs
@@ -5,6 +5,16 @@ namespace ClosedXML.Excel
 {
     internal static class TypeExtensions
     {
+        public static Type GetUnderlyingType(this Type type)
+        {
+            return Nullable.GetUnderlyingType(type) ?? type;
+        }
+
+        public static bool IsNullableType(this Type type)
+        {
+            return Nullable.GetUnderlyingType(type) != null;
+        }
+
         public static bool IsNumber(this Type type)
         {
             return type == typeof(sbyte)

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -341,6 +341,26 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void TryGetValue_Enum_Good()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            Assert.IsTrue(ws.FirstCell().SetValue(NumberStyles.AllowCurrencySymbol).TryGetValue(out NumberStyles value));
+            Assert.AreEqual(NumberStyles.AllowCurrencySymbol, value);
+
+            // Nullable alternative
+            Assert.IsTrue(ws.FirstCell().SetValue(NumberStyles.AllowCurrencySymbol).TryGetValue(out NumberStyles? value2));
+            Assert.AreEqual(NumberStyles.AllowCurrencySymbol, value2);
+        }
+
+        [Test]
+        public void TryGetValue_Enum_BadString()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            Assert.IsFalse(ws.FirstCell().SetValue("ABC").TryGetValue(out NumberStyles value));
+            Assert.IsFalse(ws.FirstCell().SetValue("ABC").TryGetValue(out NumberStyles? value2));
+        }
+
+        [Test]
         public void TryGetValue_RichText_Bad()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -98,6 +98,18 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void GetValue_Nullable()
+        {
+            var cell = new XLWorkbook().AddWorksheet().FirstCell();
+
+            Assert.IsNull(cell.Clear().GetValue<double?>());
+            Assert.AreEqual(1.5, cell.SetValue(1.5).GetValue<double?>());
+            Assert.AreEqual(2, cell.SetValue(1.5).GetValue<int?>());
+            Assert.AreEqual(2.5, cell.SetValue("2.5").GetValue<double?>());
+            Assert.Throws<FormatException>(() => cell.SetValue("text").GetValue<double?>());
+        }
+
+        [Test]
         public void InsertData1()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
@@ -489,6 +501,25 @@ namespace ClosedXML_Tests
 
             Assert.IsTrue(success);
             Assert.AreEqual("Site_x005F_x0020_Column_x005F_x0020_Test", outValue);
+        }
+
+        [Test]
+        public void TryGetValue_Nullable()
+        {
+            var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Cell("A1").Clear();
+            ws.Cell("A2").SetValue(1.5);
+            ws.Cell("A3").SetValue("2.5");
+            ws.Cell("A4").SetValue("text");
+
+            foreach (var cell in ws.Range("A1:A3").Cells())
+            {
+                Assert.IsTrue(cell.TryGetValue(out double? value));
+            }
+
+            Assert.IsFalse(ws.Cell("A4").TryGetValue(out double? _));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #1430 

Enables 2 functionalities:
- Nullables: `IXLCell.TryGetValue<double?>(out double? value)` and `IXLCell.GetValue<double?>()`
- Enums:  `IXLCell.TryGetValue<MyEnum>(out MyEnum value)` and `IXLCell.GetValue<MyEnum>()`