### PR TITLE
Update SixLabors.Fonts dependency to version 1.0.0

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
     <PackageReference Include="XLParser" Version="1.5.2" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.102.0</Version>
+    <Version>0.102.1</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.102.0.{build}
+version: 0.102.1.{build}
 
 os: Visual Studio 2019
 image: Visual Studio 2019


### PR DESCRIPTION
Sixlabors have released version 1.0 of the font library and there have been several API changes. That causes several breaks  #2148, #2146 and https://github.com/ClosedXML/ClosedXML.Report/issues/326.

This updates the default graphic engine to use modified API. It will be a single change for 0.102.1 minor fix and then cherry picked to develop branch.

Good for them, version 1.0...