### PR TITLE
Fix unit test culture errors

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1064,14 +1064,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-12)]
         public double MRound(double number, double multiple)
         {
-            return (double)XLWorkbook.EvaluateExpr($"MROUND({number}, {multiple})");
+            return (double)XLWorkbook.EvaluateExpr(string.Format(CultureInfo.InvariantCulture, "MROUND({0}, {1})", number, multiple));
         }
 
         [TestCase(123456.123, -10)]
         [TestCase(-123456.123, 5)]
         public void MRoundExceptions(double number, double multiple)
         {
-            Assert.Throws<NumberException>(() => XLWorkbook.EvaluateExpr($"MROUND({number}, {multiple})"));
+            Assert.Throws<NumberException>(() => XLWorkbook.EvaluateExpr(string.Format(CultureInfo.InvariantCulture, "MROUND({0}, {1})", number, multiple)));
         }
 
         [TestCase(0, 1)]

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -109,7 +109,7 @@ namespace ClosedXML.Tests
             Assert.IsNull(cell.Clear().GetValue<double?>());
             Assert.AreEqual(1.5, cell.SetValue(1.5).GetValue<double?>());
             Assert.AreEqual(2, cell.SetValue(1.5).GetValue<int?>());
-            Assert.AreEqual(2.5, cell.SetValue("2.5").GetValue<double?>());
+            Assert.AreEqual(2.5, cell.SetValue(2.5.ToString(CultureInfo.CurrentCulture)).GetValue<double?>());
             Assert.Throws<FormatException>(() => cell.SetValue("text").GetValue<double?>());
         }
 
@@ -558,7 +558,7 @@ namespace ClosedXML.Tests
 
             ws.Cell("A1").Clear();
             ws.Cell("A2").SetValue(1.5);
-            ws.Cell("A3").SetValue("2.5");
+            ws.Cell("A3").SetValue(2.5.ToString(CultureInfo.CurrentCulture));
             ws.Cell("A4").SetValue("text");
 
             foreach (var cell in ws.Range("A1:A3").Cells())


### PR DESCRIPTION
Some languages, e.g czech one have a separator of digits different than period (they might have a comma instead). Formulas must be in culture invariant grammar and string-to-number conversion is using current culture.