### PR TITLE
Add default format code for numbering formats to avoid exception in xl\styles.xml file

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -4555,7 +4555,7 @@ namespace ClosedXML.Excel
                 workbookStylesPart.Stylesheet.NumberingFormats.AppendChild(new NumberingFormat()
                 {
                     NumberFormatId = 0,
-                    FormatCode = ""
+                    FormatCode = "#,###"
                 });
             }
 


### PR DESCRIPTION
Add default format code for numbering formats, otherwise Excel will throw an Error in xl\styles.xml file (and all other sheel{...}.xml files as well.