### PR TITLE
Add implicit conversion from decimal to double for XLCellValue. 

### DIFF
--- a/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
@@ -43,6 +43,22 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.Throws<ArgumentException>(() => _ = (XLCellValue)nonNumber);
         }
 
+        // Decimal is not allowed as a member of an attribute, so TestCase can't be used.
+        private static readonly object[] DecimalTestCases =
+        {
+            new object[] { 5.875m, 5.875d },
+            new object[] { Decimal.MaxValue, 7.922816251426434E+28 },
+            new object[] { 1.0E-28m, 1.0000000000000001E-28d }
+        };
+
+        [TestCaseSource(nameof(DecimalTestCases))]
+        public void Creation_Decimal(Decimal decimalNumber, Double expectedNumber)
+        {
+            XLCellValue cellValue = decimalNumber;
+            Assert.True(cellValue.IsNumber);
+            Assert.AreEqual(expectedNumber, cellValue.GetNumber());
+        }
+
         [Test]
         public void Creation_Text()
         {
@@ -89,6 +105,77 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.AreEqual(XLDataType.TimeSpan, dateTime.Type);
             Assert.True(dateTime.IsTimeSpan);
             Assert.AreEqual(new TimeSpan(10, 1, 2, 3, 456), dateTime.GetTimeSpan());
+        }
+
+        [Test]
+        public void NumberTypes_HaveUnambiguousConversion()
+        {
+            {
+                sbyte sbyteNumber = 5;
+                XLCellValue sbyteCellValue = sbyteNumber;
+                Assert.IsTrue(sbyteCellValue.IsNumber);
+                Assert.AreEqual(5d, sbyteCellValue.GetNumber());
+            }
+            {
+                byte byteNumber = 6;
+                XLCellValue byteCellValue = byteNumber;
+                Assert.IsTrue(byteCellValue.IsNumber);
+                Assert.AreEqual(6d, byteCellValue.GetNumber());
+            }
+            {
+                short shortNumber = 7;
+                XLCellValue shortCellValue = shortNumber;
+                Assert.IsTrue(shortCellValue.IsNumber);
+                Assert.AreEqual(7d, shortCellValue.GetNumber());
+            }
+            {
+                ushort ushortNumber = 8;
+                XLCellValue ushortCellValue = ushortNumber;
+                Assert.IsTrue(ushortCellValue.IsNumber);
+                Assert.AreEqual(8d, ushortCellValue.GetNumber());
+            }
+            {
+                int intNumber = 9;
+                XLCellValue intCellValue = intNumber;
+                Assert.IsTrue(intCellValue.IsNumber);
+                Assert.AreEqual(9d, intCellValue.GetNumber());
+            }
+            {
+                uint uintNumber = 10;
+                XLCellValue uintCellValue = uintNumber;
+                Assert.IsTrue(uintCellValue.IsNumber);
+                Assert.AreEqual(10d, uintCellValue.GetNumber());
+            }
+            {
+                long longNumber = 11;
+                XLCellValue longCellValue = longNumber;
+                Assert.IsTrue(longCellValue.IsNumber);
+                Assert.AreEqual(11d, longCellValue.GetNumber());
+            }
+            {
+                ulong ulongNumber = 12;
+                XLCellValue ulongCellValue = ulongNumber;
+                Assert.IsTrue(ulongCellValue.IsNumber);
+                Assert.AreEqual(12d, ulongCellValue.GetNumber());
+            }
+            {
+                float floatNumber = 13.5f;
+                XLCellValue floatCellValue = floatNumber;
+                Assert.IsTrue(floatCellValue.IsNumber);
+                Assert.AreEqual(13.5d, floatCellValue.GetNumber());
+            }
+            {
+                double doubleNumber = 14.5;
+                XLCellValue doubleCellValue = doubleNumber;
+                Assert.IsTrue(doubleCellValue.IsNumber);
+                Assert.AreEqual(14.5d, doubleCellValue.GetNumber());
+            }
+            {
+                decimal decimalNumber = 15.75m;
+                XLCellValue decimalCellValue = decimalNumber;
+                Assert.IsTrue(decimalCellValue.IsNumber);
+                Assert.AreEqual(15.75d, decimalCellValue.GetNumber());
+            }
         }
 
         [Test]

--- a/ClosedXML/Excel/XLCellValue.cs
+++ b/ClosedXML/Excel/XLCellValue.cs
@@ -136,6 +136,16 @@ namespace ClosedXML.Excel
         public static implicit operator XLCellValue(DateTime dateTime) => new(dateTime);
         public static implicit operator XLCellValue(TimeSpan timeSpan) => new(timeSpan);
 
+        public static implicit operator XLCellValue(sbyte number) => new(number);
+        public static implicit operator XLCellValue(byte number) => new(number);
+        public static implicit operator XLCellValue(short number) => new(number);
+        public static implicit operator XLCellValue(ushort number) => new(number);
+        public static implicit operator XLCellValue(int number) => new(number);
+        public static implicit operator XLCellValue(uint number) => new(number);
+        public static implicit operator XLCellValue(long number) => new(number);
+        public static implicit operator XLCellValue(ulong number) => new(number);
+        public static implicit operator XLCellValue(decimal number) => new(decimal.ToDouble(number));
+
         /// <inheritdoc cref="GetBlank"/>
         public static explicit operator Blank(XLCellValue value) => value.GetBlank();
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.100.0</Version>
+    <Version>0.100.1</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->
@@ -21,7 +21,7 @@
     <PackageProjectUrl>https://github.com/ClosedXML/ClosedXML</PackageProjectUrl>
     <PackageIcon>nuget-logo.png</PackageIcon>
     <PackageTags>Excel OpenXml xlsx</PackageTags>
-    <Description>See release notes https://github.com/ClosedXML/ClosedXML/releases/tag/0.100.0 . ClosedXML is a .NET library for reading, manipulating and writing Excel 2007+ (.xlsx, .xlsm) files. It aims to provide an intuitive and user-friendly interface to dealing with the underlying OpenXML API.</Description>
+    <Description>See release notes https://github.com/ClosedXML/ClosedXML/releases/tag/0.100.0. ClosedXML is a .NET library for reading, manipulating and writing Excel 2007+ (.xlsx, .xlsm) files. It aims to provide an intuitive and user-friendly interface to dealing with the underlying OpenXML API.</Description>
     <PackageReleaseNotes>See https://github.com/ClosedXML/ClosedXML/releases/tag/$(productVersion)</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/ClosedXML/ClosedXML</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.100.0.{build}
+version: 0.100.1.{build}
 
 os: Visual Studio 2019
 image: Visual Studio 2019


### PR DESCRIPTION
Other conversions are necessary for unambiguous conversion of other number types (e.g. if long wouldn't know if to use decimal or double implicit conversion).

Resolves #1960 