### PR TITLE
WIP: Sorting cells having formulas (#105)

### DIFF
--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -317,6 +317,9 @@ namespace ClosedXML.Excel
                     if (cell1 == null) cell1 = worksheet.Cell(sp1.Row, sp1.Column);
                     if (cell2 == null) cell2 = worksheet.Cell(sp2.Row, sp2.Column);
 
+                    var formula1 = cell1.HasFormula ? cell1.FormulaR1C1 : (string)null;
+                    var formula2 = cell2.HasFormula ? cell2.FormulaR1C1 : (string)null;
+
                     //if (cell1 != null)
                     //{
                     cell1.Address = new XLAddress(cell1.Worksheet, sp2.Row, sp2.Column, false, false);
@@ -331,6 +334,9 @@ namespace ClosedXML.Excel
                     Remove(sp2);
                     //if (cell1 != null)
                     Add(sp2, cell1);
+
+                    if (formula1 != null) cell1.FormulaR1C1 = formula1;
+                    if (formula2 != null) cell2.FormulaR1C1 = formula2;
                 }
             }
         }

--- a/ClosedXML/Excel/Ranges/XLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRow.cs
@@ -250,9 +250,7 @@ namespace ClosedXML.Excel
                         switch (thisCell.DataType)
                         {
                             case XLDataType.Text:
-                                comparison = e.MatchCase
-                                                 ? thisCell.InnerText.CompareTo(otherCell.InnerText)
-                                                 : String.Compare(thisCell.InnerText, otherCell.InnerText, true);
+                                comparison = String.Compare(thisCell.GetString(), otherCell.GetString(), !e.MatchCase);
                                 break;
 
                             case XLDataType.TimeSpan:

--- a/ClosedXML_Sandbox/Program.cs
+++ b/ClosedXML_Sandbox/Program.cs
@@ -1,4 +1,6 @@
+using ClosedXML.Excel;
 using System;
+using System.Linq;
 
 namespace ClosedXML_Sandbox
 {
@@ -6,22 +8,52 @@ namespace ClosedXML_Sandbox
     {
         private static void Main(string[] args)
         {
-            Console.WriteLine("Running {0}", nameof(PerformanceRunner.OpenTestFile));
-            PerformanceRunner.TimeAction(PerformanceRunner.OpenTestFile);
-            Console.WriteLine();
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.Worksheets.Add("Table");
 
-            // Disable this block by default - I don't use it often
-#if false
+                ws.Cell("A1").SetValue("1");
+                ws.Cell("A2").SetValue("2");
+                ws.Cell("A3").SetValue("3");
+                ws.Cell("A4").SetValue("4");
+                ws.Cell("A5").SetValue("5");
+                ws.Cell("A6").SetValue("6");
+                ws.Cell("A7").SetValue("7");
+                ws.Cell("A8").SetValue("8");
 
-            Console.WriteLine("Running {0}", nameof(PerformanceRunner.RunInsertTable));
-            PerformanceRunner.TimeAction(PerformanceRunner.RunInsertTable);
-            Console.WriteLine();
+                ws.Cell("B1").SetValue("1");
+                ws.Cell("B2").SetValue("2");
+                ws.Cell("B3").SetValue("3");
+                ws.Cell("B4").SetValue("4");
+                ws.Cell("B5").SetValue("5");
+                ws.Cell("B6").SetValue("6");
+                ws.Cell("B7").SetValue("7");
+                ws.Cell("B8").SetValue("8");
 
-            Console.WriteLine("Running {0}", nameof(PerformanceRunner.PerformHeavyCalculation));
-            PerformanceRunner.TimeAction(PerformanceRunner.PerformHeavyCalculation);
-            Console.WriteLine();
-#endif
+                ws.Cell("C1").FormulaA1 = "=A1+B1";
+                ws.Cell("C2").FormulaA1 = "=A2+B2";
+                ws.Cell("C3").FormulaA1 = "=A3+B3";
+                ws.Cell("C4").FormulaA1 = "=A4+B4";
+                ws.Cell("C5").FormulaA1 = "=A5+B5";
+                ws.Cell("C6").FormulaA1 = "=A6+B6";
+                ws.Cell("C7").FormulaA1 = "=A7+B7";
+                ws.Cell("C8").FormulaA1 = "=A8+B8";
 
+                var header = ws.Row(1).InsertRowsAbove(1).First();
+                for (Int32 co = 1; co <= ws.LastColumnUsed().ColumnNumber(); co++)
+                {
+                    header.Cell(co).Value = "Column" + co.ToString();
+                }
+                var rangeTable = ws.RangeUsed();
+                var table = rangeTable.CopyTo(ws.Column(ws.LastColumnUsed().ColumnNumber() + 3)).CreateTable();
+
+                var rangeTable2 = rangeTable.RangeUsed();
+                var table2 = rangeTable2.CopyTo(ws.Column(ws.LastColumnUsed().ColumnNumber() + 3)).CreateTable();
+
+                table2.Sort("Column3 Desc");
+
+                wb.SaveAs(@"e:\closedXML\105.xlsx");
+            }
             Console.WriteLine("Press any key to continue");
             Console.ReadKey();
         }


### PR DESCRIPTION
This is a work in progress

✔️ The issue nr. 1. Sorting algorithm swaps cells leaving their A1-style formulas unchanged.  
✔️ The issue nr. 2. Cells with formulas are compared by `InnerText` which is nonsense. As a consequence, formula `A10+B10` goes before `A2+B2` no matter what are the results of those formulas.
🟥  The issue nr. 3. When two cells are compared, ClosedXML analyzes their `DataType` and if they both have `Text` they are compared as text, and 2 considered larger than 10. 

I think we should implement a comparer that will handle different combinations of data types, blanks, formulas, etc. But right now I don't have enough time. Will try to get back to this sometime later.

Fixes #105 