### PR TITLE
Separate XLCellFormula out of XLCell

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetPointTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetPointTests.cs
@@ -1,0 +1,54 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+using System;
+
+namespace ClosedXML.Tests.Excel.Coordinates
+{
+    [TestFixture]
+    public class XLSheetPointTests
+    {
+        [TestCase("A1", 1, 1)]
+        [TestCase("AA1", 27, 1)]
+        [TestCase("AAA1", 703, 1)]
+        [TestCase("Z1", 26, 1)]
+        [TestCase("ZZ1", 702, 1)]
+        [TestCase("XFD1", 16384, 1)]
+        [TestCase("A1", 1, 1)]
+        [TestCase("A999", 1, 999)]
+        [TestCase("XFD1048576", 16384, 1048576)]
+        public void ParseCellRefsAccordingToGrammar(string cellRef, int columnNumber, int rowNumber)
+        {
+            var sheetPoint = XLSheetPoint.Parse(cellRef.AsSpan());
+            Assert.AreEqual(columnNumber, sheetPoint.Column);
+            Assert.AreEqual(rowNumber, sheetPoint.Row);
+        }
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("A")]
+        [TestCase("AA")]
+        [TestCase("1")]
+        [TestCase("11")]
+        [TestCase(" A1")]
+        [TestCase("A1 ")]
+        [TestCase("A 1")]
+        [TestCase("@1")] // @ is a char 'A' - 1
+        [TestCase("[1")] // [ is a char 'Z' + 1
+        [TestCase("A:")] // : is a char '9' + 1
+        [TestCase("A/")] // / is a char '0' - 1
+        [TestCase("A1:")]
+        [TestCase("A1/")]
+        [TestCase("A@1")]
+        [TestCase("A[1")]
+        [TestCase("XFE1")]
+        [TestCase("AAAA1")]
+        [TestCase("A1048577")]
+        [TestCase("A01")]
+        [TestCase("A0")]
+        [TestCase("A-1")]
+        public void InvalidInputsAreNotParsed(string cellRef)
+        {
+            Assert.Throws<FormatException>(() => XLSheetPoint.Parse(cellRef.AsSpan()));
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates
+{
+    [TestFixture]
+    public class XLSheetRangeTests
+    {
+        [TestCase("A1", 1, 1, 1, 1)]
+        [TestCase("A1:Z100", 1, 1, 100, 26)]
+        [TestCase("BD14:EG256", 14, 56, 256, 137)]
+        [TestCase("A1:XFD1048576", 1, 1, 1048576, 16384)]
+        [TestCase("XFD1048576", 1048576, 16384, 1048576, 16384)]
+        [TestCase("XFD1048576:XFD1048576", 1048576, 16384, 1048576, 16384)]
+        public void ParseCellRefsAccordingToGrammar(string refText, int firstRow, int firstCol, int lastRow, int lastCol)
+        {
+            var reference = XLSheetRange.Parse(refText);
+            Assert.AreEqual(firstRow, reference.FirstPoint.Row);
+            Assert.AreEqual(firstCol, reference.FirstPoint.Column);
+            Assert.AreEqual(lastRow, reference.LastPoint.Row);
+            Assert.AreEqual(lastCol, reference.LastPoint.Column);
+        }
+
+        [TestCase("")]
+        [TestCase("A1:")]
+        [TestCase(":A1")]
+        [TestCase("A1: A1")]
+        [TestCase(" A1:A1")]
+        [TestCase("A1:A1 ")]
+        [TestCase("B1:A1")]
+        [TestCase("A2:A1")]
+        public void InvalidInputsAreNotParsed(string invalidRef)
+        {
+            Assert.Throws<FormatException>(() => XLSheetRange.Parse(invalidRef));
+        }
+    }
+}

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NA/@EntryIndexedValue">NA</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RC/@EntryIndexedValue">RC</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IFERROR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISBLANK/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -101,6 +101,10 @@ namespace ClosedXML.Excel
         /// <value>The formula with R1C1 references.</value>
         String FormulaR1C1 { get; set; }
 
+        /// <summary>
+        /// An indication that value of this cell is calculated by a array formula
+        /// that calculates values for cells in the referenced address. Null if not part of such formula.
+        /// </summary>
         IXLRangeAddress FormulaReference { get; set; }
 
         Boolean HasArrayFormula { get; }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -63,7 +63,7 @@ namespace ClosedXML.Excel
         /// </summary>
         public bool ShareString { get; set; }
 
-        private readonly CellFormula _formula = new();
+        private readonly XLCellFormula _formula = new();
 
         private XLComment _comment;
         private XLHyperlink _hyperlink;
@@ -1538,12 +1538,12 @@ namespace ClosedXML.Excel
 
         internal string GetFormulaR1C1(string value)
         {
-            return CellFormula.GetFormula(value, FormulaConversionType.A1ToR1C1, new XLSheetPoint(_rowNumber, _columnNumber));
+            return XLCellFormula.GetFormula(value, FormulaConversionType.A1ToR1C1, new XLSheetPoint(_rowNumber, _columnNumber));
         }
 
         internal string GetFormulaA1(string value)
         {
-            return CellFormula.GetFormula(value, FormulaConversionType.R1C1ToA1, new XLSheetPoint(_rowNumber, _columnNumber));
+            return XLCellFormula.GetFormula(value, FormulaConversionType.R1C1ToA1, new XLSheetPoint(_rowNumber, _columnNumber));
         }
 
         internal void CopyValuesFrom(XLCell source)
@@ -1970,16 +1970,6 @@ namespace ClosedXML.Excel
             return Worksheet.Cell(_rowNumber + rowsToShift, _columnNumber + columnsToShift);
         }
 
-        #region Nested type: FormulaConversionType
-
-        private enum FormulaConversionType
-        {
-            A1ToR1C1,
-            R1C1ToA1
-        };
-
-        #endregion Nested type: FormulaConversionType
-
         #region XLCell Above
 
         IXLCell IXLCell.CellAbove()
@@ -2119,239 +2109,6 @@ namespace ClosedXML.Excel
         internal bool IsSuperiorMergedCell()
         {
             return this.IsMerged() && this.Address.Equals(this.MergedRange().RangeAddress.FirstAddress);
-        }
-
-        private class CellFormula
-        {
-            private static readonly Regex A1Regex = new(
-                @"(?<=\W)(\$?[a-zA-Z]{1,3}\$?\d{1,7})(?=\W)" // A1
-                + @"|(?<=\W)(\$?\d{1,7}:\$?\d{1,7})(?=\W)" // 1:1
-                + @"|(?<=\W)(\$?[a-zA-Z]{1,3}:\$?[a-zA-Z]{1,3})(?=\W)", RegexOptions.Compiled); // A:A
-
-            private static readonly Regex R1C1Regex = new(
-                @"(?<=\W)([Rr](?:\[-?\d{0,7}\]|\d{0,7})?[Cc](?:\[-?\d{0,7}\]|\d{0,7})?)(?=\W)" // R1C1
-                + @"|(?<=\W)([Rr]\[?-?\d{0,7}\]?:[Rr]\[?-?\d{0,7}\]?)(?=\W)" // R:R
-                + @"|(?<=\W)([Cc]\[?-?\d{0,5}\]?:[Cc]\[?-?\d{0,5}\]?)(?=\W)", RegexOptions.Compiled); // C:C
-
-            internal string A1;
-            internal string R1C1;
-
-            internal bool HasAnyFormula =>
-                !String.IsNullOrWhiteSpace(A1) ||
-                !String.IsNullOrEmpty(R1C1);
-
-            /// <summary>
-            /// Get stored formula or or <c>string.Empty</c> if both A1/R1C1 are empty.
-            /// Formula doesn't contain artificial equal sign.
-            /// </summary>
-            public string GetFormulaA1(XLSheetPoint cellAddress)
-            {
-                if (String.IsNullOrWhiteSpace(A1))
-                {
-                    if (String.IsNullOrWhiteSpace(R1C1))
-                    {
-                        return String.Empty;
-                    }
-
-                    A1 = GetFormula(R1C1, FormulaConversionType.R1C1ToA1, cellAddress);
-                }
-
-                if (A1.Trim()[0] == '=')
-                    return A1.Substring(1);
-
-                if (A1.Trim().StartsWith("{="))
-                    return "{" + A1.Substring(2);
-
-                return A1;
-            }
-
-            internal static string GetFormula(string strValue, FormulaConversionType conversionType, XLSheetPoint cellAddress)
-            {
-                if (String.IsNullOrWhiteSpace(strValue))
-                    return String.Empty;
-
-                var value = ">" + strValue + "<";
-
-                var regex = conversionType == FormulaConversionType.A1ToR1C1 ? A1Regex : R1C1Regex;
-
-                var sb = new StringBuilder();
-                var lastIndex = 0;
-
-                foreach (var match in regex.Matches(value).Cast<Match>())
-                {
-                    var matchString = match.Value;
-                    var matchIndex = match.Index;
-                    if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0
-                        && value.Substring(0, matchIndex).CharCount('\'') % 2 == 0)
-                    {
-                        // Check if the match is in between quotes
-                        sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
-                        sb.Append(conversionType == FormulaConversionType.A1ToR1C1
-                            ? GetR1C1Address(matchString, cellAddress)
-                            : GetA1Address(matchString, cellAddress));
-                    }
-                    else
-                        sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
-                    lastIndex = matchIndex + matchString.Length;
-                }
-
-                if (lastIndex < value.Length)
-                    sb.Append(value.Substring(lastIndex));
-
-                var retVal = sb.ToString();
-                return retVal.Substring(1, retVal.Length - 2);
-            }
-
-            private static string GetA1Address(string r1C1Address, XLSheetPoint cellAddress)
-            {
-                var addressToUse = r1C1Address.ToUpper();
-
-                if (addressToUse.Contains(':'))
-                {
-                    var parts = addressToUse.Split(':');
-                    var p1 = parts[0];
-                    var p2 = parts[1];
-                    string leftPart;
-                    string rightPart;
-                    if (p1.StartsWith("R"))
-                    {
-                        leftPart = GetA1Row(p1, cellAddress.Row);
-                        rightPart = GetA1Row(p2, cellAddress.Row);
-                    }
-                    else
-                    {
-                        leftPart = GetA1Column(p1, cellAddress.Column);
-                        rightPart = GetA1Column(p2, cellAddress.Column);
-                    }
-
-                    return leftPart + ":" + rightPart;
-                }
-
-                try
-                {
-                    var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
-                    var rowToReturn = GetA1Row(rowPart, cellAddress.Row);
-
-                    var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
-                    var columnToReturn = GetA1Column(columnPart, cellAddress.Column);
-
-                    var retAddress = columnToReturn + rowToReturn;
-                    return retAddress;
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    return "#REF!";
-                }
-            }
-
-            private static string GetA1Column(string columnPartRC, int cellColumn)
-            {
-                string columnToReturn;
-                if (columnPartRC == "C")
-                    columnToReturn = XLHelper.GetColumnLetterFromNumber(cellColumn);
-                else
-                {
-                    var bIndex = columnPartRC.IndexOf("[");
-                    var mIndex = columnPartRC.IndexOf("-");
-                    if (bIndex >= 0)
-                    {
-                        columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                            cellColumn +
-                            Int32.Parse(columnPartRC.Substring(bIndex + 1, columnPartRC.Length - bIndex - 2))
-                            );
-                    }
-                    else if (mIndex >= 0)
-                    {
-                        columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                            cellColumn + Int32.Parse(columnPartRC.Substring(mIndex))
-                            );
-                    }
-                    else
-                    {
-                        columnToReturn = "$" +
-                                         XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPartRC.Substring(1)));
-                    }
-                }
-
-                return columnToReturn;
-            }
-
-            private static string GetA1Row(string rowPartRC, int cellRow)
-            {
-                string rowToReturn;
-                if (rowPartRC == "R")
-                    rowToReturn = cellRow.ToString();
-                else
-                {
-                    var bIndex = rowPartRC.IndexOf("[");
-                    if (bIndex >= 0)
-                    {
-                        rowToReturn =
-                            (cellRow + Int32.Parse(rowPartRC.Substring(bIndex + 1, rowPartRC.Length - bIndex - 2))).ToString();
-                    }
-                    else
-                        rowToReturn = "$" + (Int32.Parse(rowPartRC.Substring(1)));
-                }
-
-                return rowToReturn;
-            }
-
-            private static string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
-            {
-                if (a1Address.Contains(':'))
-                {
-                    var parts = a1Address.Split(':');
-                    var p1 = parts[0];
-                    var p2 = parts[1];
-                    if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
-                    {
-                        var row2 = Int32.Parse(p2.Replace("$", string.Empty));
-                        var leftPart = GetR1C1Row(row1, p1.Contains('$'), cellAddress.Row);
-                        var rightPart = GetR1C1Row(row2, p2.Contains('$'), cellAddress.Row);
-                        return leftPart + ":" + rightPart;
-                    }
-                    else
-                    {
-                        var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
-                        var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
-                        var leftPart = GetR1C1Column(column1, p1.Contains('$'), cellAddress.Column);
-                        var rightPart = GetR1C1Column(column2, p2.Contains('$'), cellAddress.Column);
-                        return leftPart + ":" + rightPart;
-                    }
-                }
-
-                var address = XLAddress.Create(a1Address);
-
-                var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
-                var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);
-
-                return rowPart + columnPart;
-            }
-
-            private static string GetR1C1Row(int rowNumber, bool fixedRow, int cellRow)
-            {
-                string rowPart;
-                var rowDiff = rowNumber - cellRow;
-                if (rowDiff != 0 || fixedRow)
-                    rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
-                else
-                    rowPart = "R";
-
-                return rowPart;
-            }
-
-            private static string GetR1C1Column(int columnNumber, bool fixedColumn, int cellColumn)
-            {
-                string columnPart;
-                var columnDiff = columnNumber - cellColumn;
-                if (columnDiff != 0 || fixedColumn)
-                    columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";
-                else
-                    columnPart = "C";
-
-                return columnPart;
-            }
-
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1717,8 +1717,8 @@ namespace ClosedXML.Excel
                 if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
                 {
                     var row2 = Int32.Parse(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Row(row1, p1.Contains('$'));
-                    var rightPart = GetR1C1Row(row2, p2.Contains('$'));
+                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), _rowNumber);
+                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), _rowNumber);
                     return leftPart + ":" + rightPart;
                 }
                 else
@@ -1733,16 +1733,16 @@ namespace ClosedXML.Excel
 
             var address = XLAddress.Create(Worksheet, a1Address);
 
-            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow);
+            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, _rowNumber);
             var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, _columnNumber);
 
             return rowPart + columnPart;
         }
 
-        private string GetR1C1Row(int rowNumber, bool fixedRow)
+        private static string GetR1C1Row(int rowNumber, bool fixedRow, int cellRow)
         {
             string rowPart;
-            var rowDiff = rowNumber - _rowNumber;
+            var rowDiff = rowNumber - cellRow;
             if (rowDiff != 0 || fixedRow)
                 rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
             else

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1631,8 +1631,8 @@ namespace ClosedXML.Excel
                 }
                 else
                 {
-                    leftPart = GetA1Column(p1);
-                    rightPart = GetA1Column(p2);
+                    leftPart = GetA1Column(p1, _columnNumber);
+                    rightPart = GetA1Column(p2, _columnNumber);
                 }
 
                 return leftPart + ":" + rightPart;
@@ -1644,7 +1644,7 @@ namespace ClosedXML.Excel
                 var rowToReturn = GetA1Row(rowPart, _rowNumber);
 
                 var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
-                var columnToReturn = GetA1Column(columnPart);
+                var columnToReturn = GetA1Column(columnPart, _columnNumber);
 
                 var retAddress = columnToReturn + rowToReturn;
                 return retAddress;
@@ -1655,32 +1655,32 @@ namespace ClosedXML.Excel
             }
         }
 
-        private string GetA1Column(string columnPart)
+        private static string GetA1Column(string columnPartRC, int cellColumn)
         {
             string columnToReturn;
-            if (columnPart == "C")
-                columnToReturn = XLHelper.GetColumnLetterFromNumber(_columnNumber);
+            if (columnPartRC == "C")
+                columnToReturn = XLHelper.GetColumnLetterFromNumber(cellColumn);
             else
             {
-                var bIndex = columnPart.IndexOf("[");
-                var mIndex = columnPart.IndexOf("-");
+                var bIndex = columnPartRC.IndexOf("[");
+                var mIndex = columnPartRC.IndexOf("-");
                 if (bIndex >= 0)
                 {
                     columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        _columnNumber +
-                        Int32.Parse(columnPart.Substring(bIndex + 1, columnPart.Length - bIndex - 2))
+                        cellColumn +
+                        Int32.Parse(columnPartRC.Substring(bIndex + 1, columnPartRC.Length - bIndex - 2))
                         );
                 }
                 else if (mIndex >= 0)
                 {
                     columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        _columnNumber + Int32.Parse(columnPart.Substring(mIndex))
+                        cellColumn + Int32.Parse(columnPartRC.Substring(mIndex))
                         );
                 }
                 else
                 {
                     columnToReturn = "$" +
-                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPart.Substring(1)));
+                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPartRC.Substring(1)));
                 }
             }
 

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1725,8 +1725,8 @@ namespace ClosedXML.Excel
                 {
                     var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
                     var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Column(column1, p1.Contains('$'));
-                    var rightPart = GetR1C1Column(column2, p2.Contains('$'));
+                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), _columnNumber);
+                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), _columnNumber);
                     return leftPart + ":" + rightPart;
                 }
             }
@@ -1734,7 +1734,7 @@ namespace ClosedXML.Excel
             var address = XLAddress.Create(Worksheet, a1Address);
 
             var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow);
-            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn);
+            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, _columnNumber);
 
             return rowPart + columnPart;
         }
@@ -1751,10 +1751,10 @@ namespace ClosedXML.Excel
             return rowPart;
         }
 
-        private string GetR1C1Column(int columnNumber, bool fixedColumn)
+        private static string GetR1C1Column(int columnNumber, bool fixedColumn, int cellColumn)
         {
             string columnPart;
-            var columnDiff = columnNumber - _columnNumber;
+            var columnDiff = columnNumber - cellColumn;
             if (columnDiff != 0 || fixedColumn)
                 columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";
             else

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -16,11 +16,6 @@ namespace ClosedXML.Excel
     [DebuggerDisplay("{Address}")]
     internal class XLCell : XLStylizedBase, IXLCell, IXLStylized
     {
-        private static readonly Regex A1Regex = new Regex(
-            @"(?<=\W)(\$?[a-zA-Z]{1,3}\$?\d{1,7})(?=\W)" // A1
-            + @"|(?<=\W)(\$?\d{1,7}:\$?\d{1,7})(?=\W)" // 1:1
-            + @"|(?<=\W)(\$?[a-zA-Z]{1,3}:\$?[a-zA-Z]{1,3})(?=\W)", RegexOptions.Compiled); // A:A
-
         public static readonly Regex A1SimpleRegex = new Regex(
             //  @"(?<=\W)" // Start with non word
             @"(?<Reference>" // Start Group to pick
@@ -53,11 +48,6 @@ namespace ClosedXML.Excel
         private static readonly Regex A1ColumnRegex = new Regex(
             @"(\$?[a-zA-Z]{1,3}:\$?[a-zA-Z]{1,3})" // A:A
             , RegexOptions.Compiled);
-
-        private static readonly Regex R1C1Regex = new Regex(
-            @"(?<=\W)([Rr](?:\[-?\d{0,7}\]|\d{0,7})?[Cc](?:\[-?\d{0,7}\]|\d{0,7})?)(?=\W)" // R1C1
-            + @"|(?<=\W)([Rr]\[?-?\d{0,7}\]?:[Rr]\[?-?\d{0,7}\]?)(?=\W)" // R:R
-            + @"|(?<=\W)([Cc]\[?-?\d{0,5}\]?:[Cc]\[?-?\d{0,5}\]?)(?=\W)", RegexOptions.Compiled); // C:C
 
         private static readonly Regex utfPattern = new Regex(@"(?<!_x005F)_x(?!005F)([0-9A-F]{4})_", RegexOptions.Compiled);
 
@@ -249,11 +239,11 @@ namespace ClosedXML.Excel
                 return true;
             }
         }
-        
+
         public Boolean GetBoolean() => Value.GetBoolean();
-        
+
         public Double GetDouble() => Value.GetNumber();
-        
+
         public string GetText() => Value.GetText();
 
         public XLError GetError() => Value.GetError();
@@ -1568,199 +1558,12 @@ namespace ClosedXML.Excel
 
         internal string GetFormulaR1C1(string value)
         {
-            return GetFormula(value, FormulaConversionType.A1ToR1C1, new XLSheetPoint(_rowNumber, _columnNumber));
+            return CellFormula.GetFormula(value, FormulaConversionType.A1ToR1C1, new XLSheetPoint(_rowNumber, _columnNumber));
         }
 
         internal string GetFormulaA1(string value)
         {
-            return GetFormula(value, FormulaConversionType.R1C1ToA1, new XLSheetPoint(_rowNumber, _columnNumber));
-        }
-
-        private static string GetFormula(string strValue, FormulaConversionType conversionType, XLSheetPoint cellAddress)
-        {
-            if (String.IsNullOrWhiteSpace(strValue))
-                return String.Empty;
-
-            var value = ">" + strValue + "<";
-
-            var regex = conversionType == FormulaConversionType.A1ToR1C1 ? A1Regex : R1C1Regex;
-
-            var sb = new StringBuilder();
-            var lastIndex = 0;
-
-            foreach (var match in regex.Matches(value).Cast<Match>())
-            {
-                var matchString = match.Value;
-                var matchIndex = match.Index;
-                if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0
-                    && value.Substring(0, matchIndex).CharCount('\'') % 2 == 0)
-                {
-                    // Check if the match is in between quotes
-                    sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
-                    sb.Append(conversionType == FormulaConversionType.A1ToR1C1
-                        ? GetR1C1Address(matchString, cellAddress)
-                        : GetA1Address(matchString, cellAddress));
-                }
-                else
-                    sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
-                lastIndex = matchIndex + matchString.Length;
-            }
-
-            if (lastIndex < value.Length)
-                sb.Append(value.Substring(lastIndex));
-
-            var retVal = sb.ToString();
-            return retVal.Substring(1, retVal.Length - 2);
-        }
-
-        private static string GetA1Address(string r1C1Address, XLSheetPoint cellAddress)
-        {
-            var addressToUse = r1C1Address.ToUpper();
-
-            if (addressToUse.Contains(':'))
-            {
-                var parts = addressToUse.Split(':');
-                var p1 = parts[0];
-                var p2 = parts[1];
-                string leftPart;
-                string rightPart;
-                if (p1.StartsWith("R"))
-                {
-                    leftPart = GetA1Row(p1, cellAddress.Row);
-                    rightPart = GetA1Row(p2, cellAddress.Row);
-                }
-                else
-                {
-                    leftPart = GetA1Column(p1, cellAddress.Column);
-                    rightPart = GetA1Column(p2, cellAddress.Column);
-                }
-
-                return leftPart + ":" + rightPart;
-            }
-
-            try
-            {
-                var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
-                var rowToReturn = GetA1Row(rowPart, cellAddress.Row);
-
-                var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
-                var columnToReturn = GetA1Column(columnPart, cellAddress.Column);
-
-                var retAddress = columnToReturn + rowToReturn;
-                return retAddress;
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                return "#REF!";
-            }
-        }
-
-        private static string GetA1Column(string columnPartRC, int cellColumn)
-        {
-            string columnToReturn;
-            if (columnPartRC == "C")
-                columnToReturn = XLHelper.GetColumnLetterFromNumber(cellColumn);
-            else
-            {
-                var bIndex = columnPartRC.IndexOf("[");
-                var mIndex = columnPartRC.IndexOf("-");
-                if (bIndex >= 0)
-                {
-                    columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        cellColumn +
-                        Int32.Parse(columnPartRC.Substring(bIndex + 1, columnPartRC.Length - bIndex - 2))
-                        );
-                }
-                else if (mIndex >= 0)
-                {
-                    columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        cellColumn + Int32.Parse(columnPartRC.Substring(mIndex))
-                        );
-                }
-                else
-                {
-                    columnToReturn = "$" +
-                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPartRC.Substring(1)));
-                }
-            }
-
-            return columnToReturn;
-        }
-
-        private static string GetA1Row(string rowPartRC, int cellRow)
-        {
-            string rowToReturn;
-            if (rowPartRC == "R")
-                rowToReturn = cellRow.ToString();
-            else
-            {
-                var bIndex = rowPartRC.IndexOf("[");
-                if (bIndex >= 0)
-                {
-                    rowToReturn =
-                        (cellRow + Int32.Parse(rowPartRC.Substring(bIndex + 1, rowPartRC.Length - bIndex - 2))).ToString();
-                }
-                else
-                    rowToReturn = "$" + (Int32.Parse(rowPartRC.Substring(1)));
-            }
-
-            return rowToReturn;
-        }
-
-        private static string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
-        {
-            if (a1Address.Contains(':'))
-            {
-                var parts = a1Address.Split(':');
-                var p1 = parts[0];
-                var p2 = parts[1];
-                if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
-                {
-                    var row2 = Int32.Parse(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), cellAddress.Row);
-                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), cellAddress.Row);
-                    return leftPart + ":" + rightPart;
-                }
-                else
-                {
-                    var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
-                    var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), cellAddress.Column);
-                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), cellAddress.Column);
-                    return leftPart + ":" + rightPart;
-                }
-            }
-
-            var address = XLAddress.Create(a1Address);
-
-            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
-            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);
-
-            return rowPart + columnPart;
-        }
-
-        private static string GetR1C1Row(int rowNumber, bool fixedRow, int cellRow)
-        {
-            string rowPart;
-            var rowDiff = rowNumber - cellRow;
-            if (rowDiff != 0 || fixedRow)
-                rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
-            else
-                rowPart = "R";
-
-            return rowPart;
-        }
-
-        private static string GetR1C1Column(int columnNumber, bool fixedColumn, int cellColumn)
-        {
-            string columnPart;
-            var columnDiff = columnNumber - cellColumn;
-            if (columnDiff != 0 || fixedColumn)
-                columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";
-            else
-                columnPart = "C";
-
-            return columnPart;
+            return CellFormula.GetFormula(value, FormulaConversionType.R1C1ToA1, new XLSheetPoint(_rowNumber, _columnNumber));
         }
 
         internal void CopyValuesFrom(XLCell source)
@@ -2340,12 +2143,210 @@ namespace ClosedXML.Excel
 
         private class CellFormula
         {
+            private static readonly Regex A1Regex = new(
+                @"(?<=\W)(\$?[a-zA-Z]{1,3}\$?\d{1,7})(?=\W)" // A1
+                + @"|(?<=\W)(\$?\d{1,7}:\$?\d{1,7})(?=\W)" // 1:1
+                + @"|(?<=\W)(\$?[a-zA-Z]{1,3}:\$?[a-zA-Z]{1,3})(?=\W)", RegexOptions.Compiled); // A:A
+
+            private static readonly Regex R1C1Regex = new(
+                @"(?<=\W)([Rr](?:\[-?\d{0,7}\]|\d{0,7})?[Cc](?:\[-?\d{0,7}\]|\d{0,7})?)(?=\W)" // R1C1
+                + @"|(?<=\W)([Rr]\[?-?\d{0,7}\]?:[Rr]\[?-?\d{0,7}\]?)(?=\W)" // R:R
+                + @"|(?<=\W)([Cc]\[?-?\d{0,5}\]?:[Cc]\[?-?\d{0,5}\]?)(?=\W)", RegexOptions.Compiled); // C:C
+
             internal string A1;
             internal string R1C1;
 
             internal bool HasAnyFormula =>
                 !String.IsNullOrWhiteSpace(A1) ||
                 !String.IsNullOrEmpty(R1C1);
+
+            internal static string GetFormula(string strValue, FormulaConversionType conversionType, XLSheetPoint cellAddress)
+            {
+                if (String.IsNullOrWhiteSpace(strValue))
+                    return String.Empty;
+
+                var value = ">" + strValue + "<";
+
+                var regex = conversionType == FormulaConversionType.A1ToR1C1 ? A1Regex : R1C1Regex;
+
+                var sb = new StringBuilder();
+                var lastIndex = 0;
+
+                foreach (var match in regex.Matches(value).Cast<Match>())
+                {
+                    var matchString = match.Value;
+                    var matchIndex = match.Index;
+                    if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0
+                        && value.Substring(0, matchIndex).CharCount('\'') % 2 == 0)
+                    {
+                        // Check if the match is in between quotes
+                        sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
+                        sb.Append(conversionType == FormulaConversionType.A1ToR1C1
+                            ? GetR1C1Address(matchString, cellAddress)
+                            : GetA1Address(matchString, cellAddress));
+                    }
+                    else
+                        sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
+                    lastIndex = matchIndex + matchString.Length;
+                }
+
+                if (lastIndex < value.Length)
+                    sb.Append(value.Substring(lastIndex));
+
+                var retVal = sb.ToString();
+                return retVal.Substring(1, retVal.Length - 2);
+            }
+
+            private static string GetA1Address(string r1C1Address, XLSheetPoint cellAddress)
+            {
+                var addressToUse = r1C1Address.ToUpper();
+
+                if (addressToUse.Contains(':'))
+                {
+                    var parts = addressToUse.Split(':');
+                    var p1 = parts[0];
+                    var p2 = parts[1];
+                    string leftPart;
+                    string rightPart;
+                    if (p1.StartsWith("R"))
+                    {
+                        leftPart = GetA1Row(p1, cellAddress.Row);
+                        rightPart = GetA1Row(p2, cellAddress.Row);
+                    }
+                    else
+                    {
+                        leftPart = GetA1Column(p1, cellAddress.Column);
+                        rightPart = GetA1Column(p2, cellAddress.Column);
+                    }
+
+                    return leftPart + ":" + rightPart;
+                }
+
+                try
+                {
+                    var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
+                    var rowToReturn = GetA1Row(rowPart, cellAddress.Row);
+
+                    var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
+                    var columnToReturn = GetA1Column(columnPart, cellAddress.Column);
+
+                    var retAddress = columnToReturn + rowToReturn;
+                    return retAddress;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    return "#REF!";
+                }
+            }
+
+            private static string GetA1Column(string columnPartRC, int cellColumn)
+            {
+                string columnToReturn;
+                if (columnPartRC == "C")
+                    columnToReturn = XLHelper.GetColumnLetterFromNumber(cellColumn);
+                else
+                {
+                    var bIndex = columnPartRC.IndexOf("[");
+                    var mIndex = columnPartRC.IndexOf("-");
+                    if (bIndex >= 0)
+                    {
+                        columnToReturn = XLHelper.GetColumnLetterFromNumber(
+                            cellColumn +
+                            Int32.Parse(columnPartRC.Substring(bIndex + 1, columnPartRC.Length - bIndex - 2))
+                            );
+                    }
+                    else if (mIndex >= 0)
+                    {
+                        columnToReturn = XLHelper.GetColumnLetterFromNumber(
+                            cellColumn + Int32.Parse(columnPartRC.Substring(mIndex))
+                            );
+                    }
+                    else
+                    {
+                        columnToReturn = "$" +
+                                         XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPartRC.Substring(1)));
+                    }
+                }
+
+                return columnToReturn;
+            }
+
+            private static string GetA1Row(string rowPartRC, int cellRow)
+            {
+                string rowToReturn;
+                if (rowPartRC == "R")
+                    rowToReturn = cellRow.ToString();
+                else
+                {
+                    var bIndex = rowPartRC.IndexOf("[");
+                    if (bIndex >= 0)
+                    {
+                        rowToReturn =
+                            (cellRow + Int32.Parse(rowPartRC.Substring(bIndex + 1, rowPartRC.Length - bIndex - 2))).ToString();
+                    }
+                    else
+                        rowToReturn = "$" + (Int32.Parse(rowPartRC.Substring(1)));
+                }
+
+                return rowToReturn;
+            }
+
+            private static string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
+            {
+                if (a1Address.Contains(':'))
+                {
+                    var parts = a1Address.Split(':');
+                    var p1 = parts[0];
+                    var p2 = parts[1];
+                    if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
+                    {
+                        var row2 = Int32.Parse(p2.Replace("$", string.Empty));
+                        var leftPart = GetR1C1Row(row1, p1.Contains('$'), cellAddress.Row);
+                        var rightPart = GetR1C1Row(row2, p2.Contains('$'), cellAddress.Row);
+                        return leftPart + ":" + rightPart;
+                    }
+                    else
+                    {
+                        var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
+                        var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
+                        var leftPart = GetR1C1Column(column1, p1.Contains('$'), cellAddress.Column);
+                        var rightPart = GetR1C1Column(column2, p2.Contains('$'), cellAddress.Column);
+                        return leftPart + ":" + rightPart;
+                    }
+                }
+
+                var address = XLAddress.Create(a1Address);
+
+                var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
+                var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);
+
+                return rowPart + columnPart;
+            }
+
+            private static string GetR1C1Row(int rowNumber, bool fixedRow, int cellRow)
+            {
+                string rowPart;
+                var rowDiff = rowNumber - cellRow;
+                if (rowDiff != 0 || fixedRow)
+                    rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
+                else
+                    rowPart = "R";
+
+                return rowPart;
+            }
+
+            private static string GetR1C1Column(int columnNumber, bool fixedColumn, int cellColumn)
+            {
+                string columnPart;
+                var columnDiff = columnNumber - cellColumn;
+                if (columnDiff != 0 || fixedColumn)
+                    columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";
+                else
+                    columnPart = "C";
+
+                return columnPart;
+            }
+
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1626,8 +1626,8 @@ namespace ClosedXML.Excel
                 string rightPart;
                 if (p1.StartsWith("R"))
                 {
-                    leftPart = GetA1Row(p1);
-                    rightPart = GetA1Row(p2);
+                    leftPart = GetA1Row(p1, _rowNumber);
+                    rightPart = GetA1Row(p2, _rowNumber);
                 }
                 else
                 {
@@ -1641,7 +1641,7 @@ namespace ClosedXML.Excel
             try
             {
                 var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
-                var rowToReturn = GetA1Row(rowPart);
+                var rowToReturn = GetA1Row(rowPart, _rowNumber);
 
                 var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
                 var columnToReturn = GetA1Column(columnPart);
@@ -1687,21 +1687,21 @@ namespace ClosedXML.Excel
             return columnToReturn;
         }
 
-        private string GetA1Row(string rowPart)
+        private static string GetA1Row(string rowPartRC, int cellRow)
         {
             string rowToReturn;
-            if (rowPart == "R")
-                rowToReturn = _rowNumber.ToString();
+            if (rowPartRC == "R")
+                rowToReturn = cellRow.ToString();
             else
             {
-                var bIndex = rowPart.IndexOf("[");
+                var bIndex = rowPartRC.IndexOf("[");
                 if (bIndex >= 0)
                 {
                     rowToReturn =
-                        (_rowNumber + Int32.Parse(rowPart.Substring(bIndex + 1, rowPart.Length - bIndex - 2))).ToString();
+                        (cellRow + Int32.Parse(rowPartRC.Substring(bIndex + 1, rowPartRC.Length - bIndex - 2))).ToString();
                 }
                 else
-                    rowToReturn = "$" + (Int32.Parse(rowPart.Substring(1)));
+                    rowToReturn = "$" + (Int32.Parse(rowPartRC.Substring(1)));
             }
 
             return rowToReturn;

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1707,7 +1707,7 @@ namespace ClosedXML.Excel
             return rowToReturn;
         }
 
-        private string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
+        private static string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
         {
             if (a1Address.Contains(':'))
             {
@@ -1731,7 +1731,7 @@ namespace ClosedXML.Excel
                 }
             }
 
-            var address = XLAddress.Create(Worksheet, a1Address);
+            var address = XLAddress.Create(a1Address);
 
             var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
             var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -887,13 +887,12 @@ namespace ClosedXML.Excel
             {
                 if (String.IsNullOrWhiteSpace(_formula.A1))
                 {
-                    if (!String.IsNullOrWhiteSpace(_formula.R1C1))
+                    if (String.IsNullOrWhiteSpace(_formula.R1C1))
                     {
-                        _formula.A1 = GetFormulaA1(_formula.R1C1);
-                        return FormulaA1;
+                        return String.Empty;
                     }
 
-                    return String.Empty;
+                    _formula.A1 = GetFormulaA1(_formula.R1C1);
                 }
 
                 if (_formula.A1.Trim()[0] == '=')

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1598,7 +1598,7 @@ namespace ClosedXML.Excel
                     // Check if the match is in between quotes
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
                     sb.Append(conversionType == FormulaConversionType.A1ToR1C1
-                        ? GetR1C1Address(matchString)
+                        ? GetR1C1Address(matchString, new XLSheetPoint(_rowNumber, _columnNumber))
                         : GetA1Address(matchString, new XLSheetPoint(_rowNumber, _columnNumber)));
                 }
                 else
@@ -1707,7 +1707,7 @@ namespace ClosedXML.Excel
             return rowToReturn;
         }
 
-        private string GetR1C1Address(string a1Address)
+        private string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
         {
             if (a1Address.Contains(':'))
             {
@@ -1717,24 +1717,24 @@ namespace ClosedXML.Excel
                 if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
                 {
                     var row2 = Int32.Parse(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), _rowNumber);
-                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), _rowNumber);
+                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), cellAddress.Row);
+                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), cellAddress.Row);
                     return leftPart + ":" + rightPart;
                 }
                 else
                 {
                     var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
                     var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), _columnNumber);
-                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), _columnNumber);
+                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), cellAddress.Column);
+                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), cellAddress.Column);
                     return leftPart + ":" + rightPart;
                 }
             }
 
             var address = XLAddress.Create(Worksheet, a1Address);
 
-            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, _rowNumber);
-            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, _columnNumber);
+            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
+            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);
 
             return rowPart + columnPart;
         }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -883,26 +883,7 @@ namespace ClosedXML.Excel
 
         public string FormulaA1
         {
-            get
-            {
-                if (String.IsNullOrWhiteSpace(_formula.A1))
-                {
-                    if (String.IsNullOrWhiteSpace(_formula.R1C1))
-                    {
-                        return String.Empty;
-                    }
-
-                    _formula.A1 = GetFormulaA1(_formula.R1C1);
-                }
-
-                if (_formula.A1.Trim()[0] == '=')
-                    return _formula.A1.Substring(1);
-
-                if (_formula.A1.Trim().StartsWith("{="))
-                    return "{" + _formula.A1.Substring(2);
-
-                return _formula.A1;
-            }
+            get => _formula.GetFormulaA1(new XLSheetPoint(_rowNumber, _columnNumber));
 
             set
             {
@@ -2158,6 +2139,31 @@ namespace ClosedXML.Excel
             internal bool HasAnyFormula =>
                 !String.IsNullOrWhiteSpace(A1) ||
                 !String.IsNullOrEmpty(R1C1);
+
+            /// <summary>
+            /// Get stored formula or or <c>string.Empty</c> if both A1/R1C1 are empty.
+            /// Formula doesn't contain artificial equal sign.
+            /// </summary>
+            public string GetFormulaA1(XLSheetPoint cellAddress)
+            {
+                if (String.IsNullOrWhiteSpace(A1))
+                {
+                    if (String.IsNullOrWhiteSpace(R1C1))
+                    {
+                        return String.Empty;
+                    }
+
+                    A1 = GetFormula(R1C1, FormulaConversionType.R1C1ToA1, cellAddress);
+                }
+
+                if (A1.Trim()[0] == '=')
+                    return A1.Substring(1);
+
+                if (A1.Trim().StartsWith("{="))
+                    return "{" + A1.Substring(2);
+
+                return A1;
+            }
 
             internal static string GetFormula(string strValue, FormulaConversionType conversionType, XLSheetPoint cellAddress)
             {

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1707,7 +1707,7 @@ namespace ClosedXML.Excel
             return rowToReturn;
         }
 
-        private string GetR1C1Address(string a1Address, int rowsToShift = 0, int columnsToShift = 0)
+        private string GetR1C1Address(string a1Address)
         {
             if (a1Address.Contains(':'))
             {
@@ -1717,32 +1717,31 @@ namespace ClosedXML.Excel
                 if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
                 {
                     var row2 = Int32.Parse(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), rowsToShift);
-                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), rowsToShift);
+                    var leftPart = GetR1C1Row(row1, p1.Contains('$'));
+                    var rightPart = GetR1C1Row(row2, p2.Contains('$'));
                     return leftPart + ":" + rightPart;
                 }
                 else
                 {
                     var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
                     var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), columnsToShift);
-                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), columnsToShift);
+                    var leftPart = GetR1C1Column(column1, p1.Contains('$'));
+                    var rightPart = GetR1C1Column(column2, p2.Contains('$'));
                     return leftPart + ":" + rightPart;
                 }
             }
 
             var address = XLAddress.Create(Worksheet, a1Address);
 
-            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, rowsToShift);
-            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, columnsToShift);
+            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow);
+            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn);
 
             return rowPart + columnPart;
         }
 
-        private string GetR1C1Row(int rowNumber, bool fixedRow, int rowsToShift)
+        private string GetR1C1Row(int rowNumber, bool fixedRow)
         {
             string rowPart;
-            rowNumber += rowsToShift;
             var rowDiff = rowNumber - _rowNumber;
             if (rowDiff != 0 || fixedRow)
                 rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
@@ -1752,10 +1751,9 @@ namespace ClosedXML.Excel
             return rowPart;
         }
 
-        private string GetR1C1Column(int columnNumber, bool fixedColumn, int columnsToShift)
+        private string GetR1C1Column(int columnNumber, bool fixedColumn)
         {
             string columnPart;
-            columnNumber += columnsToShift;
             var columnDiff = columnNumber - _columnNumber;
             if (columnDiff != 0 || fixedColumn)
                 columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1568,15 +1568,15 @@ namespace ClosedXML.Excel
 
         internal string GetFormulaR1C1(string value)
         {
-            return GetFormula(value, FormulaConversionType.A1ToR1C1);
+            return GetFormula(value, FormulaConversionType.A1ToR1C1, new XLSheetPoint(_rowNumber, _columnNumber));
         }
 
         internal string GetFormulaA1(string value)
         {
-            return GetFormula(value, FormulaConversionType.R1C1ToA1);
+            return GetFormula(value, FormulaConversionType.R1C1ToA1, new XLSheetPoint(_rowNumber, _columnNumber));
         }
 
-        private string GetFormula(string strValue, FormulaConversionType conversionType)
+        private static string GetFormula(string strValue, FormulaConversionType conversionType, XLSheetPoint cellAddress)
         {
             if (String.IsNullOrWhiteSpace(strValue))
                 return String.Empty;
@@ -1598,8 +1598,8 @@ namespace ClosedXML.Excel
                     // Check if the match is in between quotes
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
                     sb.Append(conversionType == FormulaConversionType.A1ToR1C1
-                        ? GetR1C1Address(matchString, new XLSheetPoint(_rowNumber, _columnNumber))
-                        : GetA1Address(matchString, new XLSheetPoint(_rowNumber, _columnNumber)));
+                        ? GetR1C1Address(matchString, cellAddress)
+                        : GetA1Address(matchString, cellAddress));
                 }
                 else
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1599,7 +1599,7 @@ namespace ClosedXML.Excel
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
                     sb.Append(conversionType == FormulaConversionType.A1ToR1C1
                         ? GetR1C1Address(matchString)
-                        : GetA1Address(matchString));
+                        : GetA1Address(matchString, new XLSheetPoint(_rowNumber, _columnNumber)));
                 }
                 else
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
@@ -1613,7 +1613,7 @@ namespace ClosedXML.Excel
             return retVal.Substring(1, retVal.Length - 2);
         }
 
-        private string GetA1Address(string r1C1Address)
+        private static string GetA1Address(string r1C1Address, XLSheetPoint cellAddress)
         {
             var addressToUse = r1C1Address.ToUpper();
 
@@ -1626,13 +1626,13 @@ namespace ClosedXML.Excel
                 string rightPart;
                 if (p1.StartsWith("R"))
                 {
-                    leftPart = GetA1Row(p1, _rowNumber);
-                    rightPart = GetA1Row(p2, _rowNumber);
+                    leftPart = GetA1Row(p1, cellAddress.Row);
+                    rightPart = GetA1Row(p2, cellAddress.Row);
                 }
                 else
                 {
-                    leftPart = GetA1Column(p1, _columnNumber);
-                    rightPart = GetA1Column(p2, _columnNumber);
+                    leftPart = GetA1Column(p1, cellAddress.Column);
+                    rightPart = GetA1Column(p2, cellAddress.Column);
                 }
 
                 return leftPart + ":" + rightPart;
@@ -1641,10 +1641,10 @@ namespace ClosedXML.Excel
             try
             {
                 var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
-                var rowToReturn = GetA1Row(rowPart, _rowNumber);
+                var rowToReturn = GetA1Row(rowPart, cellAddress.Row);
 
                 var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
-                var columnToReturn = GetA1Column(columnPart, _columnNumber);
+                var columnToReturn = GetA1Column(columnPart, cellAddress.Column);
 
                 var retAddress = columnToReturn + rowToReturn;
                 return retAddress;

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -921,6 +921,8 @@ namespace ClosedXML.Excel
             }
         }
 
+        internal XLCellFormula Formula => _formula;
+
         public XLHyperlink GetHyperlink()
         {
             return _hyperlink ?? CreateHyperlink();

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -602,8 +602,7 @@ namespace ClosedXML.Excel
         {
             get
             {
-                if (!String.IsNullOrWhiteSpace(_formula.A1) ||
-                    !String.IsNullOrEmpty(_formula.R1C1))
+                if (_formula.HasAnyFormula)
                 {
                     Evaluate(false);
                 }
@@ -2348,6 +2347,10 @@ namespace ClosedXML.Excel
         {
             internal string A1;
             internal string R1C1;
+
+            internal bool HasAnyFormula =>
+                !String.IsNullOrWhiteSpace(A1) ||
+                !String.IsNullOrEmpty(R1C1);
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1568,16 +1568,15 @@ namespace ClosedXML.Excel
 
         internal string GetFormulaR1C1(string value)
         {
-            return GetFormula(value, FormulaConversionType.A1ToR1C1, 0, 0);
+            return GetFormula(value, FormulaConversionType.A1ToR1C1);
         }
 
         internal string GetFormulaA1(string value)
         {
-            return GetFormula(value, FormulaConversionType.R1C1ToA1, 0, 0);
+            return GetFormula(value, FormulaConversionType.R1C1ToA1);
         }
 
-        private string GetFormula(string strValue, FormulaConversionType conversionType, int rowsToShift,
-                                  int columnsToShift)
+        private string GetFormula(string strValue, FormulaConversionType conversionType)
         {
             if (String.IsNullOrWhiteSpace(strValue))
                 return String.Empty;
@@ -1599,8 +1598,8 @@ namespace ClosedXML.Excel
                     // Check if the match is in between quotes
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
                     sb.Append(conversionType == FormulaConversionType.A1ToR1C1
-                        ? GetR1C1Address(matchString, rowsToShift, columnsToShift)
-                        : GetA1Address(matchString, rowsToShift, columnsToShift));
+                        ? GetR1C1Address(matchString)
+                        : GetA1Address(matchString));
                 }
                 else
                     sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
@@ -1614,7 +1613,7 @@ namespace ClosedXML.Excel
             return retVal.Substring(1, retVal.Length - 2);
         }
 
-        private string GetA1Address(string r1C1Address, int rowsToShift, int columnsToShift)
+        private string GetA1Address(string r1C1Address)
         {
             var addressToUse = r1C1Address.ToUpper();
 
@@ -1627,13 +1626,13 @@ namespace ClosedXML.Excel
                 string rightPart;
                 if (p1.StartsWith("R"))
                 {
-                    leftPart = GetA1Row(p1, rowsToShift);
-                    rightPart = GetA1Row(p2, rowsToShift);
+                    leftPart = GetA1Row(p1);
+                    rightPart = GetA1Row(p2);
                 }
                 else
                 {
-                    leftPart = GetA1Column(p1, columnsToShift);
-                    rightPart = GetA1Column(p2, columnsToShift);
+                    leftPart = GetA1Column(p1);
+                    rightPart = GetA1Column(p2);
                 }
 
                 return leftPart + ":" + rightPart;
@@ -1642,10 +1641,10 @@ namespace ClosedXML.Excel
             try
             {
                 var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
-                var rowToReturn = GetA1Row(rowPart, rowsToShift);
+                var rowToReturn = GetA1Row(rowPart);
 
                 var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
-                var columnToReturn = GetA1Column(columnPart, columnsToShift);
+                var columnToReturn = GetA1Column(columnPart);
 
                 var retAddress = columnToReturn + rowToReturn;
                 return retAddress;
@@ -1656,11 +1655,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        private string GetA1Column(string columnPart, int columnsToShift)
+        private string GetA1Column(string columnPart)
         {
             string columnToReturn;
             if (columnPart == "C")
-                columnToReturn = XLHelper.GetColumnLetterFromNumber(_columnNumber + columnsToShift);
+                columnToReturn = XLHelper.GetColumnLetterFromNumber(_columnNumber);
             else
             {
                 var bIndex = columnPart.IndexOf("[");
@@ -1669,48 +1668,46 @@ namespace ClosedXML.Excel
                 {
                     columnToReturn = XLHelper.GetColumnLetterFromNumber(
                         _columnNumber +
-                        Int32.Parse(columnPart.Substring(bIndex + 1, columnPart.Length - bIndex - 2)) + columnsToShift
+                        Int32.Parse(columnPart.Substring(bIndex + 1, columnPart.Length - bIndex - 2))
                         );
                 }
                 else if (mIndex >= 0)
                 {
                     columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        _columnNumber + Int32.Parse(columnPart.Substring(mIndex)) + columnsToShift
+                        _columnNumber + Int32.Parse(columnPart.Substring(mIndex))
                         );
                 }
                 else
                 {
                     columnToReturn = "$" +
-                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPart.Substring(1)) +
-                                                                        columnsToShift);
+                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPart.Substring(1)));
                 }
             }
 
             return columnToReturn;
         }
 
-        private string GetA1Row(string rowPart, int rowsToShift)
+        private string GetA1Row(string rowPart)
         {
             string rowToReturn;
             if (rowPart == "R")
-                rowToReturn = (_rowNumber + rowsToShift).ToString();
+                rowToReturn = _rowNumber.ToString();
             else
             {
                 var bIndex = rowPart.IndexOf("[");
                 if (bIndex >= 0)
                 {
                     rowToReturn =
-                        (_rowNumber + Int32.Parse(rowPart.Substring(bIndex + 1, rowPart.Length - bIndex - 2)) +
-                         rowsToShift).ToString();
+                        (_rowNumber + Int32.Parse(rowPart.Substring(bIndex + 1, rowPart.Length - bIndex - 2))).ToString();
                 }
                 else
-                    rowToReturn = "$" + (Int32.Parse(rowPart.Substring(1)) + rowsToShift);
+                    rowToReturn = "$" + (Int32.Parse(rowPart.Substring(1)));
             }
 
             return rowToReturn;
         }
 
-        private string GetR1C1Address(string a1Address, int rowsToShift, int columnsToShift)
+        private string GetR1C1Address(string a1Address, int rowsToShift = 0, int columnsToShift = 0)
         {
             if (a1Address.Contains(':'))
             {

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ClosedXML.Excel
+{
+    internal enum FormulaConversionType
+    {
+        A1ToR1C1,
+        R1C1ToA1
+    };
+
+    /// <summary>
+    /// A representation of a cell formula, not the formula itself (i.e. the tree).
+    /// </summary>
+    internal class XLCellFormula
+    {
+        private static readonly Regex A1Regex = new(
+            @"(?<=\W)(\$?[a-zA-Z]{1,3}\$?\d{1,7})(?=\W)" // A1
+            + @"|(?<=\W)(\$?\d{1,7}:\$?\d{1,7})(?=\W)" // 1:1
+            + @"|(?<=\W)(\$?[a-zA-Z]{1,3}:\$?[a-zA-Z]{1,3})(?=\W)", RegexOptions.Compiled); // A:A
+
+        private static readonly Regex R1C1Regex = new(
+            @"(?<=\W)([Rr](?:\[-?\d{0,7}\]|\d{0,7})?[Cc](?:\[-?\d{0,7}\]|\d{0,7})?)(?=\W)" // R1C1
+            + @"|(?<=\W)([Rr]\[?-?\d{0,7}\]?:[Rr]\[?-?\d{0,7}\]?)(?=\W)" // R:R
+            + @"|(?<=\W)([Cc]\[?-?\d{0,5}\]?:[Cc]\[?-?\d{0,5}\]?)(?=\W)", RegexOptions.Compiled); // C:C
+
+        internal string A1;
+        internal string R1C1;
+
+        internal bool HasAnyFormula =>
+            !String.IsNullOrWhiteSpace(A1) ||
+            !String.IsNullOrEmpty(R1C1);
+
+        /// <summary>
+        /// Get stored formula or or <c>string.Empty</c> if both A1/R1C1 are empty.
+        /// Formula doesn't contain artificial equal sign.
+        /// </summary>
+        public string GetFormulaA1(XLSheetPoint cellAddress)
+        {
+            if (String.IsNullOrWhiteSpace(A1))
+            {
+                if (String.IsNullOrWhiteSpace(R1C1))
+                {
+                    return String.Empty;
+                }
+
+                A1 = GetFormula(R1C1, FormulaConversionType.R1C1ToA1, cellAddress);
+            }
+
+            if (A1.Trim()[0] == '=')
+                return A1.Substring(1);
+
+            if (A1.Trim().StartsWith("{="))
+                return "{" + A1.Substring(2);
+
+            return A1;
+        }
+
+        internal static string GetFormula(string strValue, FormulaConversionType conversionType, XLSheetPoint cellAddress)
+        {
+            if (String.IsNullOrWhiteSpace(strValue))
+                return String.Empty;
+
+            var value = ">" + strValue + "<";
+
+            var regex = conversionType == FormulaConversionType.A1ToR1C1 ? A1Regex : R1C1Regex;
+
+            var sb = new StringBuilder();
+            var lastIndex = 0;
+
+            foreach (var match in regex.Matches(value).Cast<Match>())
+            {
+                var matchString = match.Value;
+                var matchIndex = match.Index;
+                if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0
+                    && value.Substring(0, matchIndex).CharCount('\'') % 2 == 0)
+                {
+                    // Check if the match is in between quotes
+                    sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
+                    sb.Append(conversionType == FormulaConversionType.A1ToR1C1
+                        ? GetR1C1Address(matchString, cellAddress)
+                        : GetA1Address(matchString, cellAddress));
+                }
+                else
+                    sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
+                lastIndex = matchIndex + matchString.Length;
+            }
+
+            if (lastIndex < value.Length)
+                sb.Append(value.Substring(lastIndex));
+
+            var retVal = sb.ToString();
+            return retVal.Substring(1, retVal.Length - 2);
+        }
+
+        private static string GetA1Address(string r1C1Address, XLSheetPoint cellAddress)
+        {
+            var addressToUse = r1C1Address.ToUpper();
+
+            if (addressToUse.Contains(':'))
+            {
+                var parts = addressToUse.Split(':');
+                var p1 = parts[0];
+                var p2 = parts[1];
+                string leftPart;
+                string rightPart;
+                if (p1.StartsWith("R"))
+                {
+                    leftPart = GetA1Row(p1, cellAddress.Row);
+                    rightPart = GetA1Row(p2, cellAddress.Row);
+                }
+                else
+                {
+                    leftPart = GetA1Column(p1, cellAddress.Column);
+                    rightPart = GetA1Column(p2, cellAddress.Column);
+                }
+
+                return leftPart + ":" + rightPart;
+            }
+
+            try
+            {
+                var rowPart = addressToUse.Substring(0, addressToUse.IndexOf("C"));
+                var rowToReturn = GetA1Row(rowPart, cellAddress.Row);
+
+                var columnPart = addressToUse.Substring(addressToUse.IndexOf("C"));
+                var columnToReturn = GetA1Column(columnPart, cellAddress.Column);
+
+                var retAddress = columnToReturn + rowToReturn;
+                return retAddress;
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return "#REF!";
+            }
+        }
+
+        private static string GetA1Column(string columnPartRC, int cellColumn)
+        {
+            string columnToReturn;
+            if (columnPartRC == "C")
+                columnToReturn = XLHelper.GetColumnLetterFromNumber(cellColumn);
+            else
+            {
+                var bIndex = columnPartRC.IndexOf("[");
+                var mIndex = columnPartRC.IndexOf("-");
+                if (bIndex >= 0)
+                {
+                    columnToReturn = XLHelper.GetColumnLetterFromNumber(
+                        cellColumn +
+                        Int32.Parse(columnPartRC.Substring(bIndex + 1, columnPartRC.Length - bIndex - 2))
+                    );
+                }
+                else if (mIndex >= 0)
+                {
+                    columnToReturn = XLHelper.GetColumnLetterFromNumber(
+                        cellColumn + Int32.Parse(columnPartRC.Substring(mIndex))
+                    );
+                }
+                else
+                {
+                    columnToReturn = "$" +
+                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPartRC.Substring(1)));
+                }
+            }
+
+            return columnToReturn;
+        }
+
+        private static string GetA1Row(string rowPartRC, int cellRow)
+        {
+            string rowToReturn;
+            if (rowPartRC == "R")
+                rowToReturn = cellRow.ToString();
+            else
+            {
+                var bIndex = rowPartRC.IndexOf("[");
+                if (bIndex >= 0)
+                {
+                    rowToReturn =
+                        (cellRow + Int32.Parse(rowPartRC.Substring(bIndex + 1, rowPartRC.Length - bIndex - 2))).ToString();
+                }
+                else
+                    rowToReturn = "$" + (Int32.Parse(rowPartRC.Substring(1)));
+            }
+
+            return rowToReturn;
+        }
+
+        private static string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
+        {
+            if (a1Address.Contains(':'))
+            {
+                var parts = a1Address.Split(':');
+                var p1 = parts[0];
+                var p2 = parts[1];
+                if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
+                {
+                    var row2 = Int32.Parse(p2.Replace("$", string.Empty));
+                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), cellAddress.Row);
+                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), cellAddress.Row);
+                    return leftPart + ":" + rightPart;
+                }
+                else
+                {
+                    var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
+                    var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
+                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), cellAddress.Column);
+                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), cellAddress.Column);
+                    return leftPart + ":" + rightPart;
+                }
+            }
+
+            var address = XLAddress.Create(a1Address);
+
+            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
+            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);
+
+            return rowPart + columnPart;
+        }
+
+        private static string GetR1C1Row(int rowNumber, bool fixedRow, int cellRow)
+        {
+            string rowPart;
+            var rowDiff = rowNumber - cellRow;
+            if (rowDiff != 0 || fixedRow)
+                rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
+            else
+                rowPart = "R";
+
+            return rowPart;
+        }
+
+        private static string GetR1C1Column(int columnNumber, bool fixedColumn, int cellColumn)
+        {
+            string columnPart;
+            var columnDiff = columnNumber - cellColumn;
+            if (columnDiff != 0 || fixedColumn)
+                columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";
+            else
+                columnPart = "C";
+
+            return columnPart;
+        }
+    }
+}

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -5,6 +5,14 @@ using System.Text.RegularExpressions;
 
 namespace ClosedXML.Excel
 {
+    internal enum FormulaType : byte
+    {
+        Normal,
+        Array,
+        DataTable,
+        Shared // Not used
+    }
+
     internal enum FormulaConversionType
     {
         A1ToR1C1,
@@ -26,12 +34,20 @@ namespace ClosedXML.Excel
             + @"|(?<=\W)([Rr]\[?-?\d{0,7}\]?:[Rr]\[?-?\d{0,7}\]?)(?=\W)" // R:R
             + @"|(?<=\W)([Cc]\[?-?\d{0,5}\]?:[Cc]\[?-?\d{0,5}\]?)(?=\W)", RegexOptions.Compiled); // C:C
 
-        internal string A1;
-        internal string R1C1;
+        private XLSheetPoint _input1;
+        private XLSheetPoint _input2;
+        private FormulaFlags _flags;
+        private FormulaType _type;
+
+        internal string A1 { get; set; }
+
+        internal string R1C1 { get; set; }
 
         internal bool HasAnyFormula =>
             !String.IsNullOrWhiteSpace(A1) ||
             !String.IsNullOrEmpty(R1C1);
+
+        internal FormulaType Type => _type;
 
         /// <summary>
         /// Get stored formula or or <c>string.Empty</c> if both A1/R1C1 are empty.
@@ -243,6 +259,117 @@ namespace ClosedXML.Excel
                 columnPart = "C";
 
             return columnPart;
+        }
+
+        /// <summary>
+        /// Set cell formula to a normal formula. Doesn't affect recalculation version.
+        /// </summary>
+        /// <param name="formulaA1">Doesn't start with <c>=</c>.</param>
+        internal void SetNormal(string formulaA1)
+        {
+            A1 = formulaA1;
+            R1C1 = null;
+            _type = FormulaType.Normal;
+            _flags = FormulaFlags.None;
+        }
+
+        /// <summary>
+        /// Set cell formula to an array formula. Doesn't affect recalculation version.
+        /// </summary>
+        /// <param name="arrayFormulaA1">Isn't wrapped in <c>{}</c> and doesn't start with <c>=</c>.</param>
+        /// <param name="aca">A flag for always calculate array. </param>
+        internal void SetArray(string arrayFormulaA1, bool aca)
+        {
+            A1 = "{" + arrayFormulaA1 + "}";
+            R1C1 = null;
+            _type = FormulaType.Array;
+            _flags = aca ? FormulaFlags.AlwaysCalculateArray : FormulaFlags.None;
+        }
+
+        /// <summary>
+        /// Set cell formula to a 1D data table formula. Doesn't affect recalculation version.
+        /// </summary>
+        /// <param name="dataTableFormulaA1">Doesn't start with <c>=</c>.</param>
+        /// <param name="isRowDataTable">Is data table in row (<c>true</c>) or columns (<c>false</c>)?</param>
+        /// <param name="input1Address">Address of the input cell that will be replaced in the data table. If input deleted, ignored and value can be anything.</param>
+        /// <param name="input1Deleted">Was the original address deleted?</param>
+        internal void SetDataTable1D(
+            string dataTableFormulaA1,
+            bool isRowDataTable,
+            XLSheetPoint input1Address,
+            bool input1Deleted)
+        {
+            A1 = dataTableFormulaA1;
+            R1C1 = null;
+            _type = FormulaType.DataTable;
+            _flags =
+                (isRowDataTable ? FormulaFlags.Is1DRow : FormulaFlags.None) |
+                (input1Deleted ? FormulaFlags.Input1Deleted : FormulaFlags.None);
+            _input1 = input1Address;
+        }
+
+        /// <summary>
+        /// Set cell formula to a 2D data table formula. Doesn't affect recalculation version.
+        /// </summary>
+        /// <param name="dataTableFormulaA1">Doesn't start with <c>=</c>.</param>
+        /// <param name="input1Address">Address of the input cell that will be replaced in the data table. If input deleted, ignored and value can be anything.</param>
+        /// <param name="input1Deleted">Was the original address deleted?</param>
+        /// <param name="input2Address">Address of the input cell that will be replaced in the data table. If input deleted, ignored and value can be anything.</param>
+        /// <param name="input2Deleted">Was the original address deleted?</param>
+        internal void SetDataTable2D(
+            string dataTableFormulaA1,
+            XLSheetPoint input1Address,
+            bool input1Deleted,
+            XLSheetPoint input2Address,
+            bool input2Deleted)
+        {
+            A1 = dataTableFormulaA1;
+            R1C1 = null;
+            _type = FormulaType.DataTable;
+            _flags = FormulaFlags.Is2D |
+                (input1Deleted ? FormulaFlags.Input1Deleted : FormulaFlags.None) |
+                (input2Deleted ? FormulaFlags.Input2Deleted : FormulaFlags.None);
+            _input1 = input1Address;
+            _input2 = input2Address;
+        }
+
+        /// <summary>
+        /// An enum to efficiently store various flags for formulas (bool takes up 1-4 bytes due to alignment).
+        /// Note that each type of formula uses different flags.
+        /// </summary>
+        [Flags]
+        private enum FormulaFlags : byte
+        {
+            None = 0,
+
+            /// <summary>
+            /// For Array formula. Not fully clear from documentation, but seems to be some kind of dirty flag.
+            /// Current excel just writes <c>ca="1"</c> to each cell of array formula for cases described in the DOC.
+            /// </summary>
+            AlwaysCalculateArray = 1,
+
+            /// <summary>
+            /// For data table formula. Flag whether the data table is 2D and has two inputs.
+            /// </summary>
+            Is2D = 2,
+
+            /// <summary>
+            /// For data table formula. If the set, the data table is in row, not column. It uses input1 in both case, but the position
+            /// is interpreted differently.
+            /// </summary>
+            Is1DRow = 4,
+
+            /// <summary>
+            /// For data table formula. When the input 1 cell has been deleted (not content, but the row or a column where cell was),
+            /// this flag is set.
+            /// </summary>
+            Input1Deleted = 8,
+
+            /// <summary>
+            /// For data table formula. When the input 2 cell has been deleted (not content, but the row or a column where cell was),
+            /// this flag is set.
+            /// </summary>
+            Input2Deleted = 16,
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLAddress.cs
+++ b/ClosedXML/Excel/Coordinates/XLAddress.cs
@@ -1,4 +1,3 @@
-using ClosedXML.Extensions;
 using System;
 using System.Diagnostics;
 

--- a/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
@@ -3,7 +3,7 @@ using System;
 namespace ClosedXML.Excel
 {
     /// <summary>
-    /// An point (address) in a worksheet.
+    /// An point (address) in a worksheet, an equivalent of <c>ST_CellRef</c>.
     /// </summary>
     /// <remarks>Unlike the XLAddress, sheet can never be invalid.</remarks>
     internal readonly struct XLSheetPoint : IEquatable<XLSheetPoint>
@@ -47,6 +47,65 @@ namespace ClosedXML.Excel
         public static bool operator !=(XLSheetPoint a, XLSheetPoint b)
         {
             return a.Row != b.Row || a.Column != b.Column;
+        }
+
+        /// <inheritdoc cref="Parse(ReadOnlySpan{char})"/>
+        public static XLSheetPoint Parse(String text) => Parse(text.AsSpan());
+
+        /// <summary>
+        /// Parse point per type <c>ST_CellRef</c> from
+        /// <a href="https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/db11a912-b1cb-4dff-b46d-9bedfd10cef0">2.1.1108 Part 4 Section 3.18.8, ST_CellRef (Cell Reference)</a>
+        /// </summary>
+        /// <param name="input">Input text</param>
+        /// <exception cref="FormatException">If the input doesn't match expected grammar.</exception>
+        public static XLSheetPoint Parse(ReadOnlySpan<char> input)
+        {
+            // Don't reuse inefficient logic from XLAddress
+            if (input.Length < 2)
+                throw new FormatException($"Length is less than two ('{input.ToString()}').");
+
+            var i = 0;
+            var c = input[i++];
+            if (!IsLetter(c))
+                throw new FormatException($"Doesn't start with a letter ('{input.ToString()}').");
+
+            var columnIndex = c - 'A' + 1;
+            while (i < input.Length && IsLetter(c = input[i]))
+            {
+                columnIndex = columnIndex * 26 + c - 'A' + 1;
+                i++;
+            }
+
+            if (i > 3)
+                throw new FormatException($"Input contains more than three letters ('{input.ToString()}').");
+
+            if (i == input.Length)
+                throw new FormatException($"Input doesn't contain row number ('{input.ToString()}').");
+
+            // Everything else must be digits
+            c = input[i++];
+
+            // First letter can't be 0
+            if (c is < '1' or > '9')
+                throw new FormatException($"Row must start with a non-zero digit ('{input.ToString()}').");
+
+            var rowIndex = c - '0';
+            while (i < input.Length && IsDigit(c = input[i]))
+            {
+                rowIndex = rowIndex * 10 + c - '0';
+                i++;
+            }
+
+            if (i != input.Length)
+                throw new FormatException($"Input contains unexpected characters ('{input.ToString()}').");
+
+            if (rowIndex > XLHelper.MaxRowNumber || columnIndex > XLHelper.MaxColumnNumber)
+                throw new FormatException($"Address out of bounds ('{input.ToString()}').");
+
+            return new XLSheetPoint(rowIndex, columnIndex);
+
+            static bool IsLetter(char c) => c is >= 'A' and <= 'Z';
+            static bool IsDigit(char c) => c is >= '0' and <= '9';
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
@@ -2,20 +2,31 @@ using System;
 
 namespace ClosedXML.Excel
 {
-    internal struct XLSheetPoint:IEquatable<XLSheetPoint>
+    /// <summary>
+    /// An point (address) in a worksheet.
+    /// </summary>
+    /// <remarks>Unlike the XLAddress, sheet can never be invalid.</remarks>
+    internal readonly struct XLSheetPoint : IEquatable<XLSheetPoint>
     {
-        public XLSheetPoint(Int32  row, Int32 column)
+        public XLSheetPoint(Int32 row, Int32 column)
         {
             Row = row;
             Column = column;
         }
 
+        /// <summary>
+        /// 1-based row number in a sheet.
+        /// </summary>
         public readonly Int32 Row;
+
+        /// <summary>
+        /// 1-based column number in a sheet.
+        /// </summary>
         public readonly Int32 Column;
 
         public override bool Equals(object obj)
         {
-            return Equals((XLSheetPoint)obj);
+            return obj is XLSheetPoint point && Equals(point);
         }
 
         public bool Equals(XLSheetPoint other)
@@ -28,7 +39,7 @@ namespace ClosedXML.Excel
             return (Row * -1) ^ Column;
         }
 
-        public static bool operator==(XLSheetPoint a, XLSheetPoint b)
+        public static bool operator ==(XLSheetPoint a, XLSheetPoint b)
         {
             return a.Row == b.Row && a.Column == b.Column;
         }

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ClosedXML.Excel
 {
-    internal struct XLSheetRange:IEquatable<XLSheetRange>
+    internal struct XLSheetRange : IEquatable<XLSheetRange>
     {
         public XLSheetRange(XLSheetPoint firstPoint, XLSheetPoint lastPoint)
         {
@@ -21,6 +21,33 @@ namespace ClosedXML.Excel
         public override int GetHashCode()
         {
             return FirstPoint.GetHashCode() ^ LastPoint.GetHashCode();
+        }
+
+        /// <inheritdoc cref="Parse(ReadOnlySpan{char})"/>
+        public static XLSheetRange Parse(String input) => Parse(input.AsSpan());
+
+        /// <summary>
+        /// Parse point per type <c>ST_Ref</c> from
+        /// <a href="https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/e7f22870-88a1-4c06-8e5f-d035b1179c50">2.1.1119 Part 4 Section 3.18.64, ST_Ref (Cell Range Reference)</a>
+        /// </summary>
+        /// <remarks>Can be one cell reference (A1) or two separated by a colon (A1:B2). First reference is always in top left corner</remarks>
+        /// <param name="input">Input text</param>
+        /// <exception cref="FormatException">If the input doesn't match expected grammar.</exception>
+        public static XLSheetRange Parse(ReadOnlySpan<char> input)
+        {
+            var separatorIndex = input.IndexOf(':');
+            if (separatorIndex == -1)
+            {
+                var sheetPoint = XLSheetPoint.Parse(input);
+                return new XLSheetRange(sheetPoint, sheetPoint);
+            }
+
+            var first = XLSheetPoint.Parse(input.Slice(0, separatorIndex));
+            var second = XLSheetPoint.Parse(input.Slice(separatorIndex + 1, input.Length - separatorIndex - 1));
+            if (first.Column > second.Column || first.Row > second.Row)
+                throw new FormatException($"First reference must have smaller column and row ('{input.ToString()}')");
+
+            return new XLSheetRange(first, second);
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -2,7 +2,10 @@ using System;
 
 namespace ClosedXML.Excel
 {
-    internal struct XLSheetRange : IEquatable<XLSheetRange>
+    /// <summary>
+    /// A representation of a <c>ST_Ref</c>, i.e. an area in a sheet (no reference to teh sheet).
+    /// </summary>
+    internal readonly struct XLSheetRange : IEquatable<XLSheetRange>
     {
         public XLSheetRange(XLSheetPoint firstPoint, XLSheetPoint lastPoint)
         {
@@ -10,8 +13,19 @@ namespace ClosedXML.Excel
             LastPoint = lastPoint;
         }
 
+        /// <summary>
+        /// Top-left point of the sheet range.
+        /// </summary>
         public readonly XLSheetPoint FirstPoint;
+
+        /// <summary>
+        /// Bottom-right point of the sheet range.
+        /// </summary>
         public readonly XLSheetPoint LastPoint;
+
+        public int Width => LastPoint.Column - FirstPoint.Column + 1;
+
+        public int Height => LastPoint.Row - FirstPoint.Row + 1;
 
         public bool Equals(XLSheetRange other)
         {

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1731,10 +1731,10 @@ namespace ClosedXML.Excel
             }
             else
             {
+                var cellValue = cell.CellValue;
                 if (dataType == CellValues.Number)
                 {
                     // XLCell is by default blank, so no need to set it.
-                    var cellValue = cell.CellValue;
                     if (cellValue is not null && cellValue.TryGetDouble(out var number))
                     {
                         var numberDataType = GetNumberDataType(xlCell.StyleValue.NumberFormat);
@@ -1749,8 +1749,8 @@ namespace ClosedXML.Excel
                 }
                 else if (dataType == CellValues.SharedString)
                 {
-                    if (cell.CellValue != null
-                        && Int32.TryParse(cell.CellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture, out Int32 sharedStringId)
+                    if (cellValue is not null
+                        && Int32.TryParse(cellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture, out Int32 sharedStringId)
                         && sharedStringId >= 0 && sharedStringId < sharedStrings.Length)
                     {
                         xlCell.SharedStringId = sharedStringId;
@@ -1763,15 +1763,15 @@ namespace ClosedXML.Excel
                 }
                 else if (dataType == CellValues.String) // A plain string that is a result of a formula calculation
                 {
-                    xlCell.SetOnlyValue(cell.CellValue?.Text ?? String.Empty);
+                    xlCell.SetOnlyValue(cellValue?.Text ?? String.Empty);
                 }
                 else if (dataType == CellValues.Boolean)
                 {
                     // Can be empty for formulas
-                    if (cell.CellValue is not null)
+                    if (cellValue is not null)
                     {
-                        var isTrue = string.Equals(cell.CellValue?.Text, "1", StringComparison.Ordinal) ||
-                                     string.Equals(cell.CellValue?.Text, "TRUE", StringComparison.OrdinalIgnoreCase);
+                        var isTrue = string.Equals(cellValue?.Text, "1", StringComparison.Ordinal) ||
+                                     string.Equals(cellValue?.Text, "TRUE", StringComparison.OrdinalIgnoreCase);
                         xlCell.SetOnlyValue(isTrue);
                     }
                 }
@@ -1790,15 +1790,18 @@ namespace ClosedXML.Excel
                 }
                 else if (dataType == CellValues.Error)
                 {
-                    if (cell.CellValue is not null && XLErrorParser.TryParseError(cell.CellValue.InnerText, out var error))
+                    if (cellValue is not null && XLErrorParser.TryParseError(cellValue.InnerText, out var error))
                         xlCell.SetOnlyValue(error);
                 }
                 else if (dataType == CellValues.Date)
                 {
-                    var date = DateTime.ParseExact(cell.CellValue.Text, DateCellFormats,
-                        XLHelper.ParseCulture,
-                        DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
-                    xlCell.SetOnlyValue(date);
+                    if (cellValue is not null)
+                    {
+                        var date = DateTime.ParseExact(cellValue.Text, DateCellFormats,
+                            XLHelper.ParseCulture,
+                            DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
+                        xlCell.SetOnlyValue(date);
+                    }
                 }
             }
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1801,29 +1801,6 @@ namespace ClosedXML.Excel
                         xlCell.SetOnlyValue(error);
                 }
             }
-            else if (cell.CellValue != null) // Default data type is a number
-            {
-                if (!String.IsNullOrWhiteSpace(cell.CellValue.Text))
-                    xlCell.SetOnlyValue(Double.Parse(cell.CellValue.Text, CultureInfo.InvariantCulture));
-                else
-                    xlCell.SetOnlyValue(Blank.Value); // No value and not type => blank
-
-                var numberFormatId = ((CellFormat)(s.CellFormats).ElementAt(styleIndex)).NumberFormatId;
-
-                if (numberFormatId?.HasValue ?? false)
-                {
-                    var format = s.NumberingFormats?
-                        .Cast<NumberingFormat>()
-                        .Where(nf => nf.NumberFormatId.Value == numberFormatId)
-                        .Select(nf => nf.FormatCode.Value)
-                        .FirstOrDefault();
-
-                    if (format == null)
-                        xlCell.InnerStyle.NumberFormat.NumberFormatId = Int32.Parse(numberFormatId);
-                    else
-                        xlCell.InnerStyle.NumberFormat.Format = format;
-                }
-            }
 
             if (xlCell.HasFormula)
             {

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1781,21 +1781,18 @@ namespace ClosedXML.Excel
                 }
                 else if (dataType == CellValues.Number)
                 {
-                    if (cell.CellValue != null && cell.CellValue.TryGetDouble(out var number))
+                    // XLCell is by default blank, so no need to set it.
+                    var cellValue = cell.CellValue;
+                    if (cellValue is not null && cellValue.TryGetDouble(out var number)) 
                     {
                         var numberDataType = GetNumberDataType(xlCell.StyleValue.NumberFormat);
-                        switch (numberDataType)
+                        var cellNumber = numberDataType switch
                         {
-                            case XLDataType.DateTime:
-                                xlCell.SetOnlyValue(XLCellValue.FromSerialDateTime(number));
-                                break;
-                            case XLDataType.TimeSpan:
-                                xlCell.SetOnlyValue(XLCellValue.FromSerialTimeSpan(number));
-                                break;
-                            default: // Normal number
-                                xlCell.SetOnlyValue(number);
-                                break;
-                        }
+                            XLDataType.DateTime => XLCellValue.FromSerialDateTime(number),
+                            XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(number),
+                            _ => number // Normal number
+                        };
+                        xlCell.SetOnlyValue(cellNumber);
                     }
                 }
                 else if (dataType == CellValues.Error)


### PR DESCRIPTION
XLCell contained all information about a formula. That was separated to XLCellFormula.
* It is needed for #1838 , where we have to hold all attributes for all formulas in order to stream all XML under SheetData without merging DOM from DocumentFormat.OpenXML
* 0.101 will support array formulas, current semantic is not clear and at least API should be designed to be usable. Array formulas are last thing for #1812.
* It will facilitate memory conservation. Majority of cells are not formulas, but formulas require a lot of fields. Once the link from `XLCell` to `XLCellFormula` is made nullable, it will decrease memory usage for value-only cells.