### PR TITLE
IXLCell.TryGetValue improvements

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1755,14 +1755,35 @@ namespace ClosedXML.Excel
                 return false;
             }
 
-            if (!DateTime.TryParse(currentValue.ToString(), out DateTime ts))
+            if (currentValue is T v) { value = v; return true; }
+
+            if (currentValue.IsNumber())
             {
-                value = default;
-                return false;
+                var dbl1 = Convert.ToDouble(currentValue);
+                if (dbl1.IsValidOADateNumber())
+                {
+                    value = (T)Convert.ChangeType(DateTime.FromOADate(dbl1), typeof(T));
+                    return true;
+                }
             }
 
-            value = (T)Convert.ChangeType(ts, typeof(T));
-            return true;
+            if (DateTime.TryParse(currentValue.ToString(), out DateTime ts))
+            {
+                value = (T)Convert.ChangeType(ts, typeof(T));
+                return true;
+            }
+
+            // If the cell value is a string, e.g. "42020", we could theoretically coerce it to a DateTime, but this seems to go against what is expected.
+            // Leaving this code block here, though. Maybe we revert our decision later.
+
+            //if (Double.TryParse(currentValue.ObjectToInvariantString(), out Double dbl2) && dbl2.IsValidOADateNumber())
+            //{
+            //    value = (T)Convert.ChangeType(DateTime.FromOADate(dbl2), typeof(T));
+            //    return true;
+            //}
+
+            value = default;
+            return false;
         }
 
         private static bool TryGetTimeSpanValue<T>(out T value, object currentValue)
@@ -1772,6 +1793,8 @@ namespace ClosedXML.Excel
                 value = default;
                 return false;
             }
+
+            if (currentValue is T v) { value = v; return true; }
 
             if (!TimeSpan.TryParse(currentValue.ToString(), out TimeSpan ts))
             {
@@ -1838,6 +1861,8 @@ namespace ClosedXML.Excel
                 value = default;
                 return false;
             }
+
+            if (currentValue is T v) { value = v; return true; }
 
             if (!Boolean.TryParse(currentValue.ToString(), out Boolean b))
             {

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -322,6 +322,29 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void TryGetValue_DateTime_Good2()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            bool success = ws.Cell("A1").SetFormulaA1("=TODAY() + 10").TryGetValue(out DateTime outValue);
+            Assert.IsTrue(success);
+            Assert.AreEqual(DateTime.Today.AddDays(10), outValue);
+        }
+
+        [Test]
+        public void TryGetValue_DateTime_BadButFormulaGood()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            bool success = ws.Cell("A1").SetFormulaA1("=\"44\"&\"020\"").TryGetValue(out DateTime outValue);
+            Assert.IsFalse(success);
+
+            ws.Cell("B1").SetFormulaA1("=A1+1");
+
+            success = ws.Cell("B1").TryGetValue(out outValue);
+            Assert.IsTrue(success);
+            Assert.AreEqual(new DateTime(2020, 07, 09), outValue);
+        }
+
+        [Test]
         public void TryGetValue_DateTime_BadString()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");


### PR DESCRIPTION
Fixes #1469 

Make `TryGetValue` try harder to coerce between data types.