### PR TITLE
Take word wrapping into account when adjusting row height

### DIFF
--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -306,6 +306,8 @@ namespace ClosedXML.Excel
             var glyphs = new List<GlyphBox>();
             XLStyle cellStyle = null;
             var rowHeightPx = 0;
+            var workbookMdw = (int)Math.Round(engine.GetMaxDigitWidth(Worksheet.Workbook.Style.Font, dpi.X));
+
             foreach (var cell in Row(startColumn, endColumn).CellsUsed().Cast<XLCell>())
             {
                 // Clear maintains capacity -> reduce need for GC
@@ -319,7 +321,14 @@ namespace ClosedXML.Excel
                     cellStyle = (XLStyle)cell.Style;
 
                 cell.GetGlyphBoxes(engine, dpi, glyphs);
-                var cellHeightPx = (int)Math.Ceiling(GetContentHeight(cellStyle.Alignment.TextRotation, glyphs));
+                var cellMdw = engine.GetMaxDigitWidth(cellStyle.Font, dpi.X);
+                cellMdw = Math.Round(cellMdw, MidpointRounding.AwayFromZero);
+                var columnWidthPx = XLHelper.NoCToPixels(cell.WorksheetColumn().Width, workbookMdw);
+                var pixelPadding = 2 * Math.Ceiling(cellMdw / 4) + 1;
+                var contentWidthPx = Math.Floor(columnWidthPx - pixelPadding);
+                var cellHeightPx = (int)Math.Ceiling(
+                    GetContentHeight(cellStyle.Alignment.TextRotation, cellStyle.Alignment.WrapText, contentWidthPx,
+                                     glyphs));
 
                 rowHeightPx = Math.Max(cellHeightPx, rowHeightPx);
             }
@@ -327,25 +336,103 @@ namespace ClosedXML.Excel
             return rowHeightPx;
         }
 
-        private static double GetContentHeight(int textRotationDeg, List<GlyphBox> glyphs)
+        private static double GetContentHeight(int textRotationDeg, bool wrapText, double maxWidthPx,
+                                               List<GlyphBox> glyphs)
         {
             if (textRotationDeg == 0)
             {
                 var textHeight = 0d;
                 var lineMaxHeight = 0d;
-                foreach (var glyph in glyphs)
+
+                if (!wrapText)
                 {
-                    if (!glyph.IsLineBreak)
+                    foreach (var glyph in glyphs)
                     {
-                        var cellHeightPx = glyph.LineHeight;
-                        lineMaxHeight = Math.Max(cellHeightPx, lineMaxHeight);
+                        if (!glyph.IsLineBreak)
+                        {
+                            var cellHeightPx = glyph.LineHeight;
+                            lineMaxHeight = Math.Max(cellHeightPx, lineMaxHeight);
+                        }
+                        else
+                        {
+                            // At the end of each line, add height of the line to total height.
+                            textHeight += lineMaxHeight;
+                            lineMaxHeight = 0d;
+                        }
                     }
-                    else
+                }
+                else
+                {
+                    var clusterWidth = 0d;
+                    var clusterHeight = 0d;
+                    var whiteSpaceCluster = false;
+                    var lineWidth = 0d;
+
+                    void AppendClusterToLine()
                     {
-                        // At the end of each line, add height of the line to total height.
+                        lineMaxHeight = Math.Max(clusterHeight, lineMaxHeight);
+                        lineWidth += clusterWidth;
+
+                        clusterWidth = 0;
+                        clusterHeight = 0;
+                    }
+
+                    void NewLine()
+                    {
                         textHeight += lineMaxHeight;
                         lineMaxHeight = 0d;
+                        lineWidth = 0d;
                     }
+
+                    foreach (var glyph in glyphs)
+                    {
+                        if (!glyph.IsLineBreak)
+                        {
+                            if (glyph.IsWhiteSpace != whiteSpaceCluster)
+                            {
+                                // Starting new cluster (word or white space)
+
+                                if (lineWidth + clusterWidth <= maxWidthPx)
+                                    AppendClusterToLine();
+                                else
+                                {
+                                    if (!whiteSpaceCluster)
+                                        AppendClusterToLine();
+                                    else
+                                    {
+                                        // Drop whitespace cluster at the end of line
+                                        clusterWidth = 0;
+                                        clusterHeight = 0;
+                                    }
+
+                                    NewLine();
+                                }
+
+                                whiteSpaceCluster = glyph.IsWhiteSpace;
+                            }
+
+                            if (lineWidth + clusterWidth + glyph.AdvanceWidth > maxWidthPx && !whiteSpaceCluster)
+                                NewLine();
+
+                            if (clusterWidth + glyph.AdvanceWidth > maxWidthPx && !whiteSpaceCluster)
+                            {
+                                // This word is too long to fit into a single line, make line for a fragment of it.
+                                AppendClusterToLine();
+                                NewLine();
+                            }
+
+                            clusterWidth += glyph.AdvanceWidth;
+                            clusterHeight = Math.Max(glyph.LineHeight, clusterHeight);
+                        }
+                        else
+                        {
+                            AppendClusterToLine();
+                            NewLine();
+                        }
+                    }
+
+                    // Count last word of last line
+                    AppendClusterToLine();
                 }
 
                 // If the last line ends without EOL, it must be also counted

--- a/ClosedXML/Graphics/DefaultGraphicEngine.cs
+++ b/ClosedXML/Graphics/DefaultGraphicEngine.cs
@@ -177,9 +177,12 @@ namespace ClosedXML.Graphics
             // without a TextRenderer that has unacceptable performance.
             var metric = GetMetrics(font);
             var advanceFu = 0;
+            var isWhiteSpace = false;
             for (var i = 0; i < graphemeCluster.Length; ++i)
             {
-                var glyphs = metric.GetGlyphMetrics(new CodePoint(graphemeCluster[i]), ColorFontSupport.None);
+                var codePoint = new CodePoint(graphemeCluster[i]);
+                isWhiteSpace |= CodePoint.IsWhiteSpace(codePoint);
+                var glyphs = metric.GetGlyphMetrics(codePoint, ColorFontSupport.None);
                 foreach (var glyph in glyphs)
                 {
                     advanceFu += glyph.AdvanceWidth;
@@ -192,7 +195,8 @@ namespace ClosedXML.Graphics
             return new GlyphBox(
                 (float)Math.Round(advancePx, MidpointRounding.AwayFromZero),
                 (float)Math.Round(emInPx, MidpointRounding.AwayFromZero),
-                (float)Math.Round(descentPx, MidpointRounding.AwayFromZero));
+                (float)Math.Round(descentPx, MidpointRounding.AwayFromZero),
+                isWhiteSpace);
         }
 
         private FontMetrics GetMetrics(IXLFontBase fontBase)

--- a/ClosedXML/Graphics/GlyphBox.cs
+++ b/ClosedXML/Graphics/GlyphBox.cs
@@ -18,13 +18,14 @@ namespace ClosedXML.Graphics
         /// <summary>
         /// A special glyph box that indicates a line break. Dimensions are kept at 0, so it doesn't affect any calculations.
         /// </summary>
-        internal static GlyphBox LineBreak => default;
+        internal static GlyphBox LineBreak => new(0, 0, 0, true);
 
-        public GlyphBox(float advanceWidth, float emSize, float descent)
+        public GlyphBox(float advanceWidth, float emSize, float descent, bool whiteSpace)
         {
             AdvanceWidth = advanceWidth;
             EmSize = emSize;
             Descent = descent;
+            IsWhiteSpace = whiteSpace;
         }
 
         /// <summary>
@@ -48,6 +49,8 @@ namespace ClosedXML.Graphics
         public float Descent { get; }
 
         internal bool IsLineBreak => AdvanceWidth == 0 && EmSize == 0 && Descent == 0;
+
+        internal bool IsWhiteSpace { get; }
 
         /// <summary>
         /// Get line width of the glyph box. It is calculated as central band with a text and


### PR DESCRIPTION
Hello,
This is my initial attempt to add text wrapping support when auto adjusting row height (https://github.com/ClosedXML/ClosedXML/issues/934).

Please note: This pull request is not yet intended to be merged. It serves as a base to discuss the solution. Once architectural concerns are resolved, I will add unit tests and polish the core algorithm itself.

Here's outline of my solution:
1. When text wrapping is enabled, Excel will break long lines so that text is not wider then the cell.
2. Lines can be wrapped on white space characters.
3. Content width is calculated in XLRow.CalculateMinRowHeight() method as Column Width - Pixel Padding.
4. Cell content height is calculated in XLRow.GetContentHeight(). As noted above, let's not focus on the algorithm itself this time yet. General idea is:
- scan glyphs and accumulate them into clusters (a cluster is either a word-like object or a group of white space characters),
- control line width and introduce line breaks when needed, moving current word into next line.
6. To find line break opportunities, XLRow.GetContentHeight() method needs to know which glyphs are white space.
7. GlyphBox class is extended to include IsWhiteSpace property, which is set via constructor.
8. DefaultGraphicEngine.GetGlyphBox() determines if a glyph box represents white space by checking if any of grapheme code points is a white space code point. (I am really not sure if this assumption is correct)

Please let me know if this is the right approach.
