### PR TITLE
Add more Protect() methods

### DIFF
--- a/ClosedXML/Excel/Protection/IXLElementProtection.cs
+++ b/ClosedXML/Excel/Protection/IXLElementProtection.cs
@@ -42,8 +42,8 @@ namespace ClosedXML.Excel
         IXLElementProtection<T> DisallowElement(T element);
 
         /// <summary>Protects this instance without a password.</summary>
-        /// <returns></returns>
-        IXLElementProtection<T> Protect();
+        /// <param name="algorithm">The algorithm.</param>
+        IXLElementProtection<T> Protect(Algorithm algorithm = DefaultProtectionAlgorithm);
 
         /// <summary>Protects this instance using the specified password and password hash algorithm.</summary>
         /// <param name="password">The password.</param>

--- a/ClosedXML/Excel/Protection/IXLProtectable.cs
+++ b/ClosedXML/Excel/Protection/IXLProtectable.cs
@@ -11,8 +11,17 @@ namespace ClosedXML.Excel
         TProtection Protection { get; set; }
 
         /// <summary>Protects this instance without a password.</summary>
+        TProtection Protect(TElement allowedElements);
+
+        /// <summary>Protects this instance without a password.</summary>
         /// <returns></returns>
-        new TProtection Protect();
+        new TProtection Protect(Algorithm algorithm = DefaultProtectionAlgorithm);
+
+        /// <summary>Protects this instance with the specified password, password hash algorithm and set elements that the user is allowed to change.</summary>
+        /// <param name="algorithm">The algorithm.</param>
+        /// <param name="allowedElements">The allowed elements.</param>
+        /// <returns></returns>
+        TProtection Protect(Algorithm algorithm, TElement allowedElements);
 
         /// <summary>Protects this instance using the specified password and password hash algorithm.</summary>
         /// <param name="password">The password.</param>
@@ -53,7 +62,7 @@ namespace ClosedXML.Excel
 
         /// <summary>Protects this instance without a password.</summary>
         /// <returns></returns>
-        IXLElementProtection Protect();
+        IXLElementProtection Protect(Algorithm algorithm = DefaultProtectionAlgorithm);
 
         /// <summary>Protects this instance using the specified password and password hash algorithm.</summary>
         /// <param name="password">The password.</param>

--- a/ClosedXML/Excel/Protection/IXLSheetProtection.cs
+++ b/ClosedXML/Excel/Protection/IXLSheetProtection.cs
@@ -1,6 +1,15 @@
+// Keep this file CodeMaid organised and cleaned
+using System;
+using static ClosedXML.Excel.XLProtectionAlgorithm;
+
 namespace ClosedXML.Excel
 {
     public interface IXLSheetProtection : IXLElementProtection<XLSheetProtectionElements>
     {
+        IXLSheetProtection Protect(XLSheetProtectionElements allowedElements);
+
+        IXLSheetProtection Protect(Algorithm algorithm, XLSheetProtectionElements allowedElements);
+
+        IXLSheetProtection Protect(String password, Algorithm algorithm = DefaultProtectionAlgorithm, XLSheetProtectionElements allowedElements = XLSheetProtectionElements.SelectEverything);
     }
 }

--- a/ClosedXML/Excel/Protection/IXLWorkbookProtection.cs
+++ b/ClosedXML/Excel/Protection/IXLWorkbookProtection.cs
@@ -1,6 +1,15 @@
-﻿namespace ClosedXML.Excel
+﻿// Keep this file CodeMaid organised and cleaned
+using System;
+using static ClosedXML.Excel.XLProtectionAlgorithm;
+
+namespace ClosedXML.Excel
 {
     public interface IXLWorkbookProtection : IXLElementProtection<XLWorkbookProtectionElements>
     {
+        IXLWorkbookProtection Protect(XLWorkbookProtectionElements allowedElements);
+
+        IXLWorkbookProtection Protect(Algorithm algorithm, XLWorkbookProtectionElements allowedElements);
+
+        IXLWorkbookProtection Protect(String password, Algorithm algorithm = DefaultProtectionAlgorithm, XLWorkbookProtectionElements allowedElements = XLWorkbookProtectionElements.Windows);
     }
 }

--- a/ClosedXML/Excel/Protection/XLSheetProtection.cs
+++ b/ClosedXML/Excel/Protection/XLSheetProtection.cs
@@ -74,10 +74,16 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public IXLSheetProtection Protect()
+        public IXLSheetProtection Protect(Algorithm algorithm = DefaultProtectionAlgorithm)
         {
-            return Protect(String.Empty);
+            return Protect(String.Empty, algorithm);
         }
+
+        public IXLSheetProtection Protect(XLSheetProtectionElements allowedElements)
+            => Protect(string.Empty, DefaultProtectionAlgorithm, allowedElements);
+
+        public IXLSheetProtection Protect(Algorithm algorithm, XLSheetProtectionElements allowedElements)
+            => Protect(string.Empty, algorithm, allowedElements);
 
         public IXLSheetProtection Protect(String password, Algorithm algorithm = DefaultProtectionAlgorithm, XLSheetProtectionElements allowedElements = XLSheetProtectionElements.SelectEverything)
         {
@@ -141,9 +147,15 @@ namespace ClosedXML.Excel
 
         IXLElementProtection<XLSheetProtectionElements> IXLElementProtection<XLSheetProtectionElements>.DisallowElement(XLSheetProtectionElements element) => DisallowElement(element);
 
-        IXLElementProtection<XLSheetProtectionElements> IXLElementProtection<XLSheetProtectionElements>.Protect() => Protect();
+        IXLElementProtection<XLSheetProtectionElements> IXLElementProtection<XLSheetProtectionElements>.Protect(Algorithm algorithm) => Protect(algorithm);
 
         IXLElementProtection<XLSheetProtectionElements> IXLElementProtection<XLSheetProtectionElements>.Protect(String password, Algorithm algorithm) => Protect(password, algorithm);
+
+        IXLSheetProtection IXLSheetProtection.Protect(XLSheetProtectionElements allowedElements) => Protect(allowedElements);
+
+        IXLSheetProtection IXLSheetProtection.Protect(Algorithm algorithm, XLSheetProtectionElements allowedElements) => Protect(algorithm, allowedElements);
+
+        IXLSheetProtection IXLSheetProtection.Protect(String password, Algorithm algorithm, XLSheetProtectionElements allowedElements) => Protect(password, algorithm, allowedElements);
 
         IXLElementProtection<XLSheetProtectionElements> IXLElementProtection<XLSheetProtectionElements>.Unprotect() => Unprotect();
 

--- a/ClosedXML/Excel/Protection/XLWorkbookProtection.cs
+++ b/ClosedXML/Excel/Protection/XLWorkbookProtection.cs
@@ -78,10 +78,16 @@ namespace ClosedXML.Excel
             return AllowElement(element, allowed: false);
         }
 
-        public IXLWorkbookProtection Protect()
+        public IXLWorkbookProtection Protect(Algorithm algorithm = DefaultProtectionAlgorithm)
         {
-            return Protect(String.Empty);
+            return Protect(String.Empty, algorithm);
         }
+
+        public IXLWorkbookProtection Protect(XLWorkbookProtectionElements allowedElements)
+            => Protect(string.Empty, DefaultProtectionAlgorithm, allowedElements);
+
+        public IXLWorkbookProtection Protect(Algorithm algorithm, XLWorkbookProtectionElements allowedElements)
+            => Protect(string.Empty, algorithm, allowedElements);
 
         public IXLWorkbookProtection Protect(String password, Algorithm algorithm = DefaultProtectionAlgorithm, XLWorkbookProtectionElements allowedElements = XLWorkbookProtectionElements.Windows)
         {
@@ -143,9 +149,15 @@ namespace ClosedXML.Excel
 
         IXLElementProtection<XLWorkbookProtectionElements> IXLElementProtection<XLWorkbookProtectionElements>.DisallowElement(XLWorkbookProtectionElements element) => DisallowElement(element);
 
-        IXLElementProtection<XLWorkbookProtectionElements> IXLElementProtection<XLWorkbookProtectionElements>.Protect() => Protect();
+        IXLElementProtection<XLWorkbookProtectionElements> IXLElementProtection<XLWorkbookProtectionElements>.Protect(Algorithm algorithm) => Protect(algorithm);
 
         IXLElementProtection<XLWorkbookProtectionElements> IXLElementProtection<XLWorkbookProtectionElements>.Protect(String password, Algorithm algorithm) => Protect(password, algorithm);
+
+        IXLWorkbookProtection IXLWorkbookProtection.Protect(XLWorkbookProtectionElements allowedElements) => Protect(allowedElements);
+
+        IXLWorkbookProtection IXLWorkbookProtection.Protect(Algorithm algorithm, XLWorkbookProtectionElements allowedElements) => Protect(algorithm, allowedElements);
+
+        IXLWorkbookProtection IXLWorkbookProtection.Protect(String password, Algorithm algorithm, XLWorkbookProtectionElements allowedElements) => Protect(password, algorithm, allowedElements);
 
         IXLElementProtection<XLWorkbookProtectionElements> IXLElementProtection<XLWorkbookProtectionElements>.Unprotect() => Unprotect();
 

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -980,10 +980,16 @@ namespace ClosedXML.Excel
             return protection;
         }
 
-        public IXLWorkbookProtection Protect()
+        public IXLWorkbookProtection Protect(Algorithm algorithm = DefaultProtectionAlgorithm)
         {
-            return Protection.Protect();
+            return Protection.Protect(algorithm);
         }
+
+        public IXLWorkbookProtection Protect(XLWorkbookProtectionElements allowedElements)
+            => Protection.Protect(allowedElements);
+
+        public IXLWorkbookProtection Protect(Algorithm algorithm, XLWorkbookProtectionElements allowedElements)
+            => Protection.Protect(algorithm, allowedElements);
 
         [Obsolete("Use Protect(String password, Algorithm algorithm, TElement allowedElements)")]
         public IXLWorkbookProtection Protect(Boolean lockStructure)
@@ -1008,15 +1014,24 @@ namespace ClosedXML.Excel
             return Protection.Protect(password, algorithm, allowedElements);
         }
 
-        IXLElementProtection IXLProtectable.Protect()
+        IXLElementProtection IXLProtectable.Protect(Algorithm algorithm)
         {
-            return Protect();
+            return Protect(algorithm);
         }
 
         IXLElementProtection IXLProtectable.Protect(string password, Algorithm algorithm)
         {
             return Protect(password, algorithm);
         }
+
+        IXLWorkbookProtection IXLProtectable<IXLWorkbookProtection, XLWorkbookProtectionElements>.Protect(XLWorkbookProtectionElements allowedElements)
+            => Protect(allowedElements);
+
+        IXLWorkbookProtection IXLProtectable<IXLWorkbookProtection, XLWorkbookProtectionElements>.Protect(Algorithm algorithm, XLWorkbookProtectionElements allowedElements)
+            => Protect(algorithm, allowedElements);
+
+        IXLWorkbookProtection IXLProtectable<IXLWorkbookProtection, XLWorkbookProtectionElements>.Protect(string password, Algorithm algorithm, XLWorkbookProtectionElements allowedElements)
+            => Protect(password, algorithm, allowedElements);
 
         public IXLWorkbookProtection Unprotect()
         {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -689,10 +689,16 @@ namespace ClosedXML.Excel
             set => Protection = value as XLSheetProtection;
         }
 
-        public IXLSheetProtection Protect()
+        public IXLSheetProtection Protect(Algorithm algorithm = DefaultProtectionAlgorithm)
         {
-            return Protection.Protect();
+            return Protection.Protect(algorithm);
         }
+
+        public IXLSheetProtection Protect(XLSheetProtectionElements allowedElements)
+            => Protection.Protect(allowedElements);
+
+        public IXLSheetProtection Protect(Algorithm algorithm, XLSheetProtectionElements allowedElements)
+            => Protection.Protect(algorithm, allowedElements);
 
         public IXLSheetProtection Protect(String password, Algorithm algorithm = DefaultProtectionAlgorithm)
         {
@@ -704,9 +710,9 @@ namespace ClosedXML.Excel
             return Protection.Protect(password, algorithm, allowedElements);
         }
 
-        IXLElementProtection IXLProtectable.Protect()
+        IXLElementProtection IXLProtectable.Protect(Algorithm algorithm)
         {
-            return Protect();
+            return Protect(algorithm);
         }
 
         IXLElementProtection IXLProtectable.Protect(String password, Algorithm algorithm)


### PR DESCRIPTION
In preparation for the removal of the obsolete `Protect()` methods, I realised we can do with more of the newer style `Protect()`, specifically those that don't require a password, but do accept the other options.