### PR TITLE
Fix info functions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -104,6 +104,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var actual = XLWorkbook.EvaluateExpr("IsErr(#N/A)");
             Assert.AreEqual(false, actual);
         }
+        
+        [TestCase("#DIV/0!")]
+        [TestCase("#N/A")]
+        [TestCase("#NAME?")]
+        [TestCase("#NULL!")]
+        [TestCase("#NUM!")]
+        [TestCase("#REF!")]
+        [TestCase("#VALUE!")]
+        public void IsError_Errors_true(string error)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsError({error})");
+            Assert.AreEqual(true, actual);
+        }
+
+        [TestCase("IF(TRUE,,)")]
+        [TestCase("FALSE")]
+        [TestCase("0")]
+        [TestCase("\"\"")]
+        [TestCase("\"text\"")]
+        public void IsError_NonErrors_false(string valueFormula)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsError({valueFormula})");
+            Assert.AreEqual(false, actual);
+        }
 
         #region IsEven Tests
 

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -36,64 +36,41 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         #region IsBlank Tests
 
         [Test]
-        public void IsBlank_MultipleAllEmpty_true()
+        public void IsBlank_EmptyCell_true()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                var actual = ws.Evaluate("=IsBlank(A1:A3)", "A2");
-                Assert.AreEqual(true, actual);
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var actual = ws.Evaluate("IsBlank(A1)");
+            Assert.AreEqual(true, actual);
         }
 
         [Test]
-        public void IsBlank_MultipleAllFill_false()
+        public void IsBlank_NonEmptyCell_false()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "1";
-                ws.Cell("A2").Value = "1";
-                ws.Cell("A3").Value = "1";
-                var actual = ws.Evaluate("=IsBlank(A1:A3)", "A2");
-                Assert.AreEqual(false, actual);
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = "1";
+            var actual = ws.Evaluate("IsBlank(A1)");
+            Assert.AreEqual(false, actual);
+        }
+
+        [TestCase("FALSE")]
+        [TestCase("0")]
+        [TestCase("5")]
+        [TestCase("\"\"")]
+        [TestCase("\"Hello\"")]
+        [TestCase("#DIV/0!")]
+        public void IsBlank_NonEmptyValue_false(string value)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsBlank({value})");
+            Assert.AreEqual(false, actual);
         }
 
         [Test]
-        public void IsBlank_MultipleMixedFill_false()
+        public void IsBlank_InlineBlank_true()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "1";
-                ws.Cell("A3").Value = "1";
-                var actual = ws.Evaluate("=IsBlank(A1:A3)", "A3");
-                Assert.AreEqual(false, actual);
-            }
-        }
-
-        [Test]
-        public void IsBlank_Single_false()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = " ";
-                var actual = ws.Evaluate("=IsBlank(A1)");
-                Assert.AreEqual(false, actual);
-            }
-        }
-
-        [Test]
-        public void IsBlank_Single_true()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                var actual = ws.Evaluate("=IsBlank(A1)");
-                Assert.AreEqual(true, actual);
-            }
+            var actual = XLWorkbook.EvaluateExpr("IsBlank(IF(TRUE,,))");
+            Assert.AreEqual(true, actual);
         }
 
         #endregion IsBlank Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -75,6 +75,36 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #endregion IsBlank Tests
 
+        [TestCase("IF(TRUE,,)")]
+        [TestCase("FALSE")]
+        [TestCase("0")]
+        [TestCase("\"\"")]
+        [TestCase("\"text\"")]
+        public void IsErr_NonErrorValues_false(string valueFormula)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsErr({valueFormula})");
+            Assert.AreEqual(false, actual);
+        }
+
+        [TestCase("#DIV/0!")]
+        [TestCase("#NAME?")]
+        [TestCase("#NULL!")]
+        [TestCase("#NUM!")]
+        [TestCase("#REF!")]
+        [TestCase("#VALUE!")]
+        public void IsErr_ErrorsExceptNA_true(string valueFormula)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsErr({valueFormula})");
+            Assert.AreEqual(true, actual);
+        }
+
+        [Test]
+        public void IsErr_NA_false()
+        {
+            var actual = XLWorkbook.EvaluateExpr("IsErr(#N/A)");
+            Assert.AreEqual(false, actual);
+        }
+
         #region IsEven Tests
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate($"ERROR.TYPE({argumentFormula})"));
         }
 
-        [TestCase("#NULL!",1)]
+        [TestCase("#NULL!", 1)]
         [TestCase("#DIV/0!", 2)]
         [TestCase("#VALUE!", 3)]
         [TestCase("#REF!", 4)]
@@ -104,7 +104,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var actual = XLWorkbook.EvaluateExpr("IsErr(#N/A)");
             Assert.AreEqual(false, actual);
         }
-        
+
         [TestCase("#DIV/0!")]
         [TestCase("#N/A")]
         [TestCase("#NAME?")]
@@ -142,7 +142,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var actual = XLWorkbook.EvaluateExpr($"IsEven({valueFormula})");
             Assert.AreEqual(true, actual);
         }
-        
+
         [Test]
         public void IsEven_NonIntegerValues_TruncatedForEvaluation()
         {
@@ -173,7 +173,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             Assert.AreEqual(2.0, XLWorkbook.EvaluateExpr("SUM(N(IsEven({\"2.9\";2;1})))"));
         }
-        
+
         [Test]
         public void IsEven_ReferenceToMoreThanOneCell_Error()
         {
@@ -198,44 +198,59 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #region IsLogical Tests
 
-        [Test]
-        public void IsLogical_Simpe_False()
+        [TestCase("TRUE")]
+        [TestCase("FALSE")]
+        public void IsLogical_OnlyLogical_True(string valueFormula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            var actual = XLWorkbook.EvaluateExpr($"IsLogical({valueFormula})");
+            Assert.AreEqual(true, actual);
+        }
 
-                ws.Cell("A1").Value = 123;
-
-                var actual = ws.Evaluate("=IsLogical(A1)");
-                Assert.AreEqual(false, actual);
-            }
+        [TestCase("IF(TRUE,,)")]
+        [TestCase("0")]
+        [TestCase("1")]
+        [TestCase("\"\"")]
+        [TestCase("\"text\"")]
+        [TestCase("#NAME?")]
+        [TestCase("#N/A")]
+        [TestCase("#VALUE!")]
+        [TestCase("#REF!")]
+        public void IsLogical_NonLogical_False(string valueFormula)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsLogical({valueFormula})");
+            Assert.AreEqual(false, actual);
         }
 
         [Test]
-        public void IsLogical_Simple_True()
+        public void IsLogical_ReferenceToLogical_True()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
 
-                ws.Cell("A1").Value = true;
+            ws.Cell("A1").Value = true;
 
-                var actual = ws.Evaluate("=IsLogical(A1)");
-                Assert.AreEqual(true, actual);
-            }
+            var actual = ws.Evaluate("IsLogical(A1)");
+            Assert.AreEqual(true, actual);
         }
 
         #endregion IsLogical Tests
 
         [Test]
-        public void IsNA()
+        public void IsNA_NA_True()
         {
-            object actual;
-            actual = XLWorkbook.EvaluateExpr("ISNA(#N/A)");
+            var actual = XLWorkbook.EvaluateExpr("ISNA(#N/A)");
             Assert.AreEqual(true, actual);
+        }
 
-            actual = XLWorkbook.EvaluateExpr("ISNA(#REF!)");
+        [TestCase("IF(TRUE,,)")]
+        [TestCase("TRUE")]
+        [TestCase("0")]
+        [TestCase("\"\"")]
+        [TestCase("#REF!")]
+        [TestCase("\"#N/A\"")]
+        public void IsNA_NA_False(string valueFormula)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"ISNA({valueFormula})");
             Assert.AreEqual(false, actual);
         }
 
@@ -341,7 +356,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var actual = XLWorkbook.EvaluateExpr($"IsOdd({valueFormula})");
             Assert.AreEqual(true, actual);
         }
-        
+
         [Test]
         public void IsOdd_NonIntegerValues_TruncatedForEvaluation()
         {
@@ -372,7 +387,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             Assert.AreEqual(2.0, XLWorkbook.EvaluateExpr("SUM(N(IsOdd({\"3.2\",7,2})))"));
         }
-        
+
         [Test]
         public void IsOdd_ReferenceToMoreThanOneCell_Error()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -257,43 +257,44 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         #region IsNotText Tests
 
         [Test]
-        public void IsNotText_Simple_false()
+        public void IsNotText_ReferenceToBlankCell_True()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "asd";
-                var actual = ws.Evaluate("=IsNonText(A1)");
-                Assert.AreEqual(false, actual);
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var actual = ws.Evaluate("IsNonText(A1)");
+            Assert.AreEqual(true, actual);
+        }
+
+        [TestCase("")]
+        [TestCase("  ")]
+        [TestCase("text")]
+        public void IsNotText_ReferenceToStringCell_False(string text)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = text;
+            var actual = ws.Evaluate("IsNonText(A1)");
+            Assert.AreEqual(false, actual);
         }
 
         [Test]
-        public void IsNotText_Simple_true()
+        public void IsNotText_NonTextValues_True()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "123"; //Double Value
-                ws.Cell("A2").Value = DateTime.Now; //Date Value
-                ws.Cell("A3").Value = "12,235.5"; //Comma Formatting
-                ws.Cell("A4").Value = "$12,235.5"; //Currency Value
-                ws.Cell("A5").Value = true; //Bool Value
-                ws.Cell("A6").Value = "12%"; //Percentage Value
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
+            ws.Cell("A1").Value = 123; //Double Value
+            ws.Cell("A2").Value = DateTime.Now; //Date Value
+            ws.Cell("A3").Value = true; //Bool Value
+            ws.Cell("A4").Value = XLError.IncompatibleValue; //Error value
 
-                var actual = ws.Evaluate("=IsNonText(A1)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNonText(A2)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNonText(A3)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNonText(A4)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNonText(A5)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNonText(A6)");
-                Assert.AreEqual(true, actual);
-            }
+            var actual = ws.Evaluate("IsNonText(A1)");
+            Assert.AreEqual(true, actual);
+            actual = ws.Evaluate("IsNonText(A2)");
+            Assert.AreEqual(true, actual);
+            actual = ws.Evaluate("IsNonText(A3)");
+            Assert.AreEqual(true, actual);
+            actual = ws.Evaluate("IsNonText(A4)");
+            Assert.AreEqual(true, actual);
         }
 
         #endregion IsNotText Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -447,45 +447,37 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         #region IsText Tests
 
         [Test]
-        public void IsText_Simple_false()
+        public void IsText_BlankCell_False()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "123"; //Double Value
-                ws.Cell("A2").Value = DateTime.Now; //Date Value
-                ws.Cell("A3").Value = "12,235.5"; //Comma Formatting
-                ws.Cell("A4").Value = "$12,235.5"; //Currency Value
-                ws.Cell("A5").Value = true; //Bool Value
-                ws.Cell("A6").Value = "12%"; //Percentage Value
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("B1").FormulaA1 = "ISTEXT(A1)";
 
-                var actual = ws.Evaluate("=IsText(A1)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsText(A2)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsText(A3)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsText(A4)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsText(A5)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsText(A6)");
-                Assert.AreEqual(false, actual);
-            }
+            Assert.AreEqual(false, ws.Cell("B1").Value);
         }
 
-        [Test]
-        public void IsText_Simple_true()
+        [TestCase("0")]
+        [TestCase("123")]
+        [TestCase("TRUE")]
+        [TestCase("#DIV/0!")]
+        [TestCase("IF(TRUE,,)")]
+        public void IsText_NonText_False(string nonText)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            var actual = XLWorkbook.EvaluateExpr($"ISTEXT({nonText})");
+            Assert.AreEqual(false, actual);
+        }
 
-                ws.Cell("A1").Value = "asd";
+        [TestCase("")]
+        [TestCase("abc")]
+        public void IsText_CellWithText_True(string textValue)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
 
-                var actual = ws.Evaluate("=IsText(A1)");
-                Assert.AreEqual(true, actual);
-            }
+            ws.Cell("A1").Value = textValue;
+
+            var actual = ws.Evaluate("IsText(A1)");
+            Assert.AreEqual(true, actual);
         }
 
         #endregion IsText Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -414,28 +414,34 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #endregion IsOdd Test
 
-        [Test]
-        public void IsRef()
+        [TestCase("A1")]
+        [TestCase("(A1,A5)")]
+        public void IsRef_True(string reference)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "123";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
+            ws.Cell("A1").Value = "123";
 
-                ws.Cell("B1").FormulaA1 = "ISREF(A1)";
-                ws.Cell("B2").FormulaA1 = "ISREF(5)";
-                ws.Cell("B3").FormulaA1 = "ISREF(YEAR(TODAY()))";
+            ws.Cell("B1").FormulaA1 = $"ISREF({reference})";
 
-                XLCellValue actual;
-                actual = ws.Cell("B1").Value;
-                Assert.AreEqual(true, actual);
+            Assert.AreEqual(true, ws.Cell("B1").Value);
+        }
 
-                actual = ws.Cell("B2").Value;
-                Assert.AreEqual(false, actual);
+        [TestCase("IF(TRUE,,)")]
+        [TestCase("TRUE")]
+        [TestCase("0")]
+        [TestCase("\"\"")]
+        // [TestCase("{1;2}")] Arrays not yet implemented
+        [TestCase("#N/A")]
+        [TestCase("#VALUE!")]
+        public void IsRef_NonReference_False(string nonReference)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
 
-                actual = ws.Cell("B3").Value;
-                Assert.AreEqual(false, actual);
-            }
+            ws.Cell("B1").FormulaA1 = $"ISREF({nonReference})";
+
+            Assert.AreEqual(false, ws.Cell("B1").Value);
         }
 
         #region IsText Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -304,42 +304,45 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void IsNumber_Simple_false()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "asd"; //String Value
-                ws.Cell("A2").Value = true; //Bool Value
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
+            ws.Cell("A1").Value = "asd"; //String Value
+            ws.Cell("A2").Value = true; //Bool Value
 
-                var actual = ws.Evaluate("=IsNumber(A1)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsNumber(A2)");
-                Assert.AreEqual(false, actual);
-            }
+            var actual = ws.Evaluate("IsNumber(A1)");
+            Assert.AreEqual(false, actual);
+            actual = ws.Evaluate("IsNumber(A2)");
+            Assert.AreEqual(false, actual);
         }
 
         [Test]
         public void IsNumber_Simple_true()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "123"; //Double Value
-                ws.Cell("A2").Value = DateTime.Now; //Date Value
-                ws.Cell("A3").Value = "12,235.5"; //Coma Formatting
-                ws.Cell("A4").Value = "$12,235.5"; //Currency Value
-                ws.Cell("A5").Value = "12%"; //Percentage Value
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
+            ws.Cell("A1").Value = 123; //Double Value
+            ws.Cell("A2").Value = DateTime.Now; //Date Value
+            ws.Cell("A3").Value = new TimeSpan(2, 30, 50); //TimeSpan Value
 
-                var actual = ws.Evaluate("=IsNumber(A1)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNumber(A2)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNumber(A3)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNumber(A4)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsNumber(A5)");
-                Assert.AreEqual(true, actual);
-            }
+            var actual = ws.Evaluate("=IsNumber(A1)");
+            Assert.AreEqual(true, actual);
+            actual = ws.Evaluate("=IsNumber(A2)");
+            Assert.AreEqual(true, actual);
+            actual = ws.Evaluate("=IsNumber(A3)");
+            Assert.AreEqual(true, actual);
+        }
+
+        [TestCase("TRUE")]
+        [TestCase("FALSE")]
+        [TestCase("\"\"")]
+        [TestCase("#DIV/0!")]
+        [TestCase("#NULL!")]
+        [TestCase("#VALUE!")]
+        [TestCase("#N/A")]
+        public void IsNumber_NonNumber_False(string nonNumberValue)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"IsNumber({nonNumberValue})");
+            Assert.AreEqual(false, actual);
         }
 
         #endregion IsNumber Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -36,7 +36,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         #region IsBlank Tests
 
         [Test]
-        public void IsBlank_EmptyCell_true()
+        public void IsBlank_EmptyCell_True()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -45,7 +45,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void IsBlank_NonEmptyCell_false()
+        public void IsBlank_NonEmptyCell_False()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -60,14 +60,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("\"\"")]
         [TestCase("\"Hello\"")]
         [TestCase("#DIV/0!")]
-        public void IsBlank_NonEmptyValue_false(string value)
+        public void IsBlank_NonEmptyValue_False(string value)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsBlank({value})");
             Assert.AreEqual(false, actual);
         }
 
         [Test]
-        public void IsBlank_InlineBlank_true()
+        public void IsBlank_InlineBlank_True()
         {
             var actual = XLWorkbook.EvaluateExpr("IsBlank(IF(TRUE,,))");
             Assert.AreEqual(true, actual);
@@ -80,7 +80,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("0")]
         [TestCase("\"\"")]
         [TestCase("\"text\"")]
-        public void IsErr_NonErrorValues_false(string valueFormula)
+        public void IsErr_NonErrorValues_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsErr({valueFormula})");
             Assert.AreEqual(false, actual);
@@ -92,14 +92,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("#NUM!")]
         [TestCase("#REF!")]
         [TestCase("#VALUE!")]
-        public void IsErr_ErrorsExceptNA_true(string valueFormula)
+        public void IsErr_ErrorsExceptNA_True(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsErr({valueFormula})");
             Assert.AreEqual(true, actual);
         }
 
         [Test]
-        public void IsErr_NA_false()
+        public void IsErr_NA_False()
         {
             var actual = XLWorkbook.EvaluateExpr("IsErr(#N/A)");
             Assert.AreEqual(false, actual);
@@ -112,7 +112,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("#NUM!")]
         [TestCase("#REF!")]
         [TestCase("#VALUE!")]
-        public void IsError_Errors_true(string error)
+        public void IsError_Errors_True(string error)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsError({error})");
             Assert.AreEqual(true, actual);
@@ -123,7 +123,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("0")]
         [TestCase("\"\"")]
         [TestCase("\"text\"")]
-        public void IsError_NonErrors_false(string valueFormula)
+        public void IsError_NonErrors_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsError({valueFormula})");
             Assert.AreEqual(false, actual);
@@ -131,13 +131,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #region IsEven Tests
 
-        [SetCulture("en-US")]
         [TestCase("2")]
         [TestCase("\"1 2/2\"")]
         [TestCase("\"4 1/2\"")]
         [TestCase("\"48:30:00\"")]
         [TestCase("\"1900-01-02\"")]
-        public void IsEven_SingleValue_ConvertedThroughValueSemantic(string valueFormula)
+        public void IsEven_NumberLikeValue_ConvertedThroughValueSemantic(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsEven({valueFormula})");
             Assert.AreEqual(true, actual);
@@ -166,7 +165,6 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(true, actual);
         }
 
-        [SetCulture("en-US")]
         [Test]
         [Ignore("Arrays not yet implemented.")]
         public void IsEven_Array_ReturnsArray()
@@ -215,14 +213,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("#N/A")]
         [TestCase("#VALUE!")]
         [TestCase("#REF!")]
-        public void IsLogical_NonLogical_False(string valueFormula)
+        public void IsLogical_NonLogicalValue_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsLogical({valueFormula})");
             Assert.AreEqual(false, actual);
         }
 
         [Test]
-        public void IsLogical_ReferenceToLogical_True()
+        public void IsLogical_ReferenceToLogicalValue_True()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -248,7 +246,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("\"\"")]
         [TestCase("#REF!")]
         [TestCase("\"#N/A\"")]
-        public void IsNA_NA_False(string valueFormula)
+        public void IsNA_NonNotAvailableValue_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"ISNA({valueFormula})");
             Assert.AreEqual(false, actual);
@@ -416,7 +414,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         [TestCase("A1")]
         [TestCase("(A1,A5)")]
-        public void IsRef_True(string reference)
+        public void IsRef_Reference_True(string reference)
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet");
@@ -485,65 +483,86 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         #region N Tests
 
         [Test]
+        public void N_Blank_Zero()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var actual = ws.Evaluate("N(A1)");
+            Assert.AreEqual(0.0, actual);
+        }
+
+        [Test]
         public void N_Date_SerialNumber()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                var testedDate = DateTime.Now;
-                ws.Cell("A1").Value = testedDate;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(testedDate.ToOADate(), actual);
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var testedDate = DateTime.Now;
+            ws.Cell("A1").Value = testedDate;
+            var actual = ws.Evaluate("N(A1)");
+            Assert.AreEqual(testedDate.ToSerialDateTime(), actual);
         }
 
         [Test]
         public void N_False_Zero()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = false;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(0, actual);
-            }
-        }
-
-        [Test]
-        public void N_Number_Number()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                var testedValue = 123;
-                ws.Cell("A1").Value = testedValue;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(testedValue, actual);
-            }
-        }
-
-        [Test]
-        public void N_String_Zero()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = "asd";
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(0, actual);
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = false;
+            var actual = ws.Evaluate("N(A1)");
+            Assert.AreEqual(0, actual);
         }
 
         [Test]
         public void N_True_One()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").Value = true;
-                var actual = ws.Evaluate("=N(A1)");
-                Assert.AreEqual(1, actual);
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = true;
+            var actual = ws.Evaluate("N(A1)");
+            Assert.AreEqual(1, actual);
+        }
+        [Test]
+        public void N_Number_Number()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var testedValue = 123;
+            ws.Cell("A1").Value = testedValue;
+            var actual = ws.Evaluate("N(A1)");
+            Assert.AreEqual(testedValue, actual);
+        }
+
+        [TestCase("")]
+        [TestCase("abc")]
+        public void N_String_Zero(string text)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = text;
+            var actual = ws.Evaluate("N(A1)");
+            Assert.AreEqual(0, actual);
+        }
+
+        [Test]
+        [Ignore("Array not implemented")]
+        public void N_Array_ConvertsIndividualItems()
+        {
+            var actual = XLWorkbook.EvaluateExpr("SUM(N({2,TRUE}))");
+            Assert.AreEqual(3, actual);
+        }
+
+        [TestCase("A1")]
+        [TestCase("A1:B1")]
+        [TestCase("(A1, B1)")]
+        public void N_Reference_TakesFirstCellFromFirstArea(string reference)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = 5;
+            ws.Cell("B1").Value = 10;
+
+            var actual = ws.Evaluate($"SUM(N({reference}))");
+            Assert.AreEqual(5, actual);
         }
 
         #endregion N Tests

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -131,48 +131,67 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #region IsEven Tests
 
-        [Test]
-        public void IsEven_Single_False()
+        [SetCulture("en-US")]
+        [TestCase("2")]
+        [TestCase("\"1 2/2\"")]
+        [TestCase("\"4 1/2\"")]
+        [TestCase("\"48:30:00\"")]
+        [TestCase("\"1900-01-02\"")]
+        public void IsEven_SingleValue_ConvertedThroughValueSemantic(string valueFormula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            var actual = XLWorkbook.EvaluateExpr($"IsEven({valueFormula})");
+            Assert.AreEqual(true, actual);
+        }
+        
+        [Test]
+        public void IsEven_NonIntegerValues_TruncatedForEvaluation()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
 
-                ws.Cell("A1").Value = 1;
-                ws.Cell("A2").Value = 1.2;
-                ws.Cell("A3").Value = 3;
+            ws.Cell("A1").Value = 4;
+            ws.Cell("A2").Value = 0.9;
+            ws.Cell("A3").Value = -2.9;
 
-                var actual = ws.Evaluate("=IsEven(A1)");
-                Assert.AreEqual(false, actual);
+            var actual = ws.Evaluate("=IsEven(A1)");
+            Assert.AreEqual(true, actual);
 
-                actual = ws.Evaluate("=IsEven(A2)");
-                Assert.AreEqual(false, actual);
+            actual = ws.Evaluate("=IsEven(A2)");
+            Assert.AreEqual(true, actual);
 
-                actual = ws.Evaluate("=IsEven(A3)");
-                Assert.AreEqual(false, actual);
-            }
+            actual = ws.Evaluate("=IsEven(A3)");
+            Assert.AreEqual(true, actual);
+
+            actual = ws.Evaluate("=IsEven(A4)");
+            Assert.AreEqual(true, actual);
         }
 
+        [SetCulture("en-US")]
         [Test]
-        public void IsEven_Single_True()
+        [Ignore("Arrays not yet implemented.")]
+        public void IsEven_Array_ReturnsArray()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            Assert.AreEqual(2.0, XLWorkbook.EvaluateExpr("SUM(N(IsEven({\"2.9\";2;1})))"));
+        }
+        
+        [Test]
+        public void IsEven_ReferenceToMoreThanOneCell_Error()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell(1, 2).FormulaA1 = "IsEven(A1:A2)";
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell(1, 2).Value);
+        }
 
-                ws.Cell("A1").Value = 4;
-                ws.Cell("A2").Value = 0.2;
-                ws.Cell("A3").Value = 12.2;
-
-                var actual = ws.Evaluate("=IsEven(A1)");
-                Assert.AreEqual(true, actual);
-
-                actual = ws.Evaluate("=IsEven(A2)");
-                Assert.AreEqual(true, actual);
-
-                actual = ws.Evaluate("=IsEven(A3)");
-                Assert.AreEqual(true, actual);
-            }
+        [TestCase("TRUE", XLError.IncompatibleValue)]
+        [TestCase("FALSE", XLError.IncompatibleValue)]
+        [TestCase("\"\"", XLError.IncompatibleValue)]
+        [TestCase("\"test\"", XLError.IncompatibleValue)]
+        [TestCase("#DIV/0!", XLError.DivisionByZero)]
+        [TestCase("IF(TRUE,,)", XLError.NoValueAvailable)] // Behaves differently from a reference to a blank cell
+        public void IsEven_NonNumberValues_Error(string valueFormula, XLError expectedError)
+        {
+            Assert.AreEqual(expectedError, XLWorkbook.EvaluateExpr($"IsEven({valueFormula})"));
         }
 
         #endregion IsEven Tests
@@ -311,44 +330,67 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #region IsOdd Test
 
-        [Test]
-        public void IsOdd_Simple_false()
+        [SetCulture("en-US")]
+        [TestCase("1")]
+        [TestCase("\"2 3/3\"")]
+        [TestCase("\"5 1/3\"")]
+        [TestCase("\"25:30:00\"")]
+        [TestCase("\"1900-01-03\"")]
+        public void IsOdd_SingleValue_ConvertedThroughValueSemantic(string valueFormula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            var actual = XLWorkbook.EvaluateExpr($"IsOdd({valueFormula})");
+            Assert.AreEqual(true, actual);
+        }
+        
+        [Test]
+        public void IsOdd_NonIntegerValues_TruncatedForEvaluation()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
 
-                ws.Cell("A1").Value = 4;
-                ws.Cell("A2").Value = 0.2;
-                ws.Cell("A3").Value = 12.2;
+            ws.Cell("A1").Value = 3;
+            ws.Cell("A2").Value = 1.9;
+            ws.Cell("A3").Value = -5.9;
 
-                var actual = ws.Evaluate("=IsOdd(A1)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsOdd(A2)");
-                Assert.AreEqual(false, actual);
-                actual = ws.Evaluate("=IsOdd(A3)");
-                Assert.AreEqual(false, actual);
-            }
+            var actual = ws.Evaluate("=IsOdd(A1)");
+            Assert.AreEqual(true, actual);
+
+            actual = ws.Evaluate("=IsOdd(A2)");
+            Assert.AreEqual(true, actual);
+
+            actual = ws.Evaluate("=IsOdd(A3)");
+            Assert.AreEqual(true, actual);
+
+            actual = ws.Evaluate("=IsOdd(A4)");
+            Assert.AreEqual(false, actual);
         }
 
+        [SetCulture("en-US")]
         [Test]
-        public void IsOdd_Simple_true()
+        [Ignore("Arrays not yet implemented.")]
+        public void IsOdd_Array_ReturnsArray()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet");
+            Assert.AreEqual(2.0, XLWorkbook.EvaluateExpr("SUM(N(IsOdd({\"3.2\",7,2})))"));
+        }
+        
+        [Test]
+        public void IsOdd_ReferenceToMoreThanOneCell_Error()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell(1, 2).FormulaA1 = "IsOdd(A1:A2)";
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell(1, 2).Value);
+        }
 
-                ws.Cell("A1").Value = 1;
-                ws.Cell("A2").Value = 1.2;
-                ws.Cell("A3").Value = 3;
-
-                var actual = ws.Evaluate("=IsOdd(A1)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsOdd(A2)");
-                Assert.AreEqual(true, actual);
-                actual = ws.Evaluate("=IsOdd(A3)");
-                Assert.AreEqual(true, actual);
-            }
+        [TestCase("TRUE", XLError.IncompatibleValue)]
+        [TestCase("FALSE", XLError.IncompatibleValue)]
+        [TestCase("\"\"", XLError.IncompatibleValue)]
+        [TestCase("\"test\"", XLError.IncompatibleValue)]
+        [TestCase("#DIV/0!", XLError.DivisionByZero)]
+        [TestCase("IF(TRUE,,)", XLError.NoValueAvailable)] // Behaves differently from a reference to a blank cell
+        public void IsOdd_NonNumberValues_Error(string valueFormula, XLError expectedError)
+        {
+            Assert.AreEqual(expectedError, XLWorkbook.EvaluateExpr($"IsOdd({valueFormula})"));
         }
 
         #endregion IsOdd Test

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NA/@EntryIndexedValue">NA</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISREF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISTEXT/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISREF/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISREF/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISREF/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISTEXT/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ClosedXML/Excel/CalcEngine/AnyValue.cs
+++ b/ClosedXML/Excel/CalcEngine/AnyValue.cs
@@ -85,6 +85,16 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool IsBlank => _index == BlankValue;
 
+        public bool IsLogical => _index == LogicalValue;
+
+        public bool IsNumber => _index == NumberValue;
+
+        public bool IsText => _index == TextValue;
+
+        public bool IsError => _index == ErrorValue;
+
+        public bool IsArray => _index == ArrayValue;
+
         public bool IsReference => _index == ReferenceValue;
 
         public bool TryPickScalar(out ScalarValue scalar, out CollectionValue collection)

--- a/ClosedXML/Excel/CalcEngine/AnyValue.cs
+++ b/ClosedXML/Excel/CalcEngine/AnyValue.cs
@@ -85,6 +85,8 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool IsBlank => _index == BlankValue;
 
+        public bool IsReference => _index == ReferenceValue;
+
         public bool TryPickScalar(out ScalarValue scalar, out CollectionValue collection)
         {
             scalar = _index switch

--- a/ClosedXML/Excel/CalcEngine/FunctionDefinition.cs
+++ b/ClosedXML/Excel/CalcEngine/FunctionDefinition.cs
@@ -98,6 +98,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             return result switch
             {
+                null => AnyValue.Blank,
                 bool logic => AnyValue.From(logic),
                 double number => AnyValue.From(number),
                 string text => AnyValue.From(text),

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         public static void Register(FunctionRegistry ce)
         {
             ce.RegisterFunction("ERROR.TYPE", 1, 1, Adapt(ErrorType), FunctionFlags.Scalar);
-            ce.RegisterFunction("ISBLANK", 1, int.MaxValue, IsBlank);
+            ce.RegisterFunction("ISBLANK", 1, 1, Adapt(IsBlank), FunctionFlags.Scalar);
             ce.RegisterFunction("ISERR", 1, int.MaxValue, IsErr);
             ce.RegisterFunction("ISERROR", 1, int.MaxValue, IsError);
             ce.RegisterFunction("ISEVEN", 1, IsEven);
@@ -45,18 +45,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        static object IsBlank(List<Expression> p)
+        static AnyValue IsBlank(CalcContext ctx, ScalarValue value)
         {
-            var v = (string) p[0];
-            var isBlank = string.IsNullOrEmpty(v);
-
-
-            if (isBlank && p.Count > 1) {
-                var sublist = p.GetRange(1, p.Count);
-                isBlank = (bool)IsBlank(sublist);
-            }
-
-            return isBlank;
+            return value.IsBlank;
         }
 
         static object IsErr(List<Expression> p)
@@ -171,7 +162,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         static object IsText(List<Expression> p)
         {
             //Evaluate Expressions
-            var isText = !(bool) IsBlank(p);
+            var isText = !(bool) string.IsNullOrEmpty(p[0]);
             if (isText)
             {
                 isText = !(bool) IsNumber(p);

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -18,7 +18,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("ISLOGICAL", 1, 1, Adapt(IsLogical), FunctionFlags.Scalar);
             ce.RegisterFunction("ISNA", 1, 1, Adapt(IsNa), FunctionFlags.Scalar);
             ce.RegisterFunction("ISNONTEXT", 1, 1, Adapt(IsNonText), FunctionFlags.Scalar);
-            ce.RegisterFunction("ISNUMBER", 1, int.MaxValue, IsNumber);
+            ce.RegisterFunction("ISNUMBER", 1, 1, Adapt(IsNumber), FunctionFlags.Scalar);
             ce.RegisterFunction("ISODD", 1, 1, Adapt(IsOdd), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISREF", 1, int.MaxValue, IsRef);
             ce.RegisterFunction("ISTEXT", 1, int.MaxValue, IsText);
@@ -89,7 +89,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return !value.IsText;
         }
 
-        static object IsNumber(List<Expression> p)
+        private static AnyValue IsNumber(CalcContext ctx, ScalarValue value)
+        {
+            return value.IsNumber;
+        }
+
+        private static object IsNumber(List<Expression> p)
         {
             var v = p[0].Evaluate();
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("ISNUMBER", 1, 1, Adapt(IsNumber), FunctionFlags.Scalar);
             ce.RegisterFunction("ISODD", 1, 1, Adapt(IsOdd), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISREF", 1, 1, Adapt(IsRef), FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("ISTEXT", 1, int.MaxValue, IsText);
+            ce.RegisterFunction("ISTEXT", 1, 1, Adapt(IsText), FunctionFlags.Scalar);
             ce.RegisterFunction("N", 1, N);
             ce.RegisterFunction("NA", 0, NA);
             ce.RegisterFunction("TYPE", 1, Type);
@@ -142,6 +142,11 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         private static AnyValue IsRef(CalcContext ctx, AnyValue value)
         {
             return value.IsReference;
+        }
+
+        private static AnyValue IsText(CalcContext ctx, ScalarValue value)
+        {
+            return value.IsText;
         }
 
         static object IsText(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         {
             ce.RegisterFunction("ERROR.TYPE", 1, 1, Adapt(ErrorType), FunctionFlags.Scalar);
             ce.RegisterFunction("ISBLANK", 1, 1, Adapt(IsBlank), FunctionFlags.Scalar);
-            ce.RegisterFunction("ISERR", 1, int.MaxValue, IsErr);
+            ce.RegisterFunction("ISERR", 1, 1, Adapt(IsErr), FunctionFlags.Scalar);
             ce.RegisterFunction("ISERROR", 1, int.MaxValue, IsError);
             ce.RegisterFunction("ISEVEN", 1, IsEven);
             ce.RegisterFunction("ISLOGICAL", 1, int.MaxValue, IsLogical);
@@ -50,11 +50,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return value.IsBlank;
         }
 
-        static object IsErr(List<Expression> p)
+        static AnyValue IsErr(CalcContext ctx, ScalarValue value)
         {
-            var v = p[0].Evaluate();
-
-            return v is XLError error && error != XLError.NoValueAvailable;
+            return value.TryPickError(out var error) && error != XLError.NoValueAvailable;
         }
 
         static object IsError(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -14,12 +14,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("ISBLANK", 1, 1, Adapt(IsBlank), FunctionFlags.Scalar);
             ce.RegisterFunction("ISERR", 1, 1, Adapt(IsErr), FunctionFlags.Scalar);
             ce.RegisterFunction("ISERROR", 1, 1, Adapt(IsError), FunctionFlags.Scalar);
-            ce.RegisterFunction("ISEVEN", 1, IsEven);
+            ce.RegisterFunction("ISEVEN", 1, 1, Adapt(IsEven), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISLOGICAL", 1, int.MaxValue, IsLogical);
             ce.RegisterFunction("ISNA", 1, int.MaxValue, IsNa);
             ce.RegisterFunction("ISNONTEXT", 1, int.MaxValue, IsNonText);
             ce.RegisterFunction("ISNUMBER", 1, int.MaxValue, IsNumber);
-            ce.RegisterFunction("ISODD", 1, IsOdd);
+            ce.RegisterFunction("ISODD", 1, 1, Adapt(IsOdd), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISREF", 1, int.MaxValue, IsRef);
             ce.RegisterFunction("ISTEXT", 1, int.MaxValue, IsText);
             ce.RegisterFunction("N", 1, N);
@@ -60,15 +60,18 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return value.TryPickError(out _);
         }
 
-        static object IsEven(List<Expression> p)
+        private static AnyValue IsEven(CalcContext ctx, AnyValue value)
         {
-            var v = p[0].Evaluate();
-            if (v is double)
+            return GetParity(ctx, value, static (scalar, ctx) =>
             {
-                return Math.Abs((double) v%2) < 1;
-            }
-            //TODO: Error Exceptions
-            throw new ArgumentException("Expression doesn't evaluate to double");
+                if (scalar.IsLogical)
+                    return XLError.IncompatibleValue;
+
+                if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
+                    return error;
+
+                return Math.Truncate(number) % 2 == 0;
+            });
         }
 
         static object IsLogical(List<Expression> p)
@@ -79,7 +82,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (isLogical && p.Count > 1)
             {
                 var sublist = p.GetRange(1, p.Count);
-                isLogical = (bool) IsLogical(sublist);
+                isLogical = (bool)IsLogical(sublist);
             }
 
             return isLogical;
@@ -104,7 +107,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         static object IsNonText(List<Expression> p)
         {
-            return !(bool) IsText(p);
+            return !(bool)IsText(p);
         }
 
         static object IsNumber(List<Expression> p)
@@ -121,7 +124,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 //Handle Number Styles
                 try
                 {
-                    var stringValue = (string) v;
+                    var stringValue = (string)v;
                     return double.TryParse(stringValue.TrimEnd('%', ' '), NumberStyles.Any, null, out double dv);
                 }
                 catch (Exception)
@@ -139,9 +142,18 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return isNumber;
         }
 
-        static object IsOdd(List<Expression> p)
+        private static AnyValue IsOdd(CalcContext ctx, AnyValue value)
         {
-            return !(bool) IsEven(p);
+            return GetParity(ctx, value, static (scalar, ctx) =>
+            {
+                if (scalar.IsLogical)
+                    return XLError.IncompatibleValue;
+
+                if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
+                    return error;
+
+                return Math.Truncate(number) % 2 != 0;
+            });
         }
 
         static object IsRef(List<Expression> p)
@@ -158,21 +170,21 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         static object IsText(List<Expression> p)
         {
             //Evaluate Expressions
-            var isText = !(bool) string.IsNullOrEmpty(p[0]);
+            var isText = !(bool)string.IsNullOrEmpty(p[0]);
             if (isText)
             {
-                isText = !(bool) IsNumber(p);
+                isText = !(bool)IsNumber(p);
             }
             if (isText)
             {
-                isText = !(bool) IsLogical(p);
+                isText = !(bool)IsLogical(p);
             }
             return isText;
         }
 
         static object N(List<Expression> p)
         {
-            return (double) p[0];
+            return (double)p[0];
         }
 
         static object NA(List<Expression> p)
@@ -182,15 +194,15 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         static object Type(List<Expression> p)
         {
-            if ((bool) IsNumber(p))
+            if ((bool)IsNumber(p))
             {
                 return 1;
             }
-            if ((bool) IsText(p))
+            if ((bool)IsText(p))
             {
                 return 2;
             }
-            if ((bool) IsLogical(p))
+            if ((bool)IsLogical(p))
             {
                 return 4;
             }
@@ -198,11 +210,32 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             {
                 return 16;
             }
-            if(p.Count > 1)
+            if (p.Count > 1)
             {
                 return 64;
             }
             return null;
+        }
+
+        private static AnyValue GetParity(CalcContext ctx, AnyValue value, Func<ScalarValue, CalcContext, ScalarValue> f)
+        {
+            // IsOdd/IsEven has very strange semantic that is different for pretty much every other function
+            // Array behaves differently for multi-cell references, in-place blank vs cell blank give different value...
+            if (value.TryPickScalar(out var scalar, out var coll))
+            {
+                if (scalar.IsBlank)
+                    return XLError.NoValueAvailable;
+
+                return f(scalar, ctx).ToAnyValue();
+            }
+
+            if (coll.TryPickT0(out var array, out var reference))
+                return array.Apply(x => f(x, ctx));
+
+            if (!reference.TryGetSingleCellValue(out var cellValue, ctx))
+                return XLError.IncompatibleValue;
+
+            return f(cellValue, ctx).ToAnyValue();
         }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -1,4 +1,3 @@
-using ClosedXML.Excel.CalcEngine.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -20,7 +19,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("ISNONTEXT", 1, 1, Adapt(IsNonText), FunctionFlags.Scalar);
             ce.RegisterFunction("ISNUMBER", 1, 1, Adapt(IsNumber), FunctionFlags.Scalar);
             ce.RegisterFunction("ISODD", 1, 1, Adapt(IsOdd), FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("ISREF", 1, int.MaxValue, IsRef);
+            ce.RegisterFunction("ISREF", 1, 1, Adapt(IsRef), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISTEXT", 1, int.MaxValue, IsText);
             ce.RegisterFunction("N", 1, N);
             ce.RegisterFunction("NA", 0, NA);
@@ -140,15 +139,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             });
         }
 
-        static object IsRef(List<Expression> p)
+        private static AnyValue IsRef(CalcContext ctx, AnyValue value)
         {
-            var oe = p[0] as XObjectExpression;
-            if (oe == null)
-                return false;
-
-            var crr = oe.Value as CellRangeReference;
-
-            return crr != null;
+            return value.IsReference;
         }
 
         static object IsText(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("ERROR.TYPE", 1, 1, Adapt(ErrorType), FunctionFlags.Scalar);
             ce.RegisterFunction("ISBLANK", 1, 1, Adapt(IsBlank), FunctionFlags.Scalar);
             ce.RegisterFunction("ISERR", 1, 1, Adapt(IsErr), FunctionFlags.Scalar);
-            ce.RegisterFunction("ISERROR", 1, int.MaxValue, IsError);
+            ce.RegisterFunction("ISERROR", 1, 1, Adapt(IsError), FunctionFlags.Scalar);
             ce.RegisterFunction("ISEVEN", 1, IsEven);
             ce.RegisterFunction("ISLOGICAL", 1, int.MaxValue, IsLogical);
             ce.RegisterFunction("ISNA", 1, int.MaxValue, IsNa);
@@ -45,21 +45,19 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        static AnyValue IsBlank(CalcContext ctx, ScalarValue value)
+        private static AnyValue IsBlank(CalcContext ctx, ScalarValue value)
         {
             return value.IsBlank;
         }
 
-        static AnyValue IsErr(CalcContext ctx, ScalarValue value)
+        private static AnyValue IsErr(CalcContext ctx, ScalarValue value)
         {
             return value.TryPickError(out var error) && error != XLError.NoValueAvailable;
         }
 
-        static object IsError(List<Expression> p)
+        private static AnyValue IsError(CalcContext ctx, ScalarValue value)
         {
-            var v = p[0].Evaluate();
-
-            return v is XLError;
+            return value.TryPickError(out _);
         }
 
         static object IsEven(List<Expression> p)
@@ -196,7 +194,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             {
                 return 4;
             }
-            if ((bool) IsError(p))
+            if (p[0].Evaluate() is XLError)
             {
                 return 16;
             }

--- a/ClosedXML/Excel/CalcEngine/Functions/Information.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Information.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("ISEVEN", 1, 1, Adapt(IsEven), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISLOGICAL", 1, 1, Adapt(IsLogical), FunctionFlags.Scalar);
             ce.RegisterFunction("ISNA", 1, 1, Adapt(IsNa), FunctionFlags.Scalar);
-            ce.RegisterFunction("ISNONTEXT", 1, int.MaxValue, IsNonText);
+            ce.RegisterFunction("ISNONTEXT", 1, 1, Adapt(IsNonText), FunctionFlags.Scalar);
             ce.RegisterFunction("ISNUMBER", 1, int.MaxValue, IsNumber);
             ce.RegisterFunction("ISODD", 1, 1, Adapt(IsOdd), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("ISREF", 1, int.MaxValue, IsRef);
@@ -84,9 +84,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return value.TryPickError(out var error) && error == XLError.NoValueAvailable;
         }
 
-        static object IsNonText(List<Expression> p)
+        private static AnyValue IsNonText(CalcContext ctx, ScalarValue value)
         {
-            return !(bool)IsText(p);
+            return !value.IsText;
         }
 
         static object IsNumber(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -48,6 +48,11 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, AnyValue, AnyValue> f)
+        {
+            return (ctx, args) => f(ctx, args[0]);
+        }
+
         public static CalcEngineFunction Adapt(Func<CalcContext, ScalarValue, AnyValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -293,6 +293,18 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
+        public bool TryPickLogical(out bool logical)
+        {
+            if (_index == LogicalValue)
+            {
+                logical = _logical;
+                return true;
+            }
+
+            logical = default;
+            return false;
+        }
+
         public bool TryPickNumber(out double number)
         {
             if (_index == NumberValue)

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -46,6 +46,8 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool IsBlank => _index == BlankValue;
 
+        public bool IsLogical => _index == LogicalValue;
+
         public static ScalarValue From(bool logical) => new(LogicalValue, logical, default, default, default);
 
         public static ScalarValue From(double number) => new(NumberValue, default, number, default, default);

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -52,6 +52,8 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool IsText => _index == TextValue;
 
+        public bool IsError => _index == ErrorValue;
+
         public static ScalarValue From(bool logical) => new(LogicalValue, logical, default, default, default);
 
         public static ScalarValue From(double number) => new(NumberValue, default, number, default, default);

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -48,6 +48,8 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool IsLogical => _index == LogicalValue;
 
+        public bool IsNumber => _index == NumberValue;
+
         public bool IsText => _index == TextValue;
 
         public static ScalarValue From(bool logical) => new(LogicalValue, logical, default, default, default);

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -48,6 +48,8 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool IsLogical => _index == LogicalValue;
 
+        public bool IsText => _index == TextValue;
+
         public static ScalarValue From(bool logical) => new(LogicalValue, logical, default, default, default);
 
         public static ScalarValue From(double number) => new(NumberValue, default, number, default, default);


### PR DESCRIPTION
Functions from INFO category were reimplemented (from Expression based function to AnyValue based functions) to be more compliant with Excel, including the quirks (e.g. ISODD/ISEVEN behave differently for area references `ISEVEN(A1:A3)` where A1:A3 contains 1,2,3 gives `#VALUE!` while for arrays `ISEVEN({1;2;3})` gives an array of results - that was pretty unexpected).

Info functions are needed for the function fuzzer that will in future compare result from ClosedXML to Excel (especially `TYPE` function). Also a part of ongoing effort to replace exceptions with XLError. 

Related to #1763 - needs compliant `ISNA`, through `VLOOKUP` also needs replace with exceptionless compliant function.