### PR TITLE
Refactor/simplify .csproj files

### DIFF
--- a/ClosedXML.Examples/ClosedXML.Examples.csproj
+++ b/ClosedXML.Examples/ClosedXML.Examples.csproj
@@ -2,15 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net40;net46</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
     <OutputType>Exe</OutputType>
-    <Version>0.95.4</Version>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <Configurations>Debug;Release</Configurations>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\ClosedXML.snk</AssemblyOriginatorKeyFile>
-    <AssemblyName>ClosedXML.Examples</AssemblyName>
-    <RootNamespace>ClosedXML.Examples</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClosedXML.Examples/Misc/WorkbookProtection.cs
+++ b/ClosedXML.Examples/Misc/WorkbookProtection.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using ClosedXML.Excel;
+﻿using ClosedXML.Excel;
+using System;
 
 namespace ClosedXML.Examples.Misc
 {
@@ -10,14 +10,12 @@ namespace ClosedXML.Examples.Misc
         // Public
         public void Create(String filePath)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Workbook Protection");
-                wb.Protect(true, false, "Abc@123");
-                wb.SaveAs(filePath);
-            }
+            using var wb = new XLWorkbook();
+            wb.Worksheets.Add("Workbook Protection");
+            wb.Protect("Abc@123");
+            wb.SaveAs(filePath);
         }
 
-        #endregion
+        #endregion Methods
     }
 }

--- a/ClosedXML.Sandbox/ClosedXML.Sandbox.csproj
+++ b/ClosedXML.Sandbox/ClosedXML.Sandbox.csproj
@@ -1,14 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net40;net46</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
-    <Version>0.95.4</Version>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <Configurations>Debug;Release</Configurations>
-    <AssemblyName>ClosedXML.Sandbox</AssemblyName>
-    <RootNamespace>ClosedXML.Sandbox</RootNamespace>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -2,19 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net40;net46</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
-    <Version>0.95.4</Version>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
-    <Configurations>Debug;Release;</Configurations>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\ClosedXML.snk</AssemblyOriginatorKeyFile>
-    <AssemblyName>ClosedXML.Tests</AssemblyName>
-    <RootNamespace>ClosedXML.Tests</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DefineConstants>$(AppVeyor)</DefineConstants>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU1605;CS1591;CS1658;CS1584;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClosedXML.sln
+++ b/ClosedXML.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 		ClosedXML.vsmdi = ClosedXML.vsmdi
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClosedXML.Examples", "ClosedXML.Examples\ClosedXML.Examples.csproj", "{03A518D0-1CB7-488E-861C-C4E782B27A46}"

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -2,28 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net40;net46</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
-    <AssemblyName>ClosedXML</AssemblyName>
-    <PackageId>ClosedXML</PackageId>
-    <Version>0.95.4</Version>
-    <Authors>Francois Botha, Aleksei Pankratev, Manuel de Leon, Amir Ghezelbash</Authors>
-    <Owners>Francois Botha, Aleksei Pankratev</Owners>
-    <Company />
-    <Product>ClosedXML</Product>
-    <PackageReleaseNotes>See https://github.com/ClosedXML/ClosedXML/releases/tag/$(productVersion)</PackageReleaseNotes>
-    <Description>ClosedXML is a .NET library for reading, manipulating and writing Excel 2007+ (.xlsx, .xlsm) files. It aims to provide an intuitive and user-friendly interface to dealing with the underlying OpenXML API.</Description>
-    <Copyright>MIT</Copyright>
-    <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML</PackageProjectUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageIcon>nuget-logo.png</PackageIcon>
-    <PackageIconUrl>https://raw.githubusercontent.com/ClosedXML/ClosedXML/develop/resources/logo/nuget-logo.png</PackageIconUrl>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Configurations>Debug;Release</Configurations>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\ClosedXML.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,44 @@
+<Project>
+  <!-- Set the repository root into a variable -->
+  <PropertyGroup>
+    <SourceRoot>$(MSBuildThisFileDirectory)</SourceRoot>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Version>0.95.4</Version>
+  </PropertyGroup>
+
+  <!-- Set common properties regarding assembly information and nuget packages -->
+  <PropertyGroup>
+    <Product>ClosedXML</Product>
+
+    <Authors>Francois Botha, Aleksei Pankratev, Manuel de Leon, Amir Ghezelbash</Authors>
+    <Owners>Francois Botha, Aleksei Pankratev</Owners>
+    <Company />
+
+    <Copyright>MIT</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML</PackageProjectUrl>
+    <PackageIcon>nuget-logo.png</PackageIcon>
+    <PackageTags>Excel OpenXml xlsx</PackageTags>
+    <PackageReleaseNotes>See https://github.com/ClosedXML/ClosedXML/releases/tag/$(productVersion)</PackageReleaseNotes>
+    <RepositoryUrl>https://github.com/ClosedXML/ClosedXML</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+
+    <LangVersion>8.0</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU1605;CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SourceRoot)/ClosedXML.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <!-- Additional properties that might not be applicable to a local dev environment -->
+  <PropertyGroup>
+    <DefineConstants>$(AppVeyor)</DefineConstants>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Refactor and simplify .csproj files. Move common properties into its own `Directory.Build.props` file that is included automatically in the build process.

Documentation about Directory.Build.props: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2022