### PR TITLE
Upgrade libraries that do not work well in Rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ obj/
 _ReSharper*/
 [Tt]est[Rr]esult*
 /packages
+.idea/

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -52,11 +52,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Fody" Version="5.2.0">
+    <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Janitor.Fody" Version="1.6.8" PrivateAssets="all" />
+    <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
   </ItemGroup>
@@ -67,11 +67,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="Fody" Version="5.2.0">
+    <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Janitor.Fody" Version="1.6.8" PrivateAssets="all" />
+    <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
@@ -86,6 +86,6 @@
 
     <!-- SourceLink , see https://github.com/ctaggart/SourceLink -->
     <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I started to use Rider some time ago but was not able to use it with ClosedXML as there were some strange exceptions on build.

```
  Microsoft.Build.Tasks.Git.targets(20, 5): [MSB4018] The "Microsoft.Build.Tasks.Git.LocateRepository" task failed unexpectedly.
System.TypeInitializationException: The type initializer for 'Microsoft.Build.Tasks.Git.TaskImplementation' threw an exception.
 ---> System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build.Tasks.Git, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
File name: 'Microsoft.Build.Tasks.Git, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
 ---> System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build.Tasks.Git, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
File name: 'Microsoft.Build.Tasks.Git, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
   at System.Reflection.RuntimeAssembly.nLoad(AssemblyName fileName, String codeBase, RuntimeAssembly assemblyContext, StackCrawlMark& stackMark, Boolean throwOnFileNotFound, AssemblyLoadContext assemblyLoadContext)
   at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext)
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext)
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyName(AssemblyName assemblyName)
   at Microsoft.Build.Tasks.Git.GitLoaderContext.Load(AssemblyName assemblyName) in /_/src/Microsoft.Build.Tasks.Git/GitLoaderContext.cs:line 24
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingLoad(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
   at System.Reflection.RuntimeAssembly.GetType(QCallAssembly assembly, String name, Boolean throwOnError, Boolean ignoreCase, ObjectHandleOnStack type, ObjectHandleOnStack keepAlive, ObjectHandleOnStack assemblyLoadContext)
   at System.Reflection.RuntimeAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at System.Reflection.Assembly.GetType(String name, Boolean throwOnError)
   at Microsoft.Build.Tasks.Git.TaskImplementation..cctor() in /_/src/Microsoft.Build.Tasks.Git/TaskImplementation.cs:line 35
   --- End of inner exception stack trace ---
   at Microsoft.Build.Tasks.Git.LocateRepository.Execute() in /_/src/Microsoft.Build.Tasks.Git/LocateRepository.cs:line 22
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
```

If I comment out the reference to `Microsoft.SourceLink.GitHub` the error is different:

```
  ClosedXML: [] Fody: An unhandled exception occurred:
Exception:
Could not load file or assembly 'Mono.Cecil, Version=0.11.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03'. The system cannot find the file specified.
Type:
System.IO.FileNotFoundException
StackTrace:
   at InnerWeaver.Execute()
   at Processor.ExecuteInOwnAssemblyLoadContext() in C:\projects\fody\Fody\Processor.cs:line 150
   at Processor.Inner() in C:\projects\fody\Fody\Processor.cs:line 122
   at Processor.Execute() in C:\projects\fody\Fody\Processor.cs:line 51
Source:
FodyIsolated
TargetSite:
Void Execute()
```

Luckily, upgrading `Microsoft.SourceLink.GitHub`, `Fody`, and `Janitor.Fody` seems to solve both issues.