### PR TITLE
Return strongly typed result from Evaluate methods

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
@@ -74,7 +74,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("+TRUE", true)]
         [TestCase("+FALSE", false)]
         [TestCase("+#DIV/0!", XLError.DivisionByZero)]
-        [TestCase("+A1", 0)]
+        [TestCase("ISBLANK(+A1)", true)]
         public void UnaryPlus_IsNonOpThatKeepsValueAndType(string formula, object expectedValue)
         {
             Assert.AreEqual(expectedValue, Evaluate(formula));
@@ -224,7 +224,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         #endregion
 
-        private static object Evaluate(string formula)
+        private static XLCellValue Evaluate(string formula)
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();

--- a/ClosedXML.Tests/Excel/CalcEngine/CompareOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CompareOperatorsTests.cs
@@ -151,10 +151,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1=\"\"")]
         public void Comparison_BlankIsEqualToFalseOrZeroOrEmptyString(string formula)
         {
-            Assert.That(Evaluate(formula), Is.True);
+            Assert.AreEqual(true, Evaluate(formula));
         }
 
-        private static object Evaluate(string formula)
+        private static XLCellValue Evaluate(string formula)
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -19,7 +19,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void Date()
         {
-            Object actual;
+            XLCellValue actual;
 
             actual = XLWorkbook.EvaluateExpr("Date(2008, 1, 1)");
             Assert.AreEqual(39448, actual);
@@ -81,21 +81,21 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void Datevalue()
         {
-            Object actual = XLWorkbook.EvaluateExpr("DateValue(\"8/22/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("DateValue(\"8/22/2008\")");
             Assert.AreEqual(39682, actual);
         }
 
         [Test]
         public void Day()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Day(\"8/22/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Day(\"8/22/2008\")");
             Assert.AreEqual(22, actual);
         }
 
         [Test]
         public void Days()
         {
-            Object actual = XLWorkbook.EvaluateExpr("DAYS(DATE(2016,10,1),DATE(1992,2,29))");
+            var actual = XLWorkbook.EvaluateExpr("DAYS(DATE(2016,10,1),DATE(1992,2,29))");
             Assert.AreEqual(8981, actual);
 
             actual = XLWorkbook.EvaluateExpr("DAYS(\"2016-10-1\",\"1992-2-29\")");
@@ -108,112 +108,112 @@ namespace ClosedXML.Tests.Excel.DataValidations
             CultureInfo ci = new CultureInfo(CultureInfo.InvariantCulture.LCID);
             ci.DateTimeFormat.ShortDatePattern = "dd/MM/yyyy";
             Thread.CurrentThread.CurrentCulture = ci;
-            Object actual = XLWorkbook.EvaluateExpr("Day(\"1/6/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Day(\"1/6/2008\")");
             Assert.AreEqual(1, actual);
         }
 
         [Test]
         public void Days360_Default()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Days360(\"1/30/2008\", \"2/1/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Days360(\"1/30/2008\", \"2/1/2008\")");
             Assert.AreEqual(1, actual);
         }
 
         [Test]
         public void Days360_Europe1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("DAYS360(\"1/1/2008\", \"3/31/2008\",TRUE)");
+            var actual = XLWorkbook.EvaluateExpr("DAYS360(\"1/1/2008\", \"3/31/2008\",TRUE)");
             Assert.AreEqual(89, actual);
         }
 
         [Test]
         public void Days360_Europe2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("DAYS360(\"3/31/2008\", \"1/1/2008\",TRUE)");
+            var actual = XLWorkbook.EvaluateExpr("DAYS360(\"3/31/2008\", \"1/1/2008\",TRUE)");
             Assert.AreEqual(-89, actual);
         }
 
         [Test]
         public void Days360_US1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("DAYS360(\"1/1/2008\", \"3/31/2008\",FALSE)");
+            var actual = XLWorkbook.EvaluateExpr("DAYS360(\"1/1/2008\", \"3/31/2008\",FALSE)");
             Assert.AreEqual(90, actual);
         }
 
         [Test]
         public void Days360_US2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("DAYS360(\"3/31/2008\", \"1/1/2008\",FALSE)");
+            var actual = XLWorkbook.EvaluateExpr("DAYS360(\"3/31/2008\", \"1/1/2008\",FALSE)");
             Assert.AreEqual(-89, actual);
         }
 
         [Test]
         public void EDate_Negative1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("EDate(\"3/1/2008\", -1)");
-            Assert.AreEqual(new DateTime(2008, 2, 1).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("EDate(\"3/1/2008\", -1)");
+            Assert.AreEqual(new DateTime(2008, 2, 1).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void EDate_Negative2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("EDate(\"3/31/2008\", -1)");
-            Assert.AreEqual(new DateTime(2008, 2, 29).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("EDate(\"3/31/2008\", -1)");
+            Assert.AreEqual(new DateTime(2008, 2, 29).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void EDate_Positive1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("EDate(\"3/1/2008\", 1)");
-            Assert.AreEqual(new DateTime(2008, 4, 1).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("EDate(\"3/1/2008\", 1)");
+            Assert.AreEqual(new DateTime(2008, 4, 1).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void EDate_Positive2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("EDate(\"3/31/2008\", 1)");
-            Assert.AreEqual(new DateTime(2008, 4, 30).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("EDate(\"3/31/2008\", 1)");
+            Assert.AreEqual(new DateTime(2008, 4, 30).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void EOMonth_Negative()
         {
-            Object actual = XLWorkbook.EvaluateExpr("EOMonth(\"3/1/2008\", -1)");
-            Assert.AreEqual(new DateTime(2008, 2, 29).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("EOMonth(\"3/1/2008\", -1)");
+            Assert.AreEqual(new DateTime(2008, 2, 29).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void EOMonth_Positive()
         {
-            Object actual = XLWorkbook.EvaluateExpr("EOMonth(\"3/31/2008\", 1)");
-            Assert.AreEqual(new DateTime(2008, 4, 30).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("EOMonth(\"3/31/2008\", 1)");
+            Assert.AreEqual(new DateTime(2008, 4, 30).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void Hour()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Hour(\"8/22/2008 3:30:45 PM\")");
+            var actual = XLWorkbook.EvaluateExpr("Hour(\"8/22/2008 3:30:45 PM\")");
             Assert.AreEqual(15, actual);
         }
 
         [Test]
         public void Minute()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Minute(\"8/22/2008 3:30:45 AM\")");
+            var actual = XLWorkbook.EvaluateExpr("Minute(\"8/22/2008 3:30:45 AM\")");
             Assert.AreEqual(30, actual);
         }
 
         [Test]
         public void Month()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Month(\"8/22/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Month(\"8/22/2008\")");
             Assert.AreEqual(8, actual);
         }
 
         [Test]
         public void IsoWeekNum()
         {
-            Object actual = XLWorkbook.EvaluateExpr("ISOWEEKNUM(DATEVALUE(\"2012-3-9\"))");
+            var actual = XLWorkbook.EvaluateExpr("ISOWEEKNUM(DATEVALUE(\"2012-3-9\"))");
             Assert.AreEqual(10, actual);
 
             actual = XLWorkbook.EvaluateExpr("ISOWEEKNUM(DATE(2012,12,31))");
@@ -231,21 +231,21 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 .CellBelow().SetValue(new DateTime(2008, 11, 26))
                 .CellBelow().SetValue(new DateTime(2008, 12, 4))
                 .CellBelow().SetValue(new DateTime(2009, 1, 21));
-            Object actual = ws.Evaluate("Networkdays(A2,A3,A4:A6)");
+            var actual = ws.Evaluate("Networkdays(A2,A3,A4:A6)");
             Assert.AreEqual(105, actual);
         }
 
         [Test]
         public void Networkdays_NoHolidaysGiven()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Networkdays(\"10/01/2008\", \"3/01/2009\")");
+            var actual = XLWorkbook.EvaluateExpr("Networkdays(\"10/01/2008\", \"3/01/2009\")");
             Assert.AreEqual(108, actual);
         }
 
         [Test]
         public void Networkdays_NegativeResult()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Networkdays(\"3/01/2009\", \"10/01/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Networkdays(\"3/01/2009\", \"10/01/2008\")");
             Assert.AreEqual(-108, actual);
 
             actual = XLWorkbook.EvaluateExpr("Networkdays(\"2016-01-01\", \"2015-12-23\")");
@@ -255,70 +255,70 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void Networkdays_OneHolidaysGiven()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Networkdays(\"10/01/2008\", \"3/01/2009\", \"11/26/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Networkdays(\"10/01/2008\", \"3/01/2009\", \"11/26/2008\")");
             Assert.AreEqual(107, actual);
         }
 
         [Test]
         public void Second()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Second(\"8/22/2008 3:30:45 AM\")");
+            var actual = XLWorkbook.EvaluateExpr("Second(\"8/22/2008 3:30:45 AM\")");
             Assert.AreEqual(45, actual);
         }
 
         [Test]
         public void Time()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Time(1,2,3)");
-            Assert.AreEqual(0.043090277777778, (double)actual, XLHelper.Epsilon);
+            var actual = (double)XLWorkbook.EvaluateExpr("Time(1,2,3)");
+            Assert.AreEqual(0.043090277777778, actual, XLHelper.Epsilon);
         }
 
         [Test]
         public void TimeValue1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("TimeValue(\"2:24 AM\")");
-            Assert.IsTrue(XLHelper.AreEqual(0.1, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("TimeValue(\"2:24 AM\")");
+            Assert.IsTrue(XLHelper.AreEqual(0.1, actual));
         }
 
         [Test]
         public void TimeValue2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("TimeValue(\"22-Aug-2008 6:35 AM\")");
-            Assert.IsTrue(XLHelper.AreEqual(0.27430555555555558, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("TimeValue(\"22-Aug-2008 6:35 AM\")");
+            Assert.IsTrue(XLHelper.AreEqual(0.27430555555555558, actual));
         }
 
         [Test]
         public void Today()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Today()");
-            Assert.AreEqual(DateTime.Now.Date.ToOADate(), actual);
+            var actual = (double)XLWorkbook.EvaluateExpr("Today()");
+            Assert.AreEqual(DateTime.Now.Date.ToSerialDateTime(), actual);
         }
 
         [Test]
         public void Weekday_1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\", 1)");
+            var actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\", 1)");
             Assert.AreEqual(5, actual);
         }
 
         [Test]
         public void Weekday_2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\", 2)");
+            var actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\", 2)");
             Assert.AreEqual(4, actual);
         }
 
         [Test]
         public void Weekday_3()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\", 3)");
+            var actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\", 3)");
             Assert.AreEqual(3, actual);
         }
 
         [Test]
         public void Weekday_Omitted()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Weekday(\"2/14/2008\")");
             Assert.AreEqual(5, actual);
         }
 
@@ -445,7 +445,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void Weeknum_Default()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Weeknum(\"3/9/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Weeknum(\"3/9/2008\")");
             Assert.AreEqual(11, actual);
         }
 
@@ -460,102 +460,102 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 .CellBelow().SetValue(new DateTime(2008, 11, 26))
                 .CellBelow().SetValue(new DateTime(2008, 12, 4))
                 .CellBelow().SetValue(new DateTime(2009, 1, 21));
-            Object actual = ws.Evaluate("Workday(A2,A3,A4:A6)");
-            Assert.AreEqual(new DateTime(2009, 5, 5).ToOADate(), actual);
+            var actual = ws.Evaluate("Workday(A2,A3,A4:A6)");
+            Assert.AreEqual(new DateTime(2009, 5, 5).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void Workdays_NoHolidaysGiven()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Workday(\"10/01/2008\", 151)");
-            Assert.AreEqual(new DateTime(2009, 4, 30).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("Workday(\"10/01/2008\", 151)");
+            Assert.AreEqual(new DateTime(2009, 4, 30).ToSerialDateTime(), actual);
 
             actual = XLWorkbook.EvaluateExpr("Workday(\"2016-01-01\", -10)");
-            Assert.AreEqual(new DateTime(2015, 12, 18).ToOADate(), actual);
+            Assert.AreEqual(new DateTime(2015, 12, 18).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void Workdays_OneHolidaysGiven()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Workday(\"10/01/2008\", 152, \"11/26/2008\")");
-            Assert.AreEqual(new DateTime(2009, 5, 4).ToOADate(), actual);
+            var actual = XLWorkbook.EvaluateExpr("Workday(\"10/01/2008\", 152, \"11/26/2008\")");
+            Assert.AreEqual(new DateTime(2009, 5, 4).ToSerialDateTime(), actual);
         }
 
         [Test]
         public void Year()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Year(\"8/22/2008\")");
+            var actual = XLWorkbook.EvaluateExpr("Year(\"8/22/2008\")");
             Assert.AreEqual(2008, actual);
         }
 
         [Test]
         public void Yearfrac_1_base0()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",0)");
-            Assert.IsTrue(XLHelper.AreEqual(0.25, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",0)");
+            Assert.IsTrue(XLHelper.AreEqual(0.25, actual));
         }
 
         [Test]
         public void Yearfrac_1_base1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",1)");
-            Assert.IsTrue(XLHelper.AreEqual(0.24590163934426229, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",1)");
+            Assert.IsTrue(XLHelper.AreEqual(0.24590163934426229, actual));
         }
 
         [Test]
         public void Yearfrac_1_base2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",2)");
-            Assert.IsTrue(XLHelper.AreEqual(0.25, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",2)");
+            Assert.IsTrue(XLHelper.AreEqual(0.25, actual));
         }
 
         [Test]
         public void Yearfrac_1_base3()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",3)");
-            Assert.IsTrue(XLHelper.AreEqual(0.24657534246575341, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",3)");
+            Assert.IsTrue(XLHelper.AreEqual(0.24657534246575341, actual));
         }
 
         [Test]
         public void Yearfrac_1_base4()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",4)");
-            Assert.IsTrue(XLHelper.AreEqual(0.24722222222222223, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2008\",4)");
+            Assert.IsTrue(XLHelper.AreEqual(0.24722222222222223, actual));
         }
 
         [Test]
         public void Yearfrac_2_base0()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",0)");
-            Assert.IsTrue(XLHelper.AreEqual(5.25, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",0)");
+            Assert.IsTrue(XLHelper.AreEqual(5.25, actual));
         }
 
         [Test]
         public void Yearfrac_2_base1()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",1)");
-            Assert.IsTrue(XLHelper.AreEqual(5.24452554744526, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",1)");
+            Assert.IsTrue(XLHelper.AreEqual(5.24452554744526, actual));
         }
 
         [Test]
         public void Yearfrac_2_base2()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",2)");
-            Assert.IsTrue(XLHelper.AreEqual(5.32222222222222, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",2)");
+            Assert.IsTrue(XLHelper.AreEqual(5.32222222222222, actual));
         }
 
         [Test]
         public void Yearfrac_2_base3()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",3)");
-            Assert.IsTrue(XLHelper.AreEqual(5.24931506849315, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",3)");
+            Assert.IsTrue(XLHelper.AreEqual(5.24931506849315, actual));
         }
 
         [Test]
         public void Yearfrac_2_base4()
         {
-            Object actual = XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",4)");
-            Assert.IsTrue(XLHelper.AreEqual(5.24722222222222, (double)actual));
+            var actual = (double)XLWorkbook.EvaluateExpr("Yearfrac(\"1/1/2008\", \"3/31/2013\",4)");
+            Assert.IsTrue(XLHelper.AreEqual(5.24722222222222, actual));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1543,8 +1543,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void SeriesSum()
         {
-            object actual = XLWorkbook.EvaluateExpr("SERIESSUM(2,3,4,5)");
-            Assert.AreEqual(40.0, actual);
+            Assert.AreEqual(40.0, XLWorkbook.EvaluateExpr("SERIESSUM(2,3,4,5)"));
 
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
@@ -1554,7 +1553,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").FormulaA1 = "1/FACT(4)";
             ws.Cell("A6").FormulaA1 = "-1/FACT(6)";
 
-            actual = ws.Evaluate("SERIESSUM(A2,0,2,A3:A6)");
+            var actual = ws.Evaluate("SERIESSUM(A2,0,2,A3:A6)");
             Assert.IsTrue(Math.Abs(0.70710321482284566 - (double)actual) < XLHelper.Epsilon);
         }
 
@@ -1946,7 +1945,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
                 ws.Cell(1, 3).Value = 300000;
 
-                var actualResult = ws.Evaluate(formula).CastTo<double>();
+                var actualResult = (double)ws.Evaluate(formula);
                 Assert.AreEqual(expectedResult, actualResult);
             }
         }
@@ -2039,9 +2038,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 ws.Cell(row, 2).Value = "Carrots";
                 ws.Cell(row, 3).Value = "Sarah";
 
-                var actualResult = ws.Evaluate(formula).CastTo<Double>();
+                var actualResult = ws.Evaluate(formula);
 
-                Assert.AreEqual(expectedResult, actualResult, tolerance);
+                Assert.AreEqual(expectedResult, (double)actualResult, tolerance);
             }
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -817,8 +817,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Degrees()
         {
-            object actual1 = XLWorkbook.EvaluateExpr("Degrees(180)");
-            Assert.IsTrue(Math.PI - (double)actual1 < XLHelper.Epsilon);
+            var actual = (double)XLWorkbook.EvaluateExpr("DEGREES(PI())");
+            Assert.AreEqual(180, actual, XLHelper.Epsilon);
         }
 
         [TestCase(0, 0)]
@@ -1359,8 +1359,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Radians()
         {
-            object actual = XLWorkbook.EvaluateExpr("Radians(270)");
-            Assert.IsTrue(Math.Abs(4.71238898038469 - (double)actual) < XLHelper.Epsilon);
+            var actual = (double)XLWorkbook.EvaluateExpr("Radians(270)");
+            Assert.AreEqual(4.71238898038469, actual, XLHelper.Epsilon);
         }
 
         [Test]
@@ -1560,11 +1560,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void SqrtPi()
         {
-            object actual = XLWorkbook.EvaluateExpr("SqrtPi(1)");
-            Assert.IsTrue(Math.Abs(1.7724538509055159 - (double)actual) < XLHelper.Epsilon);
+            var actual = (double)XLWorkbook.EvaluateExpr("SqrtPi(1)");
+            Assert.AreEqual(1.7724538509055159, actual, XLHelper.Epsilon);
 
-            actual = XLWorkbook.EvaluateExpr("SqrtPi(2)");
-            Assert.IsTrue(Math.Abs(2.5066282746310002 - (double)actual) < XLHelper.Epsilon);
+            actual = (double)XLWorkbook.EvaluateExpr("SqrtPi(2)");
+            Assert.AreEqual(2.5066282746310002, actual, XLHelper.Epsilon);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -32,17 +32,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Count()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=COUNT(D3:D45)").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=COUNT(D3:D45)");
             Assert.AreEqual(0, value);
 
-            value = ws.Evaluate(@"=COUNT(G3:G45)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNT(G3:G45)");
             Assert.AreEqual(43, value);
 
-            value = ws.Evaluate(@"=COUNT(G:G)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNT(G:G)");
             Assert.AreEqual(43, value);
 
-            value = (int)workbook.Evaluate(@"=COUNT(Data!G:G)");
+            value = workbook.Evaluate(@"=COUNT(Data!G:G)");
             Assert.AreEqual(43, value);
         }
 
@@ -50,17 +50,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void CountA()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=COUNTA(D3:D45)").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=COUNTA(D3:D45)");
             Assert.AreEqual(43, value);
 
-            value = ws.Evaluate(@"=COUNTA(G3:G45)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTA(G3:G45)");
             Assert.AreEqual(43, value);
 
-            value = ws.Evaluate(@"=COUNTA(G:G)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTA(G:G)");
             Assert.AreEqual(44, value);
 
-            value = (int)workbook.Evaluate(@"=COUNTA(Data!G:G)");
+            value = workbook.Evaluate(@"=COUNTA(Data!G:G)");
             Assert.AreEqual(44, value);
         }
 
@@ -68,17 +68,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void CountBlank()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=COUNTBLANK(B:B)").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=COUNTBLANK(B:B)");
             Assert.AreEqual(1048532, value);
 
-            value = ws.Evaluate(@"=COUNTBLANK(D43:D49)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTBLANK(D43:D49)");
             Assert.AreEqual(4, value);
 
-            value = ws.Evaluate(@"=COUNTBLANK(E3:E45)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTBLANK(E3:E45)");
             Assert.AreEqual(0, value);
 
-            value = ws.Evaluate(@"=COUNTBLANK(A1)").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTBLANK(A1)");
             Assert.AreEqual(1, value);
 
             Assert.Throws<MissingContextException>(() => workbook.Evaluate(@"=COUNTBLANK(E3:E45)"));
@@ -90,14 +90,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void CountIf()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=COUNTIF(D3:D45,""Central"")").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=COUNTIF(D3:D45,""Central"")");
             Assert.AreEqual(24, value);
 
-            value = ws.Evaluate(@"=COUNTIF(D:D,""Central"")").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTIF(D:D,""Central"")");
             Assert.AreEqual(24, value);
 
-            value = (int)workbook.Evaluate(@"=COUNTIF(Data!D:D,""Central"")");
+            value = workbook.Evaluate(@"=COUNTIF(Data!D:D,""Central"")");
             Assert.AreEqual(24, value);
         }
 
@@ -201,14 +201,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void CountIfs_SingleCondition()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=COUNTIFS(D3:D45,""Central"")").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=COUNTIFS(D3:D45,""Central"")");
             Assert.AreEqual(24, value);
 
-            value = ws.Evaluate(@"=COUNTIFS(D:D,""Central"")").CastTo<int>();
+            value = ws.Evaluate(@"=COUNTIFS(D:D,""Central"")");
             Assert.AreEqual(24, value);
 
-            value = (int)workbook.Evaluate(@"=COUNTIFS(Data!D:D,""Central"")");
+            value = workbook.Evaluate(@"=COUNTIFS(Data!D:D,""Central"")");
             Assert.AreEqual(24, value);
         }
 
@@ -224,7 +224,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheets.First();
 
-            int value = ws.Evaluate(formula).CastTo<int>();
+            var value = ws.Evaluate(formula);
             Assert.AreEqual(expectedResult, value);
         }
 
@@ -247,7 +247,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-12)]
         public double Geomean(string sourceValue)
         {
-            return workbook.Worksheets.First().Evaluate($"=GEOMEAN({sourceValue})").CastTo<double>();
+            return (double)workbook.Worksheets.First().Evaluate($"=GEOMEAN({sourceValue})");
         }
 
         [TestCase("D3:D45", ExpectedResult = XLError.NumberInvalid)]
@@ -280,7 +280,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-10)]
         public double DevSq(string sourceValue)
         {
-            return workbook.Worksheets.First().Evaluate($"=DEVSQ({sourceValue})").CastTo<double>();
+            return (double)workbook.Worksheets.First().Evaluate($"=DEVSQ({sourceValue})");
         }
 
         [TestCase("D3:D45", ExpectedResult = XLError.IncompatibleValue)]
@@ -321,17 +321,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Max()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=MAX(D3:D45)").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=MAX(D3:D45)");
             Assert.AreEqual(0, value);
 
-            value = ws.Evaluate(@"=MAX(G3:G45)").CastTo<int>();
+            value = ws.Evaluate(@"=MAX(G3:G45)");
             Assert.AreEqual(96, value);
 
-            value = ws.Evaluate(@"=MAX(G:G)").CastTo<int>();
+            value = ws.Evaluate(@"=MAX(G:G)");
             Assert.AreEqual(96, value);
 
-            value = (int)workbook.Evaluate(@"=MAX(Data!G:G)");
+            value = workbook.Evaluate(@"=MAX(Data!G:G)");
             Assert.AreEqual(96, value);
         }
 
@@ -355,7 +355,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
 
             //Act
-            double value = ws.Evaluate("MEDIAN(I3:I10)").CastTo<double>();
+            var value = (double)ws.Evaluate("MEDIAN(I3:I10)");
 
             //Assert
             Assert.AreEqual(244.225, value, tolerance);
@@ -378,7 +378,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
 
             //Act
-            double value = ws.Evaluate("MEDIAN(I3:I11)").CastTo<double>();
+            var value = (double)ws.Evaluate("MEDIAN(I3:I11)");
 
             //Assert
             Assert.AreEqual(189.05, value, tolerance);
@@ -398,17 +398,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Min()
         {
             var ws = workbook.Worksheets.First();
-            int value;
-            value = ws.Evaluate(@"=MIN(D3:D45)").CastTo<int>();
+            XLCellValue value;
+            value = ws.Evaluate(@"=MIN(D3:D45)");
             Assert.AreEqual(0, value);
 
-            value = ws.Evaluate(@"=MIN(G3:G45)").CastTo<int>();
+            value = ws.Evaluate(@"=MIN(G3:G45)");
             Assert.AreEqual(2, value);
 
-            value = ws.Evaluate(@"=MIN(G:G)").CastTo<int>();
+            value = ws.Evaluate(@"=MIN(G:G)");
             Assert.AreEqual(2, value);
 
-            value = (int)workbook.Evaluate(@"=MIN(Data!G:G)");
+            value = workbook.Evaluate(@"=MIN(Data!G:G)");
             Assert.AreEqual(2, value);
         }
 
@@ -419,10 +419,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             double value;
             Assert.That(() => ws.Evaluate(@"=STDEV(D3:D45)"), Throws.TypeOf<ApplicationException>());
 
-            value = ws.Evaluate(@"=STDEV(H3:H45)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=STDEV(H3:H45)");
             Assert.AreEqual(47.34511769, value, tolerance);
 
-            value = ws.Evaluate(@"=STDEV(H:H)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=STDEV(H:H)");
             Assert.AreEqual(47.34511769, value, tolerance);
 
             value = (double)workbook.Evaluate(@"=STDEV(Data!H:H)");
@@ -436,10 +436,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             double value;
             Assert.That(() => ws.Evaluate(@"=STDEVP(D3:D45)"), Throws.InvalidOperationException);
 
-            value = ws.Evaluate(@"=STDEVP(H3:H45)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=STDEVP(H3:H45)");
             Assert.AreEqual(46.79135458, value, tolerance);
 
-            value = ws.Evaluate(@"=STDEVP(H:H)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=STDEVP(H:H)");
             Assert.AreEqual(46.79135458, value, tolerance);
 
             value = (double)workbook.Evaluate(@"=STDEVP(Data!H:H)");
@@ -499,10 +499,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             double value;
             Assert.That(() => ws.Evaluate(@"=VAR(D3:D45)"), Throws.InvalidOperationException);
 
-            value = ws.Evaluate(@"=VAR(H3:H45)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=VAR(H3:H45)");
             Assert.AreEqual(2241.560169, value, tolerance);
 
-            value = ws.Evaluate(@"=VAR(H:H)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=VAR(H:H)");
             Assert.AreEqual(2241.560169, value, tolerance);
 
             value = (double)workbook.Evaluate(@"=VAR(Data!H:H)");
@@ -516,10 +516,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             double value;
             Assert.That(() => ws.Evaluate(@"=VARP(D3:D45)"), Throws.InvalidOperationException);
 
-            value = ws.Evaluate(@"=VARP(H3:H45)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=VARP(H3:H45)");
             Assert.AreEqual(2189.430863, value, tolerance);
 
-            value = ws.Evaluate(@"=VARP(H:H)").CastTo<double>();
+            value = (double)ws.Evaluate(@"=VARP(H:H)");
             Assert.AreEqual(2189.430863, value, tolerance);
 
             value = (double)workbook.Evaluate(@"=VARP(Data!H:H)");

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -18,11 +18,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Average()
         {
             double value;
-            value = workbook.Evaluate("AVERAGE(-27.5,93.93,64.51,-70.56)").CastTo<double>();
+            value = (double)workbook.Evaluate("AVERAGE(-27.5,93.93,64.51,-70.56)");
             Assert.AreEqual(15.095, value, tolerance);
 
             var ws = workbook.Worksheets.First();
-            value = ws.Evaluate("AVERAGE(G3:G45)").CastTo<double>();
+            value = (double)ws.Evaluate("AVERAGE(G3:G45)");
             Assert.AreEqual(49.3255814, value, tolerance);
 
             Assert.That(() => ws.Evaluate("AVERAGE(D3:D45)"), Throws.TypeOf<ApplicationException>());
@@ -42,7 +42,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=COUNT(G:G)").CastTo<int>();
             Assert.AreEqual(43, value);
 
-            value = workbook.Evaluate(@"=COUNT(Data!G:G)").CastTo<int>();
+            value = (int)workbook.Evaluate(@"=COUNT(Data!G:G)");
             Assert.AreEqual(43, value);
         }
 
@@ -60,7 +60,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=COUNTA(G:G)").CastTo<int>();
             Assert.AreEqual(44, value);
 
-            value = workbook.Evaluate(@"=COUNTA(Data!G:G)").CastTo<int>();
+            value = (int)workbook.Evaluate(@"=COUNTA(Data!G:G)");
             Assert.AreEqual(44, value);
         }
 
@@ -97,7 +97,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=COUNTIF(D:D,""Central"")").CastTo<int>();
             Assert.AreEqual(24, value);
 
-            value = workbook.Evaluate(@"=COUNTIF(Data!D:D,""Central"")").CastTo<int>();
+            value = (int)workbook.Evaluate(@"=COUNTIF(Data!D:D,""Central"")");
             Assert.AreEqual(24, value);
         }
 
@@ -208,7 +208,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=COUNTIFS(D:D,""Central"")").CastTo<int>();
             Assert.AreEqual(24, value);
 
-            value = workbook.Evaluate(@"=COUNTIFS(Data!D:D,""Central"")").CastTo<int>();
+            value = (int)workbook.Evaluate(@"=COUNTIFS(Data!D:D,""Central"")");
             Assert.AreEqual(24, value);
         }
 
@@ -331,7 +331,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=MAX(G:G)").CastTo<int>();
             Assert.AreEqual(96, value);
 
-            value = workbook.Evaluate(@"=MAX(Data!G:G)").CastTo<int>();
+            value = (int)workbook.Evaluate(@"=MAX(Data!G:G)");
             Assert.AreEqual(96, value);
         }
 
@@ -365,7 +365,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Median_EvenCountOfManualNumbers_ReturnsAverageOfTwoElementsInMiddleOfSortedList()
         {
             //Act
-            double value = workbook.Evaluate("MEDIAN(-27.5,93.93,64.51,-70.56)").CastTo<double>();
+            var value = (double)workbook.Evaluate("MEDIAN(-27.5,93.93,64.51,-70.56)");
 
             //Assert
             Assert.AreEqual(18.505, value, tolerance);
@@ -388,7 +388,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Median_OddCountOfManualNumbers_ReturnsElementInMiddleOfSortedList()
         {
             //Act
-            double value = workbook.Evaluate("MEDIAN(-27.5,93.93,64.51,-70.56,101.65)").CastTo<double>();
+            var value = (double)workbook.Evaluate("MEDIAN(-27.5,93.93,64.51,-70.56,101.65)");
 
             //Assert
             Assert.AreEqual(64.51, value, tolerance);
@@ -408,7 +408,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=MIN(G:G)").CastTo<int>();
             Assert.AreEqual(2, value);
 
-            value = workbook.Evaluate(@"=MIN(Data!G:G)").CastTo<int>();
+            value = (int)workbook.Evaluate(@"=MIN(Data!G:G)");
             Assert.AreEqual(2, value);
         }
 
@@ -425,7 +425,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=STDEV(H:H)").CastTo<double>();
             Assert.AreEqual(47.34511769, value, tolerance);
 
-            value = workbook.Evaluate(@"=STDEV(Data!H:H)").CastTo<double>();
+            value = (double)workbook.Evaluate(@"=STDEV(Data!H:H)");
             Assert.AreEqual(47.34511769, value, tolerance);
         }
 
@@ -442,7 +442,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=STDEVP(H:H)").CastTo<double>();
             Assert.AreEqual(46.79135458, value, tolerance);
 
-            value = workbook.Evaluate(@"=STDEVP(Data!H:H)").CastTo<double>();
+            value = (double)workbook.Evaluate(@"=STDEVP(Data!H:H)");
             Assert.AreEqual(46.79135458, value, tolerance);
         }
 
@@ -505,7 +505,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=VAR(H:H)").CastTo<double>();
             Assert.AreEqual(2241.560169, value, tolerance);
 
-            value = workbook.Evaluate(@"=VAR(Data!H:H)").CastTo<double>();
+            value = (double)workbook.Evaluate(@"=VAR(Data!H:H)");
             Assert.AreEqual(2241.560169, value, tolerance);
         }
 
@@ -522,7 +522,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=VARP(H:H)").CastTo<double>();
             Assert.AreEqual(2189.430863, value, tolerance);
 
-            value = workbook.Evaluate(@"=VARP(Data!H:H)").CastTo<double>();
+            value = (double)workbook.Evaluate(@"=VARP(Data!H:H)");
             Assert.AreEqual(2189.430863, value, tolerance);
         }
         private XLWorkbook SetupWorkbook()

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -304,7 +304,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-12)]
         public double Fisher(double sourceValue)
         {
-            return XLWorkbook.EvaluateExpr($"=FISHER({sourceValue})").CastTo<double>();
+            return (double)XLWorkbook.EvaluateExpr($"FISHER({sourceValue})");
         }
 
         // TODO : the string case will be treated correctly when Coercion is implemented better

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -158,16 +158,6 @@ namespace ClosedXML.Excel.CalcEngine
 
             return singleCellValue;
         }
-
-        internal static object ToCellContentValue(ScalarValue value)
-        {
-            return value.Match<object>(
-                () => 0,
-                logical => logical,
-                number => number,
-                text => text,
-                error => error);
-        }
     }
 
     internal delegate AnyValue CalcEngineFunction(CalcContext ctx, Span<AnyValue> arg);

--- a/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngineHelpers.cs
@@ -72,7 +72,7 @@ namespace ClosedXML.Excel.CalcEngine
                     }
 
                     // evaluate
-                    return (bool)CalcEngine.ToCellContentValue(ce.Evaluate(expression));
+                    return ce.Evaluate(expression).GetLogical();
                 }
 
                 // if criteria is a regular expression, use regex

--- a/ClosedXML/Excel/IXLWorkbook.cs
+++ b/ClosedXML/Excel/IXLWorkbook.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 using System.IO;
+using ClosedXML.Excel.CalcEngine.Exceptions;
 
 namespace ClosedXML.Excel
 {
@@ -147,7 +148,14 @@ namespace ClosedXML.Excel
 
         IXLCustomProperty CustomProperty(String name);
 
-        Object Evaluate(String expression);
+        /// <summary>
+        /// Evaluate a formula expression.
+        /// </summary>
+        /// <param name="expression">Formula expression to evaluate.</param>
+        /// <exception cref="MissingContextException">
+        /// If the expression contains a function that requires a context (e.g. current cell or worksheet).
+        /// </exception>
+        XLCellValue Evaluate(String expression);
 
         IXLCells FindCells(Func<IXLCell, Boolean> predicate);
 

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -442,7 +442,7 @@ namespace ClosedXML.Excel
         /// <param name="expression">Formula to evaluate.</param>
         /// <param name="formulaAddress">A cell address that is used to provide context for formula calculation (mostly implicit intersection).</param>
         /// <exception cref="MissingContextException">If <paramref name="formulaAddress"/> was needed for some part of calculation.</exception>
-        object Evaluate(String expression, string formulaAddress = null);
+        XLCellValue Evaluate(String expression, string formulaAddress = null);
 
         /// <summary>
         /// Force recalculation of all cell formulas.

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -869,9 +869,9 @@ namespace ClosedXML.Excel
             get { return _calcEngine ??= new XLCalcEngine(CultureInfo.CurrentCulture); }
         }
 
-        public Object Evaluate(String expression)
+        public XLCellValue Evaluate(String expression)
         {
-            return ClosedXML.Excel.CalcEngine.CalcEngine.ToCellContentValue(CalcEngine.Evaluate(expression, this));
+            return CalcEngine.Evaluate(expression, this).ToCellValue();
         }
 
         /// <summary>

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -894,9 +894,9 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Evaluate a formula and return a value. Formulas with references don't work and culture used for conversion is invariant.
         /// </summary>
-        public static Object EvaluateExpr(String expression)
+        public static XLCellValue EvaluateExpr(String expression)
         {
-            return ClosedXML.Excel.CalcEngine.CalcEngine.ToCellContentValue(CalcEngineExpr.Evaluate(expression));
+            return CalcEngineExpr.Evaluate(expression).ToCellValue();
         }
 
         public String Author { get; set; }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1657,10 +1657,10 @@ namespace ClosedXML.Excel
 
         internal XLCalcEngine CalcEngine => Workbook.CalcEngine;
 
-        public Object Evaluate(String expression, string formulaAddress = null)
+        public XLCellValue Evaluate(String expression, string formulaAddress = null)
         {
             IXLAddress address = formulaAddress is not null ? XLAddress.Create(formulaAddress) : null;
-            return ClosedXML.Excel.CalcEngine.CalcEngine.ToCellContentValue(CalcEngine.Evaluate(expression, Workbook, this, address));
+            return CalcEngine.Evaluate(expression, Workbook, this, address).ToCellValue();
         }
 
         /// <summary>

--- a/docs/migrations/migrate-to-0.100.rst
+++ b/docs/migrations/migrate-to-0.100.rst
@@ -44,8 +44,8 @@ with a specific type.
 Evaluate methods
 ================
 
-Evaluation methods ``IXLWorkbook.Evaluate(String)`` and
-``IXLWorksheet.Evaluate(String, String)`` don't return ``Object``, but
+Evaluation methods ``IXLWorkbook.Evaluate(String)``, ``XLWorkbook.EvaluateExpr(String)``
+and ``IXLWorksheet.Evaluate(String, String)`` don't return ``Object``, but
 ``XLCellValue``.
 
 Bulk data insert

--- a/docs/migrations/migrate-to-0.100.rst
+++ b/docs/migrations/migrate-to-0.100.rst
@@ -41,6 +41,11 @@ Method ``SetDataType`` has been removed from all interfaces (``IXLCell``,
 need to reinterpret existing data, do it in application code and set a new value
 with a specific type.
 
+Evaluate method
+===============
+
+Evaluation method ``XLWorkbook.Evaluate(String)`` not returns ``XLCellValue``, not ``Object``.
+
 Bulk data insert
 ================
 

--- a/docs/migrations/migrate-to-0.100.rst
+++ b/docs/migrations/migrate-to-0.100.rst
@@ -41,10 +41,12 @@ Method ``SetDataType`` has been removed from all interfaces (``IXLCell``,
 need to reinterpret existing data, do it in application code and set a new value
 with a specific type.
 
-Evaluate method
-===============
+Evaluate methods
+================
 
-Evaluation method ``XLWorkbook.Evaluate(String)`` not returns ``XLCellValue``, not ``Object``.
+Evaluation methods ``IXLWorkbook.Evaluate(String)`` and
+``IXLWorksheet.Evaluate(String, String)`` don't return ``Object``, but
+``XLCellValue``.
 
 Bulk data insert
 ================


### PR DESCRIPTION
Remove another use of the Object/unknown type in the API. Replace the `Object` result of public `Evaluate` methods with the `XLCellValue` so the consumer of the API immediately knows possible values (clearer semantic) that can be returned. It also removes boxing/unboxing of the evaluation result.