### PR TITLE
[WIP] Add method to get a worksheet by it's ID

### DIFF
--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1242,5 +1242,33 @@ namespace ClosedXML.Tests
                 Assert.AreEqual(XLWorksheetVisibility.Visible, wb.Worksheets.First().Visibility);
             }
         }
+
+        [Test]
+        public void GetWorksheetById()
+        {
+            using (var wb = new XLWorkbook())
+            {
+                wb.Worksheets.Add("Sheet 1");
+                wb.Worksheets.Add("Sheet 2");
+
+                // Get sheet number 2 and assert that the name is Sheet 2
+                Assert.IsTrue(wb.Worksheets.GetWorksheetById(2).Name == "Sheet 2");
+
+                // Test if an exception is thrown if sheet with the given ID is not found
+                Assert.Throws<InvalidOperationException>(() => wb.Worksheets.GetWorksheetById(3));
+
+                // Test if TryGetWorksheetById returns true if a sheet is found and otherwise false
+                Assert.IsTrue(wb.Worksheets.TryGetWorksheetById(2, out var result1) && result1 != null);
+                Assert.IsTrue(!wb.Worksheets.TryGetWorksheetById(3, out var result2) && result2 == null);
+
+                // Rename sheet 1 and check if the name is still valid
+                wb.Worksheet(1).Name = "New Name";
+                Assert.IsTrue(wb.Worksheets.GetWorksheetById(1).Name == "New Name");
+
+                // Reorder the sheets and test again
+                wb.Worksheets.Worksheet(1).Position = 2;
+                Assert.IsTrue(wb.Worksheets.GetWorksheetById(1).Name == "New Name");
+            }
+        }
     }
 }

--- a/ClosedXML/Excel/IXLWorksheets.cs
+++ b/ClosedXML/Excel/IXLWorksheets.cs
@@ -33,5 +33,21 @@ namespace ClosedXML.Excel
         IXLWorksheet Worksheet(String sheetName);
 
         IXLWorksheet Worksheet(Int32 position);
+
+        /// <summary>
+        /// Gets an <see cref="IXLWorksheet"/> by it's ID.
+        /// </summary>
+        /// <param name="id">The ID of the worksheet to look for</param>
+        /// <returns>The requested <see cref="IXLWorksheet"/></returns>
+        /// <throws>If no <see cref="IXLWorksheet"/> with the given ID was not found, an <see cref="InvalidOperationException"/> is thrown</throws>
+        IXLWorksheet GetWorksheetById(int id);
+
+        /// <summary>
+        /// Trys to gets an <see cref="IXLWorksheet"/> by it's ID.
+        /// </summary>
+        /// <param name="id">The ID of the worksheet to look for</param>
+        /// <param name="result">The <see cref="IXLWorksheet"/> if found, otherwise <see langword="null"/></param>
+        /// <returns><see langword="true"/> if found, otherwise <see langword="false"/></returns>
+        bool TryGetWorksheetById(int id, out IXLWorksheet result);
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -62,9 +62,10 @@ namespace ClosedXML.Excel
 
         private void ResetAllRelIds()
         {
+            var currentSheetId = 0;
             foreach (var ws in Worksheets.Cast<XLWorksheet>())
             {
-                ws.SheetId = 0;
+                ws.SheetId = ++currentSheetId;
                 ws.RelId = null;
 
                 foreach (var pt in ws.PivotTables.Cast<XLPivotTable>())

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -723,25 +723,18 @@ namespace ClosedXML.Excel
             foreach (var xlSheet in WorksheetsInternal.Cast<XLWorksheet>().OrderBy(w => w.Position))
             {
                 string rId;
-                if (xlSheet.SheetId == 0 && String.IsNullOrWhiteSpace(xlSheet.RelId))
+                if (String.IsNullOrWhiteSpace(xlSheet.RelId))
                 {
                     rId = context.RelIdGenerator.GetNext(RelType.Workbook);
 
-                    while (WorksheetsInternal.Cast<XLWorksheet>().Any(w => w.SheetId == Int32.Parse(rId.Substring(3))))
+                    while (WorksheetsInternal.Cast<XLWorksheet>().Any(w => w.RelId == rId))
                         rId = context.RelIdGenerator.GetNext(RelType.Workbook);
 
-                    xlSheet.SheetId = Int32.Parse(rId.Substring(3));
                     xlSheet.RelId = rId;
                 }
                 else
                 {
-                    if (String.IsNullOrWhiteSpace(xlSheet.RelId))
-                    {
-                        rId = String.Concat("rId", xlSheet.SheetId);
-                        context.RelIdGenerator.AddValues(new List<String> { rId }, RelType.Workbook);
-                    }
-                    else
-                        rId = xlSheet.RelId;
+                    rId = xlSheet.RelId;
                 }
 
                 if (workbook.Sheets.Cast<Sheet>().All(s => s.Id != rId))

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -89,6 +89,7 @@ namespace ClosedXML.Excel
             RightToLeft = workbook.RightToLeft;
             TabColor = XLColor.NoColor;
             SelectedRanges = new XLRanges();
+            SheetId = workbook.Worksheets.Count > 0 ? workbook.Worksheets.Max(ws => ((XLWorksheet)ws).SheetId) + 1 : 1;
 
             Author = workbook.Author;
         }

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -81,23 +81,11 @@ namespace ClosedXML.Excel
             return _worksheets.Values.Single(w => w.Position == position);
         }
 
-        /// <summary>
-        /// Gets an <see cref="IXLWorksheet"/> by it's ID.
-        /// </summary>
-        /// <param name="id">The ID of the worksheet to look for</param>
-        /// <returns>The requested <see cref="IXLWorksheet"/></returns>
-        /// <throws>If no <see cref="IXLWorksheet"/> with the given ID was not found, an <see cref="InvalidOperationException"/> is thrown</throws>
         public IXLWorksheet GetWorksheetById(int id)
         {
-            return _worksheets.Values.First(ws => ws.SheetId == id);
+            return _worksheets.Values.First(ws => ws.SheetId.Equals(id));
         }
 
-        /// <summary>
-        /// Trys to gets an <see cref="IXLWorksheet"/> by it's ID.
-        /// </summary>
-        /// <param name="id">The ID of the worksheet to look for</param>
-        /// <param name="result">The <see cref="IXLWorksheet"/> if found, otherwise <see langword="null"/></param>
-        /// <returns><see langword="true"/> if found, otherwise <see langword="false"/></returns>
         public bool TryGetWorksheetById(int id, out IXLWorksheet result)
         {
             try

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -81,6 +81,37 @@ namespace ClosedXML.Excel
             return _worksheets.Values.Single(w => w.Position == position);
         }
 
+        /// <summary>
+        /// Gets an <see cref="IXLWorksheet"/> by it's ID.
+        /// </summary>
+        /// <param name="id">The ID of the worksheet to look for</param>
+        /// <returns>The requested <see cref="IXLWorksheet"/></returns>
+        /// <throws>If no <see cref="IXLWorksheet"/> with the given ID was not found, an <see cref="InvalidOperationException"/> is thrown</throws>
+        public IXLWorksheet GetWorksheetById(int id)
+        {
+            return _worksheets.Values.First(ws => ws.SheetId == id);
+        }
+
+        /// <summary>
+        /// Trys to gets an <see cref="IXLWorksheet"/> by it's ID.
+        /// </summary>
+        /// <param name="id">The ID of the worksheet to look for</param>
+        /// <param name="result">The <see cref="IXLWorksheet"/> if found, otherwise <see langword="null"/></param>
+        /// <returns><see langword="true"/> if found, otherwise <see langword="false"/></returns>
+        public bool TryGetWorksheetById(int id, out IXLWorksheet result)
+        {
+            try
+            {
+                result = _worksheets.Values.First(ws => ws.SheetId == id);
+                return true;
+            }
+            catch
+            {
+                result = null;
+                return false;
+            }
+        }
+
         public IXLWorksheet Add()
         {
             return Add(GetNextWorksheetName());


### PR DESCRIPTION
This PR adds two functions to get a worksheet by it's ID. This helps if the name or position can change, but the ID not. 

`public IXLWorksheet GetWorksheetById(int id)` ► Gets the worksheet by ID or throws if no sheet with the given ID was found
`public bool TryGetWorksheetById(int id, out IXLWorksheet result)`  ► Doesn't throw, but requires a prameter with our.

Closes #1786 