### PR TITLE
Don't allocate XLCellFormula for each XLCell

### DIFF
--- a/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
+++ b/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
@@ -43,15 +43,14 @@ namespace ClosedXML.Excel.CalcEngine
         // ** implementation
         private object GetValue(IXLCell cell)
         {
-            if (_evaluating || (cell as XLCell).IsEvaluating)
+            if (_evaluating || ((XLCell)cell).IsEvaluating)
             {
-                throw new InvalidOperationException($"Circular Reference occured during evaluation. Cell: {cell.Address.ToString(XLReferenceStyle.Default, true)}");
+                throw new InvalidOperationException($"Circular Reference occurred during evaluation. Cell: {cell.Address.ToString(XLReferenceStyle.Default, true)}");
             }
             try
             {
                 _evaluating = true;
                 return cell.Value.ToObject();
-                
             }
             finally
             {

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <param name="expression">Formula to analyze.</param>
         /// <param name="worksheet">Worksheet used for ranges without sheet.</param>
         /// <param name="uniqueCells">All cells (including newly created blank ones) that are referenced in the formula.</param>
-        /// <returns>.</returns>
+        /// <returns>True if it was possible for get precedent cells, false otherwise (e.g. reference errors).</returns>
         public bool TryGetPrecedentCells(string expression, XLWorksheet worksheet, out ICollection<XLCell> uniqueCells)
         {
             // This sucks and doesn't work for adding/removing named ranges/worksheets. Also, it creates new cells for all found ranges.

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -496,7 +496,7 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Flag showing that the cell is in formula evaluation state.
         /// </summary>
-        internal bool IsEvaluating { get; private set; }
+        internal bool IsEvaluating => Formula is not null && Formula.IsEvaluating;
 
         public void InvalidateFormula()
         {
@@ -530,22 +530,7 @@ namespace ClosedXML.Excel
                 return;
             }
 
-            if (IsEvaluating)
-            {
-                throw new InvalidOperationException($"Cell {Address} is a part of circular reference.");
-            }
-
-            try
-            {
-                IsEvaluating = true;
-                var result = Formula.RecalculateFormula(FormulaA1, this, Worksheet);
-                Formula.ValidateRecalculationStatus(Worksheet);
-                _cellValue = result.ToCellValue();
-            }
-            finally
-            {
-                IsEvaluating = false;
-            }
+            _cellValue = Formula.RecalculateFormula(this, Worksheet).ToCellValue();
         }
 
         /// <summary>

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1756,9 +1756,13 @@ namespace ClosedXML.Excel
                     }
                 }
 
-                // Original code incremented version each time it set the values. That is no longer happening, but few
-                // examples rely on it. It should be set when cellFormula.CalculateCell is set or when value is missing.
-                xlCell.InvalidateFormula();
+                // If the cell doesn't contain value, we should invalidate it, otherwise rely on the stored value.
+                // The value is likely more reliable. It should be set when cellFormula.CalculateCell is set or
+                // when value is missing.
+                if (cell.CellValue?.Text is null)
+                {
+                    xlCell.InvalidateFormula();
+                }
             }
             // Unified code to load value. Value can be empty and only type specified (e.g. when formula doesn't save values)
             // String type is only for formulas, while shared string/inline string/date is only for pure cell values.
@@ -1834,11 +1838,6 @@ namespace ClosedXML.Excel
                         DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
                     xlCell.SetOnlyValue(date);
                 }
-            }
-
-            if (xlCell.HasFormula)
-            {
-                xlCell.NeedsRecalculation = cell.CellValue?.Text is null;
             }
 
             if (Use1904DateSystem && xlCell.DataType == XLDataType.DateTime)


### PR DESCRIPTION
`XLCell` always allocated a companion object `XLCellFormula`, even if it didn't contain a formula (done in initial PR ##1972). That uselessly allocates memory. This PR makes formula optional and moved several formula-only fields from `XLCell` to  `XLCellFormula`.

In the longer run, `XLCell` should only contain values and delegate formula to `XLCellFormula`.
`XLCellFormula` should represent a cell formula (of any type, e.g array, data-table, shared, dynamic ect). For arrays, multiple cells would refer to the same instance `XLCellFormula`.
`Formula` should represent a formula text to AST (lazy initialized), but it should be basically stateless and usable anywhere. It shouldn't deal with various formula types.
