### PR TITLE
Pass null for worksheet when instantiating XLColumns/XLRows from inside of ColumnsUsed/RowsUsed

### DIFF
--- a/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
+++ b/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
@@ -247,5 +247,45 @@ namespace ClosedXML.Tests.Excel
 
             Assert.IsFalse(column.RangeAddress.IsValid);
         }
+
+        [Test]
+        public void AssignWorksheetColumnWidthWhenAllColumnsChanged()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            var columns = ws.Columns();
+
+            columns.Width = 100;
+
+            Assert.AreEqual(100, ws.Column("G").Width, XLHelper.Epsilon);
+            Assert.AreEqual(100, ws.ColumnWidth, XLHelper.Epsilon);
+        }
+
+        [Test]
+        public void PreserveWorksheetColumnWidthWhenNotAllColumnsChanged()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            var defaultColumnWidth = ws.ColumnWidth;
+            var columns = ws.Columns(1, XLHelper.MaxColumnNumber);
+
+            columns.Width = 100;
+
+            Assert.AreEqual(100, ws.Column("G").Width, XLHelper.Epsilon);
+            Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+        }
+
+        [Test]
+        public void PreserveWorksheetColumnWidthWhenUsedColumnsChanged()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            ws.Cells("A1:E5").Value = "Not empty";
+            var defaultColumnWidth = ws.ColumnWidth;
+            var columns = ws.ColumnsUsed(XLCellsUsedOptions.Contents);
+
+            columns.Width = 100;
+
+            Assert.AreEqual(100, ws.Column("C").Width, XLHelper.Epsilon);
+            Assert.AreEqual(defaultColumnWidth, ws.Column("G").Width, XLHelper.Epsilon);
+            Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+        }
     }
 }

--- a/ClosedXML.Tests/Excel/Rows/RowTests.cs
+++ b/ClosedXML.Tests/Excel/Rows/RowTests.cs
@@ -303,5 +303,45 @@ namespace ClosedXML.Tests.Excel
             ws.Column(1).Width = 100;
             Assert.DoesNotThrow(() => ws.Row(1).Delete());
         }
+
+        [Test]
+        public void AssignWorksheetRowHeightWhenAllRowsChanged()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            var rows = ws.Rows();
+
+            rows.Height = 30;
+
+            Assert.AreEqual(30, ws.Row(11).Height, XLHelper.Epsilon);
+            Assert.AreEqual(30, ws.RowHeight, XLHelper.Epsilon);
+        }
+
+        [Test]
+        public void PreserveWorksheetRowHeightWhenNotAllRowsChanged()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            var defaultRowHeight = ws.RowHeight;
+            var rows = ws.Rows(1, XLHelper.MaxRowNumber);
+
+            rows.Height = 30;
+
+            Assert.AreEqual(30, ws.Row(11).Height, XLHelper.Epsilon);
+            Assert.AreEqual(defaultRowHeight, ws.RowHeight, XLHelper.Epsilon);
+        }
+
+        [Test]
+        public void PreserveWorksheetRowHeightWhenUsedRowsChanged()
+        {
+            var ws = new XLWorkbook().AddWorksheet();
+            ws.Cells("A1:E5").Value = "Not empty";
+            var defaultRowHeight = ws.RowHeight;
+            var rows = ws.RowsUsed(XLCellsUsedOptions.Contents);
+
+            rows.Height = 30;
+
+            Assert.AreEqual(30, ws.Row(3).Height, XLHelper.Epsilon);
+            Assert.AreEqual(defaultRowHeight, ws.Row(11).Height, XLHelper.Epsilon);
+            Assert.AreEqual(defaultRowHeight, ws.RowHeight, XLHelper.Epsilon);
+        }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -972,7 +972,7 @@ namespace ClosedXML.Excel
 
         public IXLRows RowsUsed(XLCellsUsedOptions options = XLCellsUsedOptions.AllContents, Func<IXLRow, Boolean> predicate = null)
         {
-            var rows = new XLRows(Worksheet, StyleValue);
+            var rows = new XLRows(worksheet: null, StyleValue);
             var rowsUsed = new HashSet<Int32>();
             Internals.RowsCollection.Keys.ForEach(r => rowsUsed.Add(r));
             Internals.CellsCollection.RowsUsed.Keys.ForEach(r => rowsUsed.Add(r));
@@ -1001,7 +1001,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns ColumnsUsed(XLCellsUsedOptions options = XLCellsUsedOptions.AllContents, Func<IXLColumn, Boolean> predicate = null)
         {
-            var columns = new XLColumns(Worksheet, StyleValue);
+            var columns = new XLColumns(worksheet: null, StyleValue);
             var columnsUsed = new HashSet<Int32>();
             Internals.ColumnsCollection.Keys.ForEach(r => columnsUsed.Add(r));
             Internals.CellsCollection.ColumnsUsed.Keys.ForEach(r => columnsUsed.Add(r));


### PR DESCRIPTION
Fixes #1859

The documentation to `XLRows` constuctor clearly states: "If worksheet is specified it means that the created instance represents all rows on a worksheet so changing its height will affect all rows" (https://github.com/ClosedXML/ClosedXML/blob/develop/ClosedXML/Excel/Rows/XLRows.cs#L23). Same for [`XLColumns`](https://github.com/ClosedXML/ClosedXML/blob/develop/ClosedXML/Excel/Columns/XLColumns.cs#L21). 

In `ColumnsUsed`/`RowsUsed`, the worksheet argument was initialized with the current worksheet which caused the described behavior.
