### PR TITLE
Before attempting to parse colour code, add hash before RGBA hex code if it doesn't exist

### DIFF
--- a/ClosedXML/Utils/ColorStringParser.cs
+++ b/ClosedXML/Utils/ColorStringParser.cs
@@ -9,6 +9,9 @@ namespace ClosedXML.Utils
         {
             try
             {
+                if (htmlColor[0] != '#')
+                    htmlColor = '#' + htmlColor;
+
                 return ColorTranslator.FromHtml(htmlColor);
             }
             catch


### PR DESCRIPTION
Many hex codes didn't have a `#`, especially when dealing with sparklines. This caused an exception, which was caught and subsequent color code parsing dealt with it successfully. But adding the `#` if it's omitted should result it a performance gain with colour code parsing.