### PR TITLE
Unify error handling in expressions.

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/OptimizerTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/OptimizerTests.cs
@@ -1,0 +1,47 @@
+﻿using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine
+{
+    /// <summary>
+    /// Expressions in the workbook are optimized before running, e.g. expression <c>(1+14)/5</c> is turned into <c>5</c>.
+    /// Since optimization is transparent to the user and happens during parsing, test look into internal structures.
+    /// </summary>
+    [TestFixture]
+    public class OptimizerTests
+    {
+        [Test]
+        public void Binary_operations_with_literal_is_optimized()
+        {
+            var exp = GetOptimizedExpression("1+2");
+            Assert.AreEqual(typeof(Expression), exp.GetType());
+            Assert.AreEqual(3, exp._token.Value);
+        }
+
+        [Test]
+        public void Unary_operations_with_literal_is_optimized()
+        {
+            var exp = GetOptimizedExpression("-(+7)");
+            Assert.AreEqual(typeof(Expression), exp.GetType());
+            Assert.AreEqual(-7, exp._token.Value);
+        }
+
+        [Test]
+        public void Function_call_with_only_literal_values_is_optimized()
+        {
+            var exp = GetOptimizedExpression("=SUM(2-1,15/5-2,1,2*5-3*3)");
+            Assert.AreEqual(typeof(Expression), exp.GetType());
+            Assert.AreEqual(4, exp._token.Value);
+        }
+
+        private Expression GetOptimizedExpression(string formula)
+        {
+            using (var wb = new XLWorkbook())
+            {
+                var ws = wb.AddWorksheet() as XLWorksheet;
+                return ws.CalcEngine.Parse(formula);
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -33,33 +33,19 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             {
                 p[0].Evaluate();
             }
-            catch (NullValueException)
+            catch (CalcEngineException ex)
             {
-                return 1;
-            }
-            catch (DivisionByZeroException)
-            {
-                return 2;
-            }
-            catch (CellValueException)
-            {
-                return 3;
-            }
-            catch (CellReferenceException)
-            {
-                return 4;
-            }
-            catch (NameNotRecognizedException)
-            {
-                return 5;
-            }
-            catch (NumberException)
-            {
-                return 6;
-            }
-            catch (NoValueAvailableException)
-            {
-                return 7;
+                return ex switch
+                {
+                    NullValueException _ => 1,
+                    DivisionByZeroException _ => 2,
+                    CellValueException _ => 3,
+                    CellReferenceException _ => 4,
+                    NameNotRecognizedException _ => 5,
+                    NumberException _ => 6,
+                    NoValueAvailableException _ => 7,
+                    _ => throw new NoValueAvailableException()
+                };
             }
 
             throw new NoValueAvailableException();


### PR DESCRIPTION
Streamline error handling in formulas. Errors should be always thrown as CalcEngineException exception instead of an return of an error values. That is in line with section 18.17.3, that basically says if an anything in expression causes this, the result of expression is an error (with exception of methods that work on error values).

Also, it makes various function implementation far easier, no need to check for error values anywhere other than functions that should handle it.

I only worked on error handling functions other in Informations.cs, remainder is out of scope of this PR. I have significant doubts about others (obvious errors and even typos in function names, e.g ERRORTYPE instead of ERROR.TYPE). I made some small changes to TYPE so it work with errors, but I would lump it with the others.

### Why exceptions
Error handling is rather rather incosistent.
* Most of code uses exceptions derived from `CalcEngineException`. That is true for both function implementation and CalcEngine processing of operations
* Some functions (mostly from Information.cs) return an error enum `ExpressionErrorType`
* Some functions return other exceptions (e.g. FIND returns `ArgumentException` when it doesn't find the text, MEDIAN returns `ApplicationException` on empty).

This PR basically says that CalcEngineException is the correct state and functions should use it and fixes error checking functions. 
Resolved #1763 