### PR TITLE
Update System.IO.Packaging dependency

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -31,7 +31,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta18" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.IO.Packaging" Version="4.7.0" />
+    <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
+    <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="XLParser" Version="1.5.2" />
   </ItemGroup>


### PR DESCRIPTION
Update minimum dependency version due to runtime bug https://github.com/dotnet/runtime/issues/43012.

System.IO.Packaging coede hasn't changed otherwise since 4.7.0 (at least by my quick skimming), Microsoft mostly  applied analyzers and fixed reported issues (e.g. nullability, missing readonly, inline varibale to TryGet pattern, use `is null`, use internally `ReadOnlySpan` and so one). I see no downside. Package still supportes netstandard 2 and there are only two places with conditional compiling (streams had to have a  `ReadOnlySpan` method and typed `Enum.Parse<TargetMode>`).

Resolves #1908 
