### PR TITLE
Improve pivot table save performance by avoiding multiple enumerations of CellsUsed

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -2252,22 +2252,22 @@ namespace ClosedXML.Excel
                 };
 
                 var sourceHeaderRow = source.FirstRow().RowNumber();
-                var fieldValueCells = source.CellsUsed(cell => cell.Address.ColumnNumber == columnNumber
-                                                           && cell.Address.RowNumber > sourceHeaderRow);
+                var cellsUsed = source.CellsUsed(XLCellsUsedOptions.All,
+                                                 cell => cell.Address.ColumnNumber == columnNumber
+                                                         && cell.Address.RowNumber > sourceHeaderRow)
+                                                 .ToArray();
+                var fieldValueCells = cellsUsed.Where(cell => !cell.IsEmpty()).ToArray();
                 var types = fieldValueCells.Select(cell => cell.DataType).Distinct().ToArray();
-                var containsBlank = source.CellsUsed(XLCellsUsedOptions.All,
-                    cell => cell.Address.ColumnNumber == columnNumber
-                            && cell.Address.RowNumber > sourceHeaderRow
-                            && cell.IsEmpty()).Any();
+                var containsBlank = cellsUsed.Any(cell => cell.IsEmpty());
 
                 // For a totally blank column, we need to check that all cells in column are unused
-                if (!fieldValueCells.Any())
+                if (fieldValueCells.Length == 0)
                 {
                     ptfi.IsTotallyBlankField = true;
                     containsBlank = true;
                 }
 
-                if (types.Any())
+                if (types.Length > 0)
                 {
                     if (types.Length == 1 && types.Single() == XLDataType.Number)
                     {


### PR DESCRIPTION
Most of the time taken saving pivot table is in enumerating `CellsUsed`:
![image](https://user-images.githubusercontent.com/681706/114117501-3150ff00-992a-11eb-8303-1153d12dfd7a.png)

Updating this to materialise the array once rather than multiple enumerations yielded a big performance gain in `SaveAs` for my large pivot table (from 65s `SaveAs` to 29s `SaveAs`)