### PR TITLE
Store rich text as an immutable rich text

### DIFF
--- a/ClosedXML.Tests/Excel/RichText/XLImmutableRichTextTests.cs
+++ b/ClosedXML.Tests/Excel/RichText/XLImmutableRichTextTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.RichText
+{
+    [TestFixture]
+    public class XLImmutableRichTextTests
+    {
+        [Test]
+        public void Equals_compares_text_runs_phonetic_runs_and_properties()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var richText = (XLRichText)ws.Cell("A1").CreateRichText();
+            richText
+                .AddText("こんにち").SetBold(true) // Hello in hiragana
+                .AddText("は,").SetBold(false) // object marker
+                .AddText("世界").SetFontSize(15); // world in kanji
+            richText.Phonetics
+                .SetAlignment(XLPhoneticAlignment.Distributed)
+                .Add(@"konnichi wa", 0, 6); // world in hiragana
+
+            // Assert equal
+            var immutableRichText = new XLImmutableRichText(richText);
+            var equalImmutableRichText = new XLImmutableRichText(richText);
+            Assert.AreEqual(immutableRichText, equalImmutableRichText);
+
+            // Different font of a first run
+            richText.ElementAt(0).SetBold(false);
+            var withDifferentTextRunFont = new XLImmutableRichText(richText);
+            Assert.AreNotEqual(immutableRichText, withDifferentTextRunFont);
+            richText.ElementAt(0).SetBold(true);
+
+            // Different phonetic properties
+            richText.Phonetics.SetAlignment(XLPhoneticAlignment.Left);
+            var withDifferentPhoneticsProps = new XLImmutableRichText(richText);
+            Assert.AreNotEqual(immutableRichText, withDifferentPhoneticsProps);
+            richText.Phonetics.SetAlignment(XLPhoneticAlignment.Distributed);
+
+            // Different phonetic runs
+            richText.Phonetics.Add("せかい", 6, 8);
+            var withDifferentTextPhonetics = new XLImmutableRichText(richText);
+            Assert.AreNotEqual(immutableRichText, withDifferentTextPhonetics);
+        }
+    }
+}

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -23,6 +23,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMIF/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscaled/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/Cells/ValueSlice.cs
+++ b/ClosedXML/Excel/Cells/ValueSlice.cs
@@ -140,15 +140,15 @@ namespace ClosedXML.Excel
             _values.Set(point, in modified);
         }
 
-        internal XLRichText GetRichText(XLSheetPoint point)
+        internal XLImmutableRichText? GetRichText(XLSheetPoint point)
         {
             return _values[point].RichText;
         }
 
-        internal void SetRichText(XLSheetPoint point, XLRichText richText)
+        internal void SetRichText(XLSheetPoint point, XLImmutableRichText? richText)
         {
             ref readonly var original = ref _values[point];
-            if (original.RichText != richText)
+            if (!ReferenceEquals(original.RichText, richText))
             {
                 var modified = new XLValueSliceContent(original.Value, original.Type, original.ModifiedAtVersion, original.SharedStringId, richText);
                 _values.Set(point, in modified);
@@ -220,9 +220,9 @@ namespace ClosedXML.Excel
             internal readonly XLDataType Type;
             internal readonly long ModifiedAtVersion;
             internal readonly int SharedStringId;
-            internal readonly XLRichText RichText;
+            internal readonly XLImmutableRichText? RichText;
 
-            internal XLValueSliceContent(double value, XLDataType type, long modifiedAtVersion, int sharedStringId, XLRichText richText)
+            internal XLValueSliceContent(double value, XLDataType type, long modifiedAtVersion, int sharedStringId, XLImmutableRichText? richText)
             {
                 Value = value;
                 Type = type;

--- a/ClosedXML/Excel/Cells/ValueSlice.cs
+++ b/ClosedXML/Excel/Cells/ValueSlice.cs
@@ -136,8 +136,23 @@ namespace ClosedXML.Excel
                     value = 0; // blank
             }
 
-            var modified = new XLValueSliceContent(value, cellValue.Type, original.ModifiedAtVersion, original.SharedStringId);
+            var modified = new XLValueSliceContent(value, cellValue.Type, original.ModifiedAtVersion, original.SharedStringId, original.RichText);
             _values.Set(point, in modified);
+        }
+
+        internal XLRichText GetRichText(XLSheetPoint point)
+        {
+            return _values[point].RichText;
+        }
+
+        internal void SetRichText(XLSheetPoint point, XLRichText richText)
+        {
+            ref readonly var original = ref _values[point];
+            if (original.RichText != richText)
+            {
+                var modified = new XLValueSliceContent(original.Value, original.Type, original.ModifiedAtVersion, original.SharedStringId, richText);
+                _values.Set(point, in modified);
+            }
         }
 
         internal int GetShareStringId(XLSheetPoint point)
@@ -151,7 +166,7 @@ namespace ClosedXML.Excel
             ref readonly var original = ref _values[point];
             if (original.SharedStringId != sharedStringId)
             {
-                var modified = new XLValueSliceContent(original.Value, original.Type, original.ModifiedAtVersion, sharedStringId);
+                var modified = new XLValueSliceContent(original.Value, original.Type, original.ModifiedAtVersion, sharedStringId, original.RichText);
                 _values.Set(point, in modified);
             }
         }
@@ -166,7 +181,7 @@ namespace ClosedXML.Excel
             ref readonly var original = ref _values[point];
             if (original.ModifiedAtVersion != modifiedAtVersion)
             {
-                var modified = new XLValueSliceContent(original.Value, original.Type, modifiedAtVersion, original.SharedStringId);
+                var modified = new XLValueSliceContent(original.Value, original.Type, modifiedAtVersion, original.SharedStringId, original.RichText);
                 _values.Set(point, in modified);
             }
         }
@@ -186,7 +201,7 @@ namespace ClosedXML.Excel
                 if (value.Type == XLDataType.Text)
                 {
                     _sst.DecreaseRef((int)value.Value);
-                    var blank = new XLValueSliceContent(0, XLDataType.Blank, value.ModifiedAtVersion, value.SharedStringId);
+                    var blank = new XLValueSliceContent(0, XLDataType.Blank, value.ModifiedAtVersion, value.SharedStringId, value.RichText);
                     _values.Set(e.Current, in blank);
                 }
             }
@@ -205,13 +220,15 @@ namespace ClosedXML.Excel
             internal readonly XLDataType Type;
             internal readonly long ModifiedAtVersion;
             internal readonly int SharedStringId;
+            internal readonly XLRichText RichText;
 
-            internal XLValueSliceContent(double value, XLDataType type, long modifiedAtVersion, int sharedStringId)
+            internal XLValueSliceContent(double value, XLDataType type, long modifiedAtVersion, int sharedStringId, XLRichText richText)
             {
                 Value = value;
                 Type = type;
                 ModifiedAtVersion = modifiedAtVersion;
                 SharedStringId = sharedStringId;
+                RichText = richText;
             }
         }
     }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -140,17 +140,8 @@ namespace ClosedXML.Excel
 
         private XLRichText SliceRichText
         {
-            get => _cellsCollection.MiscSlice[_rowNumber, _columnNumber].RichText;
-            set
-            {
-                ref readonly var original = ref _cellsCollection.MiscSlice[_rowNumber, _columnNumber];
-                if (original.RichText != value)
-                {
-                    var modified = original;
-                    modified.RichText = value;
-                    _cellsCollection.MiscSlice.Set(_rowNumber, _columnNumber, in modified);
-                }
-            }
+            get => _cellsCollection.ValueSlice.GetRichText(SheetPoint);
+            set => _cellsCollection.ValueSlice.SetRichText(SheetPoint, value);
         }
 
         private XLComment SliceComment

--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -70,7 +70,7 @@ namespace ClosedXML.Excel
 
         internal Slice<XLCellFormula> FormulaSlice { get; } = new();
 
-        internal Slice<XLStyleValue> StyleSlice { get; } = new();
+        internal Slice<XLStyleValue?> StyleSlice { get; } = new();
 
         internal Slice<XLMiscSliceContent> MiscSlice { get; } = new();
 

--- a/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
+++ b/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
@@ -5,8 +5,6 @@
         // Must be as flag for inline string, so the default value is false => ShareString is true by default 
         private bool _inlineString;
 
-        internal XLRichText RichText { get; set; }
-
         internal bool ShareString
         {
             get => !_inlineString;

--- a/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
+++ b/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
@@ -11,9 +11,9 @@
             set => _inlineString = !value;
         }
 
-        internal XLComment Comment { get; set; }
+        internal XLComment? Comment { get; set; }
 
-        internal XLHyperlink Hyperlink { get; set; }
+        internal XLHyperlink? Hyperlink { get; set; }
 
         internal uint? CellMetaIndex { get; set; }
 

--- a/ClosedXML/Excel/PageSetup/XLHFItem.cs
+++ b/ClosedXML/Excel/PageSetup/XLHFItem.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel
 
         public IXLRichString AddText(String text, XLHFOccurrence occurrence)
         {
-            XLRichString richText = new XLRichString(text, this.HeaderFooter.Worksheet.Style.Font, this);
+            var richText = new XLRichString(text, HeaderFooter.Worksheet.Style.Font, this, null);
 
             var hfText = new XLHFText(richText, this);
             if (occurrence == XLHFOccurrence.AllPages)

--- a/ClosedXML/Excel/RichText/IXLFormattedText.cs
+++ b/ClosedXML/Excel/RichText/IXLFormattedText.cs
@@ -36,17 +36,36 @@ namespace ClosedXML.Excel
         IXLFormattedText<T> Substring(Int32 index, Int32 length);
 
         /// <summary>
-        /// Copy the text and formatting from the original text.
+        /// Replace the text and formatting of this text by texts and formatting from the <paramref name="original"/> text.
         /// </summary>
         /// <param name="original">Original to copy from.</param>
         /// <returns>This text.</returns>
         IXLFormattedText<T> CopyFrom(IXLFormattedText<T> original);
 
+        /// <summary>
+        /// How many rich strings is the formatted text composed of.
+        /// </summary>
         Int32 Count { get; }
+
+        /// <summary>
+        /// Length of the whole formatted text.
+        /// </summary>
         Int32 Length { get; }
 
+        /// <summary>
+        /// Get text of the whole formatted text.
+        /// </summary>
         String Text { get; }
-        IXLPhonetics Phonetics { get; }
+
+        /// <summary>
+        /// Does this text has phonetics? Unlike accessing the <see cref="Phonetics"/> property, this method
+        /// doesn't create a new instance on access.
+        /// </summary>
         Boolean HasPhonetics { get; }
+
+        /// <summary>
+        /// Get or create phonetics for the text. Use <see cref="HasPhonetics"/> to check for existence to avoid unnecessary creation.
+        /// </summary>
+        IXLPhonetics Phonetics { get; }
     }
 }

--- a/ClosedXML/Excel/RichText/IXLPhonetic.cs
+++ b/ClosedXML/Excel/RichText/IXLPhonetic.cs
@@ -1,13 +1,11 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel
 {
     public interface IXLPhonetic: IEquatable<IXLPhonetic>
     {
-        String Text { get; set; }
-        Int32 Start { get; set; }
-        Int32 End { get; set; }
+        String Text { get; }
+        Int32 Start { get; }
+        Int32 End { get; }
     }
 }

--- a/ClosedXML/Excel/RichText/IXLPhonetics.cs
+++ b/ClosedXML/Excel/RichText/IXLPhonetics.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -20,10 +18,29 @@ namespace ClosedXML.Excel
         IXLPhonetics SetFontName(String value);
         IXLPhonetics SetFontFamilyNumbering(XLFontFamilyNumberingValues value);
         IXLPhonetics SetFontCharSet(XLFontCharSet value);
+        IXLPhonetics SetFontScheme(XLFontScheme value);
 
+        /// <summary>
+        /// Add a phonetic run above a base text. Phonetic runs can't overlap.
+        /// </summary>
+        /// <param name="text">Text to display above a section of a base text. Can't be empty.</param>
+        /// <param name="start">Index of a first character of a base  text above which should <paramref name="text"/> be displayed. Valid values are <c>0</c>..<c>length-1</c>.</param>
+        /// <param name="end">The excluded ending index in a base text (the hint is not displayed above the <c>end</c>). Must be &gt; <paramref name="start"/>. Valid values are <c>1</c>..<c>length</c>.</param>
         IXLPhonetics Add(String text, Int32 start, Int32 end);
+
+        /// <summary>
+        /// Remove all phonetic runs. Keeps font properties.
+        /// </summary>
         IXLPhonetics ClearText();
+
+        /// <summary>
+        /// Reset font properties to the default font of a container (likely <c>IXLCell</c>). Keeps phonetic runs, <see cref="Type"/> and <see cref="Alignment"/>.
+        /// </summary>
         IXLPhonetics ClearFont();
+
+        /// <summary>
+        /// Number of phonetic runs above the base text.
+        /// </summary>
         Int32 Count { get; }
 
         XLPhoneticAlignment Alignment { get; set; }

--- a/ClosedXML/Excel/RichText/IXLRichText.cs
+++ b/ClosedXML/Excel/RichText/IXLRichText.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 namespace ClosedXML.Excel
 {
     public interface IXLRichText : IXLFormattedText<IXLRichText>

--- a/ClosedXML/Excel/RichText/XLImmutableRichText.cs
+++ b/ClosedXML/Excel/RichText/XLImmutableRichText.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace ClosedXML.Excel
+{
+    /// <summary>
+    /// A class for holding <see cref="XLRichText"/> in a <see cref="SharedStringTable"/>.
+    /// It's immutable (keys in reverse dictionary can't change) and more memory efficient
+    /// than mutable rich text.
+    /// </summary>
+    [DebuggerDisplay("{Text}")]
+    internal sealed class XLImmutableRichText : IEquatable<XLImmutableRichText>
+    {
+        private readonly RichTextRun[] _runs;
+        private readonly PhoneticRun[] _phoneticRuns;
+
+        /// <summary>
+        /// Create an immutable rich text with same content as the original <paramref name="richText"/>.
+        /// </summary>
+        internal XLImmutableRichText(XLRichText richText)
+        {
+            Text = richText.Text;
+            _runs = new RichTextRun[richText.Count];
+            var runIdx = 0;
+            var charStartIdx = 0;
+            foreach (var richString in richText)
+            {
+                _runs[runIdx++] = new RichTextRun(richString, charStartIdx, richString.Text.Length);
+                charStartIdx += richString.Text.Length;
+            }
+
+            if (richText.HasPhonetics)
+            {
+                var rtPhonetics = richText.Phonetics;
+                _phoneticRuns = new PhoneticRun[rtPhonetics.Count];
+                var phoneticRunIdx = 0;
+                var prevPhoneticEndIdx = 0;
+                foreach (var phonetic in richText.Phonetics)
+                {
+                    if (phonetic.Start >= Text.Length)
+                        throw new ArgumentException("Phonetic run start index must be within the text boundaries.");
+
+                    if (phonetic.End > Text.Length)
+                        throw new ArgumentException("Phonetic run end index must be at most length of a text.");
+
+                    if (phonetic.Start < prevPhoneticEndIdx)
+                        throw new ArgumentException("Phonetic runs must be in ascending order and can't overlap.");
+
+                    _phoneticRuns[phoneticRunIdx++] = new PhoneticRun(phonetic.Text, phonetic.Start, phonetic.End);
+                    prevPhoneticEndIdx = phonetic.End;
+                }
+
+                PhoneticsProperties = new PhoneticProperties(rtPhonetics);
+            }
+            else
+            {
+                _phoneticRuns = Array.Empty<PhoneticRun>();
+                PhoneticsProperties = null;
+            }
+        }
+
+        /// <summary>
+        /// A text of a whole rich text, without styling.
+        /// </summary>
+        public string Text { get; }
+
+        /// <summary>
+        /// Individual rich text runs that make up the <see cref="Text"/>, in ascending order, non-overlapping.
+        /// </summary>
+        public IReadOnlyList<RichTextRun> Runs => _runs;
+
+        /// <summary>
+        /// All phonetics runs of rich text. Empty array, if no phonetic run. In ascending order, non-overlapping.
+        /// </summary>
+        public IReadOnlyList<PhoneticRun> PhoneticRuns => _phoneticRuns;
+
+        /// <summary>
+        /// Properties used to display phonetic runs.
+        /// </summary>
+        public PhoneticProperties? PhoneticsProperties { get; }
+
+        public bool Equals(XLImmutableRichText? other)
+        {
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Text == other.Text &&
+                   _runs.SequenceEqual(other._runs) &&
+                   _phoneticRuns.SequenceEqual(other._phoneticRuns) &&
+                   Nullable.Equals(PhoneticsProperties, other.PhoneticsProperties);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as XLImmutableRichText);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Text.GetHashCode();
+                hashCode = (hashCode * 397) ^ PhoneticsProperties.GetHashCode();
+                foreach (var phoneticRun in _phoneticRuns)
+                    hashCode = (hashCode * 397) ^ phoneticRun.GetHashCode();
+
+                foreach (var run in _runs)
+                    hashCode = (hashCode * 397) ^ run.GetHashCode();
+
+                return hashCode;
+            }
+        }
+
+        internal string GetRunText(RichTextRun run) => Text.Substring(run.StartIndex, run.Length);
+
+        internal readonly struct RichTextRun : IEquatable<RichTextRun>
+        {
+            internal readonly int StartIndex;
+            internal readonly int Length;
+            internal readonly XLFontValue Font;
+
+            internal RichTextRun(XLRichString richString, int startIndex, int length)
+            {
+                var key = XLFont.GenerateKey(richString);
+                Font = XLFontValue.FromKey(ref key);
+                StartIndex = startIndex;
+                Length = length;
+            }
+
+            public bool Equals(RichTextRun other)
+            {
+                return StartIndex == other.StartIndex && Length == other.Length && Font.Equals(other.Font);
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is RichTextRun other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = StartIndex;
+                    hashCode = (hashCode * 397) ^ Length;
+                    hashCode = (hashCode * 397) ^ Font.GetHashCode();
+                    return hashCode;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Phonetic runs can't overlap and must be in order (i.e. start index must be ascending).
+        /// </summary>
+        internal readonly struct PhoneticRun
+        {
+            /// <summary>
+            /// Text that is displayed above a segment indicating how should segment be read.
+            /// </summary>
+            internal readonly string Text;
+
+            /// <summary>
+            /// Starting index of displayed phonetic (first character is 0).
+            /// </summary>
+            internal readonly int StartIndex;
+
+            /// <summary>
+            /// End index, excluding (the last index is a length of the rich text).
+            /// </summary>
+            internal readonly int EndIndex;
+
+            public PhoneticRun(string text, int startIndex, int endIndex)
+            {
+                if (text.Length == 0)
+                    throw new ArgumentException("Phonetic run text can't be empty.", nameof(text));
+
+                if (startIndex < 0)
+                    throw new ArgumentException("Start index index must be greater than 0.", nameof(startIndex));
+
+                if (startIndex >= endIndex)
+                    throw new ArgumentException("Start index must be less than end index.", nameof(endIndex));
+
+                Text = text;
+                StartIndex = startIndex;
+                EndIndex = endIndex;
+            }
+
+            public bool Equals(PhoneticRun other)
+            {
+                return Text == other.Text && StartIndex == other.StartIndex && EndIndex == other.EndIndex;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is PhoneticRun other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Text.GetHashCode();
+                    hashCode = (hashCode * 397) ^ StartIndex;
+                    hashCode = (hashCode * 397) ^ EndIndex;
+                    return hashCode;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Properties of phonetic runs. All phonetic runs of a rich text have same font and other properties.
+        /// </summary>
+        internal readonly struct PhoneticProperties
+        {
+            /// <summary>
+            /// Font used for text of phonetic runs. All phonetic runs use same font. There can be no phonetic runs,
+            /// but with specified font (e.g. the mutable API has only specified font, but no text yet).
+            /// </summary>
+            public readonly XLFontValue Font;
+
+            /// <summary>
+            /// Type of phonetics. Default is <see cref="XLPhoneticType.FullWidthKatakana"/>
+            /// </summary>
+            public readonly XLPhoneticType Type;
+
+            /// <summary>
+            /// Alignment of phonetics. Default is <see cref="XLPhoneticAlignment.Left"/>
+            /// </summary>
+            public readonly XLPhoneticAlignment Alignment;
+
+            public PhoneticProperties(XLPhonetics rtPhonetics)
+            {
+                var fontKey = XLFont.GenerateKey(rtPhonetics);
+                Font = XLFontValue.FromKey(ref fontKey);
+                Type = rtPhonetics.Type;
+                Alignment = rtPhonetics.Alignment;
+            }
+
+            public bool Equals(PhoneticProperties other)
+            {
+                return Font.Equals(other.Font) && Type == other.Type && Alignment == other.Alignment;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is PhoneticProperties other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Font.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (int)Type;
+                    hashCode = (hashCode * 397) ^ (int)Alignment;
+                    return hashCode;
+                }
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/RichText/XLPhonetic.cs
+++ b/ClosedXML/Excel/RichText/XLPhonetic.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel
@@ -12,14 +10,17 @@ namespace ClosedXML.Excel
             Start = start;
             End = end;
         }
-        public String Text { get; set; }
-        public Int32 Start { get; set; }
-        public Int32 End { get; set; }
+        public String Text { get; }
+        public Int32 Start { get; }
+        public Int32 End { get; }
 
-        public bool Equals(IXLPhonetic other)
+        public bool Equals(IXLPhonetic? other)
         {
-            if (other == null)
+            if (other is null)
                 return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
 
             return Text == other.Text && Start == other.Start && End == other.End;
         }

--- a/ClosedXML/Excel/RichText/XLPhonetics.cs
+++ b/ClosedXML/Excel/RichText/XLPhonetics.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,39 +6,172 @@ namespace ClosedXML.Excel
 {
     internal class XLPhonetics : IXLPhonetics
     {
-        private readonly List<IXLPhonetic> _phonetics = new List<IXLPhonetic>();
-
+        private readonly List<IXLPhonetic> _phonetics = new();
+        private readonly XLFont _font;
         private readonly IXLFontBase _defaultFont;
+        private readonly Action _onChange;
+        private XLPhoneticAlignment _alignment;
+        private XLPhoneticType _type;
 
-        public XLPhonetics(IXLFontBase defaultFont)
+        public XLPhonetics(IXLFontBase defaultFont, Action onChange)
         {
             _defaultFont = defaultFont;
-            Type = XLPhoneticType.FullWidthKatakana;
-            Alignment = XLPhoneticAlignment.Left;
-            this.CopyFont(_defaultFont);
+            _font = new XLFont(defaultFont);
+            _type = XLPhoneticType.FullWidthKatakana;
+            _alignment = XLPhoneticAlignment.Left;
+            _onChange = onChange;
         }
 
-        public XLPhonetics(IXLPhonetics defaultPhonetics, IXLFontBase defaultFont)
+        public XLPhonetics(IXLPhonetics defaultPhonetics, IXLFontBase defaultFont, Action onChange)
         {
             _defaultFont = defaultFont;
-            Type = defaultPhonetics.Type;
-            Alignment = defaultPhonetics.Alignment;
-
-            this.CopyFont(defaultPhonetics);
+            _font = new XLFont(defaultPhonetics);
+            _type = defaultPhonetics.Type;
+            _alignment = defaultPhonetics.Alignment;
+            _onChange = onChange;
         }
 
-        public Boolean Bold { get; set; }
-        public Boolean Italic { get; set; }
-        public XLFontUnderlineValues Underline { get; set; }
-        public Boolean Strikethrough { get; set; }
-        public XLFontVerticalTextAlignmentValues VerticalAlignment { get; set; }
-        public Boolean Shadow { get; set; }
-        public Double FontSize { get; set; }
-        public XLColor FontColor { get; set; }
-        public String FontName { get; set; }
-        public XLFontFamilyNumberingValues FontFamilyNumbering { get; set; }
-        public XLFontCharSet FontCharSet { get; set; }
-        public XLFontScheme FontScheme { get; set; }
+        public Int32 Count => _phonetics.Count;
+
+        public Boolean Bold
+        {
+            get => _font.Bold;
+            set
+            {
+                _font.Bold = value;
+                _onChange();
+            }
+        }
+
+        public Boolean Italic
+        {
+            get => _font.Italic;
+            set
+            {
+                _font.Italic = value;
+                _onChange();
+            }
+        }
+
+        public XLFontUnderlineValues Underline
+        {
+            get => _font.Underline;
+            set
+            {
+                _font.Underline = value;
+                _onChange();
+            }
+        }
+
+        public Boolean Strikethrough
+        {
+            get => _font.Strikethrough;
+            set
+            {
+                _font.Strikethrough = value;
+                _onChange();
+            }
+        }
+
+        public XLFontVerticalTextAlignmentValues VerticalAlignment
+        {
+            get => _font.VerticalAlignment;
+            set
+            {
+                _font.VerticalAlignment = value;
+                _onChange();
+            }
+        }
+
+        public Boolean Shadow
+        {
+            get => _font.Shadow;
+            set
+            {
+                _font.Shadow = value;
+                _onChange();
+            }
+        }
+
+        public Double FontSize
+        {
+            get => _font.FontSize;
+            set
+            {
+                _font.FontSize = value;
+                _onChange();
+            }
+        }
+
+        public XLColor FontColor
+        {
+            get => _font.FontColor;
+            set
+            {
+                _font.FontColor = value;
+                _onChange();
+            }
+        }
+
+        public String FontName
+        {
+            get => _font.FontName;
+            set
+            {
+                _font.FontName = value;
+                _onChange();
+            }
+        }
+
+        public XLFontFamilyNumberingValues FontFamilyNumbering
+        {
+            get => _font.FontFamilyNumbering;
+            set
+            {
+                _font.FontFamilyNumbering = value;
+                _onChange();
+            }
+        }
+
+        public XLFontCharSet FontCharSet
+        {
+            get => _font.FontCharSet;
+            set
+            {
+                _font.FontCharSet = value;
+                _onChange();
+            }
+        }
+
+        public XLFontScheme FontScheme
+        {
+            get => _font.FontScheme;
+            set
+            {
+                _font.FontScheme = value;
+                _onChange();
+            }
+        }
+
+        public XLPhoneticAlignment Alignment
+        {
+            get => _alignment;
+            set
+            {
+                _alignment = value;
+                _onChange();
+            }
+        }
+
+        public XLPhoneticType Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                _onChange();
+            }
+        }
 
         public IXLPhonetics SetBold() { Bold = true; return this; }
 
@@ -76,32 +207,30 @@ namespace ClosedXML.Excel
 
         public IXLPhonetics SetFontScheme(XLFontScheme value) { FontScheme = value; return this; }
 
+        public IXLPhonetics SetAlignment(XLPhoneticAlignment phoneticAlignment) { Alignment = phoneticAlignment; return this; }
+
+        public IXLPhonetics SetType(XLPhoneticType phoneticType) { Type = phoneticType; return this; }
+
         public IXLPhonetics Add(String text, Int32 start, Int32 end)
         {
             _phonetics.Add(new XLPhonetic(text, start, end));
+            _onChange();
             return this;
         }
 
         public IXLPhonetics ClearText()
         {
             _phonetics.Clear();
+            _onChange();
             return this;
         }
 
         public IXLPhonetics ClearFont()
         {
             this.CopyFont(_defaultFont);
+            _onChange();
             return this;
         }
-
-        public Int32 Count { get { return _phonetics.Count; } }
-
-        public XLPhoneticAlignment Alignment { get; set; }
-        public XLPhoneticType Type { get; set; }
-
-        public IXLPhonetics SetAlignment(XLPhoneticAlignment phoneticAlignment) { Alignment = phoneticAlignment; return this; }
-
-        public IXLPhonetics SetType(XLPhoneticType phoneticType) { Type = phoneticType; return this; }
 
         public IEnumerator<IXLPhonetic> GetEnumerator()
         {
@@ -113,30 +242,23 @@ namespace ClosedXML.Excel
             return GetEnumerator();
         }
 
-        public bool Equals(IXLPhonetics other)
+        public bool Equals(IXLPhonetics? other) => Equals(other as XLPhonetics);
+
+        public bool Equals(XLPhonetics? other)
         {
-            if (other == null)
+            if (other is null)
                 return false;
 
-            Int32 phoneticsCount = _phonetics.Count;
-            for (Int32 i = 0; i < phoneticsCount; i++)
-            {
-                if (!_phonetics[i].Equals(other.ElementAt(i)))
-                    return false;
-            }
+            if (ReferenceEquals(this, other))
+                return true;
+
+            if (!_phonetics.SequenceEqual(other._phonetics))
+                return false;
 
             return
-                   Bold == other.Bold
-                && Italic == other.Italic
-                && Underline == other.Underline
-                && Strikethrough == other.Strikethrough
-                && VerticalAlignment == other.VerticalAlignment
-                && Shadow == other.Shadow
-                && FontSize.Equals(other.FontSize)
-                && FontColor.Equals(other.FontColor)
-                && FontName == other.FontName
-                && FontFamilyNumbering == other.FontFamilyNumbering
-                && FontScheme == other.FontScheme;
+                _font.Key.Equals(other._font.Key) &&
+                Type == other.Type &&
+                Alignment == other.Alignment;
         }
     }
 }

--- a/ClosedXML/Excel/RichText/XLRichString.cs
+++ b/ClosedXML/Excel/RichText/XLRichString.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Diagnostics;
 
@@ -9,12 +7,15 @@ namespace ClosedXML.Excel
     internal class XLRichString : IXLRichString
     {
         private readonly IXLWithRichString _withRichString;
+        private readonly XLFont _font;
+        private readonly Action _onChange;
 
-        public XLRichString(String text, IXLFontBase font, IXLWithRichString withRichString)
+        public XLRichString(String text, IXLFontBase font, IXLWithRichString withRichString, Action? onChange)
         {
             Text = text;
-            this.CopyFont(font);
+            _font = new XLFont(font);
             _withRichString = withRichString;
+            _onChange = onChange ?? (() => { });
         }
 
         public String Text { get; set; }
@@ -29,18 +30,125 @@ namespace ClosedXML.Excel
             return AddText(Environment.NewLine);
         }
 
-        public Boolean Bold { get; set; }
-        public Boolean Italic { get; set; }
-        public XLFontUnderlineValues Underline { get; set; }
-        public Boolean Strikethrough { get; set; }
-        public XLFontVerticalTextAlignmentValues VerticalAlignment { get; set; }
-        public Boolean Shadow { get; set; }
-        public Double FontSize { get; set; }
-        public XLColor FontColor { get; set; }
-        public String FontName { get; set; }
-        public XLFontFamilyNumberingValues FontFamilyNumbering { get; set; }
-        public XLFontCharSet FontCharSet { get; set; }
-        public XLFontScheme FontScheme { get; set; }
+        public Boolean Bold
+        {
+            get => _font.Bold;
+            set
+            {
+                _font.Bold = value;
+                _onChange();
+            }
+        }
+
+        public Boolean Italic
+        {
+            get => _font.Italic;
+            set
+            {
+                _font.Italic = value;
+                _onChange();
+            }
+        }
+
+        public XLFontUnderlineValues Underline
+        {
+            get => _font.Underline;
+            set
+            {
+                _font.Underline = value;
+                _onChange();
+            }
+        }
+
+        public Boolean Strikethrough
+        {
+            get => _font.Strikethrough;
+            set
+            {
+                _font.Strikethrough = value;
+                _onChange();
+            }
+        }
+
+        public XLFontVerticalTextAlignmentValues VerticalAlignment
+        {
+            get => _font.VerticalAlignment;
+            set
+            {
+                _font.VerticalAlignment = value;
+                _onChange();
+            }
+        }
+
+        public Boolean Shadow
+        {
+            get => _font.Shadow;
+            set
+            {
+                _font.Shadow = value;
+                _onChange();
+            }
+        }
+
+        public Double FontSize
+        {
+            get => _font.FontSize;
+            set
+            {
+                _font.FontSize = value;
+                _onChange();
+            }
+        }
+
+        public XLColor FontColor
+        {
+            get => _font.FontColor;
+            set
+            {
+                _font.FontColor = value;
+                _onChange();
+            }
+        }
+
+        public String FontName
+        {
+            get => _font.FontName;
+            set
+            {
+                _font.FontName = value;
+                _onChange();
+            }
+        }
+
+        public XLFontFamilyNumberingValues FontFamilyNumbering
+        {
+            get => _font.FontFamilyNumbering;
+            set
+            {
+                _font.FontFamilyNumbering = value;
+                _onChange();
+            }
+        }
+
+        public XLFontCharSet FontCharSet
+        {
+            get => _font.FontCharSet;
+            set
+            {
+                _font.FontCharSet = value;
+                _onChange();
+            }
+        }
+
+        public XLFontScheme FontScheme
+        {
+            get => _font.FontScheme;
+            set
+            {
+                _font.FontScheme = value;
+                _onChange();
+            }
+        }
 
         public IXLRichString SetBold()
         {
@@ -127,42 +235,26 @@ namespace ClosedXML.Excel
             FontScheme = value; return this;
         }
 
-        public Boolean Equals(IXLRichString other)
-        {
-            return
-                    Text == other.Text
-                && Bold.Equals(other.Bold)
-                && Italic.Equals(other.Italic)
-                && Underline.Equals(other.Underline)
-                && Strikethrough.Equals(other.Strikethrough)
-                && VerticalAlignment.Equals(other.VerticalAlignment)
-                && Shadow.Equals(other.Shadow)
-                && FontSize.Equals(other.FontSize)
-                && FontColor.Equals(other.FontColor)
-                && FontName.Equals(other.FontName)
-                && FontFamilyNumbering.Equals(other.FontFamilyNumbering)
-                && FontScheme.Equals(other.FontScheme)
-                ;
-        }
+        public override bool Equals(object obj) => Equals(obj as XLRichString);
 
-        public override bool Equals(object obj)
+        public Boolean Equals(IXLRichString? other) => Equals(other as XLRichString);
+
+        public Boolean Equals(XLRichString? other)
         {
-            return Equals((XLRichString)obj);
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Text == other.Text && _font.Key.Equals(other._font.Key);
         }
 
         public override int GetHashCode()
         {
-            return Text.GetHashCode()
-                ^ Bold.GetHashCode()
-                ^ Italic.GetHashCode()
-                ^ (Int32)Underline
-                ^ Strikethrough.GetHashCode()
-                ^ (Int32)VerticalAlignment
-                ^ Shadow.GetHashCode()
-                ^ FontSize.GetHashCode()
-                ^ FontColor.GetHashCode()
-                ^ FontName.GetHashCode()
-                ^ (Int32)FontFamilyNumbering;
+            // Since all properties of type are mutable, can't have different hashcode for any instance.
+            // Don't ever use this class in a dictionary, e.g. SST.
+            return 4; // Chosen by fair dice roll. Guaranteed to be random.
         }
     }
 }

--- a/ClosedXML/Excel/RichText/XLRichText.cs
+++ b/ClosedXML/Excel/RichText/XLRichText.cs
@@ -1,23 +1,49 @@
-#nullable disable
-
 using System;
+using System.Linq;
 
 namespace ClosedXML.Excel
 {
     internal class XLRichText : XLFormattedText<IXLRichText>, IXLRichText
     {
-        private readonly XLCell _cell;
+        // Should be set as the last thing in ctor to prevent firing changes to immutable rich text during ctor
+        private readonly XLCell? _cell;
+
+        /// <summary>
+        /// Copy ctor to return user modifiable rich text from immutable rich text stored
+        /// in the shared string table.
+        /// </summary>
+        public XLRichText(XLCell cell, XLImmutableRichText original)
+            : base(cell.Style.Font)
+        {
+            foreach (var originalRun in original.Runs)
+            {
+                var runText = original.GetRunText(originalRun);
+                AddText(new XLRichString(runText, new XLFont(originalRun.Font.Key), this, OnContentChanged));
+            }
+
+            var hasPhonetics = original.PhoneticRuns.Any() || original.PhoneticsProperties.HasValue;
+            if (hasPhonetics)
+            {
+                // Access to phonetics instantiate a new instance.
+                var phonetics = Phonetics;
+                if (original.PhoneticsProperties.HasValue)
+                {
+                    var phoneticProps = original.PhoneticsProperties.Value;
+                    phonetics.CopyFont(new XLFont(phoneticProps.Font.Key));
+                    phonetics.Type = phoneticProps.Type;
+                    phonetics.Alignment = phoneticProps.Alignment;
+                }
+
+                foreach (var phoneticRun in original.PhoneticRuns)
+                    phonetics.Add(phoneticRun.Text, phoneticRun.StartIndex, phoneticRun.EndIndex);
+            }
+
+            Container = this;
+            _cell = cell;
+        }
 
         public XLRichText(XLCell cell, IXLFontBase defaultFont)
             : base(defaultFont)
-        {
-            Container = this;
-            _cell = cell;
-            ContentChanged += OnContentChanged;
-        }
-
-        public XLRichText(XLCell cell, XLFormattedText<IXLRichText> defaultRichText, IXLFontBase defaultFont)
-            : base(defaultRichText, defaultFont)
         {
             Container = this;
             _cell = cell;
@@ -30,12 +56,19 @@ namespace ClosedXML.Excel
             _cell = cell;
         }
 
-        private void OnContentChanged(object sender, EventArgs e)
+        protected override void OnContentChanged()
         {
-            if (_cell.DataType != XLDataType.Text || !_cell.HasRichText || !ReferenceEquals(_cell.GetRichText(), this))
+            // The rich text is still being created
+            if (_cell is null)
+                return;
+
+            if (_cell.DataType != XLDataType.Text || !_cell.HasRichText)
                 throw new InvalidOperationException("The rich text isn't a content of a cell.");
 
             _cell.SetOnlyValue(Text);
+            var point = _cell.SheetPoint;
+            var richText = new XLImmutableRichText(this);
+            _cell.Worksheet.Internals.CellsCollection.ValueSlice.SetRichText(point, richText);
         }
     }
 }

--- a/ClosedXML/Excel/Style/XLFont.cs
+++ b/ClosedXML/Excel/Style/XLFont.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace ClosedXML.Excel
@@ -82,7 +83,26 @@ namespace ClosedXML.Excel
         {
         }
 
-        public XLFont(XLStyle? style = null, IXLFont? d = null) : this(style, GenerateKey(d))
+        /// <summary>
+        /// Create a new font that is attached to a style and the changes to the font object are propagated to the style.
+        /// </summary>
+        /// <param name="style">The container style that will be modified by changes of created <c>XLFont</c>.</param>
+        public XLFont(XLStyle style) : this(style, GenerateKey(style.Font))
+        {
+        }
+
+        /// <summary>
+        /// Create a new font. The changes to the object are not propagated to a style.
+        /// </summary>
+        public XLFont(IXLFontBase font) : this(null, GenerateKey(font))
+        {
+        }
+
+        public XLFont(XLFontKey key) : this(null, XLFontValue.FromKey(ref key))
+        {
+        }
+
+        private XLFont() : this(null, GenerateKey(null))
         {
         }
 
@@ -337,7 +357,7 @@ namespace ClosedXML.Excel
             sb.Append("-");
             sb.Append(Shadow.ToString());
             sb.Append("-");
-            sb.Append(FontSize.ToString());
+            sb.Append(FontSize.ToString(CultureInfo.InvariantCulture));
             sb.Append("-");
             sb.Append(FontColor);
             sb.Append("-");

--- a/ClosedXML/Extensions/FontBaseExtensions.cs
+++ b/ClosedXML/Extensions/FontBaseExtensions.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 // Keep this file CodeMaid organised and cleaned
 
 namespace ClosedXML.Excel
@@ -19,6 +17,7 @@ namespace ClosedXML.Excel
             font.FontName = sourceFont.FontName;
             font.FontFamilyNumbering = sourceFont.FontFamilyNumbering;
             font.FontCharSet = sourceFont.FontCharSet;
+            font.FontScheme = sourceFont.FontScheme;
         }
     }
 }

--- a/docs/migrations/migrate-to-0.103.rst
+++ b/docs/migrations/migrate-to-0.103.rst
@@ -1,0 +1,14 @@
+#############################
+Migration from 0.102 to 0.103
+#############################
+
+***********
+IXLPhonetic
+***********
+
+``IXLPhonetic`` no longer has a setter for its ``IXLPhonetic.Text``,
+``IXLPhonetic.Start`` and ``IXLPhonetic.End`` properties.
+
+Use ``IXLPhonetics.ClearText()`` and ``IXLPhonetics.Add(String text, Int32 start, Int32 end)``
+to redo the phonetic hints.
+


### PR DESCRIPTION
This is a step 3 of shared string table (followup of https://github.com/ClosedXML/ClosedXML/pull/2115).

It introduces a new type (internal for now) `XLImmutableRichText` and the new type is now used to store rich text in a value slice (rich text was moved from misc slice). The immutable rich text in a cell is updated when the mutable rich text is changed.

The immutable rich text is necessary for a reverse dictionary of shared string table. Mutable types are highly unsuitable for dictionary due hashcode.

I am not very happy with API of `XLRichText` (for the second time) and will likely replace it with the immutable type, but not now.