### PR TITLE
Add support for parsing array literals

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaCstToAstTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaCstToAstTests.cs
@@ -28,11 +28,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void FormulaProducesCorrectCstAndAst(string formula, string[] expectedCst, Type[] expectedAst)
         {
             var dummyFunctions = new FunctionRegistry();
-            dummyFunctions.RegisterFunction("SUM", 0, 255, x => throw new InvalidOperationException());
-            dummyFunctions.RegisterFunction("SIN", 1, 1, x => throw new InvalidOperationException());
-            dummyFunctions.RegisterFunction("RAND", 0, 0, x => throw new InvalidOperationException());
-            dummyFunctions.RegisterFunction("IF", 0, 3, x => throw new InvalidOperationException());
-            dummyFunctions.RegisterFunction("INDEX", 1, 3, x => throw new InvalidOperationException());
+            dummyFunctions.RegisterFunction("SUM", 0, 255, _ => throw new InvalidOperationException());
+            dummyFunctions.RegisterFunction("SIN", 1, 1, _ => throw new InvalidOperationException());
+            dummyFunctions.RegisterFunction("RAND", 0, 0, _ => throw new InvalidOperationException());
+            dummyFunctions.RegisterFunction("IF", 0, 3, _ => throw new InvalidOperationException());
+            dummyFunctions.RegisterFunction("INDEX", 1, 3, _ => throw new InvalidOperationException());
             var parser = new FormulaParser(dummyFunctions);
 
             var cst = parser.ParseCst(formula);
@@ -121,7 +121,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             yield return new TestCaseData(
                 "{1}",
                 new[] { GrammarNames.Formula, ConstantArray, ArrayColumns, ArrayRows, ArrayConstant, Constant, Number, TokenNumber },
-                new[] { typeof(NotSupportedNode) });
+                new[] { typeof(ArrayNode) });
 
             // Formula.Rule = OpenParen + Formula + CloseParen
             yield return new TestCaseData(
@@ -646,7 +646,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             yield return new TestCaseData(
                 "{1}",
                 new[] { GrammarNames.Formula, ConstantArray, ArrayColumns, ArrayRows, ArrayConstant, Constant, Number, TokenNumber },
-                new[] { typeof(NotSupportedNode) });
+                new[] { typeof(ArrayNode) });
 
             // ArrayColumns.Rule = MakePlusRule(ArrayColumns, semicolon, ArrayRows);
             yield return new TestCaseData(
@@ -655,7 +655,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                     ArrayRows, ArrayConstant, Constant, Number, TokenNumber, null, null, null, null, null,
                     ArrayRows, ArrayConstant, Constant, Bool, TokenBool, null, null, null, null, null,
                     ArrayRows, ArrayConstant, Constant, GrammarNames.Error, TokenError },
-                new[] { typeof(NotSupportedNode) });
+                new[] { typeof(ArrayNode) });
 
             // ArrayRows.Rule = MakePlusRule(ArrayRows, comma, ArrayConstant);
             yield return new TestCaseData(
@@ -664,7 +664,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                     ArrayConstant, Constant, Number, TokenNumber, null, null, null, null,
                     ArrayConstant, Constant, Bool, TokenBool, null, null, null, null,
                     ArrayConstant, Constant, GrammarNames.Error, TokenError },
-                new[] { typeof(NotSupportedNode) });
+                new[] { typeof(ArrayNode) });
 
             // ArrayConstant.Rule = Constant | PrefixOp + Number | RefError;
             yield return new TestCaseData(
@@ -673,7 +673,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                     ArrayConstant, Constant, GrammarNames.Error, TokenError, null, null, null, null,
                     ArrayConstant, "-", null, Number, TokenNumber, null, null, null,
                     ArrayConstant, RefError, TokenRefError },
-                new[] { typeof(NotSupportedNode) });
+                new[] { typeof(ArrayNode) });
 
             // -------------- Complex ad hoc test cases --------------
 
@@ -750,6 +750,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             public override AstNode Visit(LinkedList<Type> context, ScalarNode node)
                 => LinearizeNode(context, typeof(ScalarNode), () => base.Visit(context, node));
+
+            public override AstNode Visit(LinkedList<Type> context, ArrayNode node)
+                => LinearizeNode(context, typeof(ArrayNode), () => base.Visit(context, node));
 
             public override AstNode Visit(LinkedList<Type> context, UnaryNode node)
                 => LinearizeNode(context, typeof(UnaryNode), () => base.Visit(context, node));

--- a/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
@@ -443,5 +443,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             actual = sheet.Evaluate("VLOOKUP(3, A2:B7, 2, TRUE)");
             Assert.AreEqual(7, actual);
         }
+
+        [Test]
+        public void Vlookup_CanSearchArrays()
+        {
+            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("VLOOKUP(4, {1,2; 3,2; 5,3; 7,4}, 2)"));
+        }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/AstNode.cs
+++ b/ClosedXML/Excel/CalcEngine/AstNode.cs
@@ -28,10 +28,25 @@ namespace ClosedXML.Excel.CalcEngine
     {
         public ScalarNode(ScalarValue value)
         {
-            Value = value.ToAnyValue();
+            Value = value;
         }
 
-        public AnyValue Value { get; }
+        public ScalarValue Value { get; }
+
+        public override TResult Accept<TContext, TResult>(TContext context, IFormulaVisitor<TContext, TResult> visitor) => visitor.Visit(context, this);
+    }
+
+    /// <summary>
+    /// AST node that contains a constant array. Array is at least 1x1.
+    /// </summary>
+    internal class ArrayNode : ValueNode
+    {
+        public ArrayNode(Array value)
+        {
+            Value = value;
+        }
+
+        public Array Value { get; }
 
         public override TResult Accept<TContext, TResult>(TContext context, IFormulaVisitor<TContext, TResult> visitor) => visitor.Visit(context, this);
     }
@@ -134,7 +149,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         public override TResult Accept<TContext, TResult>(TContext context, IFormulaVisitor<TContext, TResult> visitor) => visitor.Visit(context, this);
     }
-    
+
     /// <summary>
     /// An placeholder node for AST nodes that are not yet supported in ClosedXML.
     /// </summary>

--- a/ClosedXML/Excel/CalcEngine/CalculationVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/CalculationVisitor.cs
@@ -15,6 +15,11 @@ namespace ClosedXML.Excel.CalcEngine
 
         public AnyValue Visit(CalcContext context, ScalarNode node)
         {
+            return node.Value.ToAnyValue();
+        }
+
+        public AnyValue Visit(CalcContext context, ArrayNode node)
+        {
             return node.Value;
         }
 

--- a/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
@@ -34,6 +34,8 @@ namespace ClosedXML.Excel.CalcEngine
 
         public virtual AstNode Visit(TContext context, ScalarNode node) => node;
 
+        public virtual AstNode Visit(TContext context, ArrayNode node) => node;
+
         public virtual AstNode Visit(TContext context, NotSupportedNode node) => node;
 
         public virtual AstNode Visit(TContext context, ReferenceNode referenceNode)

--- a/ClosedXML/Excel/CalcEngine/FormulaVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaVisitor.cs
@@ -4,6 +4,8 @@
     {
         public TResult Visit(TContext context, ScalarNode node);
 
+        public TResult Visit(TContext context, ArrayNode node);
+
         public TResult Visit(TContext context, UnaryNode node);
 
         public TResult Visit(TContext context, BinaryNode node);

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -175,6 +175,11 @@ namespace ClosedXML.Excel.CalcEngine
                 return XLError.CellReference;
             }
 
+            public OneOf<Reference, XLError> Visit(PrecedentAreasContext ctx, ArrayNode node)
+            {
+                return XLError.CellReference;
+            }
+
             public OneOf<Reference, XLError> Visit(PrecedentAreasContext ctx, UnaryNode node)
             {
                 var value = node.Expression.Accept(ctx, this);


### PR DESCRIPTION
This PR add support for parsing (and only parsing) of array literal in formulas. CalcEngine still has quite a few white places where evaluation will likely fail, but at least argument passing works, so it can be used `VLOOKUP(4, {1,2; 3,2; 5,3; 7,4}, 2)`.

Array is a type that is accepted by many functions and its lack of support makes my life harder than it should. 
* Test cases should cover it, but due to missing support, they either don't or are commented out. 
* Many test edge cases would be just fine with array argument as a one-liner, but because of lack of support, I had to set values to cells and pass a reference.
* Arrays are also required for future functions fuzzer
* Arrays are required for array functions.

Resolves #588