### PR TITLE
add null check to ProcessRangeRemoved

### DIFF
--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -254,7 +254,10 @@ namespace ClosedXML.Excel
             var entry = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress) range.RangeAddress)
                 .SingleOrDefault(e => Equals(e.RangeAddress, range.RangeAddress));
 
-            _dataValidationIndex.Remove(entry.RangeAddress);
+            if (entry != null)
+            {
+                _dataValidationIndex.Remove(entry.RangeAddress);
+            }
         }
 
         /// <summary>

--- a/ClosedXML_Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML_Tests/Excel/Saving/SavingTests.cs
@@ -656,5 +656,31 @@ namespace ClosedXML_Tests.Excel.Saving
             }
 
         }
+
+        [Test]
+        public void CanSaveAsWithDataValidationAfterInsertFirstRowsAboveAndInsertFirstColumnsBefore()
+        {
+            using (var wb = new XLWorkbook())
+            using (var ms = new MemoryStream())
+            {
+                var ws = wb.AddWorksheet("WithDataValidation");
+                ws.Range("B4:B4").SetDataValidation().WholeNumber.Between(0, 1);
+
+                ws.Row(1).InsertRowsAbove(1);
+                var dv = ws.DataValidations.ToArray();
+                Assert.AreEqual(1, dv.Length);
+                Assert.AreEqual("B5:B5", dv[0].Ranges.Single().RangeAddress.ToString());
+
+                Assert.DoesNotThrow(() => wb.SaveAs(ms));
+
+
+                ws.Column(1).InsertColumnsBefore(1);
+                dv = ws.DataValidations.ToArray();
+                Assert.AreEqual(1, dv.Length);
+                Assert.AreEqual("C5:C5", dv[0].Ranges.Single().RangeAddress.ToString());
+
+                Assert.DoesNotThrow(() => wb.SaveAs(ms));
+            }
+        }
     }
 }


### PR DESCRIPTION
XLDataValidations.ProcessRangeRemoved () throws a NullReferenceException when adding a row above a cell that has data validation set.
As a solution, I added a null check.