### PR TITLE
Considering options when checking for empty cell

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1560,6 +1560,9 @@ namespace ClosedXML.Excel
             if (options.HasFlag(XLCellsUsedOptions.Sparklines) && HasSparkline)
                 return false;
 
+            if (options.HasFlag(XLCellsUsedOptions.DataType) && DataType != XLDataType.Text)
+                return false;
+
             return true;
         }
 

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1520,8 +1520,11 @@ namespace ClosedXML.Excel
 
         public Boolean IsEmpty(XLCellsUsedOptions options)
         {
-            if (InnerText.Length > 0)
-                return false;
+            if (options.HasFlag (XLCellsUsedOptions.Contents))
+            {
+                if (InnerText.Length > 0)
+                    return false;
+            }
 
             if (options.HasFlag(XLCellsUsedOptions.NormalFormats))
             {

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -261,7 +261,7 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            cell.Comment.AddText ("comment");
+            cell.Comment.AddText("comment");
             bool actual = cell.IsEmpty();
             bool expected = false;
             Assert.AreEqual(expected, actual);
@@ -272,8 +272,8 @@ namespace ClosedXML_Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            cell.Comment.AddText ("comment");
-            cell.SetValue ("value");
+            cell.Comment.AddText("comment");
+            cell.SetValue("value");
 
             bool actual = cell.IsEmpty();
             bool expected = false;
@@ -281,17 +281,17 @@ namespace ClosedXML_Tests
         }
 
         [Test]
-        [TestCase (XLCellsUsedOptions.Contents, true)]
-        [TestCase (XLCellsUsedOptions.DataType, true)]
-        [TestCase (XLCellsUsedOptions.NormalFormats, true)]
-        [TestCase (XLCellsUsedOptions.ConditionalFormats, true)]
-        [TestCase (XLCellsUsedOptions.Comments, false)]
-        [TestCase (XLCellsUsedOptions.DataValidation, true)]
-        [TestCase (XLCellsUsedOptions.MergedRanges, true)]
-        [TestCase (XLCellsUsedOptions.Sparklines, true)]
-        [TestCase (XLCellsUsedOptions.AllFormats, true)]
-        [TestCase (XLCellsUsedOptions.AllContents, false)]
-        [TestCase (XLCellsUsedOptions.All, false)]
+        [TestCase(XLCellsUsedOptions.Contents, true)]
+        [TestCase(XLCellsUsedOptions.DataType, true)]
+        [TestCase(XLCellsUsedOptions.NormalFormats, true)]
+        [TestCase(XLCellsUsedOptions.ConditionalFormats, true)]
+        [TestCase(XLCellsUsedOptions.Comments, false)]
+        [TestCase(XLCellsUsedOptions.DataValidation, true)]
+        [TestCase(XLCellsUsedOptions.MergedRanges, true)]
+        [TestCase(XLCellsUsedOptions.Sparklines, true)]
+        [TestCase(XLCellsUsedOptions.AllFormats, true)]
+        [TestCase(XLCellsUsedOptions.AllContents, false)]
+        [TestCase(XLCellsUsedOptions.All, false)]
         public void IsEmpty_Comment_Options(XLCellsUsedOptions options, bool expected)
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
@@ -304,23 +304,118 @@ namespace ClosedXML_Tests
         }
 
         [Test]
-        [TestCase (XLCellsUsedOptions.Contents, false)]
-        [TestCase (XLCellsUsedOptions.DataType, true)]
-        [TestCase (XLCellsUsedOptions.NormalFormats, true)]
-        [TestCase (XLCellsUsedOptions.ConditionalFormats, true)]
-        [TestCase (XLCellsUsedOptions.Comments, false)]
-        [TestCase (XLCellsUsedOptions.DataValidation, true)]
-        [TestCase (XLCellsUsedOptions.MergedRanges, true)]
-        [TestCase (XLCellsUsedOptions.Sparklines, true)]
-        [TestCase (XLCellsUsedOptions.AllFormats, true)]
-        [TestCase (XLCellsUsedOptions.AllContents, false)]
-        [TestCase (XLCellsUsedOptions.All, false)]
+        [TestCase(XLCellsUsedOptions.Contents, false)]
+        [TestCase(XLCellsUsedOptions.DataType, true)]
+        [TestCase(XLCellsUsedOptions.NormalFormats, true)]
+        [TestCase(XLCellsUsedOptions.ConditionalFormats, true)]
+        [TestCase(XLCellsUsedOptions.Comments, false)]
+        [TestCase(XLCellsUsedOptions.DataValidation, true)]
+        [TestCase(XLCellsUsedOptions.MergedRanges, true)]
+        [TestCase(XLCellsUsedOptions.Sparklines, true)]
+        [TestCase(XLCellsUsedOptions.AllFormats, true)]
+        [TestCase(XLCellsUsedOptions.AllContents, false)]
+        [TestCase(XLCellsUsedOptions.All, false)]
         public void IsEmpty_Comment_Options_Value(XLCellsUsedOptions options, bool expected) // see #1575
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
             cell.Comment.AddText("comment");
-            cell.SetValue ("value");
+            cell.SetValue("value");
+
+            bool actual = cell.IsEmpty(options);
+
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [Test]
+        public void IsEmpty_DataType()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.DataType = XLDataType.Boolean;
+            bool actual = cell.IsEmpty();
+            bool expected = false;
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [Test]
+        public void IsEmpty_DataType_Text()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.DataType = XLDataType.Text;
+            bool actual = cell.IsEmpty();
+            bool expected = true;
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [Test]
+        public void IsEmpty_DataType_Value()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.DataType = XLDataType.Number;
+            cell.SetValue(42);
+
+            bool actual = cell.IsEmpty();
+            bool expected = false;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void IsEmpty_DataType_Text_Value()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.DataType = XLDataType.Text;
+            cell.SetValue("value");
+
+            bool actual = cell.IsEmpty();
+            bool expected = false;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase(XLCellsUsedOptions.Contents, true)]
+        [TestCase(XLCellsUsedOptions.DataType, false)]
+        [TestCase(XLCellsUsedOptions.NormalFormats, true)]
+        [TestCase(XLCellsUsedOptions.ConditionalFormats, true)]
+        [TestCase(XLCellsUsedOptions.Comments, true)]
+        [TestCase(XLCellsUsedOptions.DataValidation, true)]
+        [TestCase(XLCellsUsedOptions.MergedRanges, true)]
+        [TestCase(XLCellsUsedOptions.Sparklines, true)]
+        [TestCase(XLCellsUsedOptions.AllFormats, true)]
+        [TestCase(XLCellsUsedOptions.AllContents, false)]
+        [TestCase(XLCellsUsedOptions.All, false)]
+        public void IsEmpty_DataType_Options(XLCellsUsedOptions options, bool expected)
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.DataType = XLDataType.Number;
+
+            bool actual = cell.IsEmpty(options);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase(XLCellsUsedOptions.Contents, false)]
+        [TestCase(XLCellsUsedOptions.DataType, false)]
+        [TestCase(XLCellsUsedOptions.NormalFormats, true)]
+        [TestCase(XLCellsUsedOptions.ConditionalFormats, true)]
+        [TestCase(XLCellsUsedOptions.Comments, false)]
+        [TestCase(XLCellsUsedOptions.DataValidation, true)]
+        [TestCase(XLCellsUsedOptions.MergedRanges, true)]
+        [TestCase(XLCellsUsedOptions.Sparklines, true)]
+        [TestCase(XLCellsUsedOptions.AllFormats, true)]
+        [TestCase(XLCellsUsedOptions.AllContents, false)]
+        [TestCase(XLCellsUsedOptions.All, false)]
+        public void IsEmpty_DataType_Options_Value(XLCellsUsedOptions options, bool expected) // see #1575
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.DataType = XLDataType.Number;
+            cell.SetValue(42);
 
             bool actual = cell.IsEmpty(options);
 

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -257,6 +257,77 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void IsEmpty_Comment()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.Comment.AddText ("comment");
+            bool actual = cell.IsEmpty();
+            bool expected = false;
+            Assert.AreEqual(expected, actual);
+        }
+        
+        [Test]
+        public void IsEmpty_Comment_Value()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.Comment.AddText ("comment");
+            cell.SetValue ("value");
+
+            bool actual = cell.IsEmpty();
+            bool expected = false;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase (XLCellsUsedOptions.Contents, true)]
+        [TestCase (XLCellsUsedOptions.DataType, true)]
+        [TestCase (XLCellsUsedOptions.NormalFormats, true)]
+        [TestCase (XLCellsUsedOptions.ConditionalFormats, true)]
+        [TestCase (XLCellsUsedOptions.Comments, false)]
+        [TestCase (XLCellsUsedOptions.DataValidation, true)]
+        [TestCase (XLCellsUsedOptions.MergedRanges, true)]
+        [TestCase (XLCellsUsedOptions.Sparklines, true)]
+        [TestCase (XLCellsUsedOptions.AllFormats, true)]
+        [TestCase (XLCellsUsedOptions.AllContents, false)]
+        [TestCase (XLCellsUsedOptions.All, false)]
+        public void IsEmpty_Comment_Options(XLCellsUsedOptions options, bool expected)
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.Comment.AddText("comment");
+
+            bool actual = cell.IsEmpty(options);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase (XLCellsUsedOptions.Contents, false)]
+        [TestCase (XLCellsUsedOptions.DataType, true)]
+        [TestCase (XLCellsUsedOptions.NormalFormats, true)]
+        [TestCase (XLCellsUsedOptions.ConditionalFormats, true)]
+        [TestCase (XLCellsUsedOptions.Comments, false)]
+        [TestCase (XLCellsUsedOptions.DataValidation, true)]
+        [TestCase (XLCellsUsedOptions.MergedRanges, true)]
+        [TestCase (XLCellsUsedOptions.Sparklines, true)]
+        [TestCase (XLCellsUsedOptions.AllFormats, true)]
+        [TestCase (XLCellsUsedOptions.AllContents, false)]
+        [TestCase (XLCellsUsedOptions.All, false)]
+        public void IsEmpty_Comment_Options_Value(XLCellsUsedOptions options, bool expected) // see #1575
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell cell = ws.Cell(1, 1);
+            cell.Comment.AddText("comment");
+            cell.SetValue ("value");
+
+            bool actual = cell.IsEmpty(options);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void NaN_is_not_a_number()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -403,7 +403,7 @@ namespace ClosedXML_Tests
         [TestCase(XLCellsUsedOptions.DataType, false)]
         [TestCase(XLCellsUsedOptions.NormalFormats, true)]
         [TestCase(XLCellsUsedOptions.ConditionalFormats, true)]
-        [TestCase(XLCellsUsedOptions.Comments, false)]
+        [TestCase(XLCellsUsedOptions.Comments, true)]
         [TestCase(XLCellsUsedOptions.DataValidation, true)]
         [TestCase(XLCellsUsedOptions.MergedRanges, true)]
         [TestCase(XLCellsUsedOptions.Sparklines, true)]

--- a/ClosedXML_Tests/Excel/Comments/CommentsTests.cs
+++ b/ClosedXML_Tests/Excel/Comments/CommentsTests.cs
@@ -190,5 +190,62 @@ namespace ClosedXML_Tests.Excel.Comments
                 Assert.False(ws.Cell("A4").Comment.Visible);
             }
         }
+
+        [Test]
+        public void CanRemoveCommentsWithoutAddingOthers() // see #1575
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = new XLWorkbook())
+                {
+                    var sheet = wb.AddWorksheet("sheet1");
+
+                    //guard
+                    var cellsWithComments1 = wb.Worksheets.SelectMany(_ => _.CellsUsed(XLCellsUsedOptions.Comments)).ToArray();
+                    Assert.That(cellsWithComments1, Is.Empty);
+
+                    var a1 = sheet.Cell("A1");
+                    var b5 = sheet.Cell("B5");
+
+                    a1.SetValue("test a1");
+                    b5.SetValue("test b5");
+
+                    var cellsWithComments2 = wb.Worksheets.SelectMany(_ => _.CellsUsed(XLCellsUsedOptions.Comments)).ToArray();
+                    Assert.That(cellsWithComments2, Is.Empty);
+
+                    a1.Comment.AddText("no comment");
+
+                    //guard
+                    var cellsWithComments3 = wb.Worksheets.SelectMany(_ => _.CellsUsed(XLCellsUsedOptions.Comments)).ToArray();
+                    Assert.That(cellsWithComments3.Length, Is.EqualTo(1));
+
+                    wb.SaveAs(ms, true);
+                }
+
+                ms.Position = 0;
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var cellsWithComments = wb.Worksheets.SelectMany(_ => _.CellsUsed(XLCellsUsedOptions.Comments)).ToArray();
+
+                    Assert.That(cellsWithComments.Length, Is.EqualTo(1));
+
+                    // act
+                    cellsWithComments.ForEach(_ => _.Clear(XLClearOptions.Comments));
+
+                    wb.Save();
+                }
+
+                ms.Position = 0;
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    // assert
+                    var cellsWithComments = wb.Worksheets.SelectMany(_ => _.Cells(true, XLCellsUsedOptions.Comments)).ToArray();
+
+                    Assert.That(cellsWithComments, Is.Empty);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Change Behavior of IsEmpty(XLCellsUsedOptions) to consider XLCellsUsedOptions.Contents instead of always returning false if a content is set.