### PR TITLE
Compatibility with Linux using Sixlabors.ImageSharp

### DIFF
--- a/ClosedXML.Examples/ClosedXML.Examples.csproj
+++ b/ClosedXML.Examples/ClosedXML.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/ClosedXML.Examples/Styles/UsingColors.cs
+++ b/ClosedXML.Examples/Styles/UsingColors.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Examples.Styles
             ro++;
 
             // FromColor(Color color)
-            ws.Cell(++ro, 1).Style.Fill.BackgroundColor = XLColor.FromColor(Color.Red);
+            ws.Cell(++ro, 1).Style.Fill.BackgroundColor = XLColor.FromName("Red");
             ws.Cell(ro, 2).Value = "XLColor.FromColor(Color.Red)";
 
             ro++;

--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -3,7 +3,7 @@ using ClosedXML.Excel.Drawings;
 using ClosedXML.Utils;
 using NUnit.Framework;
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
@@ -4,7 +4,7 @@ using ClosedXML.Tests.Utils;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using System.Linq;
 

--- a/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
@@ -1,6 +1,6 @@
 using ClosedXML.Excel;
 using NUnit.Framework;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.Linq;
 
 namespace ClosedXML.Tests

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -1,53 +1,63 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <!-- netstandard 2.0 doesn't contain nullable annotations for BCL, so we want to export
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+		<!-- netstandard 2.0 doesn't contain nullable annotations for BCL, so we want to export
          annotations for our consumers, but no warnings for our code. Warnings will be
          emitted by netstandard2.1 target -->
-    <Nullable Condition="'$(TargetFramework)' == 'netstandard2.0'">annotations</Nullable>
-    <Nullable Condition="'$(TargetFramework)' == 'netstandard2.1'">enable</Nullable>
-  </PropertyGroup>
+		<Nullable Condition="'$(TargetFramework)' == 'netstandard2.0'">annotations</Nullable>
+		<Nullable Condition="'$(TargetFramework)' == 'netstandard2.1'">enable</Nullable>
+		<Nullable Condition="'$(TargetFramework)' == 'net6.0'">annotations</Nullable>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Optimize>true</Optimize>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Release'">
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <!-- NU5104 - SixLabors.Fonts is available only as a prerelease -->
-    <NoWarn>$(NoWarn);NU1605;NU5104;CS1591</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup>
+		<!-- NU5104 - SixLabors.Fonts is available only as a prerelease -->
+		<NoWarn>$(NoWarn);NU1605;NU5104;CS1591</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-    <None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\.editorconfig" Link=".editorconfig" />
+		<None Include="..\resources\logo\nuget-logo.png" Pack="true" PackagePath="\" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
-    <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
-    <PackageReference Include="Fody" Version="6.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
-    <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
-    <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-    <PackageReference Include="XLParser" Version="1.5.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+		<PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
+		<PackageReference Include="Fody" Version="6.3.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
+		<!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
+		<PackageReference Include="System.IO.Packaging" Version="6.0.0" />
+		<PackageReference Include="XLParser" Version="1.5.2" />
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Buffers" Version="4.5.1" />
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+	</ItemGroup>
 
-  <!-- Suppress false positives from vulnerability checkers. Packages are transitively referenced
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+		<PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+	</ItemGroup>
+
+	<!-- Suppress false positives from vulnerability checkers. Packages are transitively referenced
        through .NETStandard, but .NET Core/Framework use up-to-date implementation shipped with the runtime. -->
-  <ItemGroup>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+	</ItemGroup>
 </Project>

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -2,7 +2,7 @@
 
 // Keep this file CodeMaid organised and cleaned
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 
 namespace ClosedXML.Excel.Drawings

--- a/ClosedXML/Excel/Drawings/IXLPictures.cs
+++ b/ClosedXML/Excel/Drawings/IXLPictures.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 
 namespace ClosedXML.Excel.Drawings

--- a/ClosedXML/Excel/Drawings/XLMarker.cs
+++ b/ClosedXML/Excel/Drawings/XLMarker.cs
@@ -3,7 +3,7 @@
 // Keep this file CodeMaid organised and cleaned
 using System;
 using System.Diagnostics;
-using System.Drawing;
+using SixLabors.ImageSharp;
 
 namespace ClosedXML.Excel.Drawings
 {

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using System.Linq;
 using ClosedXML.Graphics;

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -1659,7 +1659,7 @@ namespace ClosedXML.Excel.IO
                     };
 
                     var moveAndSizeToMarker = pic.Markers[Drawings.XLMarkerPosition.BottomRight];
-                    if (moveAndSizeToMarker == null) moveAndSizeToMarker = new Drawings.XLMarker(picture.Worksheet.Cell("A1"), new System.Drawing.Point(picture.Width, picture.Height));
+                    if (moveAndSizeToMarker == null) moveAndSizeToMarker = new Drawings.XLMarker(picture.Worksheet.Cell("A1"), new SixLabors.ImageSharp.Point(picture.Width, picture.Height));
                     tMark = new Xdr.ToMarker
                     {
                         ColumnId = new Xdr.ColumnId((moveAndSizeToMarker.ColumnNumber - 1).ToInvariantString()),

--- a/ClosedXML/Excel/LoadOptions.cs
+++ b/ClosedXML/Excel/LoadOptions.cs
@@ -1,6 +1,6 @@
 // Keep this file CodeMaid organized and cleaned
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using ClosedXML.Graphics;
 
 namespace ClosedXML.Excel

--- a/ClosedXML/Excel/Style/Colors/XLColor_Internal.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Internal.cs
@@ -1,7 +1,7 @@
 #nullable disable
 
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 
 namespace ClosedXML.Excel
 {

--- a/ClosedXML/Excel/Style/Colors/XLColor_Public.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Public.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace ClosedXML.Excel
 {
@@ -87,7 +88,7 @@ namespace ClosedXML.Excel
                 if (ColorType == XLColorType.Indexed)
                     throw new InvalidOperationException("Cannot extract theme tint from an indexed color.");
 
-                return Color.A / 255.0;
+                return ((Argb32)Color).A / 255.0;
             }
         }
 

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -2,7 +2,8 @@ using ClosedXML.Excel.Caching;
 using ClosedXML.Utils;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace ClosedXML.Excel
 {
@@ -64,17 +65,17 @@ namespace ClosedXML.Excel
 
         public static XLColor FromArgb(Int32 argb)
         {
-            return FromColor(Color.FromArgb(argb));
+            return FromColor(new Argb32((uint)argb));
         }
 
         public static XLColor FromArgb(Int32 r, Int32 g, Int32 b)
         {
-            return FromColor(Color.FromArgb(r, g, b));
+            return FromColor(new Argb32(r, g, b));
         }
 
         public static XLColor FromArgb(Int32 a, Int32 r, Int32 g, Int32 b)
         {
-            return FromColor(Color.FromArgb(a, r, g, b));
+            return FromColor(new Argb32(r, g, b, a));
         }
 
         /// <summary>
@@ -84,13 +85,14 @@ namespace ClosedXML.Excel
         {
             unchecked
             {
-                return FromColor(Color.FromArgb(rgb | (int)0xFF000000));
+                return FromColor(new Argb32((uint)rgb | (uint)0xFF000000));
             }
         }
 
         public static XLColor FromName(String name)
         {
-            return FromColor(Color.FromName(name));
+            var colorObj = new Color();
+            return FromColor((Color)colorObj.GetType().GetField(name).GetValue(colorObj));
         }
 
         public static XLColor FromHtml(String htmlColor)

--- a/ClosedXML/Excel/Style/XLColorKey.cs
+++ b/ClosedXML/Excel/Style/XLColorKey.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using SixLabors.ImageSharp.PixelFormats;
 using System;
 
 namespace ClosedXML.Excel
@@ -8,7 +9,7 @@ namespace ClosedXML.Excel
     {
         public XLColorType ColorType { get; set; }
 
-        public System.Drawing.Color Color { get; set; }
+        public SixLabors.ImageSharp.Color Color { get; set; }
 
         public int Indexed { get; set; }
 
@@ -23,7 +24,7 @@ namespace ClosedXML.Excel
             hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Indexed ? Indexed : 0);
             hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? (int)ThemeColor : 0);
             hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? ThemeTint.GetHashCode() : 0);
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Color ? Color.ToArgb() : 0);
+            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Color ?  (int)(((Argb32)Color).Argb) : 0);
             return hashCode;
         }
 
@@ -35,7 +36,7 @@ namespace ClosedXML.Excel
                 {
                     // .NET Color.Equals() will return false for Color.FromArgb(255, 255, 255, 255) == Color.White
                     // Therefore we compare the ToArgb() values
-                    return Color.ToArgb() == other.Color.ToArgb();
+                    return (int)(((Argb32)Color).Argb) == (int)(((Argb32)other.Color).Argb);
                 }
                 if (ColorType == XLColorType.Theme)
                 {

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel
     using Ap;
     using Drawings;
     using Op;
-    using System.Drawing;
+    using SixLabors.ImageSharp;
 
     public partial class XLWorkbook
     {

--- a/ClosedXML/Extensions/ColorExtensions.cs
+++ b/ClosedXML/Extensions/ColorExtensions.cs
@@ -2,7 +2,8 @@
 
 // Keep this file CodeMaid organised and cleaned
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace ClosedXML.Excel
 {
@@ -14,13 +15,13 @@ namespace ClosedXML.Excel
         {
             byte[] bytes = new byte[4];
 
-            bytes[0] = color.A;
+            bytes[0] = ((Argb32)color).A;
 
-            bytes[1] = color.R;
+            bytes[1] = ((Argb32)color).R;
 
-            bytes[2] = color.G;
+            bytes[2] = ((Argb32)color).G;
 
-            bytes[3] = color.B;
+            bytes[3] = ((Argb32)color).B;
 
             char[] chars = new char[bytes.Length * 2];
 

--- a/ClosedXML/Graphics/BmpInfoReader.cs
+++ b/ClosedXML/Graphics/BmpInfoReader.cs
@@ -1,7 +1,7 @@
 #nullable disable
 
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using ClosedXML.Excel.Drawings;
 using ClosedXML.Utils;

--- a/ClosedXML/Graphics/EmfInfoReader.cs
+++ b/ClosedXML/Graphics/EmfInfoReader.cs
@@ -1,6 +1,6 @@
 #nullable disable
 
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using ClosedXML.Excel.Drawings;
 using ClosedXML.Utils;

--- a/ClosedXML/Graphics/GifInfoReader.cs
+++ b/ClosedXML/Graphics/GifInfoReader.cs
@@ -1,7 +1,7 @@
 #nullable disable
 
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using ClosedXML.Excel.Drawings;
 using ClosedXML.Utils;

--- a/ClosedXML/Graphics/JpegInfoReader.cs
+++ b/ClosedXML/Graphics/JpegInfoReader.cs
@@ -1,7 +1,7 @@
 #nullable disable
 
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/ClosedXML/Graphics/PcxInfoReader.cs
+++ b/ClosedXML/Graphics/PcxInfoReader.cs
@@ -1,7 +1,7 @@
 #nullable disable
 
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using ClosedXML.Excel.Drawings;
 using ClosedXML.Utils;

--- a/ClosedXML/Graphics/WebpInfoReader.cs
+++ b/ClosedXML/Graphics/WebpInfoReader.cs
@@ -2,7 +2,7 @@
 
 using ClosedXML.Utils;
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 using ClosedXML.Excel;
 using ClosedXML.Excel.Drawings;

--- a/ClosedXML/Graphics/WmfInfoReader.cs
+++ b/ClosedXML/Graphics/WmfInfoReader.cs
@@ -3,7 +3,7 @@
 using ClosedXML.Excel.Drawings;
 using ClosedXML.Utils;
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.IO;
 
 namespace ClosedXML.Graphics

--- a/ClosedXML/Graphics/XLPictureInfo.cs
+++ b/ClosedXML/Graphics/XLPictureInfo.cs
@@ -2,7 +2,7 @@
 
 using ClosedXML.Excel.Drawings;
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 
 namespace ClosedXML.Graphics
 {

--- a/ClosedXML/Utils/ColorStringParser.cs
+++ b/ClosedXML/Utils/ColorStringParser.cs
@@ -1,8 +1,9 @@
 #nullable disable
 
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
 using System.Globalization;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace ClosedXML.Utils
 {
@@ -15,19 +16,19 @@ namespace ClosedXML.Utils
 
             if (argbColor.Length == 8)
             {
-                return Color.FromArgb(
+                return new Color(new Argb32(
                     ReadHex(argbColor, 0, 2),
                     ReadHex(argbColor, 2, 2),
                     ReadHex(argbColor, 4, 2),
-                    ReadHex(argbColor, 6, 2));
+                    ReadHex(argbColor, 6, 2)));
             }
 
             if (argbColor.Length == 6)
             {
-                return Color.FromArgb(
+                return new Color(new Argb32(
                     ReadHex(argbColor, 0, 2),
                     ReadHex(argbColor, 2, 2),
-                    ReadHex(argbColor, 4, 2));
+                    ReadHex(argbColor, 4, 2)));
             }
 
             if (argbColor.Length == 3)
@@ -35,10 +36,10 @@ namespace ClosedXML.Utils
                 var r = ReadHex(argbColor, 0, 1);
                 var g = ReadHex(argbColor, 1, 1);
                 var b = ReadHex(argbColor, 2, 1);
-                return Color.FromArgb(
+                return new Color(new Argb32(
                     (r << 4) | r,
                     (g << 4) | g,
-                    (b << 4) | b);
+                    (b << 4) | b));
             }
 
             throw new FormatException($"Unable to parse color {argbColor}.");

--- a/ClosedXML/Utils/CryptographicAlgorithms.cs
+++ b/ClosedXML/Utils/CryptographicAlgorithms.cs
@@ -56,7 +56,7 @@ namespace ClosedXML.Utils
 
         public static string GetSalt(int length = 32)
         {
-            using (var random = new RNGCryptoServiceProvider())
+            using (var random = RandomNumberGenerator.Create())
             {
                 var salt = new byte[length];
                 random.GetNonZeroBytes(salt);
@@ -120,7 +120,7 @@ namespace ClosedXML.Utils
             var bytes = saltBytes.Concat(passwordBytes).ToArray();
 
             byte[] hashedBytes;
-            using (var hash = new SHA512Managed())
+            using (var hash = SHA512.Create())
             {
                 hashedBytes = hash.ComputeHash(bytes);
 

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -4,7 +4,7 @@ using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
-using Drawing = System.Drawing;
+using Drawing = SixLabors.ImageSharp;
 using X14 = DocumentFormat.OpenXml.Office2010.Excel;
 
 namespace ClosedXML.Utils
@@ -63,7 +63,7 @@ namespace ClosedXML.Utils
         /// <param name="openXMLColor">Color in OpenXML format.</param>
         /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
         /// <returns>The color in ClosedXML format.</returns>
-        public static XLColor ToClosedXMLColor(this ColorType openXMLColor, IDictionary<string, Drawing.Color>? colorCache = null)
+        public static XLColor ToClosedXMLColor(this ColorType openXMLColor, IDictionary<string, SixLabors.ImageSharp.Color>? colorCache = null)
         {
             return ConvertToClosedXMLColor(new ColorTypeAdapter(openXMLColor), colorCache);
         }
@@ -74,7 +74,7 @@ namespace ClosedXML.Utils
         /// <param name="openXMLColor">Color in OpenXML format.</param>
         /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
         /// <returns>The color in ClosedXML format.</returns>
-        public static XLColor ToClosedXMLColor(this X14.ColorType openXMLColor, IDictionary<string, Drawing.Color>? colorCache = null)
+        public static XLColor ToClosedXMLColor(this X14.ColorType openXMLColor, IDictionary<string, SixLabors.ImageSharp.Color>? colorCache = null)
         {
             return ConvertToClosedXMLColor(new X14ColorTypeAdapter(openXMLColor), colorCache);
         }
@@ -90,13 +90,13 @@ namespace ClosedXML.Utils
         /// Since these types do not implement a common interface we use dynamic.</param>
         /// <param name="colorCache">The dictionary containing parsed colors to optimize performance.</param>
         /// <returns>The color in ClosedXML format.</returns>
-        private static XLColor ConvertToClosedXMLColor(IColorTypeAdapter openXMLColor, IDictionary<string, Drawing.Color>? colorCache)
+        private static XLColor ConvertToClosedXMLColor(IColorTypeAdapter openXMLColor, IDictionary<string, SixLabors.ImageSharp.Color>? colorCache)
         {
             XLColor? retVal = null;
             if (openXMLColor.Rgb != null)
             {
                 String htmlColor = "#" + openXMLColor.Rgb.Value;
-                if (colorCache == null || !colorCache.TryGetValue(htmlColor, out Drawing.Color thisColor))
+                if (colorCache == null || !colorCache.TryGetValue(htmlColor, out SixLabors.ImageSharp.Color thisColor))
                 {
                     thisColor = ColorStringParser.ParseFromArgb(htmlColor);
                     colorCache?.Add(htmlColor, thisColor);


### PR DESCRIPTION
Compatibility with Linux using Sixlabors.ImageSharp against system.drawing.
From .NET 5.0 onwards, Linux does not support system.drawing, so it is not possible to use ClosedXml in Linux either. With these changes, this problem is solved and ClosedXml becomes cross-platform.
