### PR TITLE
Fix shape disappear if there was no image

### DIFF
--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -289,6 +289,31 @@ namespace ClosedXML.Tests
         }
 
         [Test]
+        public void CanDeletePictureOnlyOne()
+        {
+            using (var ms = new MemoryStream())
+            {
+                int originalCount;
+
+                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
+                using (var wb = new XLWorkbook(stream))
+                {
+                    var ws = wb.Worksheets.First();
+                    originalCount = ws.Pictures.Count;
+
+                    ws.Pictures.Delete(ws.Pictures.First());
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var ws = wb.Worksheets.First();
+                    Assert.AreEqual(originalCount - 1, ws.Pictures.Count);
+                }
+            }
+        }
+
+        [Test]
         public void CanDeletePictures()
         {
             using (var ms = new MemoryStream())

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -5977,6 +5977,15 @@ namespace ClosedXML.Excel
                 foreach (var removedPicture in xlPictures.Deleted)
                 {
                     worksheetPart.DrawingsPart.DeletePart(removedPicture);
+                    // Remove Image reference link
+                    foreach (var wd in worksheetPart.DrawingsPart.WorksheetDrawing)
+                    {
+                        if (wd.Descendants<Blip>().Any(x => x.Embed == removedPicture))
+                        {
+                            worksheetPart.DrawingsPart.WorksheetDrawing.RemoveChild(wd);
+                            break;
+                        }
+                    }
                 }
                 xlPictures.Deleted.Clear();
             }
@@ -5998,9 +6007,22 @@ namespace ClosedXML.Excel
                 cm.SetElement(XLWorksheetContents.Drawing, worksheetPart.Worksheet.Elements<Drawing>().First());
             }
 
+            bool isEmptyDrawingsPart(DrawingsPart drawingsPart)
+            {
+                return drawingsPart != null
+                && !drawingsPart.CustomXmlParts.Any()
+                && !drawingsPart.ImageParts.Any()
+                && !drawingsPart.DiagramStyleParts.Any()
+                && !drawingsPart.DiagramLayoutDefinitionParts.Any()
+                && !drawingsPart.DiagramPersistLayoutParts.Any()
+                && !drawingsPart.DiagramDataParts.Any()
+                && !drawingsPart.DiagramColorsParts.Any()
+                && !drawingsPart.ChartParts.Any()
+                && !drawingsPart.WebExtensionParts.Any();
+            }
+
             // Instead of saving a file with an empty Drawings.xml file, rather remove the .xml file
-            if (!xlWorksheet.Pictures.Any() && worksheetPart.DrawingsPart != null
-                && !worksheetPart.DrawingsPart.Parts.Any())
+            if (!xlWorksheet.Pictures.Any() && isEmptyDrawingsPart(worksheetPart.DrawingsPart))
             {
                 var id = worksheetPart.GetIdOfPart(worksheetPart.DrawingsPart);
                 worksheetPart.Worksheet.RemoveChild(worksheetPart.Worksheet.OfType<Drawing>().FirstOrDefault(p => p.Id == id));


### PR DESCRIPTION
Thank you for always great tools.
We have tried to fix the bug, so please check it.

Fixes #1252 

![image](https://user-images.githubusercontent.com/1159599/136206267-7d76c269-85c7-4619-b5f9-b2fcc7ee5569.png)

Fix shape disappear if there was no image.
It also fixes an issue where image reference links would appear broken when some images were deleted.

## Repro before correction

### This file is No-Image, shape only.
- Expect: Keep shapes.
- Actual: All shapes disappear.
![image](https://user-images.githubusercontent.com/1159599/136208054-a72154a7-7a06-436b-a1aa-1f89899e2f58.png)

### Delete only one image when there are multiple images.
(Added Test case CanDeletePictureOnlyOne)
- Expect: One image is delete.
- Actual: Image link is not deleted.
![image](https://user-images.githubusercontent.com/1159599/136205311-ab677606-f869-4481-be5f-da676b9d20e0.png)

- After correction:
![image](https://user-images.githubusercontent.com/1159599/136209992-36e74f52-4026-4301-ace6-5f3d962a9334.png)