### PR TITLE
Suppress false positives from vulnerability checkers

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -43,4 +43,11 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
+
+  <!-- Suppress false positives from vulnerability checkers. Packages are transitively referenced
+       through .NETStandard, but .NET Core/Framework use up-to-date implementation shipped with the runtime. -->
+  <ItemGroup>
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Vulnerability checkers constantly give out false positives, see https://github.com/ClosedXML/ClosedXML/blob/develop/SECURITY.md#netstandard-dependencies for details.

Add direct dependency to suppress it. 

NET Core and NET472+ are smart enough to not download the referenced nuget package and will use instead the runtime version (e.g. version 6 for net6). Older NET Frameworks will will use the downloaded package instead of their own (up-to-date) version.

Resolves #2099