### PR TITLE
Test for empty strings using string length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 [*.cs]
 indent_style = space
 indent_size = 4
+
+# CA1820: Test for empty strings using string length
+dotnet_diagnostic.CA1820.severity = error

--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -43,10 +43,10 @@ namespace ClosedXML.Excel.CalcEngine
             var cs = criteria as string;
             if (cs != null)
             {
-                if (value is string && (value as string).Trim() == "")
-                    return cs == "";
+                if (value is string && (value as string).Trim().Length == 0)
+                    return cs.Length == 0;
 
-                if (cs == "")
+                if (cs.Length == 0)
                     return cs.Equals(value);
 
                 // if criteria is an expression (e.g. ">20"), use calc engine

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -585,7 +585,7 @@ namespace ClosedXML.Excel.CalcEngine
 
             try
             {
-                if (input == "")
+                if (input.Length == 0)
                     return 0;
                 if (input == "-")
                     throw new NumberException();

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -120,7 +120,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         public static int RomanToArabic(string text)
         {
-            if (text == "")
+            if (text.Length == 0)
                 return 0;
             if (text.StartsWith("M", StringComparison.InvariantCultureIgnoreCase))
                 return 1000 + RomanToArabic(text.Substring(1));

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1138,13 +1138,13 @@ namespace ClosedXML.Excel
                             case DateTime d:
                                 _cellValue = d.ToOADate().ToInvariantString();
 
-                                if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
+                                if (style.NumberFormat.Format.Length == 0 && style.NumberFormat.NumberFormatId == 0)
                                     Style.NumberFormat.NumberFormatId = _cellValue.Contains('.') ? 22 : 14;
 
                                 break;
 
                             case TimeSpan ts:
-                                if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
+                                if (style.NumberFormat.Format.Length == 0 && style.NumberFormat.NumberFormatId == 0)
                                     Style.NumberFormat.NumberFormatId = 46;
 
                                 break;
@@ -2294,7 +2294,7 @@ namespace ClosedXML.Excel
         {
             _dataType = XLDataType.DateTime;
 
-            if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
+            if (style.NumberFormat.Format.Length == 0 && style.NumberFormat.NumberFormatId == 0)
                 Style.NumberFormat.NumberFormatId = onlyDatePart ? 14 : 22;
         }
 
@@ -2302,7 +2302,7 @@ namespace ClosedXML.Excel
         {
             _dataType = XLDataType.TimeSpan;
 
-            if (style.NumberFormat.Format == String.Empty && style.NumberFormat.NumberFormatId == 0)
+            if (style.NumberFormat.Format.Length == 0 && style.NumberFormat.NumberFormatId == 0)
                 Style.NumberFormat.NumberFormatId = 46;
         }
 

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -277,7 +277,7 @@ namespace ClosedXML.Excel
                 if (split.Length == 1) return column + row; // A1
                 if (split.Length == 3) return match.Groups["one"].Value; // $A$1
                 var a = XLAddress.Create(match.Groups["one"].Value);
-                if (split[0] == String.Empty) return "$" + a.ColumnLetter + row; // $A1
+                if (split[0].Length == 0) return "$" + a.ColumnLetter + row; // $A1
                 return column + "$" + a.RowNumber;
             }
 

--- a/ClosedXML_Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/ClosedXML_Tests/Excel/Ranges/MergedRangesTests.cs
@@ -306,7 +306,7 @@ namespace ClosedXML_Tests
                 range.Unmerge();
 
                 Assert.IsTrue(range.Cells().All(c => c.Style.Fill.BackgroundColor == XLColor.Red));
-                Assert.IsTrue(range.Cells().Where(c => c != firstCell).All(c => c.Value == ""));
+                Assert.IsTrue(range.Cells().Where(c => c != firstCell).All(c => c.GetString().Length == 0));
                 Assert.AreEqual("B2", firstCell.Value);
 
                 Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("B2").Style.Border.TopBorder);


### PR DESCRIPTION
Replaced `str == ""` and `str == string.Empty` 
with `str.Length == 0`

+it will increase perfomance a little bit
-perhaps it is less readable

Also I added 
```
# CA1820: Test for empty strings using string length
dotnet_diagnostic.CA1820.severity = error
```
to avoid using `str == ""` in the future
___
Here is benchmark results for `str == ""` vs `str.Length == 0`

``` ini
  .NET Core SDK=3.1.300
  [Host]     : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
  DefaultJob : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
```
|                          Method |            Mean |         Error |        StdDev |
|-------------------------------- |----------------:|--------------:|--------------:|
| Test_1_000_000_EqualityOperator | 15,394,460.9 ns | 302,780.33 ns | 488,933.80 ns |
|     Test_1_000_000_StringLength | 10,515,186.1 ns | 123,536.86 ns | 103,158.88 ns |
|     Test_1_000_EqualityOperator |      6,535.9 ns |      84.80 ns |      75.18 ns |
|         Test_1_000_StringLength |      3,056.8 ns |      33.96 ns |      30.11 ns |
|       Test_100_EqualityOperator |        672.1 ns |       7.37 ns |       5.75 ns |
|           Test_100_StringLength |        327.1 ns |       3.92 ns |       3.67 ns |

[Benchmark.cs](https://github.com/makeProjectGreatAgain/BenchmarkEmptyString/blob/master/TestComparingWithEmptyString/Benchmark.cs)
