### PR TITLE
fix Error copying range with ConditionalFormat (ColorScale) to new cell.  Fixes #1526

### DIFF
--- a/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
@@ -1,6 +1,6 @@
 using ClosedXML.Excel;
 using NUnit.Framework;
-using System.Drawing;
+using Color = System.Drawing.Color;
 using System.Linq;
 
 namespace ClosedXML.Tests
@@ -134,6 +134,22 @@ namespace ClosedXML.Tests
             Assert.AreEqual("Sheet2", ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name);
             Assert.AreEqual("A1:J2", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
             Assert.AreEqual("A1:A2", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+        }
+
+        [Test]
+        public void CopyConditionalFormatColorScaleInRange()
+        {
+            var ws = new XLWorkbook().Worksheets.Add("Sheet");
+
+            ws.Row(1).Cell(1).AddConditionalFormat()
+                .ColorScale()
+                .LowestValue(XLColor.Teal)
+                .HighestValue(XLColor.Orange);
+
+            ws.Cell(5, 2).Value = ws.Range(1, 1, 1, 5);
+
+            Assert.AreEqual(2, ws.ConditionalFormats.Count()); //existing format + copied.
+            Assert.IsTrue(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B5:B5").ConditionalFormatType == XLConditionalFormatType.ColorScale);
         }
 
         private static void FillRow(IXLRow row1)

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -259,7 +259,7 @@ namespace ClosedXML.Excel
             StopIfTrue = other.StopIfTrue;
 
             Values.Clear();
-            other.Values.ForEach(kp => Values.Add(kp.Key, new XLFormula(kp.Value)));
+            other.Values.Where(x=>x.Value != null).ForEach(kp => Values.Add(kp.Key, new XLFormula(kp.Value)));
             //CopyDictionary(Values, other.Values);
             CopyDictionary(Colors, other.Colors);
             CopyDictionary(ContentTypes, other.ContentTypes);


### PR DESCRIPTION
In XLConditionalFormat when the ConditionalFormat values are read and there is a null value (key only), it will throw a nullReferenceException

This change checks to ensure the ConditionalFormat Value is not null before adding to the copied ConditionalFormat values dictionary.
Fixes #1526 