### PR TITLE
Update some dependencies

### DIFF
--- a/ClosedXML.Examples/ClosedXML.Examples.csproj
+++ b/ClosedXML.Examples/ClosedXML.Examples.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ClosedXML\ClosedXML.csproj" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
     <PackageReference Include="morelinq" Version="2.10.0" />
   </ItemGroup>
 

--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -20,20 +20,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.18.0" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
-    <PackageReference Include="Fody" Version="6.3.0">
+    <PackageReference Include="Fody" Version="6.6.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
+    <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta18" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="XLParser" Version="1.5.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I was recently trying to track down a bug with a spreadsheet that I have where loading then saving the spreadsheet causes validation issues to be thrown. I was randomly hoping that an update to the OpenXml dependency would help but it didn't, but I thought that I might as well upstream my dependency updates anyway.

I'm just including dependency updates in this PR that should hopefully not include any breaking changes.

For reference, I tried the following dependency updates but they failed:
1. I tried updating `DocumentFormat.OpenXml` to v2.19.0 but that appears to have some breaking changes that caused some image tests in ClosedXML to start failing, so I only updated to v2.18.0 which allows all tests to pass.
2. I tried updating `XLParser` to v1.6.2 but that has a bunch of breaking changes that caused a bunch of tests in ClosedXML to start failing so I left that dependency alone.