### PR TITLE
Change ExpressionCache to use ConditionalWeakTable

### DIFF
--- a/ClosedXML/Excel/CalcEngine/ExpressionCache.cs
+++ b/ClosedXML/Excel/CalcEngine/ExpressionCache.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace ClosedXML.Excel.CalcEngine
 {
@@ -10,16 +9,15 @@ namespace ClosedXML.Excel.CalcEngine
     /// <remarks>
     /// Uses weak references to avoid accumulating unused expressions.
     /// </remarks>
-    class ExpressionCache
+    internal sealed class ExpressionCache
     {
-        Dictionary<string, WeakReference> _dct;
-        CalcEngine _ce;
-        int _hitCount;
+        private readonly ConditionalWeakTable<string, Formula> _cache;
+        private readonly CalcEngine _ce;
 
         public ExpressionCache(CalcEngine ce)
         {
             _ce = ce;
-            _dct = new Dictionary<string, WeakReference>();
+            _cache = new ConditionalWeakTable<string, Formula>();
         }
 
         // gets the parsed version of a string expression
@@ -27,43 +25,12 @@ namespace ClosedXML.Excel.CalcEngine
         {
             get
             {
-                Formula x;
-                if (_dct.TryGetValue(expression, out WeakReference wr) && wr.IsAlive)
+                if (!_cache.TryGetValue(expression, out var formula))
                 {
-                    x = wr.Target as Formula;
+                    formula = _ce.Parse(expression);
+                    _cache.Add(expression, formula);
                 }
-                else
-                {
-                    // remove all dead references from dictionary
-                    if (wr != null && _dct.Count > 100 && _hitCount++ > 100)
-                    {
-                        RemoveDeadReferences();
-                        _hitCount = 0;
-                    }
-
-                    // store this expression
-                    x = _ce.Parse(expression);
-                    _dct[expression] = new WeakReference(x);
-                }
-                return x;
-            }
-        }
-
-        // remove all dead references from the cache
-        void RemoveDeadReferences()
-        {
-            for (bool done = false; !done; )
-            {
-                done = true;
-                foreach (var k in _dct.Keys)
-                {
-                    if (!_dct[k].IsAlive)
-                    {
-                        _dct.Remove(k);
-                        done = false;
-                        break;
-                    }
-                }
+                return formula;
             }
         }
     }


### PR DESCRIPTION
We see in our CI runs from time to time following exception:

```
Error Message:
 System.NullReferenceException : Object reference not set to an instance of an object.
Stack Trace:
 at ClosedXML.Excel.CalcEngine.CalcEngine.Evaluate(String expression)
 at ClosedXML.Excel.XLWorksheet.Evaluate(String expression)
 at ClosedXML.Excel.XLCell.RecalculateFormula(String fA1)
 at ClosedXML.Excel.XLCell.Evaluate(Boolean force)
 at ClosedXML.Excel.XLCell.get_Value()
```

As our test runs are memory-intensive, my guess would be that there is a race condition with current `WeakReference` handling in `ExpressionCache`. Basically reference's target could be cleaned during the logic. Instead of adding more safeguards, I'm proposing to switch to using `ConditionalWeaktable` as it makes code more clear and less error-prone.

`CalcEngine` referencing the cache has very limited lifetime, scoped to method what I've studied the code so I don't see a reason to have such complex cleaned logic and artificial 100 item threshold either.