### PR TITLE
Insert all number types as numbers

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NA/@EntryIndexedValue">NA</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IFERROR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISBLANK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1737,15 +1737,28 @@ namespace ClosedXML.Excel
         internal void SetValue<T>(T value, int ro, int co)
         {
             var cell = Cell(ro, co);
+
+            // Thanks to magic of JIT compiler, generic method is compiled as a separate method
+            // for each T, so the whole switch removes types that don't match T and the whole
+            // switch is actually reduced only to the code for specific T (=no switch for value types).
             XLCellValue newValue = value switch
             {
                 null => Blank.Value,
                 Blank blankValue => blankValue,
                 Boolean logical => logical,
+                SByte number => number,
+                Byte number => number,
+                Int16 number => number,
+                UInt16 number => number,
+                Int32 number => number,
+                UInt32 number => number,
+                Int64 number => number,
+                UInt64 number => number,
+                Single number => number,
                 Double number => number,
+                Decimal number => number,
                 String text => text,
                 XLError error => error,
-                Int32 intNumber => intNumber,
                 DateTime date => date,
                 DateTimeOffset dateOfs => dateOfs.DateTime,
                 TimeSpan timeSpan => timeSpan,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.100.2</Version>
+    <Version>0.100.3</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.100.2.{build}
+version: 0.100.3.{build}
 
 os: Visual Studio 2019
 image: Visual Studio 2019

--- a/docs/migrations/migrate-to-0.100.rst
+++ b/docs/migrations/migrate-to-0.100.rst
@@ -250,3 +250,15 @@ the pivot table. There can be multiple values for a single source column
 (e.g. average value and minimal value).
 
 Methods for manipulating the ``IXLPivotFields`` still use source names.
+
+***********************
+XLEventTracking removed
+***********************
+
+ClosedXML used to track various events and call registered event handlers.
+That functionality was removed long ago and now even enum
+``XLEventTracking``, ``LoadOptions.EventTracking`` property
+and ``XLWorkbook`` constructors that accepted the enum were removed.
+
+To migrate the code, just remove the ``XLEventTracking`` argument from
+the constructor and remove setters of ``LoadOptions.EventTracking``.


### PR DESCRIPTION
When user inserted values through bulk operations (insert data reader), the number types other than double/int were converted to a text cell value (e.g. decimal 5 from input table was turned into a string "5" in a cell).

Resolves #1965