### PR TITLE
Ensure EmptyValueExpression evaluates to null

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Expression.cs
+++ b/ClosedXML/Excel/CalcEngine/Expression.cs
@@ -536,6 +536,8 @@ namespace ClosedXML.Excel.CalcEngine
     internal class EmptyValueExpression : Expression
     {
         internal EmptyValueExpression()
+            // Ensures a token of type LITERAL, with value of null is created
+            : base(value: null) 
         {
         }
 

--- a/ClosedXML_Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML_Tests/Excel/CalcEngine/TextTests.cs
@@ -92,6 +92,12 @@ namespace ClosedXML_Tests.Excel.CalcEngine
         }
 
         [Test]
+        public void Concat_EmptyValue()
+        {
+            Assert.AreEqual("ABC123", XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"", , ""123"", )"));
+        }
+
+        [Test]
         public void Concatenate_Value()
         {
             Object actual = XLWorkbook.EvaluateExpr(@"Concatenate(""ABC"", ""123"")");


### PR DESCRIPTION
Ensure EmptyValueExpression evaluates to null by setting internal token to a LITERAL token type with value null. 