### PR TITLE
Coercion conventions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -389,53 +389,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             }
         }
 
-        [Test]
-        public void N_False_Zero()
+        [TestCase(false, ExpectedResult = 0)]
+        [TestCase(true, ExpectedResult = 1)]
+        [TestCase(123, ExpectedResult = 123)]
+        [TestCase("asd", ExpectedResult = 0)]
+        [TestCase("5.8", ExpectedResult = 5.8)]
+        public double N(object input)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = false;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(0, actual);
-            }
-        }
-
-        [Test]
-        public void N_Number_Number()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                var testedValue = 123;
-                ws.Cell("A1").Value = testedValue;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(testedValue, actual);
-            }
-        }
-
-        [Test]
-        public void N_String_Zero()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "asd";
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(0, actual);
-            }
-        }
-
-        [Test]
-        public void N_True_One()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = true;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(1, actual);
-            }
+            var ws = new XLWorkbook().AddWorksheet();
+            ws.FirstCell().Value = input;
+            return (double)ws.Evaluate("=N(A1)");
         }
 
         #endregion N Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/LogicalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LogicalTests.cs
@@ -59,5 +59,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             actual = XLWorkbook.EvaluateExpr(@"IF(""text""=""TEXT"", 1, 2)");
             Assert.AreEqual(1, actual);
         }
+
+        [Test]
+        public void If_Empty_String()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.FirstCell().SetFormulaA1(@"=""""");
+            var actual = ws.Evaluate(@"IF(TRUE, A1, 1)");
+            Assert.AreEqual("", actual);
+        }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -157,7 +157,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("MCMLXXXIII ", 1983)]
         public void Arabic_ReturnsCorrectNumber(string roman, int arabic)
         {
-            var actual = (int)XLWorkbook.EvaluateExpr(string.Format($"ARABIC(\"{roman}\")"));
+            var actual = (double)XLWorkbook.EvaluateExpr(string.Format($"ARABIC(\"{roman}\")"));
             Assert.AreEqual(arabic, actual);
         }
 
@@ -569,10 +569,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(4, 3, 20)]
         [TestCase(10, 3, 220)]
         [TestCase(0, 0, 1)]
-        public void Combina_CalculatesCorrectValues(int number, int chosen, int expectedResult)
+        public void Combina_CalculatesCorrectValues(int number, int chosen, double expectedResult)
         {
             var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})");
-            Assert.AreEqual(expectedResult, (long)actualResult);
+            Assert.AreEqual(expectedResult, (double)actualResult);
         }
 
         [Theory]
@@ -596,14 +596,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(4.23, 3, 20)]
         [TestCase(10.4, 3.14, 220)]
         [TestCase(0, 0.4, 1)]
-        public void Combina_TruncatesNumbersCorrectly(double number, double chosen, int expectedResult)
+        public void Combina_TruncatesNumbersCorrectly(double number, double chosen, double expectedResult)
         {
             var actualResult = XLWorkbook.EvaluateExpr(string.Format(
                 @"COMBINA({0}, {1})",
                 number.ToString(CultureInfo.InvariantCulture),
                 chosen.ToString(CultureInfo.InvariantCulture)));
 
-            Assert.AreEqual(expectedResult, (long)actualResult);
+            Assert.AreEqual(expectedResult, (double)actualResult);
         }
 
         [TestCase(0, 1)]
@@ -835,7 +835,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(Math.PI, 4)]
         public void Even_ReturnsCorrectResults(double input, int expectedResult)
         {
-            var actual = (int)XLWorkbook.EvaluateExpr(string.Format(@"EVEN({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"EVEN({0})", input.ToString(CultureInfo.InvariantCulture)));
             Assert.AreEqual(expectedResult, actual);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -311,8 +311,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return XLWorkbook.EvaluateExpr($"=FISHER({sourceValue})").CastTo<double>();
         }
 
-        // TODO : the string case will be treated correctly when Coercion is implemented better
-        //[TestCase("asdf", typeof(CellValueException), "Parameter non numeric.")]
+        [TestCase("\"asdf\"", typeof(CellValueException), "Numeric input value expected.")]
         [TestCase("5", typeof(NumberException), "Incorrect value. Should be: -1 > x < 1.")]
         [TestCase("-1", typeof(NumberException), "Incorrect value. Should be: -1 > x < 1.")]
         [TestCase("1", typeof(NumberException), "Incorrect value. Should be: -1 > x < 1.")]
@@ -321,6 +320,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.Throws(
                 Is.TypeOf(exceptionType).And.Message.EqualTo(exceptionMessage),
                 () => XLWorkbook.EvaluateExpr($"=FISHER({sourceValue})"));
+        }
+
+        [Test]
+        public void Fisher_EmptyCell()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            Assert.AreEqual(0, ws.Evaluate("FISHER(A1)"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -686,7 +686,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Value_Input_String_Is_Not_A_Number()
         {
-            Assert.That(() => XLWorkbook.EvaluateExpr(@"Value(""asdf"")"), Throws.TypeOf<FormatException>());
+            Assert.Throws<CellValueException>(() => XLWorkbook.EvaluateExpr(@"Value(""asdf"")"));
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -349,7 +349,7 @@ namespace ClosedXML.Excel.CalcEngine
                 var t = _currentToken;
                 GetToken();
                 var exprArg = ParseAddSub();
-                x = new BinaryExpression(t, x, exprArg);
+                x = new BinaryExpression(t, x, exprArg, CoercionConvention.CaseInsensitive);
             }
             return x;
         }

--- a/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
+++ b/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
@@ -15,9 +15,9 @@ namespace ClosedXML.Excel.CalcEngine
         public IXLRange Range { get; }
 
         // ** IValueObject
-        public object GetValue()
+        public object GetValue(bool emptyStringAsNull)
         {
-            return GetValue(Range.FirstCell());
+            return GetValue(Range.FirstCell(), emptyStringAsNull);
         }
 
         // ** IEnumerable
@@ -43,7 +43,7 @@ namespace ClosedXML.Excel.CalcEngine
         private Boolean _evaluating;
 
         // ** implementation
-        private object GetValue(IXLCell cell)
+        private object GetValue(IXLCell cell, bool emptyStringAsNull)
         {
             if (_evaluating || (cell as XLCell).IsEvaluating)
             {
@@ -54,7 +54,14 @@ namespace ClosedXML.Excel.CalcEngine
                 _evaluating = true;
                 var f = cell.FormulaA1;
                 if (String.IsNullOrWhiteSpace(f))
-                    return cell.Value;
+                {
+                    var v = cell.Value;
+
+                    if (emptyStringAsNull && v is string s && s == "")
+                        return null;
+
+                    return v;
+                }
                 else
                 {
                     return (cell as XLCell).Evaluate();

--- a/ClosedXML/Excel/CalcEngine/Exceptions/CellValueException.cs
+++ b/ClosedXML/Excel/CalcEngine/Exceptions/CellValueException.cs
@@ -22,5 +22,30 @@ namespace ClosedXML.Excel.CalcEngine.Exceptions
         internal CellValueException(string message, Exception innerException)
             : base(message, innerException)
         { }
+
+        public static T CatchTypeConversionExceptions<T>(Func<T> func)
+        {
+            if (func is null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
+            try
+            {
+                return func.Invoke();
+            }
+            catch (Exception ex)
+            {
+                switch (ex)
+                {
+                    case InvalidCastException _:
+                    case FormatException _:
+                    case OverflowException _:
+                        throw new CellValueException("Unable to convert value to the desired type.", ex);
+                    default:
+                        throw;
+                }
+            }
+        }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -61,7 +61,11 @@ namespace ClosedXML.Excel.CalcEngine
         internal Expression(object value, CoercionConvention convention = CoercionConvention.Default)
             : this(convention)
         {
-            _token = new Token(value, TKID.ATOM, TKTYPE.LITERAL);
+            if (value.IsNumber())
+                // If we returned an int somewhere from a function, ensure we store it as a Double token
+                _token = new Token(Convert.ToDouble(value), TKID.ATOM, TKTYPE.LITERAL);
+            else
+                _token = new Token(value, TKID.ATOM, TKTYPE.LITERAL);
         }
 
         internal Expression(Token tk, CoercionConvention convention = CoercionConvention.Default)
@@ -496,7 +500,7 @@ namespace ClosedXML.Excel.CalcEngine
     {
         internal EmptyValueExpression()
             // Ensures a token of type LITERAL, with value of null is created
-            : base(value: null) 
+            : base(value: null)
         {
         }
 

--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -2,7 +2,6 @@ using ClosedXML.Excel.CalcEngine.Exceptions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 
@@ -163,7 +162,7 @@ namespace ClosedXML.Excel.CalcEngine
             }
 
             // handle everything else
-            return Convert.ToDouble(v, Thread.CurrentThread.CurrentCulture);
+            return ConvertTo<double>(v);
         }
 
         public static implicit operator bool(Expression x)
@@ -193,7 +192,7 @@ namespace ClosedXML.Excel.CalcEngine
             }
 
             // handle everything else
-            return (double)Convert.ChangeType(v, typeof(double)) != 0;
+            return ConvertTo<double>(v) != 0;
         }
 
         public static implicit operator DateTime(Expression x)
@@ -222,8 +221,12 @@ namespace ClosedXML.Excel.CalcEngine
             }
 
             // handle everything else
-            CultureInfo _ci = Thread.CurrentThread.CurrentCulture;
-            return (DateTime)Convert.ChangeType(v, typeof(DateTime), _ci);
+            return ConvertTo<DateTime>(v);
+        }
+
+        private static T ConvertTo<T>(object v)
+        {
+            return (T)Convert.ChangeType(v, typeof(T), Thread.CurrentThread.CurrentCulture);
         }
 
         #endregion ** implicit converters

--- a/ClosedXML/Excel/CalcEngine/Expression_Coercion.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression_Coercion.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Threading;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    internal partial class Expression
+    {
+        /// <summary>
+        /// Coerce a value to a different type, using Excel's convention of how date and numeric values relate
+        /// </summary>
+        /// <typeparam name="T">The type to which to coerce.</typeparam>
+        /// <returns>The coerced value</returns>
+        public T Coerce<T>()
+        {
+            return Coerce<T>(this._convention);
+        }
+
+        /// <summary>
+        /// Coerce a value to a different type, using Excel's convention of how date and numeric values relate
+        /// </summary>
+        /// <typeparam name="T">The type to which to coerce.</typeparam>
+        /// <param name="coercionConvention">The convention to use when converting to numbers</param>
+        /// <returns>The coerced value</returns>
+        public T Coerce<T>(CoercionConvention coercionConvention)
+        {
+            if (TryCoerce(coercionConvention, out T output))
+                return output;
+            else
+                throw new FormatException($"Unable to coerce Expression value to type `{typeof(T).Name}`");
+        }
+
+        /// <summary>
+        /// Try to coerce a value to a different type, using Excel's convention of how date and numeric values relate
+        /// </summary>
+        /// <typeparam name="T">The type to which to coerce.</typeparam>
+        /// <param name="result">The coerced value of the new type</param>
+        /// <returns>A value indicating whether coercion was successful</returns>
+        public bool TryCoerce<T>(out T result)
+        {
+            return TryCoerce(this._convention, out result);
+        }
+
+        /// <summary>
+        /// Try to coerce a value to a different type, using Excel's convention of how date and numeric values relate
+        /// </summary>
+        /// <typeparam name="T">The type to which to coerce.</typeparam>
+        /// <param name="coercionConvention">The convention to use when converting to numbers</param>
+        /// <param name="result">The coerced value of the new type</param>
+        /// <returns>A value indicating whether coercion was successful</returns>
+        public Boolean TryCoerce<T>(CoercionConvention coercionConvention, out T result)
+        {
+            if (this is ErrorExpression errorExpression)
+                errorExpression.ThrowApplicableException();
+
+            var value = this.Evaluate();
+
+            if (value is T t)
+            {
+                result = t;
+                return true;
+            }
+
+            var outputType = typeof(T);
+            var underlyingType = outputType.GetUnderlyingType();
+
+            if (underlyingType == typeof(string) && TryCoerceToString(value, out var s))
+            {
+                result = ConvertTo<T>(s);
+                return true;
+            }
+
+            if (underlyingType == typeof(DateTime) && TryCoerceToDateTime(value, out var dt))
+            {
+                result = ConvertTo<T>(dt);
+                return true;
+            }
+
+            if (underlyingType == typeof(TimeSpan) && TryCoerceToTimeSpan(value, out var ts))
+            {
+                result = ConvertTo<T>(ts);
+                return true;
+            }
+
+            if (underlyingType == typeof(Double) && TryCoerceToDouble(value, out var dbl))
+            {
+                result = ConvertTo<T>(dbl);
+                return true;
+            }
+
+            if (underlyingType == typeof(bool) && TryCoerceToBoolean(value, out var b))
+            {
+                result = ConvertTo<T>(b);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        private static T ConvertTo<T>(object v)
+        {
+            if (v is T t) return t;
+
+            return (T)Convert.ChangeType(v, typeof(T), Thread.CurrentThread.CurrentCulture);
+        }
+
+        private static Boolean TryCoerceToDateTime(object value, out DateTime result)
+        {
+            if (value is TimeSpan ts)
+            {
+                result = new DateTime().Add(ts);
+                return true;
+            }
+
+            if (value is Double dbl && dbl.IsValidOADateNumber())
+            {
+                result = DateTime.FromOADate(dbl);
+                return true;
+            }
+
+            // handle everything else
+            return TryConvertTo(value, out result);
+        }
+
+        private static Boolean TryCoerceToString(object value, out String result)
+        {
+            if (value == null)
+            {
+                result = string.Empty;
+                return true;
+            }
+
+            if (value is Boolean b)
+            {
+                result = b.ToString().ToUpper();
+                return true;
+            }
+
+            return TryConvertTo(value, out result);
+        }
+
+        private static Boolean TryCoerceToTimeSpan(object value, out TimeSpan result)
+        {
+            if (value is DateTime dt)
+            {
+                result = dt.Subtract(new DateTime());
+                return true;
+            }
+
+            if (value is Double dbl)
+            {
+                result = XLHelper.GetTimeSpan(dbl);
+                return true;
+            }
+
+            // handle everything else
+            return TryConvertTo(value, out result);
+        }
+
+        private static Boolean TryConvertTo<T>(object v, out T result)
+        {
+            if (v is T t)
+            {
+                result = t;
+                return true;
+            }
+
+            try
+            {
+                result = (T)Convert.ChangeType(v, typeof(T), Thread.CurrentThread.CurrentCulture);
+                return true;
+            }
+            catch
+            {
+                result = default;
+                return false;
+            }
+        }
+
+        private Boolean TryCoerceToBoolean(object value, out Boolean result)
+        {
+            result = default;
+            if (value == null)
+            {
+                result = false;
+                return true;
+            }
+
+            // handle doubles
+            if (value is Double dbl)
+            {
+                result = Math.Abs(dbl) > Double.Epsilon;
+                return true;
+            }
+
+            if (value is string s && Boolean.TryParse(s, out var b))
+            {
+                result = b;
+                return true;
+            }
+
+            // handle everything else
+            if (TryCoerceToDouble(value, out dbl))
+            {
+                result = Math.Abs(dbl) > Double.Epsilon;
+                return true;
+            }
+
+            return false;
+        }
+
+        private Boolean TryCoerceToDouble(object value, out Double result)
+        {
+            result = default;
+
+            // handle booleans
+            if (value is Boolean b)
+            {
+                result = b ? 1 : 0;
+                return true;
+            }
+
+            // handle dates
+            if (value is DateTime dt)
+            {
+                result = dt.ToOADate();
+                return true;
+            }
+
+            if (value is TimeSpan ts)
+            {
+                result = ts.TotalDays;
+                return true;
+            }
+
+            // handle string
+            if (value is string s)
+            {
+                if (this._convention.HasFlag(CoercionConvention.EmptyStringAsZero) && string.IsNullOrEmpty(s)
+                    || this._convention.HasFlag(CoercionConvention.NonEmptyStringAsZero) && !string.IsNullOrEmpty(s))
+                {
+                    result = 0;
+                    return true;
+                }
+                else if (Double.TryParse(s, out var dbl))
+                {
+                    result = dbl;
+                    return true;
+                }
+            }
+
+            // handle nulls
+            if (this._convention.HasFlag(CoercionConvention.NullAsZero) && value == null)
+            {
+                result = 0;
+                return true;
+            }
+
+            // handle everything else
+            return TryConvertTo(value, out result);
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -142,9 +142,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         private static object Datevalue(List<Expression> p)
         {
-            var date = (string)p[0];
+            var value = p[0].Evaluate();
 
-            return (int)Math.Floor(DateTime.Parse(date).ToOADate());
+            if (value is string s && DateTime.TryParse(s, out var dt))
+                return dt.ToOADate();
+
+            throw new CellValueException("Cannot parse value to date");
         }
 
         private static object Day(List<Expression> p)
@@ -156,32 +159,19 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         private static object Days(List<Expression> p)
         {
-            Type type;
+            var end_date = (DateTime)p[0];
+            var start_date = (DateTime)p[1];
 
-            int end_date;
-
-            type = p[0]._token.Value.GetType();
-            if (type == typeof(string))
-                end_date = (int)Datevalue(new List<Expression>() { p[0] });
-            else
-                end_date = (int)p[0];
-
-            int start_date;
-
-            type = p[1]._token.Value.GetType();
-            if (type == typeof(string))
-                start_date = (int)Datevalue(new List<Expression>() { p[1] });
-            else
-                start_date = (int)p[1];
-
-            return end_date - start_date;
+            return end_date.Subtract(start_date).TotalDays;
         }
 
         private static object Days360(List<Expression> p)
         {
             var date1 = (DateTime)p[0];
             var date2 = (DateTime)p[1];
-            var isEuropean = p.Count == 3 ? p[2] : false;
+            var isEuropean = false;
+            if (p.Count > 2)
+                isEuropean = p[2];
 
             return Days360(date1, date2, isEuropean);
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -27,7 +27,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("TYPE", 1, Type);
         }
 
-        static IDictionary<ErrorExpression.ExpressionErrorType, int> errorTypes = new Dictionary<ErrorExpression.ExpressionErrorType, int>()
+        private static IDictionary<ErrorExpression.ExpressionErrorType, int> errorTypes = new Dictionary<ErrorExpression.ExpressionErrorType, int>()
         {
             [ErrorExpression.ExpressionErrorType.NullValue] = 1,
             [ErrorExpression.ExpressionErrorType.DivisionByZero] = 2,
@@ -38,7 +38,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             [ErrorExpression.ExpressionErrorType.NoValueAvailable] = 7
         };
 
-        static object ErrorType(List<Expression> p)
+        private static object ErrorType(List<Expression> p)
         {
             var v = p[0].Evaluate();
 
@@ -48,13 +48,13 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 throw new NoValueAvailableException();
         }
 
-        static object IsBlank(List<Expression> p)
+        private static object IsBlank(List<Expression> p)
         {
-            var v = (string) p[0];
+            var v = (string)p[0];
             var isBlank = string.IsNullOrEmpty(v);
 
-
-            if (isBlank && p.Count > 1) {
+            if (isBlank && p.Count > 1)
+            {
                 var sublist = p.GetRange(1, p.Count);
                 isBlank = (bool)IsBlank(sublist);
             }
@@ -62,7 +62,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return isBlank;
         }
 
-        static object IsErr(List<Expression> p)
+        private static object IsErr(List<Expression> p)
         {
             var v = p[0].Evaluate();
 
@@ -70,25 +70,25 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 && ((ErrorExpression.ExpressionErrorType)v) != ErrorExpression.ExpressionErrorType.NoValueAvailable;
         }
 
-        static object IsError(List<Expression> p)
+        private static object IsError(List<Expression> p)
         {
             var v = p[0].Evaluate();
 
             return v is ErrorExpression.ExpressionErrorType;
         }
 
-        static object IsEven(List<Expression> p)
+        private static object IsEven(List<Expression> p)
         {
             var v = p[0].Evaluate();
             if (v is double)
             {
-                return Math.Abs((double) v%2) < 1;
+                return Math.Abs((double)v % 2) < 1;
             }
             //TODO: Error Exceptions
             throw new ArgumentException("Expression doesn't evaluate to double");
         }
 
-        static object IsLogical(List<Expression> p)
+        private static object IsLogical(List<Expression> p)
         {
             var v = p[0].Evaluate();
             var isLogical = v is bool;
@@ -96,13 +96,13 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (isLogical && p.Count > 1)
             {
                 var sublist = p.GetRange(1, p.Count);
-                isLogical = (bool) IsLogical(sublist);
+                isLogical = (bool)IsLogical(sublist);
             }
 
             return isLogical;
         }
 
-        static object IsNa(List<Expression> p)
+        private static object IsNa(List<Expression> p)
         {
             var v = p[0].Evaluate();
 
@@ -110,12 +110,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 && ((ErrorExpression.ExpressionErrorType)v) == ErrorExpression.ExpressionErrorType.NoValueAvailable;
         }
 
-        static object IsNonText(List<Expression> p)
+        private static object IsNonText(List<Expression> p)
         {
-            return !(bool) IsText(p);
+            return !(bool)IsText(p);
         }
 
-        static object IsNumber(List<Expression> p)
+        private static object IsNumber(List<Expression> p)
         {
             var v = p[0].Evaluate();
 
@@ -129,7 +129,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 //Handle Number Styles
                 try
                 {
-                    var stringValue = (string) v;
+                    var stringValue = (string)v;
                     return double.TryParse(stringValue.TrimEnd('%', ' '), NumberStyles.Any, null, out double dv);
                 }
                 catch (Exception)
@@ -147,12 +147,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return isNumber;
         }
 
-        static object IsOdd(List<Expression> p)
+        private static object IsOdd(List<Expression> p)
         {
-            return !(bool) IsEven(p);
+            return !(bool)IsEven(p);
         }
 
-        static object IsRef(List<Expression> p)
+        private static object IsRef(List<Expression> p)
         {
             var oe = p[0] as XObjectExpression;
             if (oe == null)
@@ -163,50 +163,50 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return crr != null;
         }
 
-        static object IsText(List<Expression> p)
+        private static object IsText(List<Expression> p)
         {
             //Evaluate Expressions
-            var isText = !(bool) IsBlank(p);
+            var isText = !(bool)IsBlank(p);
             if (isText)
             {
-                isText = !(bool) IsNumber(p);
+                isText = !(bool)IsNumber(p);
             }
             if (isText)
             {
-                isText = !(bool) IsLogical(p);
+                isText = !(bool)IsLogical(p);
             }
             return isText;
         }
 
-        static object N(List<Expression> p)
+        private static object N(List<Expression> p)
         {
-            return (double) p[0];
+            return (double)p[0];
         }
 
-        static object NA(List<Expression> p)
+        private static object NA(List<Expression> p)
         {
             return ErrorExpression.ExpressionErrorType.NoValueAvailable;
         }
 
-        static object Type(List<Expression> p)
+        private static object Type(List<Expression> p)
         {
-            if ((bool) IsNumber(p))
+            if ((bool)IsNumber(p))
             {
                 return 1;
             }
-            if ((bool) IsText(p))
+            if ((bool)IsText(p))
             {
                 return 2;
             }
-            if ((bool) IsLogical(p))
+            if ((bool)IsLogical(p))
             {
                 return 4;
             }
-            if ((bool) IsError(p))
+            if ((bool)IsError(p))
             {
                 return 16;
             }
-            if(p.Count > 1)
+            if (p.Count > 1)
             {
                 return 64;
             }

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -180,7 +180,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         private static object N(List<Expression> p)
         {
-            return (double)p[0];
+            return (double)p[0].WithCoercionConvention(CoercionConvention.StringOrNullAsZero);
         }
 
         private static object NA(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
@@ -13,10 +13,10 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("IF", 2, 3, If);
             ce.RegisterFunction("TRUE", 0, True);
             ce.RegisterFunction("FALSE", 0, False);
-            ce.RegisterFunction("IFERROR",2,IfError);
+            ce.RegisterFunction("IFERROR", 2, IfError);
         }
 
-        static object And(List<Expression> p)
+        private static object And(List<Expression> p)
         {
             var b = true;
             foreach (var v in p)
@@ -26,7 +26,7 @@ namespace ClosedXML.Excel.CalcEngine
             return b;
         }
 
-        static object Or(List<Expression> p)
+        private static object Or(List<Expression> p)
         {
             var b = false;
             foreach (var v in p)
@@ -36,12 +36,12 @@ namespace ClosedXML.Excel.CalcEngine
             return b;
         }
 
-        static object Not(List<Expression> p)
+        private static object Not(List<Expression> p)
         {
             return !p[0];
         }
 
-        static object If(List<Expression> p)
+        private static object If(List<Expression> p)
         {
             if (p[0])
             {
@@ -57,17 +57,17 @@ namespace ClosedXML.Excel.CalcEngine
             else return false;
         }
 
-        static object True(List<Expression> p)
+        private static object True(List<Expression> p)
         {
             return true;
         }
 
-        static object False(List<Expression> p)
+        private static object False(List<Expression> p)
         {
             return false;
         }
 
-        static object IfError(List<Expression> p)
+        private static object IfError(List<Expression> p)
         {
             try
             {

--- a/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
@@ -59,7 +59,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 throw new CellReferenceException("Row index has to be positive");
 
             IXLRangeColumn matching_column;
-            matching_column = range.FindColumn(c => !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) == 0);
+            matching_column = range.FindColumn(c => !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) == 0);
             if (range_lookup && matching_column == null)
             {
                 var first_column = range.FirstColumn().ColumnNumber();
@@ -68,9 +68,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 matching_column = range.FindColumn(c =>
                 {
                     var column_index_in_range = c.ColumnNumber() - first_column + 1;
-                    if (column_index_in_range < number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0 && !c.ColumnRight().Cell(1).IsEmpty() && new Expression(c.ColumnRight().Cell(1).Value).CompareTo(lookup_value) > 0)
+                    if (column_index_in_range < number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) <= 0 && !c.ColumnRight().Cell(1).IsEmpty() && new Expression(c.ColumnRight().Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) > 0)
                         return true;
-                    else if (column_index_in_range == number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value).CompareTo(lookup_value) <= 0)
+                    else if (column_index_in_range == number_of_columns_in_range && !c.Cell(1).IsEmpty() && new Expression(c.Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) <= 0)
                         return true;
                     else
                         return false;
@@ -180,7 +180,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
             if (match_type == 0)
                 foundCell = range
-                    .CellsUsed(XLCellsUsedOptions.Contents, c => lookupPredicate.Invoke(new Expression(c.Value).CompareTo(lookup_value)))
+                    .CellsUsed(XLCellsUsedOptions.Contents, c => lookupPredicate.Invoke(new Expression(c.Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value)))
                     .FirstOrDefault();
             else
             {
@@ -189,12 +189,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                     .CellsUsed(XLCellsUsedOptions.Contents)
                     .TakeWhile(c =>
                     {
-                        var currentCellExpression = new Expression(c.Value);
+                        var currentCellExpression = new Expression(c.Value, CoercionConvention.CaseInsensitive);
 
                         if (previousValue != null)
                         {
                             // When match_type != 0, we have to assume that the order of the items being search is ascending or descending
-                            var previousValueExpression = new Expression(previousValue);
+                            var previousValueExpression = new Expression(previousValue, CoercionConvention.CaseInsensitive);
                             if (!lookupPredicate.Invoke(previousValueExpression.CompareTo(currentCellExpression)))
                                 return false;
                         }
@@ -232,7 +232,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             IXLRangeRow matching_row;
             try
             {
-                matching_row = range.FindRow(r => !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) == 0);
+                matching_row = range.FindRow(r => !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) == 0);
             }
             catch (Exception ex)
             {
@@ -246,9 +246,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 matching_row = range.FindRow(r =>
                 {
                     var row_index_in_range = r.RowNumber() - first_row + 1;
-                    if (row_index_in_range < number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0 && !r.RowBelow().Cell(1).IsEmpty() && new Expression(r.RowBelow().Cell(1).Value).CompareTo(lookup_value) > 0)
+                    if (row_index_in_range < number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) <= 0 && !r.RowBelow().Cell(1).IsEmpty() && new Expression(r.RowBelow().Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) > 0)
                         return true;
-                    else if (row_index_in_range == number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value).CompareTo(lookup_value) <= 0)
+                    else if (row_index_in_range == number_of_rows_in_range && !r.Cell(1).IsEmpty() && new Expression(r.Cell(1).Value, CoercionConvention.CaseInsensitive).CompareTo(lookup_value) <= 0)
                         return true;
                     else
                         return false;

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -214,10 +214,17 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static object Fisher(List<Expression> p)
         {
-            var x = (double)p[0];
-            if (x <= -1 || x >= 1) throw new NumberException("Incorrect value. Should be: -1 > x < 1.");
+            try
+            {
+                var x = (double)p[0];
+                if (x <= -1 || x >= 1) throw new NumberException("Incorrect value. Should be: -1 > x < 1.");
 
-            return 0.5 * Math.Log((1 + x) / (1 - x));
+                return 0.5 * Math.Log((1 + x) / (1 - x));
+            }
+            catch (FormatException ex)
+            {
+                throw new CellValueException("Numeric input value expected.", ex);
+            }
         }
 
         private static object Geomean(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -48,7 +48,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static object _Char(List<Expression> p)
         {
-            var i = (int)p[0];
+            var i = (int)p[0].WithCoercionConvention(CoercionConvention.StringOrNullAsZero);
             if (i < 1 || i > 255)
                 throw new CellValueException(string.Format("The number {0} is out of the required range (1 to 255)", i));
 

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -310,15 +310,15 @@ namespace ClosedXML.Excel
         public static DateTime GetDate(Object v)
         {
             // handle dates
-            if (v is DateTime)
+            if (v is DateTime dt)
             {
-                return (DateTime)v;
+                return dt;
             }
 
             // handle doubles
-            if (v is double && ((double)v).IsValidOADateNumber())
+            if (v is double dbl && dbl.IsValidOADateNumber())
             {
-                return DateTime.FromOADate((double)v);
+                return DateTime.FromOADate(dbl);
             }
 
             // handle everything else


### PR DESCRIPTION
Something that comes up time and again is that somethings strings are compared with case INsensitivity. Sometimes not. Sometimes strings should be treated as 0. Sometimes only empty strings should be treated as 0.

This PR adds `CoercionConvention` that is an optional parameter to all `Expression` (sub)classes. Default to `CoercionConvention.NullAsZero`, which is the current behaviour. 

Now, when evaluation expressions, the convention can be passed through or overridden with `Expression.WithCoercionConvention()` for one-time alternative behaviour.

Also adds a global handler for type conversion exceptions and throws `CellValueException` it its place.