### PR TITLE
Reimplement SEARCH function and add wildcard struct

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using ClosedXML.Excel.CalcEngine;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine
+{
+    [TestFixture]
+    public class WildcardTests
+    {
+        [TestCase("")]
+        [TestCase("abc")]
+        public void Empty_Pattern_Matches_Any_String(string text)
+        {
+            Assert.AreEqual(0, SearchWildcard(text, string.Empty));
+        }
+
+        [TestCase("", "abc", 0)]
+        [TestCase("a", "abc", 0)]
+        [TestCase("ab", "abc", 0)]
+        [TestCase("abc", "abc", 0)]
+        [TestCase("bc", "abc", 1)]
+        [TestCase("c", "abc", 2)]
+        public void Substring_Of_Text_Matches_Text(string substringPattern, string text, int expectedIndex)
+        {
+            Assert.AreEqual(expectedIndex, SearchWildcard(text, substringPattern));
+        }
+
+        [TestCase("abcd", "abc")]
+        public void Pattern_Not_In_Text_Returns_Negative_One(string pattern, string text)
+        {
+            Assert.AreEqual(-1, SearchWildcard(text, pattern));
+        }
+
+        [Test]
+        public void Pattern_Comparison_Is_Case_Insensitive()
+        {
+            Assert.AreEqual(1, SearchWildcard("zabcd", "AbCd"));
+        }
+
+        [Test]
+        public void Tilde_Is_Escape_Char()
+        {
+            Assert.AreEqual(1, SearchWildcard("_abc_", "~a~B~c"));
+        }
+
+        [TestCase("~*", "*", 0)]
+        [TestCase("~*", "a", -1)]
+        [TestCase("~?", "?", 0)]
+        [TestCase("~?", "a", -1)]
+        [TestCase("~a~b~", "ab", 0)]
+        public void Escaped_Wildcards_Are_Matched_As_Chars(string pattern, string text, int expectedPosition)
+        {
+            Assert.AreEqual(expectedPosition, SearchWildcard(text, pattern));
+        }
+
+        [Test]
+        public void Question_Mark_Wildcard_Matches_Any_Char()
+        {
+            Assert.AreEqual(0, SearchWildcard("abc", "a?c"));
+        }
+
+        [TestCase("abcd", "ab*cd", 0)]
+        [TestCase(@"aaab_____cd", "ab*cd", 2)]
+        [TestCase("*abc*", "***a*b*c***", 0)]
+
+        public void Star_Wildcard_Matches_Any_Number_Of_Chars(string text, string pattern, int index)
+        {
+            Assert.AreEqual(index, SearchWildcard(text, pattern));
+        }
+
+        [Test]
+        public void Unpaired_Escape_Char_At_The_End_Of_Pattern_Is_Not_Char()
+        {
+            Assert.AreEqual(0, SearchWildcard("a", "a~"));
+        }
+
+        [Test]
+        public void Star_Wildcard_At_The_Beginning_Matches_First_Char()
+        {
+            Assert.AreEqual(0, SearchWildcard("abcccd", "*ccd"));
+        }
+
+        [Test]
+        public void Pattern_Size_Is_Limited_To_255_Chars()
+        {
+            Assert.AreEqual(0, SearchWildcard(new string('a', 1000), new string('a', 255)));
+
+            Assert.AreEqual(-1, SearchWildcard(new string('a', 1000), new string('a', 256)));
+        }
+
+        private static int SearchWildcard(string text, string pattern)
+        {
+            return new Wildcard(pattern).Search(text.AsSpan());
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -133,6 +133,32 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, string, string, OneOf<double, Blank>, AnyValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToText(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToText(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                OneOf<double, Blank> arg2Optional = Blank.Value;
+                if (args.Length > 2)
+                {
+                    var arg2Converted = ToNumber(args[2], ctx);
+                    if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                        return err2;
+
+                    arg2Optional = arg2;
+                }
+
+                return f(ctx, arg0, arg1, arg2Optional);
+            };
+        }
+
         public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, ScalarValue, AnyValue, ScalarValue, ScalarValue, AnyValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Wildcard.cs
+++ b/ClosedXML/Excel/CalcEngine/Wildcard.cs
@@ -1,0 +1,171 @@
+﻿using System;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// A wildcard is at most 255 chars long text. It can contain <c>*</c> which indicates any number characters (including zero)
+    /// and <c>?</c> which indicates any single character. If you need to find <c>*</c> or <c>?</c> in a text, prefix them with
+    /// an escape character <c>~</c>.
+    /// </summary>
+    internal readonly struct Wildcard
+    {
+        private readonly String _pattern;
+
+        public Wildcard(String pattern)
+        {
+            _pattern = pattern;
+        }
+
+        /// <summary>
+        /// Search for the wildcard anywhere in the text.
+        /// </summary>
+        /// <param name="text">Text used to search for a pattern.</param>
+        /// <returns>zero-based index of a first character in a text that matches to a pattern or -1, if match wasn't found.</returns>
+        public int Search(ReadOnlySpan<char> text)
+        {
+            return Search(_pattern.AsSpan(), text);
+        }
+
+        private static int Search(ReadOnlySpan<char> pattern, ReadOnlySpan<char> text)
+        {
+            // Excel limits pattern size to 255, likely to avoid performance problems due to backtracking.
+            if (pattern.Length > 255)
+                return -1;
+
+            // Check to remove trailing escape ~
+            if (pattern.Length >= 2 && pattern[pattern.Length - 1] == '~' && pattern[pattern.Length - 2] != '~')
+                pattern = pattern.Slice(0, pattern.Length - 1);
+
+            // pattern index should be an index of first character of a segment. Segments start and ends with a star.
+            var patternIdx = 0;
+
+            // Index of a first segment that was recognized in the text. -1 indicates not found.
+            var firstSegmentStartIdx = -1;
+
+            // Skip the first stars in the pattern. The Search method searches within the text and it doesn't have
+            // to start at the beginning, thus stars are irrelevant for Search method.
+            while (patternIdx < pattern.Length && pattern[patternIdx] == '*')
+            {
+                patternIdx++;
+
+                // If the pattern starts with a star, it must start at the beginning of a text
+                firstSegmentStartIdx = 0;
+            }
+
+            if (patternIdx >= pattern.Length)
+            {
+                // Whole pattern consists of * wildcards, any text satisfies the pattern.
+                return 0;
+            }
+
+            // Text index points to the first char of yet unprocessed text. As pattern segments are matched in a text, text index increases,
+            // so the same substring of a text can't be used to match two segments.
+            var textIdx = 0;
+
+            while (patternIdx < pattern.Length)
+            {
+                if (textIdx >= text.Length)
+                {
+                    // There is still a non-star pattern, but text has ended - there is no way we can find the last segment in the text.
+                    return -1;
+                }
+
+                // Each loop is searching only for a specific a segment in a text that hasn't yet been processed.
+                // Segment pattern starts after previous star wildcard and ends before next star wildcard/end of pattern.
+                var segmentEnd = patternIdx;
+                for (; segmentEnd < pattern.Length; ++segmentEnd)
+                {
+                    var segmentChar = pattern[segmentEnd];
+                    if (segmentChar == '*')
+                        break;
+
+                    if (segmentChar == '~' && segmentEnd + 1 < pattern.Length)
+                        segmentEnd++;
+                }
+
+                var segmentLength = segmentEnd - patternIdx;
+                var segmentPattern = pattern.Slice(patternIdx, segmentLength);
+
+                // Search only in a text that hasn't yet been used to match some previous segment pattern.
+                var textAfterPrevSegment = text.Slice(textIdx);
+                var patternPosInSegment = SearchSegment(segmentPattern, textAfterPrevSegment);
+                if (patternPosInSegment.TextStartIdx < 0)
+                {
+                    // Segment pattern is not present in the text -> whole pattern isn't in the text
+                    return -1;
+                }
+
+                if (firstSegmentStartIdx < 0)
+                    firstSegmentStartIdx = patternPosInSegment.TextStartIdx;
+
+                patternIdx += segmentLength;
+                textIdx += patternPosInSegment.TextAfterLastIdx;
+
+                // Skip stars between segments. Due to backtracking, they are rather irrelevant.
+                while (patternIdx < pattern.Length && pattern[patternIdx] == '*')
+                    patternIdx++;
+            }
+
+            return firstSegmentStartIdx;
+        }
+        
+        /// <summary>
+        /// Check if a segment can be found in a text.
+        /// </summary>
+        /// <param name="segmentPattern">Non-empty pattern without <c>*</c> wildcard, though it can contain ? and escaped *.</param>
+        /// <param name="text">Non-empty text.</param>
+        /// <returns>First index of the pattern in the <paramref name="text"/> or -1 if not found.</returns>
+        private static (int TextStartIdx, int TextAfterLastIdx) SearchSegment(ReadOnlySpan<char> segmentPattern, ReadOnlySpan<char> text)
+        {
+            var textBacktrackStart = 0;
+            var patternIdx = 0;
+            var textIdx = 0;
+
+            while (patternIdx < segmentPattern.Length)
+            {
+                if (textIdx >= text.Length)
+                {
+                    // There is unmatched star-less pattern, but text is already over -> impossible to match the rest of a segment pattern
+                    return (-1, 0);
+                }
+
+                var patternChar = segmentPattern[patternIdx++];
+                if (patternChar == '?')
+                {
+                    textIdx++;
+                    continue;
+                }
+
+                if (patternChar == '~')
+                {
+                    if (patternIdx < segmentPattern.Length)
+                    {
+                        patternChar = segmentPattern[patternIdx++];
+                    }
+                    else
+                    {
+                        // There is only escape char, but the pattern has ended. Thus we matched.
+                        return (textBacktrackStart, textIdx);
+                    }
+                }
+
+                var textChar = text[textIdx++];
+                var sameChar = textChar == patternChar ||
+                               char.ToUpperInvariant(textChar) == char.ToUpperInvariant(patternChar);
+                if (!sameChar)
+                {
+                    // Text and pattern don't match - we need to backtrack.
+                    if (++textBacktrackStart >= text.Length)
+                    {
+                        return (-1, 0);
+                    }
+
+                    textIdx = textBacktrackStart;
+                    patternIdx = 0;
+                }
+            }
+
+            return (textBacktrackStart, textIdx);
+        }
+    }
+}


### PR DESCRIPTION
`SEARCH` function was throwing exception instead of returning an error. It also didn't properly parsed escaped characters in a pattern.

Wildcards-through-regex were replaced, because properly evaluated wildcards will be needed for auto filter and it is denial-of-service waiting to happen (there is a reason why BCL regex methods have an optional timeout).

The wildcard `Search` function uses backtracking, which is not ideal. I could use Knuth Morris Pratt on each segment to get _O(n+m)_, but that doesn't work if there is a `?` in the segment pattern. I think that only way to achieve guaranteed are finite automata. Turning non-deterministic finite automata to finite deterministic automata is out of scope of this project and I don't want another dependency just for this (+I would want it to be very limited in memory allocations). So backtracking limited to 255 repetitions (same amount as Excel) it is.

Resolves #1985 .