### PR TITLE
Add new methods for adding pictures that don't require System.Drawing.Bitmap to work

### DIFF
--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -31,8 +31,6 @@ namespace ClosedXML.Tests
                     Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
                     Assert.AreEqual(200, picture.Width);
                     Assert.AreEqual(200, picture.Height);
-                    Assert.AreEqual(72, picture.DpiX);
-                    Assert.AreEqual(72, picture.DpiY);
                 }
             }
         }
@@ -54,8 +52,6 @@ namespace ClosedXML.Tests
                     Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
                     Assert.AreEqual(200, picture.Width);
                     Assert.AreEqual(200, picture.Height);
-                    Assert.AreEqual(72, picture.DpiX);
-                    Assert.AreEqual(72, picture.DpiY);
                 }
             }
         }

--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -31,6 +31,8 @@ namespace ClosedXML.Tests
                     Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
                     Assert.AreEqual(200, picture.Width);
                     Assert.AreEqual(200, picture.Height);
+                    Assert.AreEqual(72, picture.DpiX);
+                    Assert.AreEqual(72, picture.DpiY);
                 }
             }
         }
@@ -52,6 +54,8 @@ namespace ClosedXML.Tests
                     Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
                     Assert.AreEqual(200, picture.Width);
                     Assert.AreEqual(200, picture.Height);
+                    Assert.AreEqual(72, picture.DpiX);
+                    Assert.AreEqual(72, picture.DpiY);
                 }
             }
         }
@@ -66,7 +70,7 @@ namespace ClosedXML.Tests
 
                 using (var resourceStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
                 {
-                    var picture = ws.AddPicture(resourceStream, 400, 400, XLPictureFormat.Jpeg)
+                    var picture = ws.AddPicture(resourceStream, 400, 400, 72, 72, XLPictureFormat.Jpeg)
                         .WithPlacement(XLPicturePlacement.FreeFloating)
                         .MoveTo(50, 50)
                         .WithSize(200, 200);
@@ -74,6 +78,8 @@ namespace ClosedXML.Tests
                     Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
                     Assert.AreEqual(200, picture.Width);
                     Assert.AreEqual(200, picture.Height);
+                    Assert.AreEqual(72, picture.DpiX);
+                    Assert.AreEqual(72, picture.DpiY);
                 }
             }
         }

--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -56,6 +56,28 @@ namespace ClosedXML.Tests
             }
         }
 
+
+        [Test]
+        public void CanAddPictureFromStreamWithImageInfo()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet("Sheet1");
+
+                using (var resourceStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
+                {
+                    var picture = ws.AddPicture(resourceStream, 400, 400, XLPictureFormat.Jpeg)
+                        .WithPlacement(XLPicturePlacement.FreeFloating)
+                        .MoveTo(50, 50)
+                        .WithSize(200, 200);
+
+                    Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
+                    Assert.AreEqual(200, picture.Width);
+                    Assert.AreEqual(200, picture.Height);
+                }
+            }
+        }
+
         [Test]
         public void CanAddPictureFromFile()
         {

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -15,6 +15,10 @@ namespace ClosedXML.Excel.Drawings
         /// </summary>
         XLPictureFormat Format { get; }
 
+        Single DpiX { get; set; }
+
+        Single DpiY { get; set; }
+
         Int32 Height { get; set; }
 
         Int32 Id { get; }
@@ -36,10 +40,6 @@ namespace ClosedXML.Excel.Drawings
         IXLCell TopLeftCell { get; }
 
         Int32 Width { get; set; }
-
-        Single DpiX { get; set; }
-
-        Single DpiY { get; set; }
 
         IXLWorksheet Worksheet { get; }
 

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -37,6 +37,10 @@ namespace ClosedXML.Excel.Drawings
 
         Int32 Width { get; set; }
 
+        Single DpiX { get; set; }
+
+        Single DpiY { get; set; }
+
         IXLWorksheet Worksheet { get; }
 
         /// <summary>

--- a/ClosedXML/Excel/Drawings/IXLPictures.cs
+++ b/ClosedXML/Excel/Drawings/IXLPictures.cs
@@ -17,9 +17,9 @@ namespace ClosedXML.Excel.Drawings
 
         IXLPicture Add(Stream stream, XLPictureFormat format, String name);
 
-        IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format);
+        IXLPicture Add(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format);
 
-        IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format, String name);
+        IXLPicture Add(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format, String name);
 
         IXLPicture Add(Bitmap bitmap);
 

--- a/ClosedXML/Excel/Drawings/IXLPictures.cs
+++ b/ClosedXML/Excel/Drawings/IXLPictures.cs
@@ -17,6 +17,10 @@ namespace ClosedXML.Excel.Drawings
 
         IXLPicture Add(Stream stream, XLPictureFormat format, String name);
 
+        IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format);
+
+        IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format, String name);
+
         IXLPicture Add(Bitmap bitmap);
 
         IXLPicture Add(Bitmap bitmap, String name);

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -7,6 +7,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using ClosedXML.Utils;
 
 namespace ClosedXML.Excel.Drawings
 {
@@ -464,8 +465,8 @@ namespace ClosedXML.Excel.Drawings
             this.OriginalWidth = image.Width;
             this.OriginalHeight = image.Height;
 
-            this.DpiX = image.HorizontalResolution;
-            this.DpiY = image.VerticalResolution;
+            this.DpiX = GraphicsUtils.Graphics.DpiX;
+            this.DpiY = GraphicsUtils.Graphics.DpiY;
 
             this._width = image.Width;
             this._height = image.Height;

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -79,6 +79,21 @@ namespace ClosedXML.Excel.Drawings
             this.Format = formats.Single().Key;
         }
 
+        internal XLPicture(IXLWorksheet worksheet, Stream stream, int width, int height, XLPictureFormat format)
+            : this(worksheet)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            this.Format = format;
+
+            this.ImageStream = new MemoryStream();
+            stream.Position = 0;
+            stream.CopyTo(ImageStream);
+            ImageStream.Seek(0, SeekOrigin.Begin);
+
+            this.OriginalWidth = this._width = width;
+            this.OriginalHeight = this._height = height;
+        }
+
         private XLPicture(IXLWorksheet worksheet)
         {
             this.Worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -79,7 +79,7 @@ namespace ClosedXML.Excel.Drawings
             this.Format = formats.Single().Key;
         }
 
-        internal XLPicture(IXLWorksheet worksheet, Stream stream, int width, int height, XLPictureFormat format)
+        internal XLPicture(IXLWorksheet worksheet, Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format)
             : this(worksheet)
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
@@ -92,6 +92,8 @@ namespace ClosedXML.Excel.Drawings
 
             this.OriginalWidth = this._width = width;
             this.OriginalHeight = this._height = height;
+            this.DpiX = dpiX;
+            this.DpiY = dpiY;
         }
 
         private XLPicture(IXLWorksheet worksheet)
@@ -225,6 +227,10 @@ namespace ClosedXML.Excel.Drawings
                 _width = value;
             }
         }
+
+        public Single DpiX { get; set; }
+
+        public Single DpiY { get; set; }
 
         public IXLWorksheet Worksheet { get; }
 
@@ -457,6 +463,9 @@ namespace ClosedXML.Excel.Drawings
         {
             this.OriginalWidth = image.Width;
             this.OriginalHeight = image.Height;
+
+            this.DpiX = image.HorizontalResolution;
+            this.DpiY = image.VerticalResolution;
 
             this._width = image.Width;
             this._height = image.Height;

--- a/ClosedXML/Excel/Drawings/XLPictures.cs
+++ b/ClosedXML/Excel/Drawings/XLPictures.cs
@@ -57,17 +57,17 @@ namespace ClosedXML.Excel.Drawings
             return picture;
         }
 
-        public IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format)
+        public IXLPicture Add(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format)
         {
-            var picture = new XLPicture(_worksheet, stream, width, height, format);
+            var picture = new XLPicture(_worksheet, stream, width, height, dpiX, dpiY, format);
             _pictures.Add(picture);
             picture.Name = GetNextPictureName();
             return picture;
         }
 
-        public IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format, string name)
+        public IXLPicture Add(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format, string name)
         {
-            var picture = Add(stream, width, height, format);
+            var picture = Add(stream, width, height, dpiX, dpiY, format);
             picture.Name = name;
             return picture;
         }

--- a/ClosedXML/Excel/Drawings/XLPictures.cs
+++ b/ClosedXML/Excel/Drawings/XLPictures.cs
@@ -57,6 +57,21 @@ namespace ClosedXML.Excel.Drawings
             return picture;
         }
 
+        public IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format)
+        {
+            var picture = new XLPicture(_worksheet, stream, width, height, format);
+            _pictures.Add(picture);
+            picture.Name = GetNextPictureName();
+            return picture;
+        }
+
+        public IXLPicture Add(Stream stream, int width, int height, XLPictureFormat format, string name)
+        {
+            var picture = Add(stream, width, height, format);
+            picture.Name = name;
+            return picture;
+        }
+
         public IXLPicture Add(Bitmap bitmap)
         {
             var picture = new XLPicture(_worksheet, bitmap);

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -474,6 +474,10 @@ namespace ClosedXML.Excel
 
         IXLPicture AddPicture(Stream stream, XLPictureFormat format, String name);
 
+        IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format);
+
+        IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format, String name);
+
         IXLPicture AddPicture(Bitmap bitmap);
 
         IXLPicture AddPicture(Bitmap bitmap, String name);

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -474,9 +474,9 @@ namespace ClosedXML.Excel
 
         IXLPicture AddPicture(Stream stream, XLPictureFormat format, String name);
 
-        IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format);
+        IXLPicture AddPicture(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format);
 
-        IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format, String name);
+        IXLPicture AddPicture(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format, String name);
 
         IXLPicture AddPicture(Bitmap bitmap);
 

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -3383,8 +3383,8 @@ namespace ClosedXML.Excel
             if (existingAnchor != null)
                 worksheetDrawing.RemoveChild(existingAnchor);
 
-            var extentsCx = ConvertToEnglishMetricUnits(pic.Width, GraphicsUtils.Graphics.DpiX);
-            var extentsCy = ConvertToEnglishMetricUnits(pic.Height, GraphicsUtils.Graphics.DpiY);
+            var extentsCx = ConvertToEnglishMetricUnits(pic.Width, pic.DpiX);
+            var extentsCy = ConvertToEnglishMetricUnits(pic.Height, pic.DpiY);
 
             var nvps = worksheetDrawing.Descendants<Xdr.NonVisualDrawingProperties>();
             var nvpId = nvps.Any() ?
@@ -3399,8 +3399,8 @@ namespace ClosedXML.Excel
                     var absoluteAnchor = new Xdr.AbsoluteAnchor(
                         new Xdr.Position
                         {
-                            X = ConvertToEnglishMetricUnits(pic.Left, GraphicsUtils.Graphics.DpiX),
-                            Y = ConvertToEnglishMetricUnits(pic.Top, GraphicsUtils.Graphics.DpiY)
+                            X = ConvertToEnglishMetricUnits(pic.Left, pic.DpiX),
+                            Y = ConvertToEnglishMetricUnits(pic.Top, pic.DpiY)
                         },
                         new Xdr.Extent
                         {
@@ -3437,8 +3437,8 @@ namespace ClosedXML.Excel
                     {
                         ColumnId = new Xdr.ColumnId((moveAndSizeFromMarker.ColumnNumber - 1).ToInvariantString()),
                         RowId = new Xdr.RowId((moveAndSizeFromMarker.RowNumber - 1).ToInvariantString()),
-                        ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveAndSizeFromMarker.Offset.X, GraphicsUtils.Graphics.DpiX).ToInvariantString()),
-                        RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveAndSizeFromMarker.Offset.Y, GraphicsUtils.Graphics.DpiY).ToInvariantString())
+                        ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveAndSizeFromMarker.Offset.X, pic.DpiX).ToInvariantString()),
+                        RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveAndSizeFromMarker.Offset.Y, pic.DpiY).ToInvariantString())
                     };
 
                     var moveAndSizeToMarker = pic.Markers[Drawings.XLMarkerPosition.BottomRight];
@@ -3447,8 +3447,8 @@ namespace ClosedXML.Excel
                     {
                         ColumnId = new Xdr.ColumnId((moveAndSizeToMarker.ColumnNumber - 1).ToInvariantString()),
                         RowId = new Xdr.RowId((moveAndSizeToMarker.RowNumber - 1).ToInvariantString()),
-                        ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveAndSizeToMarker.Offset.X, GraphicsUtils.Graphics.DpiX).ToInvariantString()),
-                        RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveAndSizeToMarker.Offset.Y, GraphicsUtils.Graphics.DpiY).ToInvariantString())
+                        ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveAndSizeToMarker.Offset.X, pic.DpiX).ToInvariantString()),
+                        RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveAndSizeToMarker.Offset.Y, pic.DpiY).ToInvariantString())
                     };
 
                     var twoCellAnchor = new Xdr.TwoCellAnchor(
@@ -3484,8 +3484,8 @@ namespace ClosedXML.Excel
                     {
                         ColumnId = new Xdr.ColumnId((moveFromMarker.ColumnNumber - 1).ToInvariantString()),
                         RowId = new Xdr.RowId((moveFromMarker.RowNumber - 1).ToInvariantString()),
-                        ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveFromMarker.Offset.X, GraphicsUtils.Graphics.DpiX).ToInvariantString()),
-                        RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveFromMarker.Offset.Y, GraphicsUtils.Graphics.DpiY).ToInvariantString())
+                        ColumnOffset = new Xdr.ColumnOffset(ConvertToEnglishMetricUnits(moveFromMarker.Offset.X, pic.DpiX).ToInvariantString()),
+                        RowOffset = new Xdr.RowOffset(ConvertToEnglishMetricUnits(moveFromMarker.Offset.Y, pic.DpiY).ToInvariantString())
                     };
 
                     var oneCellAnchor = new Xdr.OneCellAnchor(

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1792,6 +1792,16 @@ namespace ClosedXML.Excel
             return Pictures.Add(stream, format, name);
         }
 
+        public IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format)
+        {
+            return Pictures.Add(stream, width, height, format);
+        }
+
+        public IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format, string name)
+        {
+            return Pictures.Add(stream, width, height, format, name);
+        }
+
         public IXLPicture AddPicture(Bitmap bitmap)
         {
             return Pictures.Add(bitmap);

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1792,14 +1792,14 @@ namespace ClosedXML.Excel
             return Pictures.Add(stream, format, name);
         }
 
-        public IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format)
+        public IXLPicture AddPicture(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format)
         {
-            return Pictures.Add(stream, width, height, format);
+            return Pictures.Add(stream, width, height, dpiX, dpiY, format);
         }
 
-        public IXLPicture AddPicture(Stream stream, int width, int height, XLPictureFormat format, string name)
+        public IXLPicture AddPicture(Stream stream, int width, int height, float dpiX, float dpiY, XLPictureFormat format, string name)
         {
-            return Pictures.Add(stream, width, height, format, name);
+            return Pictures.Add(stream, width, height, dpiX, dpiY, format, name);
         }
 
         public IXLPicture AddPicture(Bitmap bitmap)


### PR DESCRIPTION
Currently adding a picture to a worksheet requires System.Drawing.Bitmap to work. However, the only use for it is reading out format and size of the image.
This PR adds methods that take the format and size as parameters to be passed in. This way, pictures can be added on platforms that don't support System.Drawing.Bitmap, such as UWP, Android and iOS.