### PR TITLE
Xml compare

### DIFF
--- a/ClosedXML.Tests/Utils/PackageHelper.cs
+++ b/ClosedXML.Tests/Utils/PackageHelper.cs
@@ -360,10 +360,10 @@ namespace ClosedXML.Tests
                         leftPart.ContentType == @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" &&
                         rightPart.ContentType == @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
 
-                    var tuple1 = new Tuple<Uri, Stream>(pair.Uri, leftMemoryStream);
-                    var tuple2 = new Tuple<Uri, Stream>(pair.Uri, rightMemoryStream);
+                    var tuple1 = (leftPart.ContentType, Stream: leftMemoryStream);
+                    var tuple2 = (rightPart.ContentType, Stream: rightMemoryStream);
 
-                    if (!StreamHelper.Compare(tuple1, tuple2, stripColumnWidthsFromSheet))
+                    if (!StreamHelper.Compare(tuple1, tuple2, pair.Uri, stripColumnWidthsFromSheet))
                     {
                         pair.Status = CompareStatus.NonEqual;
                         if (compareToFirstDifference)

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -114,31 +114,31 @@ namespace ClosedXML.Tests
         /// <param name="other"></param>
         /// /// <param name="stripColumnWidths"></param>
         /// <returns></returns>
-        public static bool Compare((string ContentType, Stream Stream) tuple1, (string ContentType, Stream Stream) tuple2, Uri partUri, bool stripColumnWidths)
+        public static bool Compare((string ContentType, Stream Stream) left, (string ContentType, Stream Stream) right, Uri partUri, bool stripColumnWidths)
         {
             #region Check
 
-            if (tuple1.ContentType == null || tuple1.Stream == null)
+            if (left.ContentType == null || left.Stream == null)
             {
-                throw new ArgumentNullException(nameof(tuple1));
+                throw new ArgumentNullException(nameof(left));
             }
-            if (tuple2.ContentType == null || tuple2.Stream == null)
+            if (right.ContentType == null || right.Stream == null)
             {
-                throw new ArgumentNullException(nameof(tuple2));
+                throw new ArgumentNullException(nameof(right));
             }
-            if (tuple1.Stream.Position != 0)
+            if (left.Stream.Position != 0)
             {
-                throw new ArgumentException("Must be in position 0", nameof(tuple1));
+                throw new ArgumentException("Must be in position 0", nameof(left));
             }
-            if (tuple2.Stream.Position != 0)
+            if (right.Stream.Position != 0)
             {
-                throw new ArgumentException("Must be in position 0", nameof(tuple2));
+                throw new ArgumentException("Must be in position 0", nameof(right));
             }
 
             #endregion Check
 
-            var stringOne = new StreamReader(tuple1.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
-            var stringOther = new StreamReader(tuple2.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+            var stringOne = new StreamReader(left.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+            var stringOther = new StreamReader(right.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
 
             return stringOne == stringOther;
         }

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace ClosedXML.Tests
@@ -12,54 +11,20 @@ namespace ClosedXML.Tests
     /// </summary>
     public static class StreamHelper
     {
-        /// <summary>
-        ///     Convert stream to byte array
-        /// </summary>
-        /// <param name="pStream">Stream</param>
-        /// <returns>Byte array</returns>
-        public static byte[] StreamToArray(Stream pStream)
+        private static readonly XName colTagName = XName.Get("col", @"http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        private static readonly XName widthAttrName = XName.Get("width");
+
+        private static readonly IEnumerable<(string PartSubstring, XName NodeName)> ignoredNodes = new List<(string PartSubstring, XName NodeName)>
         {
-            long iLength = pStream.Length;
-            var bytes = new byte[iLength];
-            for (int i = 0; i < iLength; i++)
-            {
-                bytes[i] = (byte)pStream.ReadByte();
-            }
-            pStream.Close();
-            return bytes;
-        }
+            ("/docProps/core.xml", XName.Get("created", @"http://purl.org/dc/terms/")),
+            ("/docProps/core.xml", XName.Get("modified", @"http://purl.org/dc/terms/")),
+            ("sheet", XName.Get("id", @"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"))
+        };
 
-        /// <summary>
-        ///     Convert byte array to stream
-        /// </summary>
-        /// <param name="pBynaryArray">Byte array</param>
-        /// <param name="pStream">Open stream</param>
-        /// <returns></returns>
-        public static Stream ArrayToStreamAppend(byte[] pBynaryArray, Stream pStream)
+        private static readonly IEnumerable<(string PartSubstring, XName NodeName, XName AttrName)> ignoredAttributes = new List<(string PartSubstring, XName NodeName, XName AttrName)>
         {
-            #region Check params
-
-            if (ReferenceEquals(pBynaryArray, null))
-            {
-                throw new ArgumentNullException("pBynaryArray");
-            }
-            if (ReferenceEquals(pStream, null))
-            {
-                throw new ArgumentNullException("pStream");
-            }
-            if (!pStream.CanWrite)
-            {
-                throw new ArgumentException("Can't write to stream", "pStream");
-            }
-
-            #endregion Check params
-
-            foreach (byte b in pBynaryArray)
-            {
-                pStream.WriteByte(b);
-            }
-            return pStream;
-        }
+            ("sheet", XName.Get("cfRule", @"http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"), XName.Get("id"))
+        };
 
         public static void StreamToStreamAppend(Stream streamIn, Stream streamToWrite)
         {
@@ -111,10 +76,6 @@ namespace ClosedXML.Tests
         /// <summary>
         ///     Compare two streams by converting them to strings and comparing the strings
         /// </summary>
-        /// <param name="one"></param>
-        /// <param name="other"></param>
-        /// /// <param name="stripColumnWidths"></param>
-        /// <returns></returns>
         public static bool Compare((string ContentType, Stream Stream) left, (string ContentType, Stream Stream) right, Uri partUri, bool stripColumnWidths)
         {
             #region Check
@@ -143,73 +104,40 @@ namespace ClosedXML.Tests
 
             #endregion Check
 
-            var leftString = new StreamReader(left.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
-            var rightString = new StreamReader(right.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+            var leftString = new StreamReader(left.Stream).ReadToEnd();
+            var rightString = new StreamReader(right.Stream).ReadToEnd();
 
             var isXmlContent = left.ContentType.EndsWith("+xml");
-            if (isXmlContent)
-            {
-                var leftXml = XDocument.Parse(leftString);
-                var rightXml = XDocument.Parse(rightString);
-                return XNode.DeepEquals(leftXml, rightXml);
-            }
+            if (!isXmlContent)
+                return leftString == rightString;
 
-            return leftString == rightString;
+            var leftXml = XDocument.Parse(leftString);
+            RemoveIgnoredParts(leftXml, partUri, stripColumnWidths);
+            Normalize(leftXml);
+            var rightXml = XDocument.Parse(rightString);
+            RemoveIgnoredParts(rightXml, partUri, stripColumnWidths);
+            Normalize(rightXml);
+
+            return XNode.DeepEquals(leftXml, rightXml);
         }
 
-        private static string RemoveIgnoredParts(this string s, Uri uri, Boolean ignoreColumnWidths, Boolean ignoreGuids)
+        private static void RemoveIgnoredParts(XDocument document, Uri partUri, Boolean stripColumnWidths)
         {
-            foreach (var pair in uriSpecificIgnores.Where(p => p.Key.Equals(uri.OriginalString)))
-                s = pair.Value.Replace(s, "");
+            foreach (var ignoredNode in ignoredNodes.Where(i => partUri.OriginalString.Contains(i.PartSubstring)))
+                document.Descendants(ignoredNode.NodeName).Remove();
 
-            // Collapse empty xml elements
-            s = emptyXmlElementRegex.Replace(s, "<$1 />");
+            foreach (var ignoredAttr in ignoredAttributes.Where(i => partUri.OriginalString.Contains(i.PartSubstring)))
+                document.Descendants(ignoredAttr.NodeName).Attributes(ignoredAttr.AttrName).Remove();
 
-            if (ignoreColumnWidths)
-                s = RemoveColumnWidths(s);
-
-            if (ignoreGuids)
-                s = RemoveGuids(s);
-
-            return s;
+            if (stripColumnWidths)
+                document.Descendants(colTagName).Attributes(widthAttrName).Remove();
         }
 
-        private static IEnumerable<KeyValuePair<string, Regex>> uriSpecificIgnores = new List<KeyValuePair<string, Regex>>()
+        private static void Normalize(XDocument document)
         {
-            // Remove dcterms elements
-            new KeyValuePair<string, Regex>("/docProps/core.xml", new Regex(@"<dcterms:(\w+).*?<\/dcterms:\1>", RegexOptions.Compiled))
-        };
-
-        private static Regex emptyXmlElementRegex = new Regex(@"<([\w:]+)><\/\1>", RegexOptions.Compiled);
-        private static Regex columnRegex = new Regex("<x:col.*?width=\"\\d+(\\.\\d+)?\".*?\\/>", RegexOptions.Compiled);
-        private static Regex widthRegex = new Regex("width=\"\\d+(\\.\\d+)?\"\\s+", RegexOptions.Compiled);
-
-        private static String RemoveColumnWidths(String s)
-        {
-            var replacements = new Dictionary<String, String>();
-
-            foreach (var m in columnRegex.Matches(s).OfType<Match>())
-            {
-                var original = m.Groups[0].Value;
-                var replacement = widthRegex.Replace(original, "");
-                replacements.Add(original, replacement);
-            }
-
-            foreach (var r in replacements)
-            {
-                s = s.Replace(r.Key, r.Value);
-            }
-            return s;
-        }
-
-        private static Regex guidRegex = new Regex(@"{[0-9A-Fa-f]{8}-([0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}}", RegexOptions.Compiled | RegexOptions.Multiline);
-
-        private static String RemoveGuids(String s)
-        {
-            return guidRegex.Replace(s, delegate (Match m)
-            {
-                return string.Empty;
-            });
+            // Turn empty elements into self closing ones.
+            foreach (var emptyElement in document.Descendants().Where(element => !element.IsEmpty && !element.Nodes().Any()))
+                emptyElement.RemoveNodes();
         }
     }
 }

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -114,31 +114,32 @@ namespace ClosedXML.Tests
         /// <param name="other"></param>
         /// /// <param name="stripColumnWidths"></param>
         /// <returns></returns>
-        public static bool Compare(Tuple<Uri, Stream> tuple1, Tuple<Uri, Stream> tuple2, bool stripColumnWidths)
+        public static bool Compare((string ContentType, Stream Stream) tuple1, (string ContentType, Stream Stream) tuple2, Uri partUri, bool stripColumnWidths)
         {
             #region Check
 
-            if (tuple1 == null || tuple1.Item1 == null || tuple1.Item2 == null)
+            if (tuple1.ContentType == null || tuple1.Stream == null)
             {
-                throw new ArgumentNullException("one");
+                throw new ArgumentNullException(nameof(tuple1));
             }
-            if (tuple2 == null || tuple2.Item1 == null || tuple2.Item2 == null)
+            if (tuple2.ContentType == null || tuple2.Stream == null)
             {
-                throw new ArgumentNullException("other");
+                throw new ArgumentNullException(nameof(tuple2));
             }
-            if (tuple1.Item2.Position != 0)
+            if (tuple1.Stream.Position != 0)
             {
-                throw new ArgumentException("Must be in position 0", "one");
+                throw new ArgumentException("Must be in position 0", nameof(tuple1));
             }
-            if (tuple2.Item2.Position != 0)
+            if (tuple2.Stream.Position != 0)
             {
-                throw new ArgumentException("Must be in position 0", "other");
+                throw new ArgumentException("Must be in position 0", nameof(tuple2));
             }
 
             #endregion Check
 
-            var stringOne = new StreamReader(tuple1.Item2).ReadToEnd().RemoveIgnoredParts(tuple1.Item1, stripColumnWidths, ignoreGuids: true);
-            var stringOther = new StreamReader(tuple2.Item2).ReadToEnd().RemoveIgnoredParts(tuple2.Item1, stripColumnWidths, ignoreGuids: true);
+            var stringOne = new StreamReader(tuple1.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+            var stringOther = new StreamReader(tuple2.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+
             return stringOne == stringOther;
         }
 

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -136,8 +136,14 @@ namespace ClosedXML.Tests
         private static void Normalize(XDocument document)
         {
             // Turn empty elements into self closing ones.
-            foreach (var emptyElement in document.Descendants().Where(element => !element.IsEmpty && !element.Nodes().Any()))
+            foreach (var emptyElement in document.Descendants().Where(e => !e.IsEmpty && !e.Nodes().Any()))
                 emptyElement.RemoveNodes();
+
+            foreach (var element in document.Descendants().Where(e => e.Attributes().Any()))
+            {
+                var attrs = element.Attributes().OrderBy(a => a.Name.LocalName).ToList();
+                element.ReplaceAttributes(attrs);
+            }
         }
     }
 }

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace ClosedXML.Tests
 {
@@ -135,12 +136,25 @@ namespace ClosedXML.Tests
                 throw new ArgumentException("Must be in position 0", nameof(right));
             }
 
+            if (left.ContentType != right.ContentType)
+            {
+                throw new ArgumentException("Different content types.");
+            }
+
             #endregion Check
 
-            var stringOne = new StreamReader(left.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
-            var stringOther = new StreamReader(right.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+            var leftString = new StreamReader(left.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
+            var rightString = new StreamReader(right.Stream).ReadToEnd().RemoveIgnoredParts(partUri, stripColumnWidths, ignoreGuids: true);
 
-            return stringOne == stringOther;
+            var isXmlContent = left.ContentType.EndsWith("+xml");
+            if (isXmlContent)
+            {
+                var leftXml = XDocument.Parse(leftString);
+                var rightXml = XDocument.Parse(rightString);
+                return XNode.DeepEquals(leftXml, rightXml);
+            }
+
+            return leftString == rightString;
         }
 
         private static string RemoveIgnoredParts(this string s, Uri uri, Boolean ignoreColumnWidths, Boolean ignoreGuids)


### PR DESCRIPTION
Compare two XML files using XML structure and not a string. The key issue for this is that DocumentFormat.OpenXml was generating attribtues in a different order. Also, regexp are seriously not a good to manipulate xml (or any other nonregular language).