### PR TITLE
AppVeyor: corrections for obsolete compilation messages

### DIFF
--- a/ClosedXML.Examples/Misc/WorkbookProtection.cs
+++ b/ClosedXML.Examples/Misc/WorkbookProtection.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using ClosedXML.Excel;
+﻿using ClosedXML.Excel;
+using System;
 
 namespace ClosedXML.Examples.Misc
 {
@@ -13,11 +13,11 @@ namespace ClosedXML.Examples.Misc
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Workbook Protection");
-                wb.Protect(true, false, "Abc@123");
+                wb.Protect("Abc@123");
                 wb.SaveAs(filePath);
             }
         }
 
-        #endregion
+        #endregion Methods
     }
 }

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -61,7 +61,7 @@ namespace ClosedXML.Tests
             ws.SparklineGroups.Add("B2", "C3:E3");
             ws.SparklineGroups.Add("F5", "C4:E4");
 
-            var range = ws.RangeUsed(true).RangeAddress.ToString();
+            var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
             Assert.AreEqual("B2:F5", range);
         }
 

--- a/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -359,7 +359,7 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect(password: String.Empty);
+                wb.Protect(true, false);
                 Assert.IsTrue(wb.LockStructure);
                 Assert.IsFalse(wb.LockWindows);
                 Assert.IsFalse(wb.IsPasswordProtected);
@@ -406,7 +406,7 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect("Abc@123");
+                wb.Protect(true, false, "Abc@123");
                 Assert.IsTrue(wb.LockStructure);
                 Assert.IsFalse(wb.LockWindows);
                 Assert.IsTrue(wb.IsPasswordProtected);

--- a/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -359,7 +359,7 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect(true, false);
+                wb.Protect(password: String.Empty);
                 Assert.IsTrue(wb.LockStructure);
                 Assert.IsFalse(wb.LockWindows);
                 Assert.IsFalse(wb.IsPasswordProtected);
@@ -406,7 +406,7 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook())
             {
                 var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect(true, false, "Abc@123");
+                wb.Protect("Abc@123");
                 Assert.IsTrue(wb.LockStructure);
                 Assert.IsFalse(wb.LockWindows);
                 Assert.IsTrue(wb.IsPasswordProtected);


### PR DESCRIPTION
Hi Team,

I have checked the compilation messages in AppVeyor.
I adjusted WorkbookProtection.cs, XLCellTests.cs and XLWorkbookTests.cs to get rid of the obsolete messages.

Some changes were created by codemaid.