### PR TITLE
Fix call calculated value invalidation if named ranges are changed (#1536)

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -11,192 +11,172 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void NewWorkbookDoesNotNeedRecalculation()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
 
-                Assert.AreEqual(0, wb.RecalculationCounter);
-                Assert.IsFalse(cell.NeedsRecalculation);
-            }
+            Assert.AreEqual(0, wb.RecalculationCounter);
+            Assert.IsFalse(cell.NeedsRecalculation);
         }
 
         [Test]
         public void EditCellCausesCounterIncreasing()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
-                cell.Value = "1234567";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
+            cell.Value = "1234567";
 
-                Assert.Greater(wb.RecalculationCounter, 0);
-            }
+            Assert.Greater(wb.RecalculationCounter, 0);
         }
 
         [Test]
         public void StaticCellDoesNotNeedRecalculation()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
-                cell.Value = "1234567";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
+            cell.Value = "1234567";
 
-                Assert.IsFalse(cell.NeedsRecalculation);
-            }
+            Assert.IsFalse(cell.NeedsRecalculation);
         }
 
         [Test]
         public void EditCellInvalidatesDependentCells()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
-                var dependentCell = sheet.Cell(2, 1);
-                dependentCell.FormulaA1 = "=A1";
-                var _ = dependentCell.Value;
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
+            var dependentCell = sheet.Cell(2, 1);
+            dependentCell.FormulaA1 = "=A1";
+            var _ = dependentCell.Value;
 
-                cell.Value = "1234567";
+            cell.Value = "1234567";
 
-                Assert.IsTrue(dependentCell.NeedsRecalculation);
-            }
+            Assert.IsTrue(dependentCell.NeedsRecalculation);
         }
 
         [Test]
         public void EditFormulaA1InvalidatesDependentCells()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-                a1.Value = 15;
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+            a1.Value = 15;
 
-                var res1 = a4.Value;
-                a2.FormulaA1 = "=A1*20";
-                var res2 = a4.Value;
+            var res1 = a4.Value;
+            a2.FormulaA1 = "=A1*20";
+            var res2 = a4.Value;
 
-                Assert.AreEqual(15 + 150 + 1500, res1);
-                Assert.AreEqual(15 + 300 + 3000, res2);
-            }
+            Assert.AreEqual(15 + 150 + 1500, res1);
+            Assert.AreEqual(15 + 300 + 3000, res2);
         }
 
         [Test]
         public void EditFormulaR1C1InvalidatesDependentCells()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-                a1.Value = 15;
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+            a1.Value = 15;
 
-                var res1 = a4.Value;
-                a2.FormulaR1C1 = "=R[-1]C*2";
-                var res2 = a4.Value;
+            var res1 = a4.Value;
+            a2.FormulaR1C1 = "=R[-1]C*2";
+            var res2 = a4.Value;
 
-                Assert.AreEqual(15 + 150 + 1500, res1);
-                Assert.AreEqual(15 + 30 + 300, res2);
-            }
+            Assert.AreEqual(15 + 150 + 1500, res1);
+            Assert.AreEqual(15 + 30 + 300, res2);
         }
 
         [Test]
         public void InsertRowInvalidatesValues()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a4 = sheet.Cell("A4");
-                a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a4 = sheet.Cell("A4");
+            a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
 
-                var res1 = a4.Value;
-                sheet.Row(2).InsertRowsAbove(2);
-                var res2 = a4.Value;
+            var res1 = a4.Value;
+            sheet.Row(2).InsertRowsAbove(2);
+            var res2 = a4.Value;
 
-                Assert.AreEqual(3, res1);
-                Assert.AreEqual(5, res2);
-            }
+            Assert.AreEqual(3, res1);
+            Assert.AreEqual(5, res2);
         }
 
         [Test]
         public void DeleteRowInvalidatesValues()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a4 = sheet.Cell("A4");
-                a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a4 = sheet.Cell("A4");
+            a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
 
-                var res1 = a4.Value;
-                sheet.Row(2).Delete();
-                var res2 = a4.Value;
+            var res1 = a4.Value;
+            sheet.Row(2).Delete();
+            var res2 = a4.Value;
 
-                Assert.AreEqual(3, res1);
-                Assert.AreEqual(2, res2);
-            }
+            Assert.AreEqual(3, res1);
+            Assert.AreEqual(2, res2);
         }
 
         [Test]
         public void ChainedCalculationPreservesIntermediateValues()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
 
-                a1.Value = 15;
-                var res = a4.Value;
+            a1.Value = 15;
+            var res = a4.Value;
 
-                Assert.AreEqual(15 + 150 + 1500, res);
-                Assert.IsFalse(a4.NeedsRecalculation);
-                Assert.IsFalse(a3.NeedsRecalculation);
-                Assert.IsFalse(a2.NeedsRecalculation);
-                Assert.AreEqual(150, a2.CachedValue);
-                Assert.AreEqual(1500, a3.CachedValue);
-                Assert.AreEqual(15 + 150 + 1500, a4.CachedValue);
-            }
+            Assert.AreEqual(15 + 150 + 1500, res);
+            Assert.IsFalse(a4.NeedsRecalculation);
+            Assert.IsFalse(a3.NeedsRecalculation);
+            Assert.IsFalse(a2.NeedsRecalculation);
+            Assert.AreEqual(150, a2.CachedValue);
+            Assert.AreEqual(1500, a3.CachedValue);
+            Assert.AreEqual(15 + 150 + 1500, a4.CachedValue);
         }
 
         [Test]
         public void EditingAffectsDependentCells()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-                a1.Value = 15;
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+            a1.Value = 15;
 
-                var res1 = a4.Value;
-                a1.Value = 20;
-                var res2 = a4.Value;
+            var res1 = a4.Value;
+            a1.Value = 20;
+            var res2 = a4.Value;
 
-                Assert.AreEqual(15 + 150 + 1500, res1);
-                Assert.AreEqual(20 + 200 + 2000, res2);
-            }
+            Assert.AreEqual(15 + 150 + 1500, res1);
+            Assert.AreEqual(20 + 200 + 2000, res2);
         }
 
         [Test]
@@ -207,185 +187,171 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("C2", new string[] { "C5" })]
         public void EditingDoesNotAffectNonDependingCells(string changedCell, string[] affectedCells)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            sheet.Cell("A2").FormulaA1 = "A1+1";
+            sheet.Cell("A3").FormulaA1 = "SUM(A1:A2)";
+            sheet.Cell("A4").FormulaA1 = "SUM(A1:A3)";
+            sheet.Cell("B2").FormulaA1 = "B1+1";
+            sheet.Cell("B3").FormulaA1 = "SUM(B1:B2)";
+            sheet.Cell("B4").FormulaA1 = "SUM(B1:B3)";
+            sheet.Cell("C1").FormulaA1 = "SUM(A1:B1)";
+            sheet.Cell("C2").FormulaA1 = "SUM(A2:B2)";
+            sheet.Cell("C3").FormulaA1 = "SUM(A3:B3)";
+            sheet.Cell("C5").FormulaA1 = "SUM($A$1:$C$4)";
+            sheet.RecalculateAllFormulas();
+            var allCells = sheet.CellsUsed();
+
+            sheet.Cell(changedCell).Value = 100;
+            var modifiedCells = allCells.Where(cell => cell.NeedsRecalculation);
+
+            Assert.AreEqual(affectedCells.Length, modifiedCells.Count());
+            foreach (var cellAddress in affectedCells)
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                sheet.Cell("A2").FormulaA1 = "A1+1";
-                sheet.Cell("A3").FormulaA1 = "SUM(A1:A2)";
-                sheet.Cell("A4").FormulaA1 = "SUM(A1:A3)";
-                sheet.Cell("B2").FormulaA1 = "B1+1";
-                sheet.Cell("B3").FormulaA1 = "SUM(B1:B2)";
-                sheet.Cell("B4").FormulaA1 = "SUM(B1:B3)";
-                sheet.Cell("C1").FormulaA1 = "SUM(A1:B1)";
-                sheet.Cell("C2").FormulaA1 = "SUM(A2:B2)";
-                sheet.Cell("C3").FormulaA1 = "SUM(A3:B3)";
-                sheet.Cell("C5").FormulaA1 = "SUM($A$1:$C$4)";
-                sheet.RecalculateAllFormulas();
-                var allCells = sheet.CellsUsed();
-
-                sheet.Cell(changedCell).Value = 100;
-                var modifiedCells = allCells.Where(cell => cell.NeedsRecalculation);
-
-                Assert.AreEqual(affectedCells.Length, modifiedCells.Count());
-                foreach (var cellAddress in affectedCells)
-                {
-                    Assert.IsTrue(modifiedCells.Any(cell => cell.Address.ToString() == cellAddress),
-                        string.Format("Cell {0} is expected to need recalculation, but it does not", cellAddress));
-                }
+                Assert.IsTrue(modifiedCells.Any(cell => cell.Address.ToString() == cellAddress),
+                    string.Format("Cell {0} is expected to need recalculation, but it does not", cellAddress));
             }
         }
 
         [Test]
         public void CircularReferenceFailsCalculating()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
 
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=A3*10";
-                a1.FormulaA1 = "A2+A3+A4";
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=A3*10";
+            a1.FormulaA1 = "A2+A3+A4";
 
-                var getValueA1 = new TestDelegate(() => { var v = a1.Value; });
-                var getValueA2 = new TestDelegate(() => { var v = a2.Value; });
-                var getValueA3 = new TestDelegate(() => { var v = a3.Value; });
-                var getValueA4 = new TestDelegate(() => { var v = a4.Value; });
+            var getValueA1 = new TestDelegate(() => { var v = a1.Value; });
+            var getValueA2 = new TestDelegate(() => { var v = a2.Value; });
+            var getValueA3 = new TestDelegate(() => { var v = a3.Value; });
+            var getValueA4 = new TestDelegate(() => { var v = a4.Value; });
 
-                Assert.Throws(typeof(InvalidOperationException), getValueA1);
-                Assert.Throws(typeof(InvalidOperationException), getValueA2);
-                Assert.Throws(typeof(InvalidOperationException), getValueA3);
-                Assert.Throws(typeof(InvalidOperationException), getValueA4);
-            }
+            Assert.Throws(typeof(InvalidOperationException), getValueA1);
+            Assert.Throws(typeof(InvalidOperationException), getValueA2);
+            Assert.Throws(typeof(InvalidOperationException), getValueA3);
+            Assert.Throws(typeof(InvalidOperationException), getValueA4);
         }
 
         [Test]
         public void CircularReferenceRecalculationNeededDoesNotFail()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
 
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=A3*10";
-                var _ = a4.Value;
-                a1.FormulaA1 = "=SUM(A2:A4)";
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=A3*10";
+            var _ = a4.Value;
+            a1.FormulaA1 = "=SUM(A2:A4)";
 
-                var recalcNeededA1 = a1.NeedsRecalculation;
-                var recalcNeededA2 = a2.NeedsRecalculation;
-                var recalcNeededA3 = a3.NeedsRecalculation;
-                var recalcNeededA4 = a4.NeedsRecalculation;
+            var recalcNeededA1 = a1.NeedsRecalculation;
+            var recalcNeededA2 = a2.NeedsRecalculation;
+            var recalcNeededA3 = a3.NeedsRecalculation;
+            var recalcNeededA4 = a4.NeedsRecalculation;
 
-                Assert.IsTrue(recalcNeededA1);
-                Assert.IsTrue(recalcNeededA2);
-                Assert.IsTrue(recalcNeededA3);
-                Assert.IsTrue(recalcNeededA4);
-            }
+            Assert.IsTrue(recalcNeededA1);
+            Assert.IsTrue(recalcNeededA2);
+            Assert.IsTrue(recalcNeededA3);
+            Assert.IsTrue(recalcNeededA4);
         }
 
         [Test]
         public void DeleteWorksheetInvalidatesValues()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet1 = wb.Worksheets.Add("Sheet1");
-                var sheet2 = wb.Worksheets.Add("Sheet2");
-                var sheet1_a1 = sheet1.Cell("A1");
-                var sheet2_a1 = sheet2.Cell("A1");
-                sheet1_a1.FormulaA1 = "Sheet2!A1";
-                sheet2_a1.Value = "TestValue";
+            using var wb = new XLWorkbook();
+            var sheet1 = wb.Worksheets.Add("Sheet1");
+            var sheet2 = wb.Worksheets.Add("Sheet2");
+            var sheet1_a1 = sheet1.Cell("A1");
+            var sheet2_a1 = sheet2.Cell("A1");
+            sheet1_a1.FormulaA1 = "Sheet2!A1";
+            sheet2_a1.Value = "TestValue";
 
-                var val1 = sheet1_a1.Value;
-                sheet2.Delete();
-                var getValue = new TestDelegate(() => { var val2 = sheet1_a1.Value; });
+            var val1 = sheet1_a1.Value;
+            sheet2.Delete();
+            var getValue = new TestDelegate(() => { var val2 = sheet1_a1.Value; });
 
-                Assert.AreEqual("TestValue", val1.ToString());
-                Assert.Throws(typeof(ArgumentOutOfRangeException), getValue);
-            }
+            Assert.AreEqual("TestValue", val1.ToString());
+            Assert.Throws(typeof(ArgumentOutOfRangeException), getValue);
         }
 
         [Test]
         public void TestValueCellsCachedValue()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
 
-                var date = new DateTime(2018, 4, 19); ;
-                cell.Value = date;
+            var date = new DateTime(2018, 4, 19); ;
+            cell.Value = date;
 
-                Assert.AreEqual(XLDataType.DateTime, cell.DataType);
-                Assert.AreEqual(date, cell.CachedValue);
+            Assert.AreEqual(XLDataType.DateTime, cell.DataType);
+            Assert.AreEqual(date, cell.CachedValue);
 
-                cell.DataType = XLDataType.Number;
+            cell.DataType = XLDataType.Number;
 
-                Assert.AreEqual(XLDataType.Number, cell.DataType);
-                Assert.AreEqual(date.ToOADate(), cell.CachedValue);
-            }
+            Assert.AreEqual(XLDataType.Number, cell.DataType);
+            Assert.AreEqual(date.ToOADate(), cell.CachedValue);
         }
 
         [Test]
         public void CachedValueToExternalWorkbook()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\ExternalLinks\WorkbookWithExternalLink.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                var cell = ws.Cell("B2");
-                Assert.IsFalse(cell.NeedsRecalculation);
-                Assert.IsTrue(cell.HasFormula);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\ExternalLinks\WorkbookWithExternalLink.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            var cell = ws.Cell("B2");
+            Assert.IsFalse(cell.NeedsRecalculation);
+            Assert.IsTrue(cell.HasFormula);
 
-                // This will fail when we start supporting external links
-                Assert.IsTrue(cell.FormulaA1.StartsWith("[1]"));
+            // This will fail when we start supporting external links
+            Assert.IsTrue(cell.FormulaA1.StartsWith("[1]"));
 
-                Assert.AreEqual("hello world", cell.CachedValue);
-                Assert.AreEqual("hello world", cell.Value);
+            Assert.AreEqual("hello world", cell.CachedValue);
+            Assert.AreEqual("hello world", cell.Value);
 
-                Assert.AreEqual(11, ws.Evaluate("LEN(B2)"));
+            Assert.AreEqual(11, ws.Evaluate("LEN(B2)"));
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => wb.RecalculateAllFormulas());
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => wb.RecalculateAllFormulas());
         }
 
         [Test]
         public void ChangingDataTypeChangesCachedValue()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Test");
-                ws.Cell(1, 1).Value = new DateTime(2019, 1, 1, 14, 0, 0);
-                ws.Cell(1, 2).Value = new DateTime(2019, 1, 1, 17, 45, 0);
-                var cell = ws.Cell(1, 3);
-                cell.FormulaA1 = "=B1-A1";
-                cell.Style.DateFormat.Format = "hh:mm";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Test");
+            ws.Cell(1, 1).Value = new DateTime(2019, 1, 1, 14, 0, 0);
+            ws.Cell(1, 2).Value = new DateTime(2019, 1, 1, 17, 45, 0);
+            var cell = ws.Cell(1, 3);
+            cell.FormulaA1 = "=B1-A1";
+            cell.Style.DateFormat.Format = "hh:mm";
 
-                Assert.IsNull(cell.CachedValue);
+            Assert.IsNull(cell.CachedValue);
 
-                double value = (double)cell.Value;
-                Assert.AreEqual(value, cell.CachedValue);
+            double value = (double)cell.Value;
+            Assert.AreEqual(value, cell.CachedValue);
 
-                cell.DataType = XLDataType.DateTime;
-                Assert.AreEqual(DateTime.FromOADate(value), cell.CachedValue);
-                Assert.AreEqual("03:45", cell.GetFormattedString());
+            cell.DataType = XLDataType.DateTime;
+            Assert.AreEqual(DateTime.FromOADate(value), cell.CachedValue);
+            Assert.AreEqual("03:45", cell.GetFormattedString());
 
-                cell.DataType = XLDataType.Number;
-                Assert.AreEqual(value, (double)cell.CachedValue, 1e-10);
-                Assert.AreEqual("0.15625", cell.GetFormattedString());
+            cell.DataType = XLDataType.Number;
+            Assert.AreEqual(value, (double)cell.CachedValue, 1e-10);
+            Assert.AreEqual("0.15625", cell.GetFormattedString());
 
-                cell.DataType = XLDataType.TimeSpan;
-                Assert.AreEqual(TimeSpan.FromDays(value), (TimeSpan)cell.CachedValue);
-                Assert.AreEqual("03:45:00", cell.GetFormattedString()); // I think the seconds in this string is due to a shortcoming in the ExcelNumberFormat library
-            }
+            cell.DataType = XLDataType.TimeSpan;
+            Assert.AreEqual(TimeSpan.FromDays(value), (TimeSpan)cell.CachedValue);
+            Assert.AreEqual("03:45:00", cell.GetFormattedString()); // I think the seconds in this string is due to a shortcoming in the ExcelNumberFormat library
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/PrecedentCellsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/PrecedentCellsTests.cs
@@ -11,75 +11,63 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void GetPrecedentRangesPreventsDuplication()
         {
-            using (var ms = new MemoryStream())
-            {
-                using (XLWorkbook wb = new XLWorkbook())
-                {
-                    var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
-                    var sheet2 = wb.AddWorksheet("Sheet2");
-                    var formula = "=MAX(A2:E2)/COUNTBLANK(A2:E2)*MAX(B1:C3)+SUM(Sheet2!B1:C3)+SUM($A$2:$E$2)+A2+B$2+$C$2";
+            using var ms = new MemoryStream();
+            using XLWorkbook wb = new XLWorkbook();
+            var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+            var sheet2 = wb.AddWorksheet("Sheet2");
+            var formula = "=MAX(A2:E2)/COUNTBLANK(A2:E2)*MAX(B1:C3)+SUM(Sheet2!B1:C3)+SUM($A$2:$E$2)+A2+B$2+$C$2";
 
-                    var ranges = sheet1.CalcEngine.GetPrecedentRanges(formula);
+            var ranges = sheet1.CalcEngine.GetPrecedentRanges(formula);
 
-                    Assert.AreEqual(6, ranges.Count());
-                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "A2:E2"));
-                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "B1:C3"));
-                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet2" && r.RangeAddress.ToString() == "B1:C3"));
-                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "A2:A2"));
-                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "B$2:B$2"));
-                    Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "$C$2:$C$2"));
-                }
-            }
+            Assert.AreEqual(6, ranges.Count());
+            Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "A2:E2"));
+            Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "B1:C3"));
+            Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet2" && r.RangeAddress.ToString() == "B1:C3"));
+            Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "A2:A2"));
+            Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "B$2:B$2"));
+            Assert.IsTrue(ranges.Any(r => r.RangeAddress.Worksheet.Name == "Sheet1" && r.RangeAddress.ToString() == "$C$2:$C$2"));
         }
 
         [Test]
         public void GetPrecedentRangesDealsWithNamedRanges()
         {
-            using (var ms = new MemoryStream())
-            {
-                using (XLWorkbook wb = new XLWorkbook())
-                {
-                    var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
-                    sheet1.NamedRanges.Add("NAMED_RANGE", sheet1.Range("A2:B3"));
-                    var formula = "=SUM(NAMED_RANGE)";
+            using var ms = new MemoryStream();
+            using XLWorkbook wb = new XLWorkbook();
+            var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+            sheet1.NamedRanges.Add("NAMED_RANGE", sheet1.Range("A2:B3"));
+            var formula = "=SUM(NAMED_RANGE)";
 
-                    var ranges = sheet1.CalcEngine.GetPrecedentRanges(formula);
+            var ranges = sheet1.CalcEngine.GetPrecedentRanges(formula);
 
-                    Assert.AreEqual(1, ranges.Count());
-                    Assert.AreEqual("$A$2:$B$3", ranges.First().RangeAddress.ToString());
-                }
-            }
+            Assert.AreEqual(1, ranges.Count());
+            Assert.AreEqual("$A$2:$B$3", ranges.First().RangeAddress.ToString());
         }
 
         [Test]
         public void GetPrecedentCells()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using XLWorkbook wb = new XLWorkbook();
+            var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+            var sheet2 = wb.AddWorksheet("Sheet2");
+            var formula = "=MAX(A2:E2)/COUNTBLANK(A2:E2)*MAX(B1:C3)+SUM(Sheet2!B1:C3)+SUM($A$2:$E$2)+A2+B$2+$C$2";
+            var expectedAtSheet1 = new string[]
+                { "A2", "B2", "C2", "D2", "E2", "B1", "C1", "B3", "C3" };
+            var expectedAtSheet2 = new string[]
+                { "B1", "C1", "B2", "C2", "B3", "C3" };
+
+            var cells = sheet1.CalcEngine.GetPrecedentCells(formula);
+
+            Assert.AreEqual(15, cells.Count());
+            foreach (var address in expectedAtSheet1)
             {
-                using (XLWorkbook wb = new XLWorkbook())
-                {
-                    var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
-                    var sheet2 = wb.AddWorksheet("Sheet2");
-                    var formula = "=MAX(A2:E2)/COUNTBLANK(A2:E2)*MAX(B1:C3)+SUM(Sheet2!B1:C3)+SUM($A$2:$E$2)+A2+B$2+$C$2";
-                    var expectedAtSheet1 = new string[]
-                        { "A2", "B2", "C2", "D2", "E2", "B1", "C1", "B3", "C3" };
-                    var expectedAtSheet2 = new string[]
-                        { "B1", "C1", "B2", "C2", "B3", "C3" };
-
-                    var cells = sheet1.CalcEngine.GetPrecedentCells(formula);
-
-                    Assert.AreEqual(15, cells.Count());
-                    foreach (var address in expectedAtSheet1)
-                    {
-                        Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet1.Name && cell.Address.ToString() == address),
-                            string.Format("Address {0}!{1} is not presented", sheet1.Name, address));
-                    }
-                    foreach (var address in expectedAtSheet2)
-                    {
-                        Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet2.Name && cell.Address.ToString() == address),
-                            string.Format("Address {0}!{1} is not presented", sheet2.Name, address));
-                    }
-                }
+                Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet1.Name && cell.Address.ToString() == address),
+                    string.Format("Address {0}!{1} is not presented", sheet1.Name, address));
+            }
+            foreach (var address in expectedAtSheet2)
+            {
+                Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet2.Name && cell.Address.ToString() == address),
+                    string.Format("Address {0}!{1} is not presented", sheet2.Name, address));
             }
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/PrecedentCellsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/PrecedentCellsTests.cs
@@ -46,7 +46,6 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void GetPrecedentCells()
         {
-            using var ms = new MemoryStream();
             using XLWorkbook wb = new XLWorkbook();
             var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
             var sheet2 = wb.AddWorksheet("Sheet2");
@@ -56,18 +55,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var expectedAtSheet2 = new string[]
                 { "B1", "C1", "B2", "C2", "B3", "C3" };
 
-            var cells = sheet1.CalcEngine.GetPrecedentCells(formula);
+            var cells = sheet1.CalcEngine.GetPrecedentObjects(formula).OfType<XLCell>();
 
             Assert.AreEqual(15, cells.Count());
             foreach (var address in expectedAtSheet1)
             {
                 Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet1.Name && cell.Address.ToString() == address),
-                    string.Format("Address {0}!{1} is not presented", sheet1.Name, address));
+                    $"Address {sheet1.Name}!{address} is not presented");
             }
             foreach (var address in expectedAtSheet2)
             {
                 Assert.IsTrue(cells.Any(cell => cell.Address.Worksheet.Name == sheet2.Name && cell.Address.ToString() == address),
-                    string.Format("Address {0}!{1} is not presented", sheet2.Name, address));
+                    $"Address {sheet2.Name}!{address} is not presented");
             }
         }
 
@@ -80,9 +79,28 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 var ws2 = wb.AddWorksheet("Worksheet!");
                 var expectedCell = ws2.Cell("B2");
 
-                var cells = ws1.CalcEngine.GetPrecedentCells("='Worksheet!'!B2*2");
+                var cells = ws1.CalcEngine.GetPrecedentObjects("='Worksheet!'!B2*2").OfType<XLCell>();
                 Assert.AreSame(expectedCell, cells.Single());
             }
+        }
+
+        [Test]
+        public void GetPrecedentNamedRanges()
+        {
+            using XLWorkbook wb = new XLWorkbook();
+            var sheet1 = wb.AddWorksheet("Sheet1") as XLWorksheet;
+            var sheet2 = wb.AddWorksheet("Sheet2");
+            sheet1.Range("B1:B2").AddToNamed("Named1", XLScope.Workbook);
+            sheet1.Range("D1:D2").AddToNamed("Named2", XLScope.Worksheet);
+            sheet2.Range("D1:D3").AddToNamed("Named3", XLScope.Worksheet);
+
+            var formula = "=SUM(Named1)+SUMPRODUCT(Named2, Sheet2!Named3)";
+
+            var precedentRanges = sheet1.CalcEngine.GetPrecedentObjects(formula).OfType<XLNamedRange>().ToList();
+            Assert.AreEqual(3, precedentRanges.Count());
+            Assert.True(precedentRanges.Any(nr => nr.Name == "Named1"));
+            Assert.True(precedentRanges.Any(nr => nr.Name == "Named2"));
+            Assert.True(precedentRanges.Any(nr => nr.Name == "Named3"));
         }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -37,7 +37,6 @@ namespace ClosedXML.Excel.CalcEngine
         private Dictionary<string, object> _vars;       // table with variables
         private object _dataContext;                    // object with properties
         private bool _optimize;                         // optimize expressions when parsing
-        protected ExpressionCache _cache;               // cache with parsed expressions
         private CultureInfo _ci;                        // culture info used to parse numbers/dates
         private char _decimal, _listSep, _percent;      // localized decimal separator, list separator, percent sign
 
@@ -53,7 +52,6 @@ namespace ClosedXML.Excel.CalcEngine
             _tkTbl = GetSymbolTable();
             _fnTbl = GetFunctionTable();
             _vars = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-            _cache = new ExpressionCache(this);
             _optimize = true;
 #if DEBUG
             //this.Test();
@@ -118,28 +116,8 @@ namespace ClosedXML.Excel.CalcEngine
         /// </remarks>
         public object Evaluate(string expression)
         {
-            var x = _cache != null
-                    ? _cache[expression]
-                    : Parse(expression);
+            var x = Parse(expression);
             return x.Evaluate();
-        }
-
-        /// <summary>
-        /// Gets or sets whether the calc engine should keep a cache with parsed
-        /// expressions.
-        /// </summary>
-        public bool CacheExpressions
-        {
-            get { return _cache != null; }
-            set
-            {
-                if (value != CacheExpressions)
-                {
-                    _cache = value
-                        ? new ExpressionCache(this)
-                        : null;
-                }
-            }
         }
 
         /// <summary>

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -967,7 +967,7 @@ namespace ClosedXML.Excel.CalcEngine
                     {
                         if (c.HasFormula)
                         {
-                            var expression = ce.ExpressionCache[c.FormulaA1];
+                            var expression = ce.Parse(c.FormulaA1);
                             return !hasSubtotalInFormula(expression);
                         }
                         else

--- a/ClosedXML/Excel/CalcEngine/IXLVersionable.cs
+++ b/ClosedXML/Excel/CalcEngine/IXLVersionable.cs
@@ -1,0 +1,11 @@
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// An interface for marking entities that track <see cref="XLWorkbook.RecalculationCounter"/> when modified.
+    /// Serves for determining when <see cref="XLCell.CachedValue"/> has to be re-evaluated.
+    /// </summary>
+    internal interface IXLVersionable
+    {
+        long ModifiedAtVersion { get; }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -27,8 +27,6 @@ namespace ClosedXML.Excel.CalcEngine
 
         private IList<IXLRange> _cellRanges;
 
-        public ExpressionCache ExpressionCache => this._cache;
-
         /// <summary>
         /// Get a collection of cell ranges included into the expression. Order is not preserved.
         /// </summary>

--- a/ClosedXML/Excel/CalcEngine/XLCellByAddressComparer.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCellByAddressComparer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    internal class XLCellByAddressComparer : IEqualityComparer<IXLCell>
+    {
+        private readonly XLAddressComparer _addressComparer;
+
+        public XLCellByAddressComparer()
+        {
+            _addressComparer = new XLAddressComparer(true);
+        }
+
+        public bool Equals(IXLCell x, IXLCell y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+
+            if (ReferenceEquals(x, null) ||
+                ReferenceEquals(y, null))
+                return false;
+
+            return _addressComparer.Equals(x.Address, y.Address);
+        }
+
+        public int GetHashCode(IXLCell obj)
+        {
+            return _addressComparer.GetHashCode(obj.Address);
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/XLRangeByAddressComparer.cs
+++ b/ClosedXML/Excel/CalcEngine/XLRangeByAddressComparer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    internal class XLRangeByAddressComparer : IEqualityComparer<IXLRange>
+    {
+        private readonly XLRangeAddressComparer _rangeAddressComparer;
+
+        public XLRangeByAddressComparer()
+        {
+            _rangeAddressComparer = new XLRangeAddressComparer(true);
+        }
+
+        public bool Equals(IXLRange x, IXLRange y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+
+            if (ReferenceEquals(x, null) ||
+                ReferenceEquals(y, null))
+                return false;
+
+            return _rangeAddressComparer.Equals(x.RangeAddress, y.RangeAddress);
+        }
+
+        public int GetHashCode(IXLRange obj)
+        {
+            return _rangeAddressComparer.GetHashCode(obj.RangeAddress);
+        }
+    }
+}

--- a/ClosedXML/Excel/NamedRanges/XLNamedRanges.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRanges.cs
@@ -105,6 +105,7 @@ namespace ClosedXML.Excel
 
             var namedRange = new XLNamedRange(this, rangeName, validateName, rangeAddress, comment);
             _namedRanges.Add(rangeName, namedRange);
+            Workbook.InvalidateFormulas();
             return namedRange;
         }
 
@@ -118,28 +119,33 @@ namespace ClosedXML.Excel
         {
             var namedRange = new XLNamedRange(this, rangeName, ranges, comment);
             _namedRanges.Add(rangeName, namedRange);
+            Workbook.InvalidateFormulas();
             return namedRange;
         }
 
         public IXLNamedRange Add(String rangeName, IXLNamedRange namedRange)
         {
             _namedRanges.Add(rangeName, namedRange);
+            Workbook.InvalidateFormulas();
             return namedRange;
         }
 
         public void Delete(String rangeName)
         {
             _namedRanges.Remove(rangeName);
+            Workbook.InvalidateFormulas();
         }
 
         public void Delete(Int32 rangeIndex)
         {
             _namedRanges.Remove(_namedRanges.ElementAt(rangeIndex).Key);
+            Workbook.InvalidateFormulas();
         }
 
         public void DeleteAll()
         {
             _namedRanges.Clear();
+            Workbook.InvalidateFormulas();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1536 

Previously, when checking if cell cached value has to be recalculated, we only analyzed precedent cells. But if a formula uses named ranges and they start to point to another location, the cached value was not properly invalidated. Now, instead of `PrecedentCells`, we obtain a collection consisting of named ranges and cells (under `IXLVersionable` interface) that affect the current cell. 

I also had to remove `ExpressionCache` from `CalcEngine` because it might store a reference to the old range after a named range was modified.