### PR TITLE
Upgrade netcoreapp2.0 to netcoreapp3.1 in Sandbox and Examples

### DIFF
--- a/ClosedXML_Examples/ClosedXML_Examples.csproj
+++ b/ClosedXML_Examples/ClosedXML_Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net40;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net40;net46</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
     <Version>0.95.4</Version>
@@ -11,7 +11,7 @@
     <AssemblyOriginatorKeyFile>ClosedXML.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
   </PropertyGroup>
 

--- a/ClosedXML_Sandbox/ClosedXML_Sandbox.csproj
+++ b/ClosedXML_Sandbox/ClosedXML_Sandbox.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net40;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net40;net46</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Version>0.95.4</Version>
     <NoWarn>$(NoWarn);NU1605</NoWarn>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
   </PropertyGroup>
 
@@ -21,7 +21,7 @@
     <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET46_</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">


### PR DESCRIPTION
@Pankraty Any objections? Seems like a default VS2019 installation doesn't include `netcoreapp2.x` anymore.