### PR TITLE
UnaryExpression will now handle string values properly

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -286,9 +286,15 @@ namespace ClosedXML.Excel.CalcEngine
             switch (_token.ID)
             {
                 case TKID.ADD:
-                    return +(double)Expression;
+                    return Expression.Evaluate();
 
                 case TKID.SUB:
+                    var value = Expression.Evaluate() as string;
+
+                    // If string not parsable to double, #VALUE error
+                    if (value != null && !double.TryParse(value, out _))
+                        throw new CellValueException();
+
                     return -(double)Expression;
             }
             throw new ArgumentException("Bad expression.");

--- a/ClosedXML_Tests/Excel/CalcEngine/ExpressionTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/ExpressionTests.cs
@@ -1,0 +1,44 @@
+﻿using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine;
+using ClosedXML.Excel.CalcEngine.Exceptions;
+using NUnit.Framework;
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace ClosedXML_Tests.Excel.CalcEngine
+{
+    [TestFixture]
+    public class ExpressionTests
+    {
+        [OneTimeSetUp]
+        public void SetCultureInfo()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+        }
+
+        [Test]
+        public void UnaryExpression()
+        {
+            // String
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("=+\"TestString\""), "TestString"); // Plus
+            Assert.Throws<CellValueException>(() => XLWorkbook.EvaluateExpr("=-\"TestString\"")); // Minus
+
+            // Double
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("+2.1"), 2.1); // Plus
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("-2.1"), -2.1); // Minus
+
+            // Boolean True
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("+TRUE"), true); // Plus
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("-TRUE"), -1); // Minus
+
+            // Boolean False
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("+FALSE"), false); // Plus
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("-FALSE"), 0); // Minus
+
+            // DateTime
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("+TODAY()"), DateTime.Today); // Plus
+            Assert.AreEqual(XLWorkbook.EvaluateExpr("-TODAY()"), -DateTime.Today.ToOADate()); // Minus
+        }
+    }
+}


### PR DESCRIPTION
Plus will not be ignored from UnaryExpression
Minus string that can't be parsed to double will not properly throw CellValueException

Fixes #1487 