### PR TITLE
#1456 Add CreateSafeSheetName method

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -100,9 +100,6 @@ namespace ClosedXML.Excel
             get { return XLRangeType.Worksheet; }
         }
 
-        //private IXLStyle _style;
-        private const String InvalidNameChars = @":\/?*[]";
-
         public string LegacyDrawingId;
         public Boolean LegacyDrawingIsNew;
         private Double _columnWidth;
@@ -202,21 +199,7 @@ namespace ClosedXML.Excel
             {
                 if (_name == value) return;
 
-                if (String.IsNullOrWhiteSpace(value))
-                    throw new ArgumentException("Worksheet names cannot be empty");
-
-                if (value.IndexOfAny(InvalidNameChars.ToCharArray()) != -1)
-                    throw new ArgumentException("Worksheet names cannot contain any of the following characters: " +
-                                                InvalidNameChars);
-
-                if (value.Length > 31)
-                    throw new ArgumentException("Worksheet names cannot be more than 31 characters");
-
-                if (value.StartsWith("'", StringComparison.Ordinal))
-                    throw new ArgumentException("Worksheet names cannot start with an apostrophe");
-
-                if (value.EndsWith("'", StringComparison.Ordinal))
-                    throw new ArgumentException("Worksheet names cannot end with an apostrophe");
+                XLHelper.ValidateSheetName(value);
 
                 Workbook.WorksheetsInternal.Rename(_name, value);
                 _name = value;

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
     /// <summary>
     /// 	Common methods
     /// </summary>
-    public static class XLHelper
+    public static partial class XLHelper
     {
         public const int MinRowNumber = 1;
         public const int MinColumnNumber = 1;

--- a/ClosedXML/XLHelper_ASF.cs
+++ b/ClosedXML/XLHelper_ASF.cs
@@ -1,0 +1,113 @@
+﻿// Keep this file CodeMaid organised and cleaned
+
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using System;
+using System.Linq;
+
+namespace ClosedXML.Excel
+{
+    public static partial class XLHelper
+    {
+        private const int MaxWorksheetNameCharsCount = 31;
+        private static readonly char[] illegalWorksheetCharacters = "\u0000\u0003:\\/?*[]".ToCharArray();
+
+        /// <summary>
+        /// Creates a valid sheet name, which conforms to the following rules.
+        /// A sheet name:
+        /// is never null,
+        /// has minimum length of 1 and
+        /// maximum length of 31,
+        /// doesn't contain special chars: (: 0x0000 0x0003 / \ ? * ] [).
+        /// Sheet names must not begin or end with ' (apostrophe)
+        /// </summary>
+        /// <param name="nameProposal">can be any string, will be truncated if necessary, allowed to be null</param>
+        /// <param name="replaceChar">the char to replace invalid characters.</param>
+        /// <returns>a valid string, "empty" if too short, "null" if null</returns>
+        // This method was ported and adapted from the POI project at https://github.com/apache/poi/blob/trunk/src/java/org/apache/poi/ss/util/WorkbookUtil.java
+        public static string CreateSafeSheetName(string nameProposal, char replaceChar = ' ')
+        {
+            if (illegalWorksheetCharacters.Contains(replaceChar) || replaceChar == '\'')
+                throw new ArgumentException("Invalid replacement character.", nameof(replaceChar));
+
+            if (nameProposal == null)
+            {
+                return "null";
+            }
+            if (nameProposal.Length < 1)
+            {
+                return "empty";
+            }
+            int length = Math.Min(MaxWorksheetNameCharsCount, nameProposal.Length);
+            var shortenedName = nameProposal.Substring(0, length);
+            var result = new System.Text.StringBuilder(shortenedName);
+            for (int i = 0; i < length; i++)
+            {
+                char ch = result[i];
+                if (illegalWorksheetCharacters.Contains(result[i]))
+                    result[i] = replaceChar;
+
+                if (ch == '\'' && (i == 0 || i == length - 1))
+                    result[i] = replaceChar;
+            }
+            return result.ToString();
+        }
+
+        /// <summary>
+        /// Validates the name of the sheet.
+        /// The character count MUST be greater than or equal to 1 and less than or equal to 31.
+        /// The string MUST NOT contain the any of the following characters:
+        /// - 0x0000
+        /// - 0x0003
+        /// - colon (:)
+        /// - backslash(\)
+        /// - asterisk(*)
+        /// - question mark(?)
+        /// - forward slash(/)
+        /// - opening square bracket([)
+        /// - closing square bracket(])
+        /// The string MUST NOT begin or end with the single quote(') character.
+        /// </summary>
+        /// <param name="sheetName">Name of the sheet.</param>
+        /// <exception cref="ArgumentException">
+        /// </exception>
+        ///
+        // This method was ported from the POI project at https://github.com/apache/poi/blob/trunk/src/java/org/apache/poi/ss/util/WorkbookUtil.java
+        public static void ValidateSheetName(String sheetName)
+        {
+            if (String.IsNullOrWhiteSpace(sheetName))
+            {
+                throw new ArgumentException("sheetName must not be null or whitespace");
+            }
+
+            int len = sheetName.Length;
+            if (len < 1 || len > MaxWorksheetNameCharsCount)
+            {
+                throw new ArgumentException($"sheetName '{sheetName}' is invalid - character count MUST be greater than or equal to 1 and less than or equal to {MaxWorksheetNameCharsCount}");
+            }
+
+            for (int i = 0; i < len; i++)
+            {
+                if (illegalWorksheetCharacters.Contains(sheetName[i]))
+                    throw new ArgumentException($"Invalid char ({sheetName[i]}) found at index ({i}) in sheet name '{sheetName}'");
+            }
+            if (sheetName[0] == '\'' || sheetName[len - 1] == '\'')
+            {
+                throw new ArgumentException($"Invalid sheet name '{sheetName}'. Sheet names must not begin or end with (').");
+            }
+        }
+    }
+}

--- a/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML_Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -12,6 +12,8 @@ namespace ClosedXML_Tests
     [TestFixture]
     public class XLWorksheetTests
     {
+        private readonly static char[] illegalWorksheetCharacters = "\u0000\u0003:\\/?*[]".ToCharArray();
+
         [Test]
         public void ColumnCountTime()
         {
@@ -327,6 +329,19 @@ namespace ClosedXML_Tests
             };
 
             Assert.Throws(typeof(ArgumentException), addWorksheet);
+        }
+
+        [Test]
+        public void WorksheetNameCannotBeEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => new XLWorkbook().AddWorksheet(" "));
+        }
+
+        [TestCaseSource(nameof(illegalWorksheetCharacters))]
+        public void WorksheetNameCannotContainIllegalCharacters(char c)
+        {
+            var proposedName = $"Sheet{c}Name";
+            Assert.Throws<ArgumentException>(() => new XLWorkbook().AddWorksheet(proposedName));
         }
 
         [Test]
@@ -1173,7 +1188,7 @@ namespace ClosedXML_Tests
         [TestCase("noactive_twoselected.xlsx")]
         public void FirstSheetIsActive_WhenNotSpecified(string fileName)
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\NoActiveSheet\"+fileName)))
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\NoActiveSheet\" + fileName)))
             using (var wb = new XLWorkbook(stream))
             {
                 Assert.IsTrue(wb.Worksheets.First().TabActive);

--- a/ClosedXML_Tests/XLHelperTests.cs
+++ b/ClosedXML_Tests/XLHelperTests.cs
@@ -1,5 +1,6 @@
 using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
 
 namespace ClosedXML_Tests
 {
@@ -106,6 +107,55 @@ namespace ClosedXML_Tests
         {
             string result = XLHelper.ReplaceRelative("$A:$A", 2, "B");
             Assert.AreEqual("$A:$A", result);
+        }
+
+        [TestCase("Sheet1", "Sheet1")]
+        [TestCase("O'Brien's sales", "O'Brien's sales")]
+        [TestCase(" data # ", " data # ")]
+        [TestCase("data $1.00", "data $1.00")]
+        [TestCase("data ", "data?")]
+        [TestCase("abc def", "abc/def")]
+        [TestCase("data 0 ", "data[0]")]
+        [TestCase("data ", "data*")]
+        [TestCase("abc def", "abc\\def")]
+        [TestCase(" data", "'data")]
+        [TestCase("data ", "data'")]
+        [TestCase("d'at'a", "d'at'a")]
+        [TestCase("sheet a4", "sheet:a4")]
+        [TestCase("null", null)]
+        [TestCase("empty", "")]
+        [TestCase("1234567890123456789012345678901", "1234567890123456789012345678901TOOLONG")]
+        public void CreateSafeSheetNames(string expected, string input)
+        {
+            var actual = XLHelper.CreateSafeSheetName(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase("Sheet1", ExpectedResult = "Sheet1")]
+        [TestCase("O'Brien's sales", ExpectedResult = "O'Brien's sales")]
+        [TestCase(" data # ", ExpectedResult = " data # ")]
+        [TestCase("data $1.00", ExpectedResult = "data $1.00")]
+        [TestCase("data?", ExpectedResult = "data_")]
+        [TestCase("abc/def", ExpectedResult = "abc_def")]
+        [TestCase("data[0]", ExpectedResult = "data_0_")]
+        [TestCase("data*", ExpectedResult = "data_")]
+        [TestCase("abc\\def", ExpectedResult = "abc_def")]
+        [TestCase("'data", ExpectedResult = "_data")]
+        [TestCase("data'", ExpectedResult = "data_")]
+        [TestCase("d'at'a", ExpectedResult = "d'at'a")]
+        [TestCase("sheet:a4", ExpectedResult = "sheet_a4")]
+        [TestCase(null, ExpectedResult = "null")]
+        [TestCase("", ExpectedResult = "empty")]
+        [TestCase("1234567890123456789012345678901TOOLONG", ExpectedResult = "1234567890123456789012345678901")]
+        public string CreateSafeSheetNamesWithUnderscore(string input)
+        {
+            return XLHelper.CreateSafeSheetName(input, replaceChar: '_');
+        }
+
+        [Test]
+        public void CreateSafeSheetNamesInvalidReplacementChar()
+        {
+            Assert.Throws<ArgumentException>(() => XLHelper.CreateSafeSheetName("abc\\def", replaceChar: ':'));
         }
     }
 }

--- a/ClosedXML_Tests/XLHelperTests.cs
+++ b/ClosedXML_Tests/XLHelperTests.cs
@@ -3,50 +3,9 @@ using NUnit.Framework;
 
 namespace ClosedXML_Tests
 {
-    /// <summary>
-    ///     This is a test class for XLHelperTests and is intended
-    ///     to contain all XLHelperTests Unit Tests
-    /// </summary>
     [TestFixture]
     public class XLHelperTests
     {
-        /// <summary>
-        ///     Gets or sets the test context which provides
-        ///     information about and functionality for the current test run.
-        /// </summary>
-        public TestContext TestContext { get; set; }
-
-        // 
-        //You can use the following additional attributes as you write your tests:
-        //
-        //Use ClassInitialize to run code before running the first test in the class
-        //[ClassInitialize()]
-        //public static void MyClassInitialize(TestContext testContext)
-        //{
-        //}
-        //
-        //Use ClassCleanup to run code after all tests in a class have run
-        //[ClassCleanup()]
-        //public static void MyClassCleanup()
-        //{
-        //}
-        //
-        //Use TestInitialize to run code before running each test
-        //[TestInitialize()]
-        //public void MyTestInitialize()
-        //{
-        //}
-        //
-        //Use TestCleanup to run code after each test has run
-        //[TestCleanup()]
-        //public void MyTestCleanup()
-        //{
-        //}
-        //
-
-        /// <summary>
-        ///     A test for IsValidColumn
-        /// </summary>
         [Test]
         public void IsValidColumnTest()
         {


### PR DESCRIPTION
Added CreateSafeSheetName method to **XLHelper** class.

Creates a valid sheet name, which is conform to the rules:
- minimum length is 1
- maximum length is 31
- doesn't contain special chars: : 0x0000, 0x0003, / \ ? * ] [
- Sheet names must not begin or end with ' (apostrophe)
- never null

Fixes #1456 