### PR TITLE
Make AutoFilter filtering slighly less buggy.

### DIFF
--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -95,8 +95,8 @@ namespace ClosedXML.Excel
                             filterMatch = row.Cell(columnIndex).DataType == XLDataType.DateTime &&
                                     condition(row.Cell(columnIndex).GetDateTime());
                         else
-                            filterMatch = row.Cell(columnIndex).DataType == XLDataType.Number &&
-                                    condition(row.Cell(columnIndex).GetDouble());
+                            filterMatch = row.Cell(columnIndex).TryGetValue(out double number) &&
+                                    condition(number);
 
                         if (filter.Connector == XLConnector.And)
                         {


### PR DESCRIPTION
 Only a stopgap, until cells have a proper types (#1894) and values can be compared though ScalarValue/AnyValue. Then the autofilter conditions will have to completely rewritten, but that is hte future.