### PR TITLE
Simplify depdendency graph for newer target frameworks

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -30,10 +30,13 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="XLParser" Version="1.5.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/ClosedXML/Graphics/XLPictureInfo.cs
+++ b/ClosedXML/Graphics/XLPictureInfo.cs
@@ -40,6 +40,7 @@ namespace ClosedXML.Graphics
                 throw new ArgumentException("Size of picture too large.");
             Format = format;
             SizePx = new Size((int)width, (int)height);
+            SizePhys = Size.Empty;
             DpiX = dpiX;
             DpiY = dpiY;
         }


### PR DESCRIPTION
Remove package dependencies to System packages for newer target frameworks, where the System packages are part of the framework anyway.