### PR TITLE
Add a text-to-number coercion

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
@@ -1,4 +1,5 @@
-﻿using ClosedXML.Excel;
+﻿using System;
+using ClosedXML.Excel;
 using ClosedXML.Excel.CalcEngine;
 using NUnit.Framework;
 
@@ -18,6 +19,42 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(firstValue, secondValue);
         }
 
+        [TestCase("100%", 1)]
+        [TestCase("-100%", -1)]
+        [TestCase("200%", 2)]
+        [TestCase("0000%", 0)]
+        [TestCase("1%", 0.01)]
+        [TestCase("+1%", 0.01)]
+        [TestCase(" -75 % ", -0.75)]
+        [TestCase(" - 100 % ", -1, Ignore = ".NET parser doesn't allow whitespace between sign and number.")]
+        public void Percent_Format9(string percent, double? expectedValue) // Format 9 '0%'
+        {
+            AssertCoercion(percent, expectedValue);
+        }
+
+        [TestCase("100.5%", 1.005)]
+        [TestCase("100 . 5%", null)]
+        [TestCase(" - 100.59 % ", -1.0059, Ignore = ".NET parser doesn't allow whitespace between sign and number.")]
+        [TestCase("0.123456%", 0.00123456)]
+        [TestCase(".5%", 0.005)]
+        [TestCase("  -.375 % ", -0.00375)]
+        [TestCase("100.%", 1)]
+        public void Percent_Format10(string percent, double? expectedValue) // Format 10 '0.00%'
+        {
+            AssertCoercion(percent, expectedValue);
+        }
+
+        [TestCase("(100%)", -1, Ignore = ".NET parser doesn't parse percents.")]
+        [TestCase("(-100%)", null)] // Can't have minus sign inside the brackets
+        [TestCase("-(100%)", null)] // Can't have minus sign outside the brackets
+        [TestCase("1,000.00%", 10)]
+        [TestCase("(1,000.00%)", -10, Ignore = ".NET parser doesn't parse percents.")]
+        [TestCase(" % 100", 1)] // Percents can be at start or end, position doesn't matter
+        public void Percent_UnlistedFormats(string percent, double? expectedValue) // 
+        {
+            AssertCoercion(percent, expectedValue);
+        }
+
         [TestCase("0 1/2", 0.5)]
         [TestCase("0 /20", null)]
         [TestCase("0 1/32768", null)] // Denominator can be at most 2^15-1
@@ -34,24 +71,131 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("   1 10/20  ", 1.5)]
         [TestCase("1  1/2", null)] // Between whole part and nominator must be exactly one space
         [TestCase("1 1 /2", null)] // Can't have spaces between nominator and denominator
-        [TestCase("1 1/ 2", null)] 
+        [TestCase("1 1/ 2", null)]
         [TestCase("1	1/2", null)] // Tab and other whitespaces aren't allowed
-        [TestCase("0 1/0", null)]
+        [TestCase("0 1/0", null)] // Division by zero
         public void Fraction_Format12_13(string fraction, double? expectedValue) // Format 12+13 '# ??/??' and  '# ?/?'
         {
             AssertCoercion(fraction, expectedValue);
         }
 
+        [TestCase("02/28/20", 43889)]
+        [TestCase("002/28/20", null)]
+        [TestCase("02/028/20", null)]
+        [TestCase("02/28/022", null)]
+        public void Date_Format14(string date, double? expectedValue) // Format 14 is taken from region setting, but for en (and MS errata) says 'm/d/yyyy'
+        {
+            AssertCoercion(date, expectedValue);
+        }
+
+        [TestCase("30-apr-2000", 36646)]
+        [TestCase("30-apr-20", 43951)] // 2020-04-30	
+        [TestCase("31-dec-9999", 2958465)]
+        [TestCase("1-jan-10000", null)]
+        [TestCase("1 - jan - 2022  ", 44562)] // Can have whitespace in the date
+        [TestCase(" 1-jan-2022", null, Ignore = ".NET parser doesn't respect the whitespace styles of a date during parsing.")] // Can't have whitespaces at the start
+        [TestCase("31-dec-1899", null)] // Check 1900 "leap" year issue...
+        [TestCase("1-jan-1900", 1)]
+        [TestCase("28-feb-1900", 59)]
+        [TestCase("1-mar-1900", 61)]
+        public void Date_Format15(string date, double? expectedValue) // Format 15 d-mmm-yy
+        {
+            AssertCoercion(date, expectedValue);
+        }
+
+        [TestCase("0-mar", null)] // Zero day not accepted
+        [TestCase("1-mar", 44621)]
+        [TestCase("1-marc", 44621, Ignore = ".NET parser recognizes only abbreviation or full name of a month.")]
+        [TestCase("1-march", 44621)]
+        [TestCase(" 1 - apr  ", 44652)] // Unlike many others, this format also allows space at the start, not just inside and at the end
+        [TestCase("31-apr", null)] // April has only 30 days
+        public void Date_Format16(string text, double? expectedValue) // Format 16 'd-mmm'
+        {
+            if (expectedValue is not null)
+            {
+                var date = DateTime.FromOADate(expectedValue.Value);
+                expectedValue = new DateTime(DateTime.Now.Year, date.Month, date.Day).ToOADate();
+            }
+
+            AssertCoercion(text, expectedValue);
+        }
+
+        // In en locale, there should be an extra pattern MMM-dd that is before the standard MMM-yy, but .NET Framework doesn't have it.
+        // To overcome missing locale, use numbers over 31 for year (otherwise they should be interpreted as days)
+        [TestCase("jan-02", 44563, Ignore = ".NET misses culture, en interprets it as MMM-dd, but czech as MMM-yy, so the MMM-dd is the extra culture for en.")] // interpreted as 2022-01-02
+        [TestCase("jan-31", 44592, Ignore = "Missing excel culture mapping")] // 2022-01-02
+        [TestCase("jan-32", 11689)] // 1932-01-01
+        [TestCase("feb-29", 47150, Ignore = "Missing excel culture mapping")] // 2029-02-01
+        [TestCase("feb-30", 10990)] // 1930-02-01
+        [TestCase("feb-31", 11355)] // 1931-02-01
+        [TestCase("feb-003", null)] // three digits not allowed
+        [TestCase("aug   -   55", 20302)] // spaces are allowed inside the pattern
+        [TestCase(" aug-55", null, Ignore = ".NET allow whitespaces even without specified DateTimeStyle.AllowLeadingWhite")] // starting spaces not allowed 
+        [TestCase("aug-55 ", 20302)] // trailing spaces allowed
+        [TestCase("MaR-42", 15401)] // case insensitive
+        [TestCase("marc-2", 44622, Ignore = ".NET parser recognizes only abbreviation or full name of a month.")] // name can be more than three long abbr
+        [TestCase("march-55", 20149)]
+        [TestCase("ma-2", null)] // Name of month must be at least three chars long	
+        public void Date_Format17(string text, double? expectedValue) // Format 17 'mmm-yy'
+        {
+            AssertCoercion(text, expectedValue);
+        }
+
+        [TestCase("1:20 AM", 0.055555555555555552d)]
+        [TestCase("1:20 aM", 0.055555555555555552d)]
+        [TestCase("1:60 AM", null)] // Minutes must be 0-59 range
+        [TestCase("1:59 AM", 0.082638888888888887d)]
+        [TestCase("13:00 AM", null)] // AM only allows hours in 0-12 range
+        [TestCase("7:30 A", 0.3125)] // only starting letter of AM
+        [TestCase("1:9 AM", 0.04791666666666667d)] // Single digit minutes
+        public void Date_Format18(string text, double? expectedValue) // Format 18 'h:mm AM/PM'
+        {
+            AssertCoercion(text, expectedValue);
+        }
+
+        [TestCase("12:0:0 PM", 0.5)]
+        [TestCase("12:0:18 aM", 0.00020833333333333335d)] // case insensitive AM designator
+        [TestCase("13:0:0 PM", null)] // hours can't be outside of 0-12, unlike other format
+        [TestCase("13:0:0 AM", null)]
+        [TestCase("00:60:00 AM", null)] // minutes can't be outside of 0-59, unlike other format
+        [TestCase("00:59:00 AM", 0.040972222222222222d)]
+        [TestCase("00:00:60 AM", null)] // seconds can't be outside of 0-59, unlike other format
+        [TestCase("00:00:59 AM", 0.00068287037037037036d)]
+        [TestCase("00:00: AM", null)] // can't omit second part (differs from time span).
+        [TestCase("1:2:3 AM", 0.043090277777777776d)]
+        public void Date_Format19(string text, double? expectedValue) // Format 19 'h:mm:ss AM/PM'
+        {
+            AssertCoercion(text, expectedValue);
+        }
+
+        [TestCase("2/5/2022 0:0", 44597)]
+        [TestCase("05/5/2022 0:0", 44686)] // Extra zero padding allowed
+        [TestCase("005/5/2022 0:0", null)] // 0 prefix requires at most 2 digits
+        [TestCase("13/5/2022 0:0", null)] // Month outside of range
+        [TestCase("11/030/2022 0:0", null)]
+        [TestCase("11/30/02022 0:0", null)] // Extra zero before year not allowed
+        [TestCase("11/30/2022 24:59", 44896.04097, Ignore = "Excel can have out of range parts, but .NET parsers can't.")]
+        [TestCase("11/30/2022 24:60", null)] // Both parts are out of range
+        [TestCase("11/30/2022 23:160", 44896.06944, Ignore = "Excel can have one of of range part, but .NET parser can't.")]
+        [TestCase("11/30/2022 9999:59", 45311.66597, Ignore = "Excel parser accepts numbers over limit for hours.")]
+        [TestCase("11/30/2022 10000:59", null)] // Hours can't be over 9999
+        [TestCase("aug 10, 2022 14:10", 44783.590277777781d, Ignore = "Excel specific parsing of months accepts anything from three letters up to full name, but such pattern is not in any en-US DateTimeFormat pattern.")]
+        [TestCase("august 10, 2022 14:10", 44783.590277777781d)]
+        public void DateTime_Format22(string text, double? expectedValue) // Format 22 'm/d/yyyy h:mm'. Specification incorrectly states 'm/d/yy h:mm', but fixed per MS errata.
+        {
+            AssertCoercion(text, expectedValue);
+        }
+
         [TestCase("00:00", 0)] // Can parse zero
         [TestCase("90:00", 3.75)] // Minutes can be can be over 60
-        [TestCase("59:59", 2.499305556)] // Even if looks like mm:ss parsed as h:mm
+        [TestCase("59:59", 2.499305556)] // Even if looks like mm:ss, it is actually parsed as h:mm
         [TestCase("10:", 0.416666667)] // Last part can be omitted and zero is used
         [TestCase("9999:", 416.625)] // Upper limit of first part is parseable
         [TestCase("10000:", null)] // Part value over a limit is not parseable
         [TestCase(":5", null)] // Can't omit first part
         [TestCase("24:60", null)] // Only one part can be outside of limit, here are both
-        [TestCase("30:59", 1.290972222)] // Hour part over limit
-        [TestCase("23:300", 1.166666667)] // Minute part over limit
+        [TestCase("30:59", 1.290972222)] // Hour part can be over 23
+        [TestCase("23:300", 1.166666667)] // Minute part over over 59
         public void TimeSpan_Format20(string timeSpan, double? expectedValue) // 'h:mm'
         {
             AssertCoercion(timeSpan, expectedValue, Tolerance);
@@ -130,6 +274,31 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("$100%", null)]
         [TestCase("($100%)", null)]
         public void Currency(string currency, double? expectedValue) // Currency doesn't have a format in ECMA-376, Part 1, §18.8.30, but VALUE includes currency formats
+        {
+            AssertCoercion(currency, expectedValue);
+        }
+
+        [SetCulture("cs-CZ")]
+        [TestCase("$1", null)] // Fallback currency doesn't work nor it should
+        [TestCase("Kč 1", null, Ignore = "Excel requires correct placement of currency symbol, while .NET parser accepts any position.")] // incorrect placement
+        [TestCase("100.5", null)] // incorrect decimal placement
+        [TestCase("10e2 Kč", 1000)]
+        [TestCase("30-apr-2000", null)]
+        [TestCase("02/28/20", null)]
+        [TestCase("10:30 AM", 0.4375)] // AM seems to work for some reason
+        [TestCase("10:30 dop.", 0.4375)]
+        [TestCase("3-leden", 44564)]
+        [TestCase("3-led", 44564)]
+        [TestCase("1-leden-2020", 43831)]
+        [TestCase("1-led-2020", 43831)]
+        [TestCase("led-5", 38353)]
+        [TestCase("12:0:18 odp.", 0.50020833333333337d)]
+        [TestCase("12:0:18 PM", 0.50020833333333337d)]
+        [TestCase("12:0:18 odp", 0.50020833333333337d, Ignore = "Excel can parse even partial PM designator, but .NET requires a full PM designator including the dot at the end.")]
+        [TestCase("12:0:18 PM.", 0.50020833333333337d, Ignore = "Excel allows PM designator with a dot at the end.")]
+        [TestCase("11/30/2022 25:59", null)]
+        [TestCase("25:70,05", 0.018171875)] // For min:sec fraction timespan, both can be over limit, also note use of decimal separator
+        public void ParsingTokensAndFormatsDependOnCulture(string currency, double? expectedValue)
         {
             AssertCoercion(currency, expectedValue);
         }

--- a/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
@@ -1,0 +1,77 @@
+﻿using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine
+{
+    [TestFixture]
+    public class TextToNumberCoercionTests
+    {
+        [Test]
+        public void TimeSpan_MaximumResolutionIsOneMs()
+        {
+            var firstValue = (double)XLWorkbook.EvaluateExpr("\"0:0:0.0015\" * 1");
+            var secondValue = (double)XLWorkbook.EvaluateExpr("\"0:0:0.0024\" * 1");
+            Assert.AreEqual(firstValue, secondValue);
+        }
+
+        [TestCase("00:00", 0)] // Can parse zero
+        [TestCase("90:00", 3.75)] // Minutes can be can be over 60
+        [TestCase("59:59", 2.499305556)] // Even if looks like mm:ss parsed as h:mm
+        [TestCase("10:", 0.416666667)] // Last part can be omitted and zero is used
+        [TestCase("9999:", 416.625)] // Upper limit of first part is parseable
+        [TestCase("10000:", null)] // Part value over a limit is not parseable
+        [TestCase(":5", null)] // Can't omit first part
+        [TestCase("24:60", null)] // Only one part can be outside of limit, here are both
+        [TestCase("30:59", 1.290972222)] // Hour part over limit
+        [TestCase("23:300", 1.166666667)] // Minute part over limit
+        public void TimeSpan_Format20(string timeSpan, double? expectedValue) // 'h:mm'
+        {
+            var parsedValue = XLWorkbook.EvaluateExpr($"\"{timeSpan}\"*1");
+            if (expectedValue is null)
+                Assert.AreEqual(XLError.IncompatibleValue, parsedValue);
+            else
+                Assert.AreEqual(expectedValue.Value, (double)parsedValue, 0.000001);
+        }
+
+        [TestCase("0:01:01", 0.000706019)]
+        [TestCase("000:01:01", null)] // Extra zeros.
+        [TestCase("00:001:01", null)] // Three digits in a part that starts with 0
+        [TestCase("0:01:001", null)] // Three digits in a part that starts with 0
+        [TestCase("00:60:60", null)] // Only one part can be over the limit, but here are minutes and seconds
+        [TestCase("24:60:00", null)] // Only one part can be over the limit, but here are hours and minutes
+        [TestCase("24:00:60", null)] // Only one part can be over the limit, but here are hours and seconds
+        [TestCase("23:60:06", 1.000069444)]
+        [TestCase("  24   :  00  :   59  ", 1.00068287)] // Extra padding
+        [TestCase("24:0:", 1)] // Last part can be omitted 
+        [TestCase("0::0", null)] // Parts in the middle can't be omitted
+        [TestCase(":0:0", null)] // First part can't be omitted
+        public void TimeSpan_Format21(string timeSpan, double? expectedValue) // 'h:mm:ss'
+        {
+            var parsedValue = XLWorkbook.EvaluateExpr($"\"{timeSpan}\"*1");
+            if (expectedValue is null)
+                Assert.AreEqual(XLError.IncompatibleValue, parsedValue);
+            else
+                Assert.AreEqual(expectedValue.Value, (double)parsedValue, 0.000001);
+        }
+
+        [TestCase("14:30.0", 0.010069444)] // Happy case, can be over 12 (to differ from AM/PM times)
+        [TestCase("14:300.0", 0.013194444)] // Seconds part can be outside of normal range
+        [TestCase("140:30.0", 0.097569444)] // Minutes part can be outside of normal range
+        [TestCase("30:300.0", 0.024305556)] // Both parts can be outside the range
+        [TestCase("140:60.0", null)] // Both hours and minutes are out of range
+        [TestCase("60:000.0", null)] // The minutes part starts with 0, but has over 2 digits
+        [TestCase("59:300.0", 0.044444444)] // Seconds are added to the minutes, the result is 1:04 minutes
+        [TestCase("59:300.59", 0.044451273)] // Can specify 2 digit ms
+        [TestCase("00:57.180", 0.000661806)] // Can specify 3 digit ms
+        public void TimeSpan_Format47(string timeSpan, double? expectedValue) // 'mm:ss.0'
+        {
+            var parsedValue = XLWorkbook.EvaluateExpr($"\"{timeSpan}\"*1");
+            if (expectedValue is null)
+                Assert.AreEqual(XLError.IncompatibleValue, parsedValue);
+            else
+                Assert.AreEqual(expectedValue.Value, (double)parsedValue, 0.000001);
+        }
+
+    }
+}

--- a/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
@@ -18,6 +18,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(firstValue, secondValue);
         }
 
+        [TestCase("0 1/2", 0.5)]
+        [TestCase("0 /20", null)]
+        [TestCase("0 1/32768", null)] // Denominator can be at most 2^15-1
+        [TestCase("0 1/32767", 3.0518509475997192E-05d)]
+        [TestCase("0 32768/1", null)] // Nominator can be at most 2^15-1
+        [TestCase("0 32767/1", 32767)]
+        [TestCase("1 32767/032767", null)] // Fraction can be only 5 digits at most
+        [TestCase("1 00100/025", 5)]
+        [TestCase("1 100/-2", null)] // Fractions can't be negative
+        [TestCase("1 -1/2", null)]
+        [TestCase("- 1 1/2", -1.5)] // can use minus sign
+        [TestCase("+1 1/2", 1.5)] // or plus sign
+        [TestCase("1.5 1/2", null)] // Can't use dot in whole part
+        [TestCase("   1 10/20  ", 1.5)]
+        [TestCase("1  1/2", null)] // Between whole part and nominator must be exactly one space
+        [TestCase("1 1 /2", null)] // Can't have spaces between nominator and denominator
+        [TestCase("1 1/ 2", null)] 
+        [TestCase("1	1/2", null)] // Tab and other whitespaces aren't allowed
+        [TestCase("0 1/0", null)]
+        public void Fraction_Format12_13(string fraction, double? expectedValue) // Format 12+13 '# ??/??' and  '# ?/?'
+        {
+            AssertCoercion(fraction, expectedValue);
+        }
+
         [TestCase("00:00", 0)] // Can parse zero
         [TestCase("90:00", 3.75)] // Minutes can be can be over 60
         [TestCase("59:59", 2.499305556)] // Even if looks like mm:ss parsed as h:mm

--- a/ClosedXML/Excel/CalcEngine/DateTimeParser.cs
+++ b/ClosedXML/Excel/CalcEngine/DateTimeParser.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Linq;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    internal static class DateTimeParser
+    {
+        private const DateTimeStyles Style = DateTimeStyles.NoCurrentDateDefault | DateTimeStyles.AllowInnerWhite | DateTimeStyles.AllowTrailingWhite;
+
+        // It's highly likely that Excel has its own database of culture specific patterns for parsing.
+        // Excel has it's own parser (that accepts 1900-02-29 ^_^), never seems to parse name of a day,
+        // values of hours can be up to 9999 and safely overflow...
+        // Although for displaying, Excel takes a cue from region setting pattern, not so for parsing (at least
+        // couldn't produce observable difference by changing setting of a culture in region dialogue).
+        // .NET Core and .NET Framework also produce different patterns for GetAllDateTimePatterns.
+        // This is not a perfect solution by any means, but best we can do in absence of knowledge
+        // what patterns Excel uses for which cultures.
+        private static readonly ConcurrentDictionary<CultureInfo, string[]> CultureSpecificPatterns = new();
+
+        private static readonly string[] TimeOfDayPatterns = { "h:m tt", "h:m t", "h:m:s tt", "h:m:s t" };
+
+        public static bool TryParseCultureDate(string s, CultureInfo culture, out DateTime date)
+        {
+            var datePatterns = CultureSpecificPatterns.GetOrAdd(culture, static ci =>
+            {
+                var shortDatePatterns = ci.DateTimeFormat.GetAllDateTimePatterns('d')
+                    .Concat(ci.DateTimeFormat.GetAllDateTimePatterns('D'))
+                    .Where(pattern => !pattern.Contains("dddd")) // It doesn't seem that Excel parser is capable of parsing day names in any culture
+                    .Distinct().ToArray();
+
+                // Not sure about this, but reasonably close. Hours pattern is probably generated (e.g. 'as-IN' culture
+                // has AM designator before hours in patterns, but Excel requires it to be at the end). There most likely
+                // isn't a pattern to just use. Example: for en-US, Excel type coercion can transform "aug 10, 2022 14:10",
+                // but every single format from CultureInfo.DateTimeFormat requires AM/PM. and two digits for minutes (thus
+                // the input couldn't match in any format => excel has likely it's own logic, independent of region setting).
+                var timePatterns = new[] { "h:m tt", "H:m", "h:m" };
+                var longDatePatterns = shortDatePatterns
+                    .SelectMany(datePattern => timePatterns.Select(timePattern => FormattableString.Invariant($"{datePattern} {timePattern}")));
+
+                // ISO8601 should be parseable in all cultures, not sure if Excel does.
+                return shortDatePatterns.Concat(longDatePatterns).Concat(new[] { "yyyy-MM-DD" }).Distinct().ToArray();
+            });
+
+            return DateTime.TryParseExact(s, datePatterns, culture, Style, out date);
+        }
+
+        public static bool TryParseTimeOfDay(string s, CultureInfo c, out DateTime timeOfDay)
+        {
+            if (DateTime.TryParseExact(s, TimeOfDayPatterns, c, Style, out timeOfDay))
+                return true;
+
+            if (DateTime.TryParseExact(s, TimeOfDayPatterns, CultureInfo.InvariantCulture, Style, out timeOfDay))
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/FractionParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FractionParser.cs
@@ -1,0 +1,40 @@
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// Parse a fraction for text-to-number type coercion.
+    /// </summary>
+    internal static class FractionParser
+    {
+        private static readonly Regex FractionRegex = new(@"^ *([+-]?) *([0-9]+) ([0-9]{1,5})/([0-9]{1,5}) *$", RegexOptions.CultureInvariant);
+
+        public static bool TryParse(string s, out double result)
+        {
+            result = default;
+            var match = FractionRegex.Match(s);
+            if (!match.Success)
+                return false;
+
+            var denominator = ParseInt(match.Groups[4]);
+            if (denominator == 0 || denominator > short.MaxValue)
+                return false;
+
+            var numerator = ParseInt(match.Groups[3]);
+            if (numerator > short.MaxValue)
+                return false;
+
+            var sign = match.Groups[1];
+            var wholeNumber = ParseInt(match.Groups[2]);
+
+            var fraction = wholeNumber + numerator / (double)denominator;
+            var hasNegativeSign = sign.Success && sign.Value.Length > 0 && sign.Value[0] == '-';
+            result = hasNegativeSign ? -fraction : fraction;
+            return true;
+
+            static int ParseInt(Capture capture) =>
+                int.Parse(capture.Value, NumberStyles.None, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -153,6 +153,9 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static OneOf<double, XLError> TextToNumber(string text, CultureInfo culture)
         {
+            if (string.IsNullOrWhiteSpace(text))
+                return XLError.IncompatibleValue;
+
             // Numbers. The parsing method recognizes braces as negative number, includes currency parsing.
             // Format 1 '0'
             //        2 '0.00'
@@ -162,6 +165,12 @@ namespace ClosedXML.Excel.CalcEngine
             //       48 '##0.0E+0'
             if (double.TryParse(text, NumberStyles.Any, culture, out var number))
                 return number;
+
+            // Fractions
+            // Format 12 '# ?/?'
+            //        13 '# ??/??'
+            if (FractionParser.TryParse(text, out var fraction))
+                return fraction;
 
             // Time span uses a different parser from time within a day.
             // Format 20 'h:mm'

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -153,10 +153,23 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static OneOf<double, XLError> TextToNumber(string text, CultureInfo culture)
         {
-            if (double.TryParse(text, NumberStyles.Float, culture, out var number))
+            // Numbers. The parsing method recognizes braces as negative number, includes currency parsing.
+            // Format 1 '0'
+            //        2 '0.00'
+            //        3 '#,##0'
+            //        4 '#,##0.00'
+            //       11 '0.00E+00'
+            //       48 '##0.0E+0'
+            if (double.TryParse(text, NumberStyles.Any, culture, out var number))
                 return number;
+
+            // Time span uses a different parser from time within a day.
+            // Format 20 'h:mm'
+            //        21 'h:mm:ss'
+            //        47 'mm:ss.0'
             if (TimeSpanParser.TryParseTime(text, culture, out var timeSpan))
                 return timeSpan.ToSerialDateTime();
+
             return XLError.IncompatibleValue;
         }
 

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -153,9 +153,11 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static OneOf<double, XLError> TextToNumber(string text, CultureInfo culture)
         {
-            return double.TryParse(text, NumberStyles.Float, culture, out var number)
-                ? number
-                : XLError.IncompatibleValue;
+            if (double.TryParse(text, NumberStyles.Float, culture, out var number))
+                return number;
+            if (TimeSpanParser.TryParseTime(text, culture, out var timeSpan))
+                return timeSpan.ToSerialDateTime();
+            return XLError.IncompatibleValue;
         }
 
         public bool TryPickNumber(out double number)

--- a/ClosedXML/Excel/CalcEngine/TimeSpanParser.cs
+++ b/ClosedXML/Excel/CalcEngine/TimeSpanParser.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Globalization;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// A parser of timespan format used by excel during coercion from text to number. <see cref="TimeSpan" /> parsing methods
+    /// don't allow for several features required by excel (e.g. seconds/minutes over 60, hours over 24).
+    /// Parser can parse following formats from ECMA-376, Part 1, §18.8.30. due to standard text-to-number coercion:
+    /// <list type="bullet">
+    ///     <item>Format 20 - <c>h:mm</c>.</item>
+    ///     <item>Format 21 - <c>h:mm:ss</c>.</item>
+    ///     <item>Format 47 - <c>mm:ss.0</c> (format is incorrectly described as <c>mmss.0</c> in the standard,
+    ///           but fixed in an implementation errata).</item>
+    /// </list>
+    /// Timespan is never interpreted through format 45 (<c>mm:ss</c>), instead preferring the format 20 (<c>h:mm</c>).
+    /// Timespan is never interpreted through format 46 (<c>[h]:mm:ss</c>], such values are covered by format 21 (<c>h:mm:ss</c>).
+    /// </summary>
+    /// <remarks>
+    /// Note that the decimal fraction differs format 20 and 47, thus mere addition of decimal
+    /// place means significantly different values. Parser also copies features of Excel, like whitespaces around
+    /// a decimal place (<c>10:20 . 5</c> is allowed).
+    /// <example>
+    /// <c>20:30</c> is detected as format 20 and the first number is interpreted as hours, thus the serial time is 0.854167.
+    /// <c>20:30.0</c> is detected as format 47 and the first number is interpreted as minutes, thus the serial time is 0.014236111.
+    /// </example>
+    /// </remarks>
+    internal static class TimeSpanParser
+    {
+        public static bool TryParseTime(string s, CultureInfo ci, out TimeSpan result)
+        {
+            var timeSeparator = ci.DateTimeFormat.TimeSeparator;
+            var decimalSeparator = ci.NumberFormat.NumberDecimalSeparator;
+            result = default;
+            var i = 0;
+            SkipWhitespace(ref i, s);
+            if (!TryReadNumber(ref i, s, out var hoursOrMinutes))
+                return false;
+
+            SkipWhitespace(ref i, s);
+
+            if (!InputMatches(ref i, s, timeSeparator))
+                return false;
+
+            SkipWhitespace(ref i, s);
+            if (i == s.Length) // Special case ' 10 : '
+            {
+                result = new TimeSpan(hoursOrMinutes, 0, 0);
+                return true;
+            }
+
+            if (!TryReadNumber(ref i, s, out var minutesOrSeconds))
+                return false;
+
+            SkipWhitespace(ref i, s);
+
+            if (i == s.Length) // Case '10:00'
+            {
+                result = new TimeSpan(hoursOrMinutes, minutesOrSeconds, 0);
+                return hoursOrMinutes < 24 || minutesOrSeconds < 60;
+            }
+
+            if (InputMatches(ref i, s, decimalSeparator))
+            {
+                SkipWhitespace(ref i, s);
+                var ms = ReadFractionInMs(ref i, s); // '10:20.' is allowed without digits
+                SkipWhitespace(ref i, s);
+                result = new TimeSpan(0, 0, hoursOrMinutes, minutesOrSeconds, ms);
+                return i == s.Length &&
+                       (hoursOrMinutes < 60 || minutesOrSeconds < 60); // No check for min/sec over limit
+            }
+
+            // Longer path for h:m:s[.f]
+            if (!InputMatches(ref i, s,
+                    timeSeparator)) // There is some other character after '10:00', but only ':' ('10:20:0')
+                return false;
+
+            SkipWhitespace(ref i, s);
+            if (i == s.Length) // Case ' 10 : 0 : '
+            {
+                result = new TimeSpan(hoursOrMinutes, minutesOrSeconds, 0);
+                return hoursOrMinutes < 24 || minutesOrSeconds < 60;
+            }
+
+            if (!TryReadNumber(ref i, s, out var seconds)) // Seconds
+                return false;
+
+            // At lost two can be over limit
+            if ((hoursOrMinutes >= 24 && minutesOrSeconds >= 60)
+                || (hoursOrMinutes >= 24 && seconds >= 60)
+                || (minutesOrSeconds >= 60 && seconds >= 60))
+                return false;
+
+
+            SkipWhitespace(ref i, s);
+            if (i == s.Length) // Case ' 1 : 0 : 0 . '
+            {
+                result = new TimeSpan(hoursOrMinutes, minutesOrSeconds, seconds);
+                return true;
+            }
+
+            if (!InputMatches(ref i, s,
+                    decimalSeparator)) // The only allowed character is a decimal separator for '1:0:0.'
+                return false;
+
+            SkipWhitespace(ref i, s);
+            var milliseconds = ReadFractionInMs(ref i, s);
+            SkipWhitespace(ref i, s);
+
+            if (i == s.Length) // Case ' 1 : 0 : 0 . 0 '
+            {
+                result = new TimeSpan(0, hoursOrMinutes, minutesOrSeconds, seconds, milliseconds);
+                return (hoursOrMinutes < 24 && minutesOrSeconds < 60)
+                       || (hoursOrMinutes < 24 && seconds < 60)
+                       || (minutesOrSeconds < 60 && seconds < 60); // Just one 1 field under limit is enough
+            }
+
+            return false; // There was some unexpected chars at the end
+
+            static bool TryReadNumber(ref int i, string t, out int num)
+            {
+                var start = i;
+                num = 0;
+                var digitCount = 0;
+                while (i < t.Length && t[i] >= '0' && t[i] <= '9')
+                {
+                    num = num * 10 + t[i] - '0';
+                    digitCount++;
+                    i++;
+                }
+
+                if (digitCount == 0 || num > 9999)
+                    return false;
+                if (t[start] == '0' && digitCount > 2)
+                    return false;
+                return true;
+            }
+
+            static int ReadFractionInMs(ref int i, string t)
+            {
+                var num = 0;
+                var digitCount = 0;
+                while (i < t.Length && t[i] >= '0' && t[i] <= '9')
+                {
+                    num = num * 10 + t[i] - '0';
+                    digitCount++;
+                    i++;
+                }
+
+                // Maximum resolution is 1 ms of pattern
+                return (int)Math.Round(num / Math.Pow(10, digitCount - 3), MidpointRounding.AwayFromZero);
+            }
+
+            static void SkipWhitespace(ref int i, string t)
+            {
+                while (i < t.Length && t[i] == ' ') i++;
+            }
+
+            static bool InputMatches(ref int i, string t, string expected)
+            {
+                for (var expectedIdx = 0; expectedIdx < expected.Length; ++expectedIdx)
+                {
+                    var inputIdx = i + expectedIdx;
+                    if (inputIdx == t.Length || expected[expectedIdx] != t[inputIdx])
+                    {
+                        return false;
+                    }
+                }
+
+                i += expected.Length; // Branch can differ depending on the input (':' vs '.'), so move only when input matches
+                return true;
+            }
+        }
+    }
+}

--- a/ClosedXML/Extensions/DateTimeExtensions.cs
+++ b/ClosedXML/Extensions/DateTimeExtensions.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel
 
         public static double ToSerialDateTime(this TimeSpan time)
         {
-            return ((time.Hours % 24) + (time.Minutes % 60) / 60.0 + (time.Seconds % 60) / 3600.0) / 24.0;
+            return time.TotalMilliseconds / (24 * 60 * 60 * 1000);
         }
     }
 }


### PR DESCRIPTION
This was **not** fun. 

I can just image a that conversation when they were writing the specification:

> **Technical writer:** So I got a task to document type coercion for the Open XML standard. How does it work?
**Dev:** That's a deep hole. We have number, fractions, currencies, percents, time spans and dates. We use our own parser that accepts a lot of inputs that are just not generally considered fine, like 1000 hours in a date and so on.
**Technical writer:** Can we utilize some other standards?
**Dev:** Not really, this goes way back to first versions in 1980s and 90s, there wasn't even unicode back then. Each country had it's own separate build with a baked-in culture, so it couldn't change parsing methods on the fly.
**Technical writer:** What if I open an excel from US that has a date in a format 'MM/dd/yyyy' and open it different country with a different date format?
**Dev:** Yeah, the date won't be coerced to number in the new country.
**Technical writer:** Are date formats described in some other official specification? ISO8601... anything?
**Dev:** Don't think so. Just our internal docs.
**Technical writers:** What about numbers? They have pretty well established grammar. 
**Dev:** Yeah, there are some not-so-accepted features, like a allowed whitespacespace between a sign and a number, like "- 1"
**Technical writer:** So the coercion is a culture specific and doesn't conform to any kind of public standard, thanks to compatibility going back decades.
**Dev:** That pretty much sums it up.
**Technical writer:** Screw it. This will do.

> An implementation is permitted to provide an implicit conversion from string-constant to number. However, the
rules by which such conversions take place are implementation-defined. [Example: An implementation might
choose to accept "123"+10 by converting the string "123" to the number 123. Such conversions might be locale-
specific in that a string-constant such as "10,56" might be converted to 10.56 in some locales, but not in others,
depending on the radix point character. end example]


Related to #1891.