### PR TITLE
Update fonts library to beta19

### DIFF
--- a/ClosedXML.Tests/Graphics/FontTests.cs
+++ b/ClosedXML.Tests/Graphics/FontTests.cs
@@ -82,6 +82,15 @@ namespace ClosedXML.Tests.Graphics
             Assert.AreEqual(expectedWidthOfLetterB, widthOfLetterB, 0.0001);
         }
 
+        [TestCase]
+        public void Issue_1916_CanMeasureSpecificArabicText()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell(1, 1).Value = @"اصين";
+            ws.Column(1).AdjustToContents();
+        }
+
         private class DummyFont : IXLFontBase
         {
             public DummyFont(string name, double size)

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta18" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />

--- a/docs/migrations/migrate-to-0.101.rst
+++ b/docs/migrations/migrate-to-0.101.rst
@@ -1,0 +1,10 @@
+#############################
+Migration from 0.100 to 0.101
+#############################
+
+******************
+Dependency updates
+******************
+
+Library ``SixLabors.Fonts`` has been updated from *1.0.0-beta18* to
+*1.0.0-beta19* to due to bug fixing of font measurement.


### PR DESCRIPTION
Beta18 had a bug for arabic text that caused it to throw exceptions.

Resolves #1916 