### PR TITLE
Use space as culture group separator in AutoFilterTests

### DIFF
--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -237,8 +237,9 @@ namespace ClosedXML.Tests
             {
                 // Set thread culture to French, which should format numbers using a space as thousands separator
                 var culture = CultureInfo.CreateSpecificCulture("fr-FR");
-                // but use a period instead of a comma as for decimal separator
+                // but use a period instead of a comma as for decimal separator and space as group separator
                 culture.NumberFormat.CurrencyDecimalSeparator = ".";
+                culture.NumberFormat.CurrencyGroupSeparator = " ";
 
                 Thread.CurrentThread.CurrentCulture = culture;
 


### PR DESCRIPTION
This test case was failing locally for me when running under full framework. My locale is fi-FI. And parsing target was "10 000.00"