### PR TITLE
Support inserting DateTimeOffset into table

### DIFF
--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -1176,5 +1176,13 @@ namespace ClosedXML.Tests
 
             Assert.Throws<FormatException>(() => c.ToString("dummy"));
         }
+
+        [Test]
+        public void ConvertOtherSupportedTypes()
+        {
+            Assert.AreEqual("", XLCell.ConvertOtherSupportedTypes(DBNull.Value));
+            Assert.AreEqual("748bdf0c-3e7d-415e-967d-a875a27634ed", XLCell.ConvertOtherSupportedTypes(new Guid("748BDF0C-3E7D-415E-967D-A875A27634ED")));
+            Assert.AreEqual(DateTime.Today, XLCell.ConvertOtherSupportedTypes(DateTime.Today));
+        }
     }
 }

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -569,6 +569,21 @@ namespace ClosedXML.Tests
             Assert.IsFalse(ws.Cell("A4").TryGetValue(out double? _));
         }
 
+        [TestCase(2019, 11, 5, 11, 30, 5, 0, ExpectedResult = "2019-11-05 11:30:05.000")]
+        [TestCase(2019, 11, 5, 11, 30, 5, 2, ExpectedResult = "2019-11-05 11:30:05.000")]
+        [TestCase(2019, 11, 5, 11, 30, 5, -10, ExpectedResult = "2019-11-05 11:30:05.000")]
+        public string ValueSetDateTimeOffset(int year, int month, int days, int hours, int minutes, int seconds, int offsetInHours)
+        {
+            var cell = new XLWorkbook().Worksheets.Add("Sheet1").FirstCell();
+
+            cell.Value = new DateTimeOffset(year, month, days, hours, minutes, seconds, new TimeSpan(offsetInHours * TimeSpan.TicksPerHour));
+
+            // C# Supports 7 digits milliseconds, but excel only 3
+            const string format = "yyyy-MM-dd HH:mm:ss.fff";
+
+            return cell.GetDateTime().ToString(format);
+        }
+
         [Test]
         public void SetCellValueToGuid()
         {
@@ -1182,6 +1197,7 @@ namespace ClosedXML.Tests
         {
             Assert.AreEqual("", XLCell.ConvertOtherSupportedTypes(DBNull.Value));
             Assert.AreEqual("748bdf0c-3e7d-415e-967d-a875a27634ed", XLCell.ConvertOtherSupportedTypes(new Guid("748BDF0C-3E7D-415E-967D-A875A27634ED")));
+            Assert.AreEqual(new DateTime(2022, 06, 30, 12, 57, 00), XLCell.ConvertOtherSupportedTypes(new DateTimeOffset(2022, 06, 30, 12, 57, 00, new TimeSpan(2 * TimeSpan.TicksPerHour))));
             Assert.AreEqual(DateTime.Today, XLCell.ConvertOtherSupportedTypes(DateTime.Today));
         }
     }

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -945,6 +945,23 @@ namespace ClosedXML.Tests.Excel
         }
 
         [Test]
+        public void CanInsertDateTimeOffset()
+        {
+            var now = DateTimeOffset.Now;
+
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            ws1.FirstCell().InsertTable(new[] { new { TimeStamp = now } });
+
+            // C# Supports 7 digits milliseconds, but excel only 3
+            const string format = "yyyy-MM-dd HH:mm:ss.fff";
+
+            var actual = ws1.Cell("A2").GetDateTime().ToString(format);
+            var expected = now.DateTime.ToString(format);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void CopyDetachedTableDifferentWorksheets()
         {
             var wb = new XLWorkbook();

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -219,6 +219,7 @@ namespace ClosedXML.Excel
             {
                 DBNull dbnull when dbnull.Equals(DBNull.Value) => string.Empty,
                 Guid _ or char _ or Enum _ => value.ObjectToInvariantString(),
+                DateTimeOffset dto => dto.DateTime,
                 _ => value,
             };
         }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>
 
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Continuation of https://github.com/ClosedXML/ClosedXML/pull/1305

>Ah ok, that makes more sense. For InsertTable we want to support all data types that are natively supported by SQL. Is DateTimeOffset supported by SQL? And if so, please add unit tests for InsertTable, which is the root issue here.

`DateTimeOffset` is supported by SQL: https://www.w3schools.com/sql/sql_datatypes.asp
Relates to: https://github.com/ClosedXML/ClosedXML/issues/954