### PR TITLE
Fix "picture names cannot be empty" on Excel file opening

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1125,7 +1125,7 @@ namespace ClosedXML.Excel
                         stream.CopyTo(ms);
                         var vsdp = GetPropertiesFromAnchor(anchor);
 
-                        var picture = (ws as XLWorksheet).AddPicture(ms, vsdp.Name, Convert.ToInt32(vsdp.Id.Value)) as XLPicture;
+                        var picture = (ws as XLWorksheet).AddPicture(ms, String.IsNullOrWhiteSpace(vsdp.Name) ? "noname" : (string)vsdp.Name, Convert.ToInt32(vsdp.Id.Value)) as XLPicture;
                         picture.RelId = imgId;
 
                         Xdr.ShapeProperties spPr = anchor.Descendants<Xdr.ShapeProperties>().First();


### PR DESCRIPTION
Files created in Excel may contain pictures without a name, but you still want to open them.
Fix with minimal impact on the core logic.