### PR TITLE
Add specific handling for cell value of "Infinity".

### DIFF
--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -83,6 +83,66 @@ namespace ClosedXML.Tests
             Assert.AreEqual(CultureInfo.CurrentCulture.NumberFormat.PositiveInfinitySymbol, cell.Value);
         }
 
+        /// <summary>
+        /// Checks that a cell with the value of the string <c>Infinity</c>
+        /// is assigned the data type <see cref="XLDataType.Text"/>.
+        /// </summary>
+        [Test]
+        public void CellValueOfStringInfinityStoredAsTextDataType()
+        {
+            using var workbook = new XLWorkbook();
+            var sheet = workbook.Worksheets.Add();
+            const string infinity = "Infinity";
+            var cell = sheet.Cell("A1");
+            cell.Value = infinity;
+            Assert.That(cell.DataType, Is.EqualTo(XLDataType.Text));
+        }
+
+        /// <summary>
+        /// Checks that a cell with the value of the string <c>Infinity</c>
+        /// has the correct value.
+        /// </summary>
+        [Test]
+        public void CellValueOfStringInfinityStoredCorrectly()
+        {
+            using var workbook = new XLWorkbook();
+            var sheet = workbook.Worksheets.Add();
+            const string infinity = "Infinity";
+            var cell = sheet.Cell("A1");
+            cell.Value = infinity;
+            Assert.That(cell.Value, Is.EqualTo(infinity));
+        }
+
+        /// <summary>
+        /// Checks that a cell with the value of the string <c>-Infinity</c>
+        /// is assigned the data type <see cref="XLDataType.Text"/>.
+        /// </summary>
+        [Test]
+        public void CellValueOfStringNegativeInfinityStoredAsTextDataType()
+        {
+            using var workbook = new XLWorkbook();
+            var sheet = workbook.Worksheets.Add();
+            const string negativeInfinity = "-Infinity";
+            var cell = sheet.Cell("A1");
+            cell.Value = negativeInfinity;
+            Assert.That(cell.DataType, Is.EqualTo(XLDataType.Text));
+        }
+
+        /// <summary>
+        /// Checks that a cell with the value of the string <c>-Infinity</c>
+        /// has the correct value.
+        /// </summary>
+        [Test]
+        public void CellValueOfStringNegativeInfinityStoredCorrectly()
+        {
+            using var workbook = new XLWorkbook();
+            var sheet = workbook.Worksheets.Add();
+            const string negativeInfinity = "-Infinity";
+            var cell = sheet.Cell("A1");
+            cell.Value = negativeInfinity;
+            Assert.That(cell.Value, Is.EqualTo(negativeInfinity));
+        }
+
         [Test]
         public void Double_NaN_is_a_string()
         {

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -299,15 +299,25 @@ namespace ClosedXML.Excel
         /// a candidate for a number.
         /// </remarks>
         /// <param name="value">The value to test.</param>
-        /// <returns>
-        /// <see langword="true"/> if <paramref name="value"/> is a candidate
-        /// for a number, <see langword="false"/> otherwise.
-        /// </returns>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is a candidate for a number, <see langword="false"/> otherwise.</returns>
         private static bool ValueIsCandidateForNumber(string value)
         {
             // Trim the value once so it isn't done every time.
             var valueTrimmed = value.Trim();
-            return DisallowedDoubleValues.All(disallowedValue => !string.Equals(valueTrimmed, disallowedValue, StringComparison.OrdinalIgnoreCase));
+            return !DisallowedDoubleValues.Any(disallowedValue => string.Equals(valueTrimmed, disallowedValue, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Tries to parse <paramref name="value"/> as a <see cref="double"/>.
+        /// </summary>
+        /// <param name="value">The value to parse.</param>
+        /// <param name="parsed">The parsed value or <see langword="default"/> for <see cref="double"/> if <paramref name="value"/> cannot be parsed.</param>
+        /// <returns><see langword="true"/> if <paramref name="value"/> was successfully parsed, <see langword="false"/> otherwise.</returns>
+        private static bool TryParseDouble(string value, out double parsed)
+        {
+            parsed = default;
+            return ValueIsCandidateForNumber(value)
+                   && double.TryParse(value, XLHelper.NumberStyle, XLHelper.ParseCulture, out parsed);
         }
 
         private string DeduceCellValueByParsing(string value, XLStyleValue style)
@@ -330,8 +340,7 @@ namespace ClosedXML.Excel
 
                 this.Style.SetIncludeQuotePrefix();
             }
-            else if (ValueIsCandidateForNumber(value) &&
-                     Double.TryParse(value, XLHelper.NumberStyle, XLHelper.ParseCulture, out Double _))
+            else if (TryParseDouble(value, out _))
                 _dataType = XLDataType.Number;
             else if (TimeSpan.TryParse(value, out TimeSpan ts))
             {

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -305,6 +305,8 @@ namespace ClosedXML.Excel
                 this.Style.SetIncludeQuotePrefix();
             }
             else if (!string.Equals(value.Trim(), "NaN", StringComparison.OrdinalIgnoreCase) &&
+                     !string.Equals(value.Trim(), "Infinity", StringComparison.OrdinalIgnoreCase) &&
+                     !string.Equals(value.Trim(), "-Infinity", StringComparison.OrdinalIgnoreCase) &&
                      Double.TryParse(value, XLHelper.NumberStyle, XLHelper.ParseCulture, out Double _))
                 _dataType = XLDataType.Number;
             else if (TimeSpan.TryParse(value, out TimeSpan ts))


### PR DESCRIPTION
I was recently the victim of issue #1676, so I patched it by adding special handling for `Infinity` and `-Infinity`. The underlying issue results from .NET's `double` type parsing `Infinity` and `-Infinity` into actual `double` values (of `double.PositiveInfinity` and `double.NegativeInfinity` respectively). This is fine for most use cases where values of positive and negative infinity are acceptable, but not for Excel since Excel has no representation of infinity. ClosedXML writes these values as numeric types to Excel, but since Excel lacks a representation for infinity, this causes Excel to think the workbook is corrupted. I'm not 100% sure, but I imagine this is because Excel tries to read the string `Infinity` as a number (since ClosedXML marked the cell's data type as numeric), but it cannot do so since `Infinity` is a string of characters.

In my tests, Excel will see this issue and fix it if you ask it to do so (when it prompts for repair, select "yes"). However, this isn't suitable for a production environment where workbooks are being prepared programmatically and delivered to customers. Handling these cases specifically will generate a workbook without any prompts for repair.