### PR TITLE
KnownTypeMapping

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -249,8 +249,19 @@ namespace ClosedXML.Excel
         }
 
         // TODO: Replace with (string, bool) ValueTuple later
-        private Tuple<string, bool> SetKnownTypedValue<T>(T value, XLStyleValue style, Boolean acceptString)
+        private Tuple<string, bool> SetKnownTypedValue<T>(T value, XLStyleValue style, Boolean acceptString, Boolean mapped = false)
         {
+            // Map types to a specific known type, avoid endless loop
+            if (!mapped && null != value && value is IConvertible)
+            {
+                var valueType = value.GetType();
+                if (Worksheet.Workbook.KnownTypeMapping.TryGetValue(valueType, out Type mappedType))
+                {
+                    var mappedValue = Convert.ChangeType(value, mappedType);
+                    return SetKnownTypedValue(mappedValue, style, acceptString, mapped: true);
+                }
+            }
+
             string parsedValue;
             bool parsed;
             if (value is String && acceptString || value is char || value is Guid || value is Enum)

--- a/ClosedXML/Excel/IXLWorkbook.cs
+++ b/ClosedXML/Excel/IXLWorkbook.cs
@@ -76,6 +76,11 @@ namespace ClosedXML.Excel
         IXLPageSetup PageOptions { get; set; }
 
         /// <summary>
+        ///   Gets the set of known type mappings.
+        /// </summary>
+        IDictionary<Type, Type> KnownTypeMapping { get; }
+
+        /// <summary>
         ///   Gets or sets the workbook's properties.
         /// </summary>
         XLWorkbookProperties Properties { get; set; }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -1,4 +1,4 @@
-using ClosedXML.Excel.CalcEngine;
+﻿using ClosedXML.Excel.CalcEngine;
 using DocumentFormat.OpenXml;
 using System;
 using System.Collections.Generic;
@@ -195,6 +195,11 @@ namespace ClosedXML.Excel
         ///   <para>All new worksheets will use these outline options.</para>
         /// </summary>
         public IXLOutline Outline { get; set; }
+
+        /// <summary>
+        ///   Gets the set of known type mappings.
+        /// </summary>
+        public IDictionary<Type, Type> KnownTypeMapping { get; } = new Dictionary<Type, Type>();
 
         /// <summary>
         ///   Gets or sets the workbook's properties.

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel.CalcEngine;
+using ClosedXML.Excel.CalcEngine;
 using DocumentFormat.OpenXml;
 using System;
 using System.Collections.Generic;

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -1,4 +1,4 @@
-using ClosedXML.Excel;
+﻿using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -190,6 +190,23 @@ namespace ClosedXML_Tests
 
             Assert.AreEqual(new DateTime(2000, 1, 1), ws.Cell("A1").GetDateTime());
             Assert.AreEqual(String.Empty, ws.Cell("A5").Value);
+        }
+
+        [Test]
+        public void InsertData_Objects_with_KnownTypeMapping()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            ws.Workbook.KnownTypeMapping.Add(typeof(XLDataType), typeof(int));
+            ws.Workbook.KnownTypeMapping.Add(typeof(XLTableCellType), typeof(string));
+            ws.Workbook.KnownTypeMapping.Add(typeof(int), typeof(string));
+            var item = new { I = XLDataType.TimeSpan, S = XLTableCellType.Header, X = 1 };
+            IXLRange range = ws.Cell(2, 2).InsertData(new[] { item }, false);
+
+            Assert.AreEqual(XLDataType.Text, ws.FirstCell().DataType);
+            Assert.AreEqual("Sheet1!B2:D2", range.ToString());
+            Assert.AreEqual((int)XLDataType.TimeSpan, range.Cell(1, 1).Value);
+            Assert.AreEqual(XLTableCellType.Header.ToString(), range.Cell(1, 2).Value);
+            Assert.AreEqual("1", range.Cell(1, 3).Value);
         }
 
         [Test]
@@ -601,6 +618,42 @@ namespace ClosedXML_Tests
             Assert.AreEqual(XLDataType.Text, ws.FirstCell().DataType);
             Assert.AreEqual(dataType.ToString(), ws.FirstCell().Value);
             Assert.AreEqual(dataType.ToString(), ws.FirstCell().GetString());
+        }
+
+        [Test]
+        public void SetCellValueToEnum_AsString()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            ws.Workbook.KnownTypeMapping.Add(typeof(XLDataType), typeof(string));
+            var dataType = XLDataType.Number;
+            ws.FirstCell().Value = dataType;
+            Assert.AreEqual(XLDataType.Text, ws.FirstCell().DataType);
+            Assert.AreEqual(dataType.ToString(), ws.FirstCell().Value);
+            Assert.AreEqual(dataType.ToString(), ws.FirstCell().GetString());
+
+            dataType = XLDataType.TimeSpan;
+            ws.FirstCell().SetValue(dataType);
+            Assert.AreEqual(XLDataType.Text, ws.FirstCell().DataType);
+            Assert.AreEqual(dataType.ToString(), ws.FirstCell().Value);
+            Assert.AreEqual(dataType.ToString(), ws.FirstCell().GetString());
+        }
+
+        [Test]
+        public void SetCellValueToEnum_AsInt()
+        {
+            var ws = new XLWorkbook().AddWorksheet("Sheet1");
+            ws.Workbook.KnownTypeMapping.Add(typeof(XLDataType), typeof(int));
+            var dataType = XLDataType.Number;
+            ws.FirstCell().Value = dataType;
+            Assert.AreEqual(XLDataType.Number, ws.FirstCell().DataType);
+            Assert.AreEqual((int)dataType, ws.FirstCell().Value);
+            Assert.AreEqual(((int)dataType).ToString(), ws.FirstCell().GetString());
+
+            dataType = XLDataType.TimeSpan;
+            ws.FirstCell().SetValue(dataType);
+            Assert.AreEqual(XLDataType.Number, ws.FirstCell().DataType);
+            Assert.AreEqual((int)dataType, ws.FirstCell().Value);
+            Assert.AreEqual(((int)dataType).ToString(), ws.FirstCell().GetString());
         }
 
         [Test]


### PR DESCRIPTION
This change allows us to choose the known type for types which are `IConvertible`.

We have a type called `Date`. A type mapping allows us to convert properties of this type to the system type `DateTime`.

It is also an extension to issue #953. At the moment an `Enum` is handled as a `String`. With this short extension we can choose between `String`, `Int32` or whatever we cant to.