### PR TITLE
Fix NRE during normal style loading

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -170,17 +170,11 @@ namespace ClosedXML.Excel
                     Properties.Manager = efp.Properties.GetFirstChild<Manager>().Text;
             }
 
-            Stylesheet s = null;
-            if (dSpreadsheet.WorkbookPart.WorkbookStylesPart != null &&
-                dSpreadsheet.WorkbookPart.WorkbookStylesPart.Stylesheet != null)
-            {
-                s = dSpreadsheet.WorkbookPart.WorkbookStylesPart.Stylesheet;
-            }
-
-            NumberingFormats numberingFormats = s == null ? null : s.NumberingFormats;
-            Fills fills = s == null ? null : s.Fills;
-            Borders borders = s == null ? null : s.Borders;
-            Fonts fonts = s == null ? null : s.Fonts;
+            Stylesheet s = dSpreadsheet.WorkbookPart.WorkbookStylesPart?.Stylesheet;
+            NumberingFormats numberingFormats = s?.NumberingFormats;
+            Fills fills = s?.Fills;
+            Borders borders = s?.Borders;
+            Fonts fonts = s?.Fonts;
             Int32 dfCount = 0;
             Dictionary<Int32, DifferentialFormat> differentialFormats;
             if (s != null && s.DifferentialFormats != null)
@@ -189,8 +183,7 @@ namespace ClosedXML.Excel
                 differentialFormats = new Dictionary<Int32, DifferentialFormat>();
 
             // If the loaded workbook has a changed "Normal" style, it might affect the default width of a column.
-            var normalStyle = dSpreadsheet.WorkbookPart.WorkbookStylesPart.Stylesheet.CellStyles.Elements<CellStyle>()
-                .FirstOrDefault(x => x.BuiltinId is not null && x.BuiltinId.Value == 0);
+            var normalStyle = s?.CellStyles.Elements<CellStyle>().FirstOrDefault(x => x.BuiltinId is not null && x.BuiltinId.Value == 0);
             if (normalStyle != null)
             {
                 var normalStyleKey = ((XLStyle)Style).Key;


### PR DESCRIPTION
Version used [0.101.0-rc](https://www.nuget.org/packages/ClosedXML/0.101.0-rc)

`WorkbookStylesPart` has been annotated with nullable attribute and when we tried the latest RC, a NRE is being thrown due to files not having styles part:

```text
System.NullReferenceException : Object reference not set to an instance of an object.
   at ClosedXML.Excel.XLWorkbook.LoadSpreadsheetDocument(SpreadsheetDocument dSpreadsheet) in C:\Work\OpenSource\ClosedXML\ClosedXML\Excel\XLWorkbook_Load.cs:line 192
   at ClosedXML.Excel.XLWorkbook.LoadSheets(Stream stream) in C:\Work\OpenSource\ClosedXML\ClosedXML\Excel\XLWorkbook_Load.cs:line 50
   at ClosedXML.Excel.XLWorkbook.Load(Stream stream) in C:\Work\OpenSource\ClosedXML\ClosedXML\Excel\XLWorkbook_Load.cs:line 38
   at ClosedXML.Excel.XLWorkbook..ctor(Stream stream, LoadOptions loadOptions) in C:\Work\OpenSource\ClosedXML\ClosedXML\Excel\XLWorkbook.cs:line 707
   at ClosedXML.Excel.XLWorkbook..ctor(Stream stream) in C:\Work\OpenSource\ClosedXML\ClosedXML\Excel\XLWorkbook.cs:line 698
```
This PR adds a null check which makes our test suite green again. I tried to make use consistent by using same variable that was already checked for null earlier so should be more obvious that it can be nullable. In ideal work of course the `XLWorkbook_Load.cs` would have nullable enabled, but that would be a bigger change.