### PR TITLE
Update IXLCell.cs Wrong summary on GetDouble()

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -278,7 +278,7 @@ namespace ClosedXML.Excel
         Boolean GetBoolean();
 
         /// <summary>
-        /// Gets the cell's value as a Boolean.
+        /// Gets the cell's value as a Double.
         /// </summary>
         /// <remarks>Shortcut for <c>Value.GetNumber()</c></remarks>
         /// <exception cref="InvalidCastException">If the value of the cell is not a number.</exception>


### PR DESCRIPTION
Pretty self-explanatory. The GetDouble function had the copy-pasted summary of the GetBoolean function, leading to confusion during usage.