### PR TITLE
Add chart export function

### DIFF
--- a/ClosedXML/Excel/Charts/ChartAxis.cs
+++ b/ClosedXML/Excel/Charts/ChartAxis.cs
@@ -1,0 +1,45 @@
+using System;
+using DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace ClosedXML.Excel.Charts
+{
+    public class ChartAxis
+    {
+        private static UInt32 s_uniqueId = 1;
+
+        public String Name { get; set; }
+        public ChartAxisType Type { get; set; }
+        public ChartAxis RelatedAxis { get; set; }
+        public bool Invisible { get; set; }
+        public AxisPositionValues Position { get; set; }
+        public double? MinValue { get; set; }
+        public double? MaxValue { get; set; }
+
+        public bool InvertOrientation { get; set; }
+        public int TickMark { get; set; }
+        public bool CrossMax { get; set; }
+
+        public CrossBetweenValues CrossBetween { get; set; }
+
+        private UInt32 m_UniqueId { get; set; }
+        internal UInt32 Id
+        {
+            get
+            {
+                if (m_UniqueId == 0)
+                    m_UniqueId = s_uniqueId++;
+                return m_UniqueId;
+            }
+        }
+
+        public enum ChartAxisType
+        {
+            Undefined,
+            Category,
+            ValuePercent100WithAllTickmarks,
+            ValueGeneric,
+            FakeCategory,
+            ValueDifference,
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartGenerator.cs
+++ b/ClosedXML/Excel/Charts/ChartGenerator.cs
@@ -263,6 +263,10 @@ namespace ClosedXML.Excel.Charts
             SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
             pieSeries.Append(seriesText);
 
+            //User Color
+            if(seriesData.HexColor != null)
+                pieSeries.Append(ChartStyle.SetHexColor(seriesData.HexColor));
+
             //DataLabel
             DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
             pieSeries.Append(dataLabels);
@@ -391,6 +395,10 @@ namespace ClosedXML.Excel.Charts
             SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
             barChartSeries.Append(seriesText);
 
+            //User Color
+            if(seriesData.HexColor != null)
+                barChartSeries.Append(ChartStyle.SetHexColor(seriesData.HexColor));
+
             //TODO
             InvertIfNegative invertIfNegative = new InvertIfNegative { Val = false };
             barChartSeries.Append(invertIfNegative);
@@ -464,7 +472,7 @@ namespace ClosedXML.Excel.Charts
 
             var r = new Run();
             var rPr = new RunProperties() { Language = "de-DE" };
-            var t = new Text(chartXl.ChartType == XLChartType.Pie ? chartXl.GetSeries(0).SeriesName.Value : title);
+            var t = new Text(chartXl.ChartType == XLChartType.Pie ? title + "\n" + chartXl.GetSeries(0).SeriesName.Value : title);
             r.Append(rPr); r.Append(t);
 
             paragraph.Append(r);
@@ -542,6 +550,11 @@ namespace ClosedXML.Excel.Charts
         private static void AddColorFill(this OpenXmlElement element, ChartSeriesData seriesData)
         {
             SolidFill solidFill = new SolidFill();
+            if(seriesData.HexColor != null)
+            {
+                RgbColorModelHex rgbColorModelHex = new RgbColorModelHex() { Val = seriesData.HexColor };
+                solidFill.Append(rgbColorModelHex);
+            }
 
             ChartShapeProperties chartShapeProperties = new ChartShapeProperties();
 

--- a/ClosedXML/Excel/Charts/ChartGenerator.cs
+++ b/ClosedXML/Excel/Charts/ChartGenerator.cs
@@ -1,0 +1,561 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Drawing;
+using System.Linq;
+using Xdr = DocumentFormat.OpenXml.Drawing.Spreadsheet;
+using System;
+
+namespace ClosedXML.Excel.Charts
+{
+    public static class ChartGenerator
+    {
+        public static RadarChart CreateRadarChart(XLChart chartData)
+        {
+            var radarStyleValue = RadarStyleValues.Marker;
+            if (chartData.HasFill)
+                radarStyleValue = RadarStyleValues.Filled;
+            RadarChart radarChart = new RadarChart();
+
+            RadarStyle radarStyle = new RadarStyle { Val = radarStyleValue };
+            radarChart.Append(radarStyle);
+
+            VaryColors varyColors = new VaryColors { Val = false };
+            radarChart.Append(varyColors);
+
+            ChartAxis xAxis = null;
+            ChartAxis yAxis = null;
+            foreach (var series in chartData.Series)
+            {
+                if (series.SeriesType == ChartSeriesType.Scatter || series.SeriesType == ChartSeriesType.Radar)
+                {
+                    var scatterChartSeries = GenerateRadarChartSeries(series, chartData.TableReferenced);
+                    radarChart.Append(scatterChartSeries);
+                    xAxis = series.XAxis;
+                    yAxis = series.YAxis;
+                }
+            }
+
+            AxisId axisId1 = new AxisId { Val = xAxis.Id };
+            AxisId axisId2 = new AxisId { Val = yAxis.Id };
+            radarChart.Append(axisId1);
+            radarChart.Append(axisId2);
+
+            return radarChart;
+
+        }
+
+        public static OpenXmlElement CreatePieChart(XLChart chartData, OpenXmlElement chart)
+        {
+            VaryColors varyColors = new VaryColors { Val = true };
+            chart.Append(varyColors);
+
+            foreach (var series in chartData.Series)
+            {
+                if (series.SeriesType == ChartSeriesType.Pie)
+                {
+                    var pieSeries = GeneratePieChartSeries(series, chartData.TableReferenced);
+                    chart.Append(pieSeries);
+                }
+            }
+
+            chart.Append(new FirstSliceAngle() { Val = 0 });
+
+            if (chart is DoughnutChart)
+                chart.Append(new HoleSize() { Val = 50 });
+
+            return chart;
+        }
+
+        public static ScatterChart CreateScatterChart(XLChart chartData)
+        {
+            ScatterChart scatterChart = new ScatterChart();
+
+            ScatterStyle scatterStyle = new ScatterStyle { Val = ScatterStyleValues.LineMarker };
+            scatterChart.Append(scatterStyle);
+
+            VaryColors varyColors = new VaryColors { Val = false };
+            scatterChart.Append(varyColors);
+
+            ChartAxis xAxis = null;
+            ChartAxis yAxis = null;
+            foreach (var series in chartData.Series)
+            {
+                if (series.SeriesType == ChartSeriesType.Scatter)
+                {
+                    var scatterChartSeries = GenerateScatterChartSeries(series, chartData.TableReferenced);
+                    scatterChart.Append(scatterChartSeries);
+                    xAxis = series.XAxis;
+                    yAxis = series.YAxis;
+                }
+            }
+
+            AxisId axisId1 = new AxisId { Val = xAxis.Id };
+            AxisId axisId2 = new AxisId { Val = yAxis.Id };
+            scatterChart.Append(axisId1);
+            scatterChart.Append(axisId2);
+
+            return scatterChart;
+        }
+
+        public static AreaChart CreateAreaChart(XLChart chartData, GroupingValues groupingValue)
+        {
+            AreaChart areaChart = new AreaChart();
+
+            Grouping grouping = new Grouping { Val = groupingValue };
+            areaChart.Append(grouping);
+
+            VaryColors varyColors = new VaryColors { Val = false };
+            areaChart.Append(varyColors);
+
+            ChartAxis xAxis = null;
+            ChartAxis yAxis = null;
+            foreach (var series in chartData.Series)
+            {
+                if (series.SeriesType == ChartSeriesType.Area)
+                {
+                    var areaChartSeries = GenerateAreaChartSeries(series, chartData.TableReferenced);
+                    areaChart.Append(areaChartSeries);
+                    xAxis = series.XAxis;
+                    yAxis = series.YAxis;
+                }
+            }
+
+            AxisId axisId1 = new AxisId { Val = xAxis.Id };
+            AxisId axisId2 = new AxisId { Val = yAxis.Id };
+            areaChart.Append(axisId1);
+            areaChart.Append(axisId2);
+
+            return areaChart;
+        }
+
+        public static LineChart CreateLineChart(XLChart chartData)
+        {
+            LineChart lineChart = new LineChart();
+
+            Grouping grouping = new Grouping() { Val = GroupingValues.Standard };
+            lineChart.Append(grouping);
+
+            VaryColors varyColors = new VaryColors { Val = false };
+            lineChart.Append(varyColors);
+
+            ChartAxis xAxis = null;
+            ChartAxis yAxis = null;
+            foreach (var series in chartData.Series)
+            {
+                if (series.SeriesType == ChartSeriesType.Line)
+                {
+                    var lineChartSeries = GenerateLineChartSeries(series, chartData.TableReferenced);
+                    lineChart.Append(lineChartSeries);
+                    xAxis = series.XAxis;
+                    yAxis = series.YAxis;
+                }
+            }
+
+            ShowMarker showMarker = new ShowMarker { Val = chartData.ShowMarkers };
+            lineChart.Append(showMarker);
+
+            Smooth smooth = new Smooth { Val = false };
+            lineChart.Append(smooth);
+
+            AxisId axisId1 = new AxisId { Val = xAxis.Id };
+            AxisId axisId2 = new AxisId { Val = yAxis.Id };
+            lineChart.Append(axisId1);
+            lineChart.Append(axisId2);
+
+            return lineChart;
+        }
+
+        public static BarChart CreateBarChart(XLChart chartData, BarDirectionValues direction, ChartSeriesType type, BarGroupingValues grouping)
+        {
+            BarChart barChart = new BarChart();
+
+            BarDirection barDirection = new BarDirection { Val = direction };
+            barChart.Append(barDirection);
+
+            BarGrouping barGrouping = new BarGrouping { Val = grouping };
+            barChart.Append(barGrouping);
+
+            VaryColors varyColors = new VaryColors { Val = false };
+            barChart.Append(varyColors);
+
+            ChartAxis xAxis = null;
+            ChartAxis yAxis = null;
+            foreach (var serie in chartData.Series)
+            {
+                var barChartSeries = GenerateBarChartSeries(serie, chartData.TableReferenced);
+                barChart.Append(barChartSeries);
+                xAxis = serie.XAxis;
+                yAxis = serie.YAxis;
+            }
+
+            if (chartData.SecondaryValueAxisEnabled)
+            {
+                GapWidth gapWidth = new GapWidth { Val = (ushort)219U };
+                barChart.Append(gapWidth);
+
+                Overlap overlap = new Overlap { Val = -27 };
+                barChart.Append(overlap);
+            }
+            else
+            {
+                GapWidth gapWidth = new GapWidth { Val = (UInt16)150U };
+                barChart.Append(gapWidth);
+
+                Overlap overlap = new Overlap { Val = 100 };
+                barChart.Append(overlap);
+            }
+
+            AxisId axisId1 = new AxisId { Val = xAxis.Id };
+            AxisId axisId2 = new AxisId { Val = yAxis.Id };
+            barChart.Append(axisId1);
+            barChart.Append(axisId2);
+
+            return barChart;
+        }
+
+        private static RadarChartSeries GenerateRadarChartSeries(ChartSeriesData seriesData, bool tableReferenced)
+        {
+            RadarChartSeries radarChartSeries = new RadarChartSeries();
+
+            radarChartSeries.AddIndexAndOrder(seriesData);
+
+            // Series text
+            SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
+            radarChartSeries.Append(seriesText);
+
+            radarChartSeries.AddNoFill(seriesData);
+            //Lines
+            if (!seriesData.HasNoFill)
+                radarChartSeries.AddColorFill(seriesData);
+
+            //SeriesMarker
+            if (seriesData.ShowMarkers)
+            {
+                radarChartSeries.Append(ChartStyle.AddMarker(seriesData));
+            }
+            else
+            {
+                radarChartSeries.Append(ChartStyle.AddNoMarker());
+            }
+
+            //DataLabel
+            DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
+            radarChartSeries.Append(dataLabels);
+
+            //CategoryData
+            CategoryAxisData categoryAxisData = tableReferenced ? ChartPartGenerator.GenerateReferencedCategoryAxisData(seriesData) : ChartPartGenerator.GenerateCategoryAxisData(seriesData);
+            radarChartSeries.Append(categoryAxisData);
+
+            //ValueData
+            Values values = tableReferenced ? ChartPartGenerator.GenerateReferencedValues(seriesData) : ChartPartGenerator.GenerateValues(seriesData);
+            radarChartSeries.Append(values);
+
+            return radarChartSeries;
+        }
+
+        private static PieChartSeries GeneratePieChartSeries(ChartSeriesData seriesData, bool tableReferenced)
+        {
+            PieChartSeries pieSeries = new PieChartSeries();
+            pieSeries.AddIndexAndOrder(seriesData);
+
+            // Series text
+            SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
+            pieSeries.Append(seriesText);
+
+            //DataLabel
+            DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
+            pieSeries.Append(dataLabels);
+
+            // Category data
+            CategoryAxisData categoryAxisData = tableReferenced ? ChartPartGenerator.GenerateReferencedCategoryAxisData(seriesData) : ChartPartGenerator.GenerateCategoryAxisData(seriesData);
+            pieSeries.Append(categoryAxisData);
+
+            // Value data
+            Values values = tableReferenced ? ChartPartGenerator.GenerateReferencedValues(seriesData) : ChartPartGenerator.GenerateValues(seriesData);
+            pieSeries.Append(values);
+
+
+            return pieSeries;
+        }
+
+        private static ScatterChartSeries GenerateScatterChartSeries(ChartSeriesData seriesData, bool tableReferenced)
+        {
+            ScatterChartSeries scatterChartSeries = new ScatterChartSeries();
+
+            scatterChartSeries.AddIndexAndOrder(seriesData);
+
+            // Series text
+            SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
+            scatterChartSeries.Append(seriesText);
+
+            //Lines
+            ChartShapeProperties chartShapeProperties = new ChartShapeProperties();
+
+            Outline outline = new Outline() { Width = 19050 /*25400, CapType = LineCapValues.Round*/ };
+            outline.Append(new NoFill());
+
+            chartShapeProperties.Append(outline);
+            scatterChartSeries.Append(chartShapeProperties);
+
+            //SeriesMarker
+            scatterChartSeries.Append(ChartStyle.AddMarker(seriesData));
+
+            //DataLabels
+            DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
+            scatterChartSeries.Append(dataLabels);
+
+            //ValueData
+            scatterChartSeries.Append(tableReferenced ? ChartPartGenerator.GenerateReferencedXValues(seriesData) : ChartPartGenerator.GenerateXValues(seriesData));
+            scatterChartSeries.Append(tableReferenced ? ChartPartGenerator.GenerateReferencedYValues(seriesData) : ChartPartGenerator.GenerateYValues(seriesData));
+
+            //Line Smoothing
+            Smooth smooth = new Smooth { Val = seriesData.IsSmoothLine };
+            scatterChartSeries.Append(smooth);
+
+            return scatterChartSeries;
+        }
+
+        private static AreaChartSeries GenerateAreaChartSeries(ChartSeriesData seriesData, bool tableReferenced)
+        {
+            AreaChartSeries areaChartSeries = new AreaChartSeries();
+
+            areaChartSeries.AddIndexAndOrder(seriesData);
+
+            // Series text
+            SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
+            areaChartSeries.Append(seriesText);
+
+            areaChartSeries.AddNoFill(seriesData);
+            if (!seriesData.HasNoFill)
+                areaChartSeries.AddColorFill(seriesData);
+
+            //DataLabels
+            DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
+            areaChartSeries.Append(dataLabels);
+
+            // Category data
+            CategoryAxisData categoryAxisData = tableReferenced ? ChartPartGenerator.GenerateReferencedCategoryAxisData(seriesData) : ChartPartGenerator.GenerateCategoryAxisData(seriesData);
+            areaChartSeries.Append(categoryAxisData);
+
+            // Value data
+            Values values = tableReferenced ? ChartPartGenerator.GenerateReferencedValues(seriesData) : ChartPartGenerator.GenerateValues(seriesData);
+            areaChartSeries.Append(values);
+
+            return areaChartSeries;
+        }
+
+        private static LineChartSeries GenerateLineChartSeries(ChartSeriesData seriesData, bool tableReferenced)
+        {
+            LineChartSeries lineChartSeries = new LineChartSeries();
+
+            lineChartSeries.AddIndexAndOrder(seriesData);
+
+            //SeriesText
+            SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
+            lineChartSeries.Append(seriesText);
+
+            lineChartSeries.AddNoFill(seriesData);
+            if (!seriesData.HasNoFill)
+                lineChartSeries.AddColorFill(seriesData);
+
+            Marker marker = new Marker { Symbol = new Symbol { Val = MarkerStyleValues.None } };
+            lineChartSeries.Append(marker);
+
+            //DataLabels
+            DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
+            lineChartSeries.Append(dataLabels);
+
+            //CategoryData
+            CategoryAxisData categoryAxisData = tableReferenced ? ChartPartGenerator.GenerateReferencedCategoryAxisData(seriesData) : ChartPartGenerator.GenerateCategoryAxisData(seriesData);
+            lineChartSeries.Append(categoryAxisData);
+
+            //ValueData
+            Values values = tableReferenced ? ChartPartGenerator.GenerateReferencedValues(seriesData) : ChartPartGenerator.GenerateValues(seriesData);
+            lineChartSeries.Append(values);
+
+            //Line Smoothing
+            Smooth smooth = new Smooth { Val = seriesData.IsSmoothLine };
+            lineChartSeries.Append(smooth);
+
+            return lineChartSeries;
+        }
+
+        private static BarChartSeries GenerateBarChartSeries(ChartSeriesData seriesData, bool tableReferenced)
+        {
+            BarChartSeries barChartSeries = new BarChartSeries();
+
+            barChartSeries.AddIndexAndOrder(seriesData);
+
+            //Series text
+            SeriesText seriesText = ChartPartGenerator.GenerateSeriesText(seriesData);
+            barChartSeries.Append(seriesText);
+
+            //TODO
+            InvertIfNegative invertIfNegative = new InvertIfNegative { Val = false };
+            barChartSeries.Append(invertIfNegative);
+
+            //GenerateDataLabels
+            DataLabels dataLabels = ChartPartGenerator.GenerateReferencedDataLables(seriesData);
+            barChartSeries.Append(dataLabels);
+
+            //CategoryData
+            CategoryAxisData categoryAxisData = tableReferenced ? ChartPartGenerator.GenerateReferencedCategoryAxisData(seriesData) : ChartPartGenerator.GenerateCategoryAxisData(seriesData);
+            barChartSeries.Append(categoryAxisData);
+
+            //ValueData
+            Values values = tableReferenced ? ChartPartGenerator.GenerateReferencedValues(seriesData) : ChartPartGenerator.GenerateValues(seriesData);
+            barChartSeries.Append(values);
+
+            return barChartSeries;
+        }
+
+        private static void AddIndexAndOrder(this OpenXmlElement element, ChartSeriesData seriesData)
+        {
+            Index index = new Index { Val = (uint)seriesData.Index };
+            element.Append(index);
+
+            Order order = new Order { Val = (uint)seriesData.Index };
+            element.Append(order);
+        }
+
+        public static Legend AddChartLegend()
+        {
+            Legend legend = new Legend();
+
+            LegendPosition legendPosition = new LegendPosition() { Val = LegendPositionValues.Right };
+            legend.Append(legendPosition);
+
+            Overlay overlay = new Overlay() { Val = false };
+            legend.Append(overlay);
+
+            legend.Append(ChartStyle.SetTextProperties());
+
+            return legend;
+        }
+
+        public static void AddChartTitle(DocumentFormat.OpenXml.Drawing.Charts.Chart chart, string title, XLChart chartXl)
+        {
+            var ctitle = new Title();
+
+            var tx = new ChartText();
+            var rich = new RichText();
+            var bodyProperties = new BodyProperties() { Rotation = 0, UseParagraphSpacing = true, VerticalOverflow = TextVerticalOverflowValues.Ellipsis, Vertical = TextVerticalValues.Horizontal, Wrap = TextWrappingValues.Square, Anchor = TextAnchoringTypeValues.Center, AnchorCenter = true };
+            var lstSyle = new ListStyle();
+
+            var paragraph = new Paragraph();
+            var paraProp = new ParagraphProperties();
+            var defRPr = new DefaultRunProperties() { Bold = false, Italic = false, Underline = TextUnderlineValues.None, Strike = TextStrikeValues.NoStrike, Kerning = 1200, Spacing = 0, Baseline = 0, FontSize = 1400 };
+            var solidFill = new SolidFill();
+            var schemeColor = new SchemeColor() { Val = SchemeColorValues.Text1 };
+            var lumMod = new LuminanceModulation() { Val = 65000 };
+            var lumOff = new LuminanceOffset() { Val = 35000 };
+            schemeColor.Append(lumMod); schemeColor.Append(lumOff);
+            solidFill.Append(schemeColor);
+            defRPr.Append(solidFill);
+
+            var latin = new LatinFont() { Typeface = "+mn-lt" };
+            var ea = new EastAsianFont() { Typeface = "+mn-ea" };
+            var cs = new ComplexScriptFont() { Typeface = "+mn-cs" };
+            defRPr.Append(latin); defRPr.Append(ea); defRPr.Append(cs);
+
+            paraProp.Append(defRPr);
+            paragraph.Append(paraProp);
+
+            var r = new Run();
+            var rPr = new RunProperties() { Language = "de-DE" };
+            var t = new Text(chartXl.ChartType == XLChartType.Pie ? chartXl.GetSeries(0).SeriesName.Value : title);
+            r.Append(rPr); r.Append(t);
+
+            paragraph.Append(r);
+
+            rich.Append(bodyProperties); rich.Append(lstSyle); rich.Append(paragraph);
+            tx.Append(rich);
+            ctitle.Append(tx);
+
+            var overlay = new Overlay() { Val = false };
+            ctitle.Append(overlay);
+
+            ctitle.Append(ChartStyle.SetTextProperties());
+
+            chart.AppendChild(ctitle);
+        }
+
+        public static void SetPosition(WorksheetPart worksheetPart, ChartPart chartPart, XLChart chart)
+        {
+            if (worksheetPart.DrawingsPart.WorksheetDrawing == null)
+                worksheetPart.DrawingsPart.WorksheetDrawing = new DocumentFormat.OpenXml.Drawing.Spreadsheet.WorksheetDrawing();
+
+            var nvps = worksheetPart.DrawingsPart.WorksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>();
+            var nvpId = nvps.Any() ?
+                (UInt32Value)worksheetPart.DrawingsPart.WorksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>().Max(p => p.Id.Value) + 1 :
+                1U;
+
+            var width = chart.Size.Width + chart.ChartPosition.X;
+            var height = chart.Size.Height + chart.ChartPosition.Y;
+
+            var columnId = chart.ChartPosition.X;
+            var rowId = chart.ChartPosition.Y;
+            Xdr.FromMarker fMark = new Xdr.FromMarker
+            {
+                ColumnId = new Xdr.ColumnId(columnId.ToString()),
+                RowId = new Xdr.RowId(rowId.ToString()),
+                ColumnOffset = new Xdr.ColumnOffset("0"),
+                RowOffset = new Xdr.RowOffset("0")
+            };
+            Xdr.ToMarker tMark = new Xdr.ToMarker
+            {
+                ColumnId = new Xdr.ColumnId(width.ToString()),
+                RowId = new Xdr.RowId(height.ToString()),
+                ColumnOffset = new Xdr.ColumnOffset("0"),
+                RowOffset = new Xdr.RowOffset("0")
+            };
+
+            var twoCellAnchor = new Xdr.TwoCellAnchor(fMark, tMark,
+                new Xdr.GraphicFrame
+                {
+                    Macro = "",
+                    NonVisualGraphicFrameProperties = new Xdr.NonVisualGraphicFrameProperties(
+                        new Xdr.NonVisualDrawingProperties() { Id = nvpId, Name = chart.ChartTitle },
+                        new Xdr.NonVisualGraphicFrameDrawingProperties()),
+                    Transform = new Xdr.Transform(
+                        new Offset() { X = 0L, Y = 0L },
+                        new Extents() { Cx = 0L, Cy = 0L }),
+                    Graphic = new Graphic(
+                        new GraphicData(
+                            new ChartReference() { Id = worksheetPart.DrawingsPart.GetIdOfPart(chartPart) })
+                        { Uri = "http://schemas.openxmlformats.org/drawingml/2006/chart" }),
+                },
+                new Xdr.ClientData());
+
+            worksheetPart.DrawingsPart.WorksheetDrawing.Append(twoCellAnchor);
+        }
+
+        private static void AddNoFill(this OpenXmlElement element, ChartSeriesData seriesData)
+        {
+            if (seriesData.HasNoFill)
+            {
+                element.Append(ChartStyle.GetNoFillProperties(false));
+            }
+        }
+
+        private static void AddColorFill(this OpenXmlElement element, ChartSeriesData seriesData)
+        {
+            SolidFill solidFill = new SolidFill();
+
+            ChartShapeProperties chartShapeProperties = new ChartShapeProperties();
+
+            if (seriesData.SeriesType == ChartSeriesType.Line || seriesData.SeriesType == ChartSeriesType.Radar)
+            {
+                if (seriesData.HasLine)
+                    chartShapeProperties.Append(new Outline(solidFill));
+                else
+                    chartShapeProperties.Append(new Outline(new NoFill()));
+            }
+            else
+                chartShapeProperties.Append(solidFill);
+
+            element.Append(chartShapeProperties);
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartLabel.cs
+++ b/ClosedXML/Excel/Charts/ChartLabel.cs
@@ -1,0 +1,15 @@
+using System;
+using DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace ClosedXML.Excel.Charts
+{
+    public class ChartLabel
+    {
+        public bool IsEnabled { get; set; }
+        public int DecimalNumbers { get; set; }
+        public string UnitSuffix { get; set; }
+        public DataLabelPositionValues Position { get; set; }
+        public LabelType LabelType { get; set; }
+        public String HexColor { get; set; }
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartPartGenerator.cs
+++ b/ClosedXML/Excel/Charts/ChartPartGenerator.cs
@@ -31,6 +31,7 @@ namespace ClosedXML.Excel.Charts
                 case LabelType.CategoryValueLabel:
                     DataLabels categoryLabels = new DataLabels();
                     categoryLabels.Append(new NumberingFormat { FormatCode = "General", SourceLinked = false });
+                    categoryLabels.Append(ChartStyle.SetTextProperties());
                     if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
                         SetSafeLabelPosition(seriesData, categoryLabels);
                     categoryLabels.Append(new ShowLegendKey { Val = false });
@@ -40,11 +41,11 @@ namespace ClosedXML.Excel.Charts
                     categoryLabels.Append(new ShowPercent { Val = false });
                     categoryLabels.Append(new ShowBubbleSize { Val = false });
                     categoryLabels.Append(new ShowLeaderLines { Val = false });
-                    categoryLabels.Append(ChartStyle.SetTextProperties());
                     return categoryLabels;
                 case LabelType.PercentValuesOutsideEnd:
                     DataLabels dataLabels = new DataLabels();
                     dataLabels.Append(new NumberingFormat { FormatCode = "General", SourceLinked = false });
+                    dataLabels.Append(ChartStyle.SetTextProperties());
                     if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
                     {
                         seriesData.Label.Position = DataLabelPositionValues.OutsideEnd;
@@ -57,13 +58,25 @@ namespace ClosedXML.Excel.Charts
                     dataLabels.Append(new ShowPercent { Val = false });
                     dataLabels.Append(new ShowBubbleSize { Val = false });
                     dataLabels.Append(new ShowLeaderLines { Val = false });
-                    dataLabels.Append(ChartStyle.SetTextProperties());
                     return dataLabels;
                 case LabelType.SingleElementLabels:
-                    return GenerateDataLabels(seriesData);
+                    DataLabels labels = new DataLabels();
+                    labels.Append(new NumberingFormat { FormatCode = "#,##0.000", SourceLinked = false });
+                    labels.Append(ChartStyle.SetTextProperties());
+                    if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
+                        SetSafeLabelPosition(seriesData, labels);
+                    labels.Append(new ShowLegendKey { Val = false });
+                    labels.Append(new ShowValue { Val = true });
+                    labels.Append(new ShowCategoryName { Val = false });
+                    labels.Append(new ShowSeriesName { Val = false });
+                    labels.Append(new ShowPercent { Val = false });
+                    labels.Append(new ShowBubbleSize { Val = false });
+                    labels.Append(new ShowLeaderLines { Val = false });
+                    return labels;
                 case LabelType.RegularLabel:
                     DataLabels regularLabels = new DataLabels();
                     regularLabels.Append(new NumberingFormat { FormatCode = "General", SourceLinked = false });
+                    regularLabels.Append(ChartStyle.SetTextProperties());
                     if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
                         SetSafeLabelPosition(seriesData, regularLabels);
                     regularLabels.Append(new ShowLegendKey { Val = false });
@@ -73,7 +86,6 @@ namespace ClosedXML.Excel.Charts
                     regularLabels.Append(new ShowPercent { Val = false });
                     regularLabels.Append(new ShowBubbleSize { Val = false });
                     regularLabels.Append(new ShowLeaderLines { Val = false });
-                    regularLabels.Append(ChartStyle.SetTextProperties());
                     return regularLabels;
                 default:
                     return null;
@@ -99,7 +111,7 @@ namespace ClosedXML.Excel.Charts
                 var p = new Paragraph();
                 var r = new Run();
                 r.Append(new RunProperties() { Language = "de-DE" });
-                r.Append(new Text(seriesData.Names[i]));
+                r.Append(new Text(seriesData.Names[i] ?? null));
                 p.Append(r);
 
                 rich.Append(p);
@@ -135,7 +147,6 @@ namespace ClosedXML.Excel.Charts
             dataLabels.Append(new ShowLeaderLines { Val = false });
 
             return dataLabels;
-
         }
 
         public static RichText GenerateRichTextSingleElement(String text, String language = null, String hexColor = null)
@@ -403,13 +414,21 @@ namespace ClosedXML.Excel.Charts
             UInt32 i = 0;
             foreach (var valueText in values)
             {
-                NumericPoint numericPoint = new NumericPoint { Index = i };
-                NumericValue numericValue = new NumericValue { Text = valueText };
+                if(valueText == null)
+                {
+                    i++;
+                }
+                else
+                {
+                    NumericPoint numericPoint = new NumericPoint { Index = i };
+                    NumericValue numericValue = new NumericValue { Text = valueText };
 
-                numericPoint.Append(numericValue);
-                numberLiteral.Append(numericPoint);
+                    numericPoint.Append(numericValue);
+                    numberLiteral.Append(numericPoint);
 
-                i++;
+                    i++;
+                }
+                
             }
             return numberLiteral;
         }

--- a/ClosedXML/Excel/Charts/ChartPartGenerator.cs
+++ b/ClosedXML/Excel/Charts/ChartPartGenerator.cs
@@ -1,0 +1,417 @@
+using DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Drawing.Charts;
+using System;
+
+namespace ClosedXML.Excel.Charts
+{
+    public static class ChartPartGenerator
+    {
+        private static void SetSafeLabelPosition(ChartSeriesData seriesData, DataLabels label)
+        {
+            var pos = seriesData.Label.Position;
+            if (seriesData.SeriesType == ChartSeriesType.Area)
+                return;
+
+            if (seriesData.SeriesType == ChartSeriesType.Bar || seriesData.SeriesType == ChartSeriesType.Column || seriesData.SeriesType == ChartSeriesType.Column100Percent || seriesData.SeriesType == ChartSeriesType.Pie)
+                if (pos == DataLabelPositionValues.Center || pos == DataLabelPositionValues.InsideEnd || pos == DataLabelPositionValues.OutsideEnd || pos == DataLabelPositionValues.InsideBase)
+                    label.Append(new DataLabelPosition { Val = pos });
+
+            if (seriesData.SeriesType == ChartSeriesType.Line || seriesData.SeriesType == ChartSeriesType.Scatter)
+                if (pos == DataLabelPositionValues.Center || pos == DataLabelPositionValues.Left || pos == DataLabelPositionValues.Right || pos == DataLabelPositionValues.Top || pos == DataLabelPositionValues.Bottom)
+                    label.Append(new DataLabelPosition { Val = pos });
+        }
+
+        public static DataLabels GenerateReferencedDataLables(ChartSeriesData seriesData)
+        {
+            if (!seriesData.Label.IsEnabled)
+                return null;
+
+            switch (seriesData.Label.LabelType)
+            {
+                case LabelType.CategoryValueLabel:
+                    DataLabels categoryLabels = new DataLabels();
+                    categoryLabels.Append(new NumberingFormat { FormatCode = "General", SourceLinked = false });
+                    if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
+                        SetSafeLabelPosition(seriesData, categoryLabels);
+                    categoryLabels.Append(new ShowLegendKey { Val = false });
+                    categoryLabels.Append(new ShowValue { Val = false });
+                    categoryLabels.Append(new ShowCategoryName { Val = true });
+                    categoryLabels.Append(new ShowSeriesName { Val = false });
+                    categoryLabels.Append(new ShowPercent { Val = false });
+                    categoryLabels.Append(new ShowBubbleSize { Val = false });
+                    categoryLabels.Append(new ShowLeaderLines { Val = false });
+                    categoryLabels.Append(ChartStyle.SetTextProperties());
+                    return categoryLabels;
+                case LabelType.PercentValuesOutsideEnd:
+                    DataLabels dataLabels = new DataLabels();
+                    dataLabels.Append(new NumberingFormat { FormatCode = "General", SourceLinked = false });
+                    if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
+                    {
+                        seriesData.Label.Position = DataLabelPositionValues.OutsideEnd;
+                        SetSafeLabelPosition(seriesData, dataLabels);
+                    }
+                    dataLabels.Append(new ShowLegendKey { Val = false });
+                    dataLabels.Append(new ShowValue { Val = true });
+                    dataLabels.Append(new ShowCategoryName { Val = false });
+                    dataLabels.Append(new ShowSeriesName { Val = false });
+                    dataLabels.Append(new ShowPercent { Val = false });
+                    dataLabels.Append(new ShowBubbleSize { Val = false });
+                    dataLabels.Append(new ShowLeaderLines { Val = false });
+                    dataLabels.Append(ChartStyle.SetTextProperties());
+                    return dataLabels;
+                case LabelType.SingleElementLabels:
+                    return GenerateDataLabels(seriesData);
+                case LabelType.RegularLabel:
+                    DataLabels regularLabels = new DataLabels();
+                    regularLabels.Append(new NumberingFormat { FormatCode = "General", SourceLinked = false });
+                    if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
+                        SetSafeLabelPosition(seriesData, regularLabels);
+                    regularLabels.Append(new ShowLegendKey { Val = false });
+                    regularLabels.Append(new ShowValue { Val = true });
+                    regularLabels.Append(new ShowCategoryName { Val = false });
+                    regularLabels.Append(new ShowSeriesName { Val = false });
+                    regularLabels.Append(new ShowPercent { Val = false });
+                    regularLabels.Append(new ShowBubbleSize { Val = false });
+                    regularLabels.Append(new ShowLeaderLines { Val = false });
+                    regularLabels.Append(ChartStyle.SetTextProperties());
+                    return regularLabels;
+                default:
+                    return null;
+            }
+        }
+
+        public static DataLabels GenerateDataLabels(ChartSeriesData seriesData)
+        {
+            if (!seriesData.Label.IsEnabled)
+                return null;
+
+            DataLabels dataLabels = new DataLabels();
+
+            for (int i = 0; i < seriesData.Names.Length; i++)
+            {
+                DataLabel dataLabel = new DataLabel();
+                var index = new Index() { Val = (uint)i };
+                var tx = new ChartText();
+                var rich = new RichText();
+                rich.Append(new BodyProperties());
+                rich.Append(new ListStyle());
+
+                var p = new Paragraph();
+                var r = new Run();
+                r.Append(new RunProperties() { Language = "de-DE" });
+                r.Append(new Text(seriesData.Names[i]));
+                p.Append(r);
+
+                rich.Append(p);
+                tx.Append(rich);
+                dataLabel.Append(index);
+                dataLabel.Append(tx);
+
+                if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
+                {
+                    dataLabels.Append(new DataLabelPosition { Val = seriesData.Label.Position });
+                }
+                dataLabel.Append(new ShowLegendKey { Val = false });
+                dataLabel.Append(new ShowValue { Val = false });
+                dataLabel.Append(new ShowCategoryName { Val = false });
+                dataLabel.Append(new ShowSeriesName { Val = false });
+                dataLabel.Append(new ShowPercent { Val = false });
+                dataLabel.Append(new ShowBubbleSize { Val = false });
+
+                dataLabels.Append(dataLabel);
+            }
+
+            dataLabels.Append(ChartStyle.SetTextProperties());
+            if (seriesData.Label.Position != DataLabelPositionValues.BestFit)
+            {
+                dataLabels.Append(new DataLabelPosition { Val = seriesData.Label.Position });
+            }
+            dataLabels.Append(new ShowLegendKey { Val = false });
+            dataLabels.Append(new ShowValue { Val = false });
+            dataLabels.Append(new ShowCategoryName { Val = false });
+            dataLabels.Append(new ShowSeriesName { Val = false });
+            dataLabels.Append(new ShowPercent { Val = false });
+            dataLabels.Append(new ShowBubbleSize { Val = false });
+            dataLabels.Append(new ShowLeaderLines { Val = false });
+
+            return dataLabels;
+
+        }
+
+        public static RichText GenerateRichTextSingleElement(String text, String language = null, String hexColor = null)
+        {
+            if (language == null)
+                language = "de-DE";
+
+            RichText richText = new RichText();
+            BodyProperties bodyProperties = new BodyProperties();
+            ListStyle listStyle = new ListStyle();
+
+            Paragraph paragraph = new Paragraph();
+
+            ParagraphProperties paragraphProperties = new ParagraphProperties();
+            paragraphProperties.Append(new DefaultRunProperties());
+
+            Run run = new Run();
+
+            RunProperties runProperties = new RunProperties { Language = language, Dirty = false };
+            runProperties.SetAttribute(new DocumentFormat.OpenXml.OpenXmlAttribute(String.Empty, @"smtClean", String.Empty, @"0"));
+
+            if (hexColor != null)
+            {
+                SolidFill solidFill = new SolidFill();
+                RgbColorModelHex rgbColorModelHex = new RgbColorModelHex { Val = hexColor };
+
+                solidFill.Append(rgbColorModelHex);
+                runProperties.Append(solidFill);
+            }
+
+            Text textObject = new Text { Text = text };
+
+            run.Append(runProperties);
+            run.Append(textObject);
+            EndParagraphRunProperties endParagraphRunProperties = new EndParagraphRunProperties { Language = language, Dirty = false };
+
+            paragraph.Append(paragraphProperties);
+            paragraph.Append(run);
+            paragraph.Append(endParagraphRunProperties);
+
+            richText.Append(bodyProperties);
+            richText.Append(listStyle);
+            richText.Append(paragraph);
+
+            return richText;
+        }
+
+        public static SeriesText GenerateReferencedSeriesText(ChartSeriesData seriesData)
+        {
+            SeriesText seriesText = new SeriesText();
+
+            StringReference seriesStringReference = new StringReference();
+            Formula seriesFormula = new Formula { Text = seriesData.SeriesName.Reference };
+
+            StringCache seriesStringCache = new StringCache();
+            PointCount seriesPointCount = new PointCount { Val = 1U };
+
+            StringPoint seriesStringPoint = new StringPoint { Index = 0U };
+            NumericValue seriesNumericValue = new NumericValue { Text = seriesData.SeriesName.Value };
+
+            seriesStringPoint.Append(seriesNumericValue);
+
+            seriesStringCache.Append(seriesPointCount);
+            seriesStringCache.Append(seriesStringPoint);
+
+            seriesStringReference.Append(seriesFormula);
+            seriesStringReference.Append(seriesStringCache);
+
+            seriesText.Append(seriesStringReference);
+
+            return seriesText;
+        }
+
+        public static SeriesText GenerateSeriesText(ChartSeriesData seriesData)
+        {
+            // Series text
+            SeriesText seriesText = new SeriesText();
+            NumericValue numericValue = new NumericValue() { Text = seriesData.SeriesName.Value };
+            seriesText.Append(numericValue);
+
+            return seriesText;
+        }
+
+        public static CategoryAxisData GenerateReferencedCategoryAxisData(ChartSeriesData seriesData)
+        {
+            CategoryAxisData categoryAxisData = new CategoryAxisData();
+
+            StringReference stringReference = new StringReference();
+
+            Formula formula = new Formula { Text = seriesData.Category.Reference };
+            stringReference.Append(formula);
+
+            StringCache stringCache = new StringCache();
+            PointCount pointCount = new PointCount { Val = (UInt32)seriesData.Category.Values.Length };
+            stringCache.Append(pointCount);
+
+            UInt32 i = 0;
+            foreach (var categoryText in seriesData.Category.Values)
+            {
+                StringPoint stringPoint = new StringPoint { Index = i };
+                NumericValue numericValue = new NumericValue { Text = categoryText };
+
+                stringPoint.Append(numericValue);
+                stringCache.Append(stringPoint);
+
+                i++;
+            }
+
+            stringReference.Append(stringCache);
+            categoryAxisData.Append(stringReference);
+
+            return categoryAxisData;
+        }
+
+        public static CategoryAxisData GenerateCategoryAxisData(ChartSeriesData seriesData)
+        {
+            CategoryAxisData categoryAxisData = new CategoryAxisData();
+            categoryAxisData.Append(GetStringLiteral(seriesData));
+
+            return categoryAxisData;
+        }
+
+        public static StringLiteral GetStringLiteral(ChartSeriesData seriesData)
+        {
+            StringLiteral stringLiteral = new StringLiteral();
+            PointCount pointCount = new PointCount() { Val = (UInt32)seriesData.Category.Values.Length };
+            stringLiteral.Append(pointCount);
+
+            UInt32 i = 0;
+            foreach (var categoryText in seriesData.Category.Values)
+            {
+                StringPoint stringPoint = new StringPoint { Index = i };
+                NumericValue numericValue = new NumericValue { Text = categoryText };
+
+                stringPoint.Append(numericValue);
+                stringLiteral.Append(stringPoint);
+
+                i++;
+            }
+            return stringLiteral;
+        }
+
+        public static Values GenerateValues(ChartSeriesData seriesData)
+        {
+            Values values = new Values();
+
+            values.Append(GetNumberLiteral(seriesData.Values.Values));
+
+            return values;
+        }
+
+        public static Values GenerateReferencedValues(ChartSeriesData seriesData)
+        {
+            Values values = new Values();
+
+            values.Append(GetNumberReference(seriesData.Values.Reference, seriesData.Values.Values));
+
+            return values;
+        }
+
+        public static XValues GenerateXValues(ChartSeriesData seriesData)
+        {
+            XValues values = new XValues();
+            values.Append(GetStringLiteral(seriesData));
+
+            return values;
+        }
+
+        public static YValues GenerateYValues(ChartSeriesData seriesData)
+        {
+            YValues values = new YValues();
+            values.Append(GetNumberLiteral(seriesData.Values.Values));
+
+            return values;
+        }
+
+        public static XValues GenerateReferencedXValues(ChartSeriesData seriesData)
+        {
+            var values = new XValues();
+
+            NumberReference numberReference = GenerateNumberReference(seriesData);
+            values.Append(numberReference);
+
+            return values;
+        }
+
+        public static YValues GenerateReferencedYValues(ChartSeriesData seriesData)
+        {
+            var values = new YValues();
+
+            NumberReference numberReference = GenerateNumberReference(seriesData);
+            values.Append(numberReference);
+
+            return values;
+        }
+
+        public static NumberReference GenerateNumberReference(ChartSeriesData seriesData)
+        {
+            NumberReference numberReference = new NumberReference();
+            Formula formula = new Formula { Text = seriesData.Values.Reference };
+            numberReference.Append(formula);
+
+            NumberingCache numberingCache = new NumberingCache();
+            FormatCode formatCode = new FormatCode { Text = "General" };
+            numberingCache.Append(formatCode);
+
+            PointCount pointCount = new PointCount { Val = (UInt32)seriesData.Values.Values.Length };
+            numberingCache.Append(pointCount);
+
+            UInt32 i = 0;
+            foreach (var valueText in seriesData.Values.Values)
+            {
+                NumericPoint numericPoint = new NumericPoint { Index = i };
+                NumericValue numericValue = new NumericValue { Text = valueText };
+
+                numericPoint.Append(numericValue);
+                numberingCache.Append(numericPoint);
+
+                i++;
+            }
+
+            numberReference.Append(numberingCache);
+            return numberReference;
+        }
+
+        private static NumberReference GetNumberReference(String reference, String[] values)
+        {
+            NumberReference numberReference = new NumberReference();
+            Formula formula = new Formula { Text = reference };
+            numberReference.Append(formula);
+
+            NumberingCache numberingCache = new NumberingCache();
+            FormatCode formatCode = new FormatCode { Text = "General" };
+            numberingCache.Append(formatCode);
+
+            PointCount pointCount = new PointCount { Val = (UInt32)values.Length };
+            numberingCache.Append(pointCount);
+
+            UInt32 i = 0;
+            foreach (var valueText in values)
+            {
+                NumericPoint numericPoint = new NumericPoint { Index = i };
+                NumericValue numericValue = new NumericValue { Text = valueText };
+
+                numericPoint.Append(numericValue);
+                numberingCache.Append(numericPoint);
+
+                i++;
+            }
+
+            numberReference.Append(numberingCache);
+            return numberReference;
+        }
+
+        private static NumberLiteral GetNumberLiteral(String[] values)
+        {
+            NumberLiteral numberLiteral = new NumberLiteral();
+
+            FormatCode formatCode = new FormatCode("General");
+            numberLiteral.Append(formatCode);
+
+            PointCount pointCount = new PointCount { Val = (UInt32)values.Length };
+            numberLiteral.Append(pointCount);
+
+            UInt32 i = 0;
+            foreach (var valueText in values)
+            {
+                NumericPoint numericPoint = new NumericPoint { Index = i };
+                NumericValue numericValue = new NumericValue { Text = valueText };
+
+                numericPoint.Append(numericValue);
+                numberLiteral.Append(numericPoint);
+
+                i++;
+            }
+            return numberLiteral;
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartSeriesData.cs
+++ b/ClosedXML/Excel/Charts/ChartSeriesData.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace ClosedXML.Excel.Charts
+{
+    public class ChartSeriesData
+    {
+        ///// <summary>
+        ///// Index der Serie
+        ///// </summary>
+        public int Index { get; set; }
+
+        public ChartSeriesType SeriesType { get; set; }
+        public SingleReferenceData SeriesName { get; set; }
+        public ReferenceData Category { get; set; }
+        public ReferenceData Values { get; set; }
+        public String[] Names
+        {
+            get
+            {
+                return Values.Values;
+            }
+        }
+
+        public ChartAxis XAxis { get; set; }
+        public ChartAxis YAxis { get; set; }
+
+        public ChartLabel Label { get; set; }
+
+        public bool HasNoFill { get; set; }
+        public String HexColor { get; set; }
+        public bool HasLine { get; set; }
+        public bool ShowMarkers { get; set; }
+        public bool IsTrendLine { get; set; }
+        public bool IsSmoothLine { get; set; }
+
+        public ChartSeriesData(int seriesElementCount)
+        {
+            Category = new ReferenceData { Values = new string[seriesElementCount] };
+            Values = new ReferenceData { Values = new string[seriesElementCount] };
+            Label = new ChartLabel();
+        }
+
+        public ChartSeriesData(ReferenceData category, ReferenceData value)
+        {
+            Category = category;
+            Values = value;
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartSeriesType.cs
+++ b/ClosedXML/Excel/Charts/ChartSeriesType.cs
@@ -1,0 +1,14 @@
+namespace ClosedXML.Excel.Charts
+{
+    public enum ChartSeriesType
+    {
+        Bar,
+        Column,
+        Column100Percent,
+        Line,
+        Area,
+        Scatter,
+        Radar,
+        Pie
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartStyle.cs
+++ b/ClosedXML/Excel/Charts/ChartStyle.cs
@@ -1,0 +1,130 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Drawing;
+using DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace ClosedXML.Excel.Charts
+{
+    public class ChartStyle
+    {
+        public static TextProperties SetTextProperties(OpenXmlCompositeElement axisElement, XLChart chartData)
+        {
+            int rotation = 5400000;
+            var txPr = new TextProperties();
+            if (chartData.ChartType == XLChartType.Radar || chartData.Rotated)
+                rotation = 0;
+            var bodyProp = new BodyProperties() { Rotation = axisElement is CategoryAxis ? rotation : 0, UseParagraphSpacing = true, VerticalOverflow = TextVerticalOverflowValues.Ellipsis, Vertical = TextVerticalValues.Horizontal, Wrap = TextWrappingValues.Square, Anchor = TextAnchoringTypeValues.Center, AnchorCenter = true };
+            var spAutoFit = new ShapeAutoFit();
+            bodyProp.Append(spAutoFit);
+            var listSyle = new ListStyle();
+            txPr.Append(bodyProp); txPr.Append(listSyle);
+
+            var p = new Paragraph();
+            var pPr = new ParagraphProperties();
+            var defRProp = new DefaultRunProperties() { Bold = false, Italic = false, Underline = TextUnderlineValues.None, Strike = TextStrikeValues.NoStrike, Kerning = 1200, Spacing = 0, Baseline = 0 };
+            var solidFill = new SolidFill();
+            var schemeColor = new SchemeColor() { Val = SchemeColorValues.Text1 };
+            var lumMod = new LuminanceModulation() { Val = 65000 };
+            var lumOff = new LuminanceOffset() { Val = 35000 };
+            schemeColor.Append(lumMod); schemeColor.Append(lumOff);
+            solidFill.Append(schemeColor);
+            defRProp.Append(solidFill);
+
+            var latin2 = new LatinFont() { Typeface = "+mn-lt" };
+            var ea2 = new EastAsianFont() { Typeface = "+mn-ea" };
+            var cs2 = new ComplexScriptFont() { Typeface = "+mn-cs" };
+            defRProp.Append(latin2); defRProp.Append(ea2); defRProp.Append(cs2);
+
+            pPr.Append(defRProp);
+            p.Append(pPr);
+
+            txPr.Append(p);
+
+            return txPr;
+        }
+
+        public static TextProperties SetTextProperties()
+        {
+            var txPr = new TextProperties();
+            var bodyProp = new BodyProperties() { Rotation = 0, UseParagraphSpacing = true, VerticalOverflow = TextVerticalOverflowValues.Ellipsis, Vertical = TextVerticalValues.Horizontal, Wrap = TextWrappingValues.Square, Anchor = TextAnchoringTypeValues.Center, AnchorCenter = true };
+            var spAutoFit = new ShapeAutoFit();
+            bodyProp.Append(spAutoFit);
+            var listSyle = new ListStyle();
+            txPr.Append(bodyProp); txPr.Append(listSyle);
+
+            var p = new Paragraph();
+            var pPr = new ParagraphProperties();
+            var defRProp = new DefaultRunProperties() { Bold = false, Italic = false, Underline = TextUnderlineValues.None, Strike = TextStrikeValues.NoStrike, Kerning = 1200, Spacing = 0, Baseline = 0/*, FontSize = 1400*/ };
+            var solidFill = new SolidFill();
+            var schemeColor = new SchemeColor() { Val = SchemeColorValues.Text1 };
+            var lumMod = new LuminanceModulation() { Val = 65000 };
+            var lumOff = new LuminanceOffset() { Val = 35000 };
+            schemeColor.Append(lumMod); schemeColor.Append(lumOff);
+            solidFill.Append(schemeColor);
+            defRProp.Append(solidFill);
+
+            var latin2 = new LatinFont() { Typeface = "+mn-lt" };
+            var ea2 = new EastAsianFont() { Typeface = "+mn-ea" };
+            var cs2 = new ComplexScriptFont() { Typeface = "+mn-cs" };
+            defRProp.Append(latin2); defRProp.Append(ea2); defRProp.Append(cs2);
+
+            pPr.Append(defRProp);
+            p.Append(pPr);
+
+            txPr.Append(p);
+
+            return txPr;
+        }
+
+        public static ChartShapeProperties SetShapeProperties()
+        {
+            var spPr = new ChartShapeProperties();
+            var ln = new DocumentFormat.OpenXml.Drawing.Outline() { Width = 9525, CapType = DocumentFormat.OpenXml.Drawing.LineCapValues.Flat, CompoundLineType = DocumentFormat.OpenXml.Drawing.CompoundLineValues.Single, Alignment = DocumentFormat.OpenXml.Drawing.PenAlignmentValues.Center };
+            var solidFill = new DocumentFormat.OpenXml.Drawing.SolidFill();
+            var schemeClr = new DocumentFormat.OpenXml.Drawing.SchemeColor() { Val = DocumentFormat.OpenXml.Drawing.SchemeColorValues.Text1 };
+            var lumMod = new DocumentFormat.OpenXml.Drawing.LuminanceModulation() { Val = 15000 };
+            var lumOff = new DocumentFormat.OpenXml.Drawing.LuminanceOffset() { Val = 85000 };
+            schemeClr.Append(lumMod); schemeClr.Append(lumOff);
+            solidFill.Append(schemeClr);
+            ln.Append(solidFill);
+            var effectLst = new DocumentFormat.OpenXml.Drawing.EffectList();
+            spPr.Append(ln); spPr.Append(effectLst);
+
+            return spPr;
+        }
+
+        public static ChartShapeProperties GetNoFillProperties(bool outline)
+        {
+            ChartShapeProperties chartShapeProperties = new ChartShapeProperties();
+            if (outline)
+            {
+                var ol = new Outline();
+                ol.Append(new NoFill());
+                chartShapeProperties.Append(ol);
+            }
+            else
+            {
+                chartShapeProperties.Append(new NoFill());
+            }
+            return chartShapeProperties;
+        }
+
+        public static Marker AddMarker(ChartSeriesData seriesData)
+        {
+            Marker marker = new Marker();
+
+            Symbol symbol = new Symbol { Val = MarkerStyleValues.Square };
+            marker.Append(symbol);
+
+            Size size = new Size() { Val = 5 };
+            marker.Append(size);
+
+            return marker;
+        }
+
+        public static Marker AddNoMarker()
+        {
+            Marker marker = new Marker { Symbol = new Symbol { Val = MarkerStyleValues.None } };
+            return marker;
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ChartStyle.cs
+++ b/ClosedXML/Excel/Charts/ChartStyle.cs
@@ -6,6 +6,17 @@ namespace ClosedXML.Excel.Charts
 {
     public class ChartStyle
     {
+        public static ChartShapeProperties SetHexColor(string HexColor)
+        {
+            ChartShapeProperties chartShapeProperties = new ChartShapeProperties();
+            SolidFill solidFill = new SolidFill();
+            RgbColorModelHex rgbColorModelHex = new RgbColorModelHex() { Val = HexColor };
+            solidFill.Append(rgbColorModelHex);
+            chartShapeProperties.Append(solidFill);
+
+            return chartShapeProperties;
+        }
+        
         public static TextProperties SetTextProperties(OpenXmlCompositeElement axisElement, XLChart chartData)
         {
             int rotation = 5400000;
@@ -117,6 +128,22 @@ namespace ClosedXML.Excel.Charts
 
             Size size = new Size() { Val = 5 };
             marker.Append(size);
+
+            if(seriesData.HexColor != null)
+            {
+                ChartShapeProperties shapeProperties = new ChartShapeProperties();
+
+                SolidFill solidFill = new SolidFill();
+                solidFill.Append(new RgbColorModelHex() { Val = seriesData.HexColor });
+                shapeProperties.Append(solidFill);
+
+                Outline outline = new Outline();
+                NoFill noFill = new NoFill();
+                outline.Append(noFill);
+                shapeProperties.Append(outline);
+
+                marker.Append(shapeProperties);
+            }           
 
             return marker;
         }

--- a/ClosedXML/Excel/Charts/IXLChart.cs
+++ b/ClosedXML/Excel/Charts/IXLChart.cs
@@ -1,8 +1,13 @@
+using ClosedXML.Excel.Charts;
+using DocumentFormat.OpenXml.Drawing.Charts;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    public enum XLChartType {
+    public enum XLChartType
+    {
         Area,
         Area3D,
         AreaStacked,
@@ -77,14 +82,37 @@ namespace ClosedXML.Excel
         XYScatterStraightLinesNoMarkers,
         XYScatterStraightLinesWithMarkers
     }
-    public interface IXLChart: IXLDrawing<IXLChart>
+    public interface IXLChart : IXLDrawing<IXLChart>
     {
-        Boolean RightAngleAxes { get; set; }
-        IXLChart SetRightAngleAxes();
-        IXLChart SetRightAngleAxes(Boolean rightAngleAxes);
+        String RelId { get; set; }
+        IXLWorksheet Worksheet { get; set; }
+
+        System.Drawing.Point ChartPosition { get; set; }
 
         XLChartType ChartType { get; set; }
-        IXLChart SetChartType(XLChartType chartType);
+        string ChartTitle { get; set; }
+        System.Drawing.Size Size { get; set; }
+
+        bool SecondaryValueAxisEnabled { get; }
+        bool ShowLegend { get; set; }
+        bool Border { get; set; }
+        bool ShowMarkers { get; set; }
+        bool TableReferenced { get; set; }
+
+        int SeriesCount { get; }
+
+        List<ChartAxis> Axes { get; set; }
+
+        ChartSeriesData AddSeries(ReferenceData category, ReferenceData value);
+        void AddSeries(ChartSeriesData series);
+
+        XLChart CopyPieChart(IXLChart chartToCopy);
+
+        ChartSeriesData GetSeries(int index);
+
+        List<ChartSeriesData> GetAllSeries();
+
+        void DeleteSeries();
 
     }
 }

--- a/ClosedXML/Excel/Charts/IXLCharts.cs
+++ b/ClosedXML/Excel/Charts/IXLCharts.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
+using System;
 
 namespace ClosedXML.Excel
 {
     public interface IXLCharts: IEnumerable<IXLChart>
     {
-        void Add(IXLChart chart);
+        IXLChart Add(IXLChart chart);
+
+        IXLChart Chart(Int32 index);
     }
 }

--- a/ClosedXML/Excel/Charts/LabelType.cs
+++ b/ClosedXML/Excel/Charts/LabelType.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClosedXML.Excel.Charts
+{
+    public enum LabelType
+    {
+        None,
+        RegularLabel,
+        SingleElementLabels,
+        PercentValuesOutsideEnd,
+        CategoryValueLabel
+    }
+}

--- a/ClosedXML/Excel/Charts/PlotAreaGenerator.cs
+++ b/ClosedXML/Excel/Charts/PlotAreaGenerator.cs
@@ -1,0 +1,203 @@
+using DocumentFormat.OpenXml.Drawing.Charts;
+using DocumentFormat.OpenXml;
+
+namespace ClosedXML.Excel.Charts
+{
+    public static class PlotAreaGenerator
+    {
+        public static PlotArea GeneratePlotArea(XLChart chart)
+        {
+            PlotArea plotArea = new PlotArea();
+
+            Layout layout = new Layout();
+            plotArea.Append(layout);
+
+            if (!chart.CreateChartPerSeries && chart.ChartType != XLChartType.Pie && chart.ChartType != XLChartType.Doughnut)
+            {
+                AddChart(chart, plotArea);
+                GenerateAxes(chart, plotArea);
+            }
+            else
+            {
+                AddChart(chart, plotArea);
+            }
+
+            return plotArea;
+        }
+
+        private static void AddChart(XLChart chart, PlotArea plotArea)
+        {
+            var barDirectionValue = BarDirectionValues.Column;
+            if (chart.Rotated)
+                barDirectionValue = BarDirectionValues.Bar;
+
+            switch (chart.ChartType)
+            {
+                case XLChartType.ColumnClustered:
+                case XLChartType.BarClustered: plotArea.Append(ChartGenerator.CreateBarChart(chart, barDirectionValue, ChartSeriesType.Bar, BarGroupingValues.Clustered)); break;
+                case XLChartType.ColumnStacked100Percent:
+                case XLChartType.BarStacked100Percent: plotArea.Append(ChartGenerator.CreateBarChart(chart, barDirectionValue, ChartSeriesType.Column100Percent, BarGroupingValues.PercentStacked)); break;
+                case XLChartType.ColumnStacked:
+                case XLChartType.BarStacked: plotArea.Append(ChartGenerator.CreateBarChart(chart, barDirectionValue, ChartSeriesType.Column, BarGroupingValues.Stacked)); break;
+                case XLChartType.Line: plotArea.Append(ChartGenerator.CreateLineChart(chart)); break;
+                case XLChartType.Area: plotArea.Append(ChartGenerator.CreateAreaChart(chart, GroupingValues.Standard)); break;
+                case XLChartType.AreaStacked100Percent: plotArea.Append(ChartGenerator.CreateAreaChart(chart, GroupingValues.PercentStacked)); break;
+                case XLChartType.AreaStacked: plotArea.Append(ChartGenerator.CreateAreaChart(chart, GroupingValues.Stacked)); break;
+                case XLChartType.XYScatterMarkers: plotArea.Append(ChartGenerator.CreateScatterChart(chart)); break;
+                case XLChartType.Pie:
+                    PieChart pieChart = new PieChart();
+                    plotArea.Append(ChartGenerator.CreatePieChart(chart, pieChart)); break;
+                case XLChartType.Doughnut:
+                    DoughnutChart doughnutChart = new DoughnutChart();
+                    plotArea.Append(ChartGenerator.CreatePieChart(chart, doughnutChart)); break;
+                case XLChartType.Radar: plotArea.Append(ChartGenerator.CreateRadarChart(chart)); break;
+            }
+        }
+
+        private static void GenerateAxes(XLChart chartData, PlotArea plotArea)
+        {
+            foreach (var axis in chartData.Axes)
+            {
+                switch (axis.Type)
+                {
+                    case ChartAxis.ChartAxisType.Category:
+                        CategoryAxis categoryAxis = new CategoryAxis();
+                        categoryAxis = GenerateAxis(categoryAxis, axis, chartData) as CategoryAxis;
+                        plotArea.Append(categoryAxis);
+                        break;
+                    case ChartAxis.ChartAxisType.ValueGeneric:
+                        ValueAxis valueAxisGen = new ValueAxis();
+                        valueAxisGen = GenerateAxis(valueAxisGen, axis, chartData) as ValueAxis;
+                        plotArea.Append(valueAxisGen);
+                        break;
+                    case ChartAxis.ChartAxisType.ValuePercent100WithAllTickmarks:
+                        ValueAxis valueAxis = new ValueAxis();
+                        valueAxis = GenerateValueAxis100Percent(axis);
+                        plotArea.Append(valueAxis);
+                        break;
+                }
+            }
+        }
+
+        private static OpenXmlCompositeElement GenerateAxis(OpenXmlCompositeElement axisElement, ChartAxis axis, XLChart chartData)
+        {
+            AxisId axisId = new AxisId { Val = axis.Id };
+            axisElement.Append(axisId);
+
+            Scaling scaling = new Scaling();
+            Orientation orientation = new Orientation { Val = axis.InvertOrientation ? OrientationValues.MaxMin : OrientationValues.MinMax };
+            scaling.Append(orientation);
+            axisElement.Append(scaling);
+
+            Delete delete = new Delete { Val = axis.Invisible };
+            AxisPosition axisPosition = new AxisPosition { Val = axis.Position };
+            axisElement.Append(delete);
+            axisElement.Append(axisPosition);
+
+            if (axisElement is ValueAxis || chartData.ChartType == XLChartType.Radar)
+            {
+                var majorGridline = new MajorGridlines();
+                majorGridline.Append(ChartStyle.SetShapeProperties());
+                axisElement.Append(majorGridline);
+            }
+
+            NumberingFormat numberingFormat = new NumberingFormat { FormatCode = @"General", SourceLinked = true };
+            TickLabelPosition tickLabelPosition = new TickLabelPosition();
+            if (chartData.HasTickLabel)
+            {
+                tickLabelPosition = new TickLabelPosition { Val = TickLabelPositionValues.NextTo };
+            }
+            else
+            {
+                tickLabelPosition = new TickLabelPosition { Val = TickLabelPositionValues.None };
+            }
+            CrossingAxis crossingAxis = new CrossingAxis { Val = axis.RelatedAxis.Id };
+            Crosses crosses = new Crosses { Val = CrossesValues.AutoZero };
+
+            AutoLabeled autoLabeled1 = new AutoLabeled { Val = true };
+            LabelAlignment labelAlignment1 = new LabelAlignment { Val = LabelAlignmentValues.Center };
+            LabelOffset labelOffset1 = new LabelOffset { Val = (ushort)100U };
+            NoMultiLevelLabels noMultiLevelLabels1 = new NoMultiLevelLabels { Val = false };
+
+            if (axisElement is ValueAxis)
+                axisElement.Append(numberingFormat);
+
+            SetTickMark(axisElement, axis);
+            axisElement.Append(tickLabelPosition);
+            axisElement.Append(ChartStyle.SetTextProperties(axisElement, chartData));
+            axisElement.Append(crossingAxis);
+            axisElement.Append(crosses);
+
+            if (axisElement is CategoryAxis)
+            {
+                axisElement.Append(autoLabeled1);
+                axisElement.Append(labelAlignment1);
+                axisElement.Append(labelOffset1);
+                axisElement.Append(noMultiLevelLabels1);
+            }
+            if (axisElement is CategoryAxis)
+                return axisElement as CategoryAxis;
+
+            return axisElement as ValueAxis;
+        }
+
+        private static ValueAxis GenerateValueAxis100Percent(ChartAxis axis)
+        {
+            ValueAxis valueAxis = new ValueAxis();
+
+            AxisId axisId = new AxisId { Val = axis.Id };
+            valueAxis.Append(axisId);
+
+            Scaling scaling = new Scaling();
+            Orientation orientation = new Orientation { Val = OrientationValues.MinMax };
+            scaling.Append(orientation);
+            valueAxis.Append(scaling);
+
+            Delete delete = new Delete { Val = axis.Invisible };
+            AxisPosition axisPosition = new AxisPosition { Val = axis.Position };
+            valueAxis.Append(delete);
+            valueAxis.Append(axisPosition);
+
+            var majorGridline = new MajorGridlines();
+            majorGridline.Append(ChartStyle.SetShapeProperties());
+            valueAxis.Append(majorGridline);
+
+            NumberingFormat numberingFormat = new NumberingFormat { FormatCode = @"0%", SourceLinked = true };
+            TickLabelPosition tickLabelPosition = new TickLabelPosition { Val = TickLabelPositionValues.NextTo };
+            CrossingAxis crossingAxis = new CrossingAxis { Val = axis.RelatedAxis.Id };
+            Crosses crosses = new Crosses { Val = CrossesValues.AutoZero };
+
+            valueAxis.Append(numberingFormat);
+            SetTickMark(valueAxis, axis);
+            valueAxis.Append(tickLabelPosition);
+            valueAxis.Append(ChartStyle.SetTextProperties());
+            valueAxis.Append(crossingAxis);
+            valueAxis.Append(crosses);
+
+            return valueAxis;
+        }
+
+        private static void SetTickMark(OpenXmlCompositeElement axisElement, ChartAxis axis)
+        {
+            switch (axis.TickMark)
+            {
+                case 2:
+                    axisElement.Append(new MajorTickMark { Val = TickMarkValues.Inside });
+                    axisElement.Append(new MinorTickMark { Val = TickMarkValues.Inside });
+                    break;
+                case 3:
+                    axisElement.Append(new MajorTickMark { Val = TickMarkValues.Outside });
+                    axisElement.Append(new MinorTickMark { Val = TickMarkValues.Outside });
+                    break;
+                case 4:
+                    axisElement.Append(new MajorTickMark { Val = TickMarkValues.Cross });
+                    axisElement.Append(new MinorTickMark { Val = TickMarkValues.Cross });
+                    break;
+                default:
+                    axisElement.Append(new MajorTickMark { Val = TickMarkValues.None });
+                    axisElement.Append(new MinorTickMark { Val = TickMarkValues.None });
+                    break;
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ReferenceBase.cs
+++ b/ClosedXML/Excel/Charts/ReferenceBase.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClosedXML.Excel.Charts
+{
+    public abstract class ReferenceBase
+    {
+        public int ReferenceColumn { get; set; }
+        public int ReferenceRow { get; set; }
+
+        public abstract String Reference { get; }
+
+        public String ReferenceTable { get; set; }
+
+        public String ReferenceDirect { get; set; }
+
+        public String ReferenceColumnName
+        {
+            get { return GetColumnName(ReferenceColumn); }
+        }
+
+        protected ReferenceBase()
+        {
+            ReferenceColumn = 1;
+            ReferenceRow = 1;
+            ReferenceTable = @"Tabelle1";
+        }
+
+        protected static String GetColumnName(int index)
+        {
+            if (index < 1)
+                throw new ArgumentOutOfRangeException(@"index");
+
+            const int firstChar = 65;
+
+            string result = string.Empty;
+            int value = index;
+
+            while (value > 0)
+            {
+                int remainder = (value - 1) % 26;
+                result = (char)(firstChar + remainder) + result;
+                value = (int)(Math.Floor((double)((value - remainder) / 26)));
+            }
+            return result;
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/ReferenceData.cs
+++ b/ClosedXML/Excel/Charts/ReferenceData.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClosedXML.Excel.Charts
+{
+    public class ReferenceData : ReferenceBase
+    {
+        public String[] Values { get; set; }
+
+        public int ReferenceRowEnd
+        {
+            get { return ReferenceRow + Values.Length - 1; }
+        }
+
+        public override String Reference
+        {
+            get
+            {
+                if (ReferenceDirect == null)
+                    return ReferenceTable + '!' + ReferenceColumnName + ReferenceRow + ':' + ReferenceColumnName + ReferenceRowEnd;
+                return ReferenceDirect;
+            }
+        }
+
+        public ReferenceData()
+        {
+            ReferenceRow = 2;
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/SingleReferenceData.cs
+++ b/ClosedXML/Excel/Charts/SingleReferenceData.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClosedXML.Excel.Charts
+{
+    public class SingleReferenceData : ReferenceBase
+    {
+        public override String Reference
+        {
+            get
+            {
+                if (ReferenceDirect == null)
+                    return ReferenceTable + '!' + ReferenceColumnName + ReferenceRow;
+                return ReferenceDirect;
+            }
+        }
+
+        public String Value { get; set; }
+
+        public SingleReferenceData(String value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/ClosedXML/Excel/Charts/XLCharts.cs
+++ b/ClosedXML/Excel/Charts/XLCharts.cs
@@ -2,9 +2,16 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    internal class XLCharts: IXLCharts
+    public class XLCharts : IXLCharts
     {
         private List<IXLChart> charts = new List<IXLChart>();
+        private readonly IXLWorksheet _worksheet;
+
+        public XLCharts(IXLWorksheet worksheet)
+        {
+            _worksheet = worksheet;
+        }
+
         public IEnumerator<IXLChart> GetEnumerator()
         {
             return charts.GetEnumerator();
@@ -15,9 +22,15 @@ namespace ClosedXML.Excel
             return GetEnumerator();
         }
 
-        public void Add(IXLChart chart)
+        public IXLChart Chart(int index)
+        {
+            return charts[index];
+        }
+
+        public IXLChart Add(IXLChart chart)
         {
             charts.Add(chart);
+            return chart;
         }
     }
 }

--- a/ClosedXML/Excel/Drawings/XLDrawing.cs
+++ b/ClosedXML/Excel/Drawings/XLDrawing.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ClosedXML.Excel
 {
-    internal class XLDrawing<T>: IXLDrawing<T>
+    public class XLDrawing<T>: IXLDrawing<T>
     {
         internal T Container;
         public XLDrawing()

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -375,6 +375,14 @@ namespace ClosedXML.Excel
 
         IXLRange SortLeftToRight(XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
 
+        IXLCharts Charts { get; }
+
+        //IXLChart AddChart(Dictionary<string, int> data, String name, XLChartType chartType);
+
+        IXLChart AddChart(IXLChart chart);
+
+        IXLChart Chart(Int32 index);
+        
         //IXLCharts Charts { get; }
 
         Boolean ShowFormulas { get; set; }

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -3384,6 +3384,9 @@ namespace ClosedXML.Excel
 
             DocumentFormat.OpenXml.Drawing.Charts.PlotVisibleOnly plotVisibleOnly = new DocumentFormat.OpenXml.Drawing.Charts.PlotVisibleOnly() { Val = false };
             chart.Append(plotVisibleOnly);
+            
+            DocumentFormat.OpenXml.Drawing.Charts.DisplayBlanksAs displayBlanksAs = new DocumentFormat.OpenXml.Drawing.Charts.DisplayBlanksAs() { Val = DocumentFormat.OpenXml.Drawing.Charts.DisplayBlanksAsValues.Gap };
+            chart.Append(displayBlanksAs);
 
             if (!chartxl.Border)
             {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -78,7 +78,7 @@ namespace ClosedXML.Excel
             _rowHeight = workbook.RowHeight;
             RowHeightChanged = Math.Abs(workbook.RowHeight - XLWorkbook.DefaultRowHeight) > XLHelper.Epsilon;
             Name = sheetName;
-            Charts = new XLCharts();
+            Charts = new XLCharts(this);
             ShowFormulas = workbook.ShowFormulas;
             ShowGridLines = workbook.ShowGridLines;
             ShowOutlineSymbols = workbook.ShowOutlineSymbols;
@@ -157,6 +157,16 @@ namespace ClosedXML.Excel
         public XLDataValidations DataValidations { get; private set; }
 
         public IXLCharts Charts { get; private set; }
+        
+        public IXLChart Chart(Int32 index)
+        {
+            return Charts.Chart(index);
+        }
+
+        public IXLChart AddChart(IXLChart chart)
+        {
+            return Charts.Add(chart);
+        }
 
         public XLSheetProtection Protection
         {


### PR DESCRIPTION
Since the chart export was not possible until now, it has now been implemented and integrated into the existing system. A loading function for charts does not yet exists, but it can of course be added in the future. But in my opinion, it still is a major progress to make chart exports possible at all.

The GenerateWorksheetPartContent(..) function in the XLWorkBook.Save.cs File was extended by the region charts. In it, a chart anchor is set, through which the chart part can be positioned. A plot area is then created in the chart part, in which the respective chart type is then inserted. You can also set many different settings that influence the layout of the charts.

To add a chart to the worksheet, a new object XLChart must be created and filled. This is where the axes are defined, the data they contain, and the formatting that determines how the chart is displayed in the Excel sheet.

The data is either taken from a referenced table or can be inserted manually. For this purpose, the data is presented in individual series, which must be added to the chart. The object ChartSeriesData created for this purpose contains mainly the values of the categories, the categories themselves and the series names. If the data is taken from a referenced table, the direct reference must also be specified.

Charts with any content can be created and added to the Excel worksheet.