### PR TITLE
Remove the custom preprocessor symbols

### DIFF
--- a/ClosedXML.Examples/ClosedXML.Examples.csproj
+++ b/ClosedXML.Examples/ClosedXML.Examples.csproj
@@ -13,18 +13,6 @@
     <RootNamespace>ClosedXML.Examples</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET40_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET46_</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Resources\*.jpg" />
     <EmbeddedResource Include="Resources\*.png" />

--- a/ClosedXML.Sandbox/ClosedXML.Sandbox.csproj
+++ b/ClosedXML.Sandbox/ClosedXML.Sandbox.csproj
@@ -11,26 +11,7 @@
     <RootNamespace>ClosedXML.Sandbox</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET40_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET46_</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
 

--- a/ClosedXML.Sandbox/ReflectionExtensions.cs
+++ b/ClosedXML.Sandbox/ReflectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if _NET40_
+﻿#if NET40
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -16,18 +16,6 @@
   <PropertyGroup>
     <DefineConstants>$(AppVeyor)</DefineConstants>
   </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET40_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET46_</DefineConstants>
-  </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="**\*.xlsx" Exclude="**\~$*.xlsx;bin\**" />
@@ -55,7 +43,7 @@
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\ClosedXML\ClosedXML.csproj" />
     <ProjectReference Include="..\ClosedXML.Examples\ClosedXML.Examples.csproj" />

--- a/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -440,7 +440,7 @@ namespace ClosedXML.Tests.Excel
             }
         }
 
-#if _NET40_
+#if NET40
         [Ignore(".NET 40 does not support Janitor.Fody")]
 #endif
 

--- a/ClosedXML.Tests/OleDb/OleDbTests.cs
+++ b/ClosedXML.Tests/OleDb/OleDbTests.cs
@@ -1,4 +1,4 @@
-﻿#if !APPVEYOR && _NETFRAMEWORK_
+﻿#if !APPVEYOR && NETFRAMEWORK
 using ClosedXML.Excel;
 using ClosedXML.Tests.Utils;
 using NUnit.Framework;

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -31,18 +31,6 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);_NETSTANDARD_;_NETSTANDARD2_0_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET40_</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <DefineConstants>$(DefineConstants);_NETFRAMEWORK_;_NET46_</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -240,7 +240,7 @@ namespace ClosedXML.Excel.Drawings
             this.ImageStream.Dispose();
         }
 
-#if _NET40_
+#if NET40
 
         public void Dispose()
         {

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -43,7 +43,7 @@ namespace ClosedXML.Excel
             return FromColor(Color.FromArgb(a, r, g, b));
         }
 
-#if _NETFRAMEWORK_
+#if NETFRAMEWORK
         public static XLColor FromKnownColor(KnownColor color)
         {
             return FromColor(Color.FromKnownColor(color));

--- a/ClosedXML/Excel/Style/XLBorder.cs
+++ b/ClosedXML/Excel/Style/XLBorder.cs
@@ -590,7 +590,7 @@ namespace ClosedXML.Excel
                     }));
             }
 
-#if _NET40_
+#if NET40
 
             public void Dispose()
             {

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -808,7 +808,7 @@ namespace ClosedXML.Excel
             Worksheets.ForEach(w => (w as XLWorksheet).Cleanup());
         }
 
-#if _NET40_
+#if NET40
         public void Dispose()
         {
             // net40 doesn't support Janitor.Fody, so let's dispose manually

--- a/ClosedXML/Excel/XLWorksheetInternals.cs
+++ b/ClosedXML/Excel/XLWorksheetInternals.cs
@@ -31,7 +31,7 @@ namespace ClosedXML.Excel
             MergedRanges.RemoveAll();
         }
 
-#if _NET40_
+#if NET40
 
         public void Dispose()
         {

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -251,19 +251,6 @@ namespace ClosedXML.Excel
             return rows;
         }
 
-#if false
-// Not using this anymore, but keeping it around for in case we bring back .NET3.5 support.
-        public static bool IsNullOrWhiteSpace(string value)
-        {
-#if _NET35_
-            if (value == null) return true;
-            return value.All(c => char.IsWhiteSpace(c));
-#else
-            return String.IsNullOrWhiteSpace(value);
-#endif
-        }
-#endif
-
         private static readonly Regex A1RegexRelative = new Regex(
       @"(?<=\W)(?<one>\$?[a-zA-Z]{1,3}\$?\d{1,7})(?=\W)" // A1
     + @"|(?<=\W)(?<two>\$?\d{1,7}:\$?\d{1,7})(?=\W)" // 1:1


### PR DESCRIPTION
The .NET SDK already provides target framework [preprocessor symbols](https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-a-target-framework), there is no need to define additional ones.

Also, it's 2022 so the commented out code that says "keeping it around for in case we bring back .NET3.5 support" has been removed.