### PR TITLE
Improve Rows() method performance (#1482)

### DIFF
--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -8,8 +8,12 @@ namespace ClosedXML.Excel
 
     internal class XLColumns : XLStylizedBase, IXLColumns, IXLStylized
     {
-        private readonly List<XLColumn> _columns = new List<XLColumn>();
+        private readonly List<XLColumn> _columnsCollection = new List<XLColumn>();
         private readonly XLWorksheet _worksheet;
+        private bool IsMaterialized => _lazyEnumerable == null;
+
+        private IEnumerable<XLColumn> _lazyEnumerable;
+        private IEnumerable<XLColumn> Columns => _lazyEnumerable ?? _columnsCollection.AsEnumerable();
 
         /// <summary>
         /// Create a new instance of <see cref="XLColumns"/>.
@@ -17,17 +21,19 @@ namespace ClosedXML.Excel
         /// <param name="worksheet">If worksheet is specified it means that the created instance represents
         /// all columns on a worksheet so changing its width will affect all columns.</param>
         /// <param name="defaultStyle">Default style to use when initializing child entries.</param>
-        public XLColumns(XLWorksheet worksheet, XLStyleValue defaultStyle = null)
+        /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLColumn"/> to support lazy initialization.</param>
+        public XLColumns(XLWorksheet worksheet, XLStyleValue defaultStyle = null, IEnumerable<XLColumn> lazyEnumerable = null)
             : base(defaultStyle)
         {
             _worksheet = worksheet;
+            _lazyEnumerable = lazyEnumerable;
         }
 
         #region IXLColumns Members
 
         public IEnumerator<IXLColumn> GetEnumerator()
         {
-            return _columns.Cast<IXLColumn>().OrderBy(r => r.ColumnNumber()).GetEnumerator();
+            return Columns.Cast<IXLColumn>().OrderBy(r => r.ColumnNumber()).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -39,7 +45,7 @@ namespace ClosedXML.Excel
         {
             set
             {
-                _columns.ForEach(c => c.Width = value);
+                Columns.ForEach(c => c.Width = value);
 
                 if (_worksheet == null) return;
 
@@ -58,7 +64,7 @@ namespace ClosedXML.Excel
             else
             {
                 var toDelete = new Dictionary<IXLWorksheet, List<Int32>>();
-                foreach (XLColumn c in _columns)
+                foreach (XLColumn c in Columns)
                 {
                     if (!toDelete.TryGetValue(c.Worksheet, out List<Int32> list))
                     {
@@ -79,48 +85,48 @@ namespace ClosedXML.Excel
 
         public IXLColumns AdjustToContents()
         {
-            _columns.ForEach(c => c.AdjustToContents());
+            Columns.ForEach(c => c.AdjustToContents());
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow));
+            Columns.ForEach(c => c.AdjustToContents(startRow));
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow, Int32 endRow)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow, endRow));
+            Columns.ForEach(c => c.AdjustToContents(startRow, endRow));
             return this;
         }
 
         public IXLColumns AdjustToContents(Double minWidth, Double maxWidth)
         {
-            _columns.ForEach(c => c.AdjustToContents(minWidth, maxWidth));
+            Columns.ForEach(c => c.AdjustToContents(minWidth, maxWidth));
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow, minWidth, maxWidth));
+            Columns.ForEach(c => c.AdjustToContents(startRow, minWidth, maxWidth));
             return this;
         }
 
         public IXLColumns AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth)
         {
-            _columns.ForEach(c => c.AdjustToContents(startRow, endRow, minWidth, maxWidth));
+            Columns.ForEach(c => c.AdjustToContents(startRow, endRow, minWidth, maxWidth));
             return this;
         }
 
         public void Hide()
         {
-            _columns.ForEach(c => c.Hide());
+            Columns.ForEach(c => c.Hide());
         }
 
         public void Unhide()
         {
-            _columns.ForEach(c => c.Unhide());
+            Columns.ForEach(c => c.Unhide());
         }
 
         public void Group()
@@ -140,33 +146,33 @@ namespace ClosedXML.Excel
 
         public void Group(Boolean collapse)
         {
-            _columns.ForEach(c => c.Group(collapse));
+            Columns.ForEach(c => c.Group(collapse));
         }
 
         public void Group(Int32 outlineLevel, Boolean collapse)
         {
-            _columns.ForEach(c => c.Group(outlineLevel, collapse));
+            Columns.ForEach(c => c.Group(outlineLevel, collapse));
         }
 
         public void Ungroup(Boolean ungroupFromAll)
         {
-            _columns.ForEach(c => c.Ungroup(ungroupFromAll));
+            Columns.ForEach(c => c.Ungroup(ungroupFromAll));
         }
 
         public void Collapse()
         {
-            _columns.ForEach(c => c.Collapse());
+            Columns.ForEach(c => c.Collapse());
         }
 
         public void Expand()
         {
-            _columns.ForEach(c => c.Expand());
+            Columns.ForEach(c => c.Expand());
         }
 
         public IXLCells Cells()
         {
             var cells = new XLCells(false, XLCellsUsedOptions.All);
-            foreach (XLColumn container in _columns)
+            foreach (XLColumn container in Columns)
                 cells.Add(container.RangeAddress);
             return cells;
         }
@@ -174,7 +180,7 @@ namespace ClosedXML.Excel
         public IXLCells CellsUsed()
         {
             var cells = new XLCells(true, XLCellsUsedOptions.All);
-            foreach (XLColumn container in _columns)
+            foreach (XLColumn container in Columns)
                 cells.Add(container.RangeAddress);
             return cells;
         }
@@ -189,7 +195,7 @@ namespace ClosedXML.Excel
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         { 
             var cells = new XLCells(true, options);
-            foreach (XLColumn container in _columns)
+            foreach (XLColumn container in Columns)
                 cells.Add(container.RangeAddress);
             return cells;
         }
@@ -199,14 +205,14 @@ namespace ClosedXML.Excel
         /// </summary>
         public IXLColumns AddVerticalPageBreaks()
         {
-            foreach (XLColumn col in _columns)
+            foreach (XLColumn col in Columns)
                 col.Worksheet.PageSetup.AddVerticalPageBreak(col.ColumnNumber());
             return this;
         }
 
         public IXLColumns SetDataType(XLDataType dataType)
         {
-            _columns.ForEach(c => c.DataType = dataType);
+            Columns.ForEach(c => c.DataType = dataType);
             return this;
         }
 
@@ -223,7 +229,7 @@ namespace ClosedXML.Excel
                     yield return _worksheet.Style;
                 else
                 {
-                    foreach (IXLStyle s in _columns.SelectMany(col => col.Styles))
+                    foreach (IXLStyle s in Columns.SelectMany(col => col.Styles))
                     {
                         yield return s;
                     }
@@ -239,7 +245,7 @@ namespace ClosedXML.Excel
                     yield return _worksheet;
                 else
                 {
-                    foreach (XLColumn column in _columns)
+                    foreach (XLColumn column in Columns)
                         yield return column;
                 }
             }
@@ -259,17 +265,18 @@ namespace ClosedXML.Excel
 
         public void Add(XLColumn column)
         {
-            _columns.Add(column);
+            Materialize();
+            _columnsCollection.Add(column);
         }
 
         public void CollapseOnly()
         {
-            _columns.ForEach(c => c.Collapsed = true);
+            Columns.ForEach(c => c.Collapsed = true);
         }
 
         public IXLColumns Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
-            _columns.ForEach(c => c.Clear(clearOptions));
+            Columns.ForEach(c => c.Clear(clearOptions));
             return this;
         }
 
@@ -277,6 +284,15 @@ namespace ClosedXML.Excel
         {
             foreach (var range in this)
                 range.Select();
+        }
+
+        private void Materialize()
+        {
+            if (IsMaterialized)
+                return;
+
+            _columnsCollection.AddRange(Columns);
+            _lazyEnumerable = null;
         }
     }
 }

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -8,8 +8,13 @@ namespace ClosedXML.Excel
 
     internal class XLRows : XLStylizedBase, IXLRows, IXLStylized
     {
-        private readonly List<XLRow> _rows = new List<XLRow>();
+        private readonly List<XLRow> _rowsCollection = new List<XLRow>();
         private readonly XLWorksheet _worksheet;
+
+        private bool IsMaterialized => _lazyEnumerable == null;
+
+        private IEnumerable<XLRow> _lazyEnumerable;
+        private IEnumerable<XLRow> Rows => _lazyEnumerable ?? _rowsCollection.AsEnumerable();
 
 
         /// <summary>
@@ -18,17 +23,19 @@ namespace ClosedXML.Excel
         /// <param name="worksheet">If worksheet is specified it means that the created instance represents
         /// all rows on a worksheet so changing its height will affect all rows.</param>
         /// <param name="defaultStyle">Default style to use when initializing child entries.</param>
-        public XLRows(XLWorksheet worksheet, XLStyleValue defaultStyle = null)
+        /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLRow"/> to support lazy initialization.</param>
+        public XLRows(XLWorksheet worksheet, XLStyleValue defaultStyle = null, IEnumerable<XLRow> lazyEnumerable = null)
             : base(defaultStyle)
         {
             _worksheet = worksheet;
+            _lazyEnumerable = lazyEnumerable;
         }
 
         #region IXLRows Members
 
         public IEnumerator<IXLRow> GetEnumerator()
         {
-            return _rows.Cast<IXLRow>().OrderBy(r => r.RowNumber()).GetEnumerator();
+            return Rows.Cast<IXLRow>().OrderBy(r => r.RowNumber()).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -40,7 +47,7 @@ namespace ClosedXML.Excel
         {
             set
             {
-                _rows.ForEach(c => c.Height = value);
+                Rows.ForEach(c => c.Height = value);
                 if (_worksheet == null) return;
                 _worksheet.RowHeight = value;
                 _worksheet.Internals.RowsCollection.ForEach(r => r.Value.Height = value);
@@ -57,7 +64,7 @@ namespace ClosedXML.Excel
             else
             {
                 var toDelete = new Dictionary<IXLWorksheet, List<Int32>>();
-                foreach (XLRow r in _rows)
+                foreach (XLRow r in Rows)
                 {
                     if (!toDelete.TryGetValue(r.Worksheet, out List<Int32> list))
                     {
@@ -78,48 +85,48 @@ namespace ClosedXML.Excel
 
         public IXLRows AdjustToContents()
         {
-            _rows.ForEach(r => r.AdjustToContents());
+            Rows.ForEach(r => r.AdjustToContents());
             return this;
         }
 
         public IXLRows AdjustToContents(Int32 startColumn)
         {
-            _rows.ForEach(r => r.AdjustToContents(startColumn));
+            Rows.ForEach(r => r.AdjustToContents(startColumn));
             return this;
         }
 
         public IXLRows AdjustToContents(Int32 startColumn, Int32 endColumn)
         {
-            _rows.ForEach(r => r.AdjustToContents(startColumn, endColumn));
+            Rows.ForEach(r => r.AdjustToContents(startColumn, endColumn));
             return this;
         }
 
         public IXLRows AdjustToContents(Double minHeight, Double maxHeight)
         {
-            _rows.ForEach(r => r.AdjustToContents(minHeight, maxHeight));
+            Rows.ForEach(r => r.AdjustToContents(minHeight, maxHeight));
             return this;
         }
 
         public IXLRows AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight)
         {
-            _rows.ForEach(r => r.AdjustToContents(startColumn, minHeight, maxHeight));
+            Rows.ForEach(r => r.AdjustToContents(startColumn, minHeight, maxHeight));
             return this;
         }
 
         public IXLRows AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight)
         {
-            _rows.ForEach(r => r.AdjustToContents(startColumn, endColumn, minHeight, maxHeight));
+            Rows.ForEach(r => r.AdjustToContents(startColumn, endColumn, minHeight, maxHeight));
             return this;
         }
 
         public void Hide()
         {
-            _rows.ForEach(r => r.Hide());
+            Rows.ForEach(r => r.Hide());
         }
 
         public void Unhide()
         {
-            _rows.ForEach(r => r.Unhide());
+            Rows.ForEach(r => r.Unhide());
         }
 
         public void Group()
@@ -139,33 +146,33 @@ namespace ClosedXML.Excel
 
         public void Group(Boolean collapse)
         {
-            _rows.ForEach(r => r.Group(collapse));
+            Rows.ForEach(r => r.Group(collapse));
         }
 
         public void Group(Int32 outlineLevel, Boolean collapse)
         {
-            _rows.ForEach(r => r.Group(outlineLevel, collapse));
+            Rows.ForEach(r => r.Group(outlineLevel, collapse));
         }
 
         public void Ungroup(Boolean ungroupFromAll)
         {
-            _rows.ForEach(r => r.Ungroup(ungroupFromAll));
+            Rows.ForEach(r => r.Ungroup(ungroupFromAll));
         }
 
         public void Collapse()
         {
-            _rows.ForEach(r => r.Collapse());
+            Rows.ForEach(r => r.Collapse());
         }
 
         public void Expand()
         {
-            _rows.ForEach(r => r.Expand());
+            Rows.ForEach(r => r.Expand());
         }
 
         public IXLCells Cells()
         {
             var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
-            foreach (XLRow container in _rows)
+            foreach (XLRow container in Rows)
                 cells.Add(container.RangeAddress);
             return cells;
         }
@@ -173,7 +180,7 @@ namespace ClosedXML.Excel
         public IXLCells CellsUsed()
         {
             var cells = new XLCells(true, XLCellsUsedOptions.AllContents);
-            foreach (XLRow container in _rows)
+            foreach (XLRow container in Rows)
                 cells.Add(container.RangeAddress);
             return cells;
         }
@@ -189,21 +196,21 @@ namespace ClosedXML.Excel
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
             var cells = new XLCells(true, options);
-            foreach (XLRow container in _rows)
+            foreach (XLRow container in Rows)
                 cells.Add(container.RangeAddress);
             return cells;
         }
 
         public IXLRows AddHorizontalPageBreaks()
         {
-            foreach (XLRow row in _rows)
+            foreach (XLRow row in Rows)
                 row.Worksheet.PageSetup.AddHorizontalPageBreak(row.RowNumber());
             return this;
         }
 
         public IXLRows SetDataType(XLDataType dataType)
         {
-            _rows.ForEach(c => c.DataType = dataType);
+            Rows.ForEach(c => c.DataType = dataType);
             return this;
         }
 
@@ -218,7 +225,7 @@ namespace ClosedXML.Excel
                     yield return _worksheet;
                 else
                 {
-                    foreach (XLRow row in _rows)
+                    foreach (XLRow row in Rows)
                         yield return row;
                 }
             }
@@ -233,7 +240,7 @@ namespace ClosedXML.Excel
                     yield return _worksheet.Style;
                 else
                 {
-                    foreach (IXLStyle s in _rows.SelectMany(row => row.Styles))
+                    foreach (IXLStyle s in Rows.SelectMany(row => row.Styles))
                     {
                         yield return s;
                     }
@@ -255,12 +262,13 @@ namespace ClosedXML.Excel
 
         public void Add(XLRow row)
         {
-            _rows.Add(row);
+            Materialize();
+            _rowsCollection.Add(row);
         }
 
         public IXLRows Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
-            _rows.ForEach(c => c.Clear(clearOptions));
+            Rows.ForEach(c => c.Clear(clearOptions));
             return this;
         }
 
@@ -268,6 +276,15 @@ namespace ClosedXML.Excel
         {
             foreach (var range in this)
                 range.Select();
+        }
+
+        private void Materialize()
+        {
+            if (IsMaterialized)
+                return;
+
+            _rowsCollection.AddRange(Rows);
+            _lazyEnumerable = null;
         }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -330,15 +330,12 @@ namespace ClosedXML.Excel
 
         public IXLColumns Columns()
         {
-            var retVal = new XLColumns(this, StyleValue);
             var columnMap = new HashSet<Int32>();
 
-            if (Internals.CellsCollection.Count > 0)
-                columnMap.UnionWith(Internals.CellsCollection.ColumnsUsed.Keys);
+            columnMap.UnionWith(Internals.CellsCollection.ColumnsUsed.Keys);
+            columnMap.UnionWith(Internals.ColumnsCollection.Keys);
 
-            if (Internals.ColumnsCollection.Count > 0)
-                columnMap.UnionWith(Internals.ColumnsCollection.Keys);
-
+            var retVal = new XLColumns(this, StyleValue);
             foreach (int c in columnMap)
                 retVal.Add(Column(c));
 
@@ -396,15 +393,12 @@ namespace ClosedXML.Excel
 
         public IXLRows Rows()
         {
-            var retVal = new XLRows(this, StyleValue);
             var rowMap = new HashSet<Int32>();
 
-            if (Internals.CellsCollection.Count > 0)
-                rowMap.UnionWith(Internals.CellsCollection.RowsUsed.Keys);
+            rowMap.UnionWith(Internals.CellsCollection.RowsUsed.Keys);
+            rowMap.UnionWith(Internals.RowsCollection.Keys);
 
-            if (Internals.RowsCollection.Count > 0)
-                rowMap.UnionWith(Internals.RowsCollection.Keys);
-
+            var retVal = new XLRows(this, StyleValue);
             foreach (int r in rowMap)
                 retVal.Add(Row(r));
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -335,10 +335,7 @@ namespace ClosedXML.Excel
             columnMap.UnionWith(Internals.CellsCollection.ColumnsUsed.Keys);
             columnMap.UnionWith(Internals.ColumnsCollection.Keys);
 
-            var retVal = new XLColumns(this, StyleValue);
-            foreach (int c in columnMap)
-                retVal.Add(Column(c));
-
+            var retVal = new XLColumns(this, StyleValue, columnMap.Select(Column));
             return retVal;
         }
 
@@ -398,10 +395,7 @@ namespace ClosedXML.Excel
             rowMap.UnionWith(Internals.CellsCollection.RowsUsed.Keys);
             rowMap.UnionWith(Internals.RowsCollection.Keys);
 
-            var retVal = new XLRows(this, StyleValue);
-            foreach (int r in rowMap)
-                retVal.Add(Row(r));
-
+            var retVal = new XLRows(this, StyleValue, rowMap.Select(Row));
             return retVal;
         }
 


### PR DESCRIPTION
Fixes #1482 

Benchmark:
```
var number = 1000;
for (int i = 0; i < 10; i++)
{
    using var ms = new MemoryStream();
    var data = Enumerable.Range(0, number).Select(i => Guid.NewGuid());
    var wb = new XLWorkbook();
    wb.AddWorksheet().FirstCell().InsertData(data);
    wb.SaveAs(ms);

    using var workBook = new XLWorkbook(ms);
    var sw = new Stopwatch();
    sw.Start();
    var worksheet = workBook.Worksheets.ElementAt(0);
    var row = worksheet.Rows().ElementAt(1);
    var cell = row.Cell(1).Value?.ToString().Trim();
    Console.WriteLine($"{number}\t{sw.ElapsedMilliseconds}");
    number *= 2;
}
```
Output:
```
1000    3
2000    3
4000    10
8000    42
16000   174
32000   757
64000   2759
128000  10737
256000  45718
512000  188466
```