### PR TITLE
Update DocumentFormat.OpenXML to 2.19.0

### DIFF
--- a/ClosedXML.Examples/ClosedXML.Examples.csproj
+++ b/ClosedXML.Examples/ClosedXML.Examples.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ClosedXML\ClosedXML.csproj" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
     <PackageReference Include="morelinq" Version="2.10.0" />
   </ItemGroup>
 

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Unfortunetly I am not sure why the tests fail, if someone tells me why they fail I could maybe try and fix them. It would be cool to have OpenXML SDK updated to newest version