### PR TITLE
Added OpenSettings to LoadOptions

### DIFF
--- a/ClosedXML/Excel/LoadOptions.cs
+++ b/ClosedXML/Excel/LoadOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Drawing;
 using ClosedXML.Graphics;
+using DocumentFormat.OpenXml.Packaging;
 
 namespace ClosedXML.Excel
 {
@@ -36,5 +37,15 @@ namespace ClosedXML.Excel
             get => _dpi;
             set => _dpi = value.X > 0 && value.Y > 0 ? value : throw new ArgumentException("DPI must be positive");
         }
+
+        /// <summary>
+        /// Represents the settings when opening a document.
+        /// </summary>
+        public OpenSettings OpenSettings { get; set; }
+
+        /// <summary>
+        /// In ReadWrite mode. False for Read only mode.
+        /// </summary>
+        public bool IsEditable { get; set; }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -684,7 +684,7 @@ namespace ClosedXML.Excel
             _loadSource = XLLoadSource.File;
             _originalFile = file;
             _spreadsheetDocumentType = GetSpreadsheetDocumentType(_originalFile);
-            Load(file);
+            Load(file, loadOptions);
 
             if (loadOptions.RecalculateAllFormulas)
                 this.RecalculateAllFormulas();
@@ -704,7 +704,7 @@ namespace ClosedXML.Excel
         {
             _loadSource = XLLoadSource.Stream;
             _originalStream = stream;
-            Load(stream);
+            Load(stream, loadOptions);
 
             if (loadOptions.RecalculateAllFormulas)
                 this.RecalculateAllFormulas();

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -28,25 +28,29 @@ namespace ClosedXML.Excel
     {
         private readonly Dictionary<String, Color> _colorList = new Dictionary<string, Color>();
 
-        private void Load(String file)
+        private void Load(String file, LoadOptions loadOptions)
         {
-            LoadSheets(file);
+            LoadSheets(file, loadOptions);
         }
 
-        private void Load(Stream stream)
+        private void Load(Stream stream, LoadOptions loadOptions)
         {
-            LoadSheets(stream);
+            LoadSheets(stream, loadOptions);
         }
 
-        private void LoadSheets(String fileName)
+        private void LoadSheets(String fileName, LoadOptions loadOptions)
         {
-            using (var dSpreadsheet = SpreadsheetDocument.Open(fileName, false))
+            using (var dSpreadsheet = loadOptions.OpenSettings == null ?
+                SpreadsheetDocument.Open(fileName, loadOptions.IsEditable) :
+                SpreadsheetDocument.Open(fileName, loadOptions.IsEditable, loadOptions.OpenSettings))
                 LoadSpreadsheetDocument(dSpreadsheet);
         }
 
-        private void LoadSheets(Stream stream)
+        private void LoadSheets(Stream stream, LoadOptions loadOptions)
         {
-            using (var dSpreadsheet = SpreadsheetDocument.Open(stream, false))
+            using (var dSpreadsheet = loadOptions.OpenSettings == null ?
+                SpreadsheetDocument.Open(stream, loadOptions.IsEditable) :
+                SpreadsheetDocument.Open(stream, loadOptions.IsEditable, loadOptions.OpenSettings))
                 LoadSpreadsheetDocument(dSpreadsheet);
         }
 


### PR DESCRIPTION
Added OpenSettings to LoadOptions so we can customize how the sheet is opened with the XLWorkbook constructor.

This allows us to use the RelationshipErrorHandlerFactory on the OpenSettings with new XLWorkbook(stream, options).

Otherwise there's no way to handle malformed uris graciously. This complements the solution for this issue: https://github.com/ClosedXML/ClosedXML/issues/249