### PR TITLE
Get areas a formula depends on

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -1,0 +1,286 @@
+﻿using System.Collections.Generic;
+using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine
+{
+    [TestFixture]
+    internal class DependencyTreeTests
+    {
+        [Test]
+        [TestCaseSource(nameof(AreaDependenciesTestCases))]
+        public void Area_dependencies_are_extracted_from_formula(string formula, IReadOnlyList<XLSheetArea> expectedAreas)
+        {
+            var dependencies = GetDependencies(formula);
+            CollectionAssert.AreEquivalent(expectedAreas, dependencies.Areas);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(NameDependenciesTestCases))]
+        public void Name_dependencies_are_kept_for_dependencies_update(string formula, IReadOnlyList<XLName> expectedNames)
+        {
+            var dependencies = GetDependencies(formula);
+            CollectionAssert.AreEquivalent(expectedNames, dependencies.Names);
+        }
+
+        private static CellFormulaDependencies GetDependencies(string formula)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
+            var tree = new DependencyTree(wb.CalcEngine);
+            var cell = ws.Cell("A1");
+            cell.SetFormulaA1(formula);
+
+            var dependencies = tree.AddFormula((XLWorksheet)ws, ((XLCell)cell).Formula);
+            return dependencies;
+        }
+
+        public static IEnumerable<object[]> AreaDependenciesTestCases
+        {
+            get
+            {
+                // When a visitor visits a node, there are two choices for found references:
+                // * propagate the reference to parent node (in most cases checked by range operator)
+                // * add the reference directly to the dependencies
+
+                // A formula that is a simple reference is propagated to the root
+                yield return new object[]
+                {
+                    "A1",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1"))
+                    }
+                };
+
+                // References are in a multiple levels of an expression without ref expression or
+                // a function are added
+                yield return new object[]
+                {
+                    "7+A1/(B1+C1)",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B1")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("C1"))
+                    }
+                };
+
+                // Unary implicit intersection is propagated
+                yield return new object[]
+                {
+                    // Due to issue ClosedParser#1, implicit intersection is not a part
+                    // of ref_expression and I can't use `D3:@A1:C2` as a test case
+                    "@A1:A4",
+                    new[]
+                    {
+                        // Implicit intersection 
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:A4")),
+                    }
+                };
+
+                // Unary spill operator propagates a reference
+                yield return new object[]
+                {
+                    "F2#:A7",
+                    new[]
+                    {
+                        // This is not correct, but until spill operator works,
+                        // but for now it provides best approximate for now.
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A2:F7")),
+                    }
+                };
+
+                // Unary value operators (in this case percent) applied on reference adds it
+                yield return new object[]
+                {
+                    "4+A4%",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A4")),
+                    }
+                };
+
+                // Union operation propagates references
+                yield return new object[]
+                {
+                    "(A1:B2,C1:D2):E3",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:E3"))
+                    }
+                };
+
+                // Range operation propagates
+                yield return new object[]
+                {
+                    // Due to greedy nature, the A1:C4 is the first reference and D2 is the second
+                    "A1:C4:D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:D4")),
+                    }
+                };
+
+                // Range operation with multiple operands
+                yield return new object[]
+                {
+                    "A1:C4:IF(E10, D2, A10)",
+                    new[]
+                    {
+                        // E10 is a value argument, thus isn't propagated, only added
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("E10")),
+                        // Areas from same sheet are unified into a single larger area
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:D10"))
+                    }
+                };
+
+                // Range operator with multiple combinations
+                yield return new object[]
+                {
+                    "IF(G4,Sheet!A1,Other!A2):IF(H3,Other!C4,C5)",
+                    new[]
+                    {
+                        // G4 and H3 are not propagated to range operation, only added
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("G4")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("H3")),
+
+                        // Largest possible area in each sheet, based on references in the sheet
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:C5")),
+                        new XLSheetArea("Other", XLSheetRange.Parse("A2:C4"))
+                    }
+                };
+
+                // Range operation when an argument isn't a reference doesn't
+                // create a range from both, adds
+                yield return new object[]
+                {
+                    "INDEX({1},1,1):D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("D2")),
+                    }
+                };
+
+                // Intersection - special case of one area against another area
+                yield return new object[]
+                {
+                    "A1:C3 B2:D2",
+                    new[]
+                    {
+                        // In this special case, intersection is evaluated
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B2:C2")),
+                    }
+                };
+
+                // Intersection - multi area operands. Due to complexity, keep
+                // original ranges as dependencies.
+                yield return new object[]
+                {
+                    "A1:E10 IF(TRUE,A1:C3,B2:D2)",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:C3")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B2:D2")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:E10")),
+                    }
+                };
+
+                // Value binary operation on references adds the references
+                yield return new object[]
+                {
+                    "A1:B2 + A1:C4",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:B2")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:C4")),
+                    }
+                };
+
+                // IF function - value is added and true/false values are propagated
+                yield return new object[]
+                {
+                    "IF(A1,B1,C1):D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B1:D2")),
+                    }
+                };
+
+                // IF function, but only false argument is reference
+                yield return new object[]
+                {
+                    "IF(A1,5,B1):D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B1:D2")),
+                    }
+                };
+
+                // IF function, but only true argument is reference and is propagated
+                yield return new object[]
+                {
+                    "IF(A1,B1):D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B1:D2")),
+                    }
+                };
+
+                // INDEX function propagates whole range of first argument
+                yield return new object[]
+                {
+                    "INDEX(A1:C4,2,5):D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1:D4")),
+                    }
+                };
+
+                // CHOOSE function adds first argument and propagates remaining arguments
+                yield return new object[]
+                {
+                    "CHOOSE(A1,B1,5,C1):D2",
+                    new[]
+                    {
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("A1")),
+                        new XLSheetArea("Sheet", XLSheetRange.Parse("B1:D2")),
+                    }
+                };
+
+                // Non-ref functions add arguments
+                yield return new object[]
+                {
+                    "POWER(SomeSheet!C4,Other!B1)",
+                    new[]
+                    {
+                        new XLSheetArea("SomeSheet", XLSheetRange.Parse("C4")),
+                        new XLSheetArea("Other", XLSheetRange.Parse("B1")),
+                    }
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> NameDependenciesTestCases
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    "WorkbookName  + 5",
+                    new[] { new XLName("WorkbookName") }
+                };
+
+                yield return new object[]
+                {
+                    "Sheet!Name",
+                    new[] { new XLName("Sheet", "Name") }
+                };
+            }
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Coordinates/XLNameTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLNameTests.cs
@@ -7,28 +7,28 @@ namespace ClosedXML.Tests.Excel.Coordinates
     public class XLNameTests
     {
         [Test]
-        public void Workbook_name_is_compared_case_insensitive()
+        public void Workbook_scoped_name_is_compared_case_insensitive()
         {
-            var left = new XLName("name");
-            var right = new XLName("NAME");
+            var lowerCase = new XLName("name");
+            var upperCase = new XLName("NAME");
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.AreEqual(lowerCase, upperCase);
+            Assert.AreEqual(lowerCase.GetHashCode(), upperCase.GetHashCode());
 
-            Assert.AreNotEqual(left, new XLName("different_name"));
+            Assert.AreNotEqual(lowerCase, new XLName("different_name"));
         }
 
         [Test]
-        public void Sheet_name_is_compared_case_insensitive()
+        public void Sheet_scoped_name_is_compared_case_insensitive()
         {
-            var left = new XLName("sheet", "name");
-            var right = new XLName("SHEET", "NAME");
+            var lowerCase = new XLName("sheet", "name");
+            var upperCase = new XLName("SHEET", "NAME");
 
-            Assert.AreEqual(left, right);
-            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+            Assert.AreEqual(lowerCase, upperCase);
+            Assert.AreEqual(lowerCase.GetHashCode(), upperCase.GetHashCode());
 
-            Assert.AreNotEqual(left, new XLName("Different sheet", "name"));
-            Assert.AreNotEqual(left, new XLName("sheet", "different_name"));
+            Assert.AreNotEqual(lowerCase, new XLName("Different sheet", "name"));
+            Assert.AreNotEqual(lowerCase, new XLName("sheet", "different_name"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLNameTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLNameTests.cs
@@ -1,0 +1,34 @@
+﻿using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates
+{
+    [TestFixture]
+    public class XLNameTests
+    {
+        [Test]
+        public void Workbook_name_is_compared_case_insensitive()
+        {
+            var left = new XLName("name");
+            var right = new XLName("NAME");
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+
+            Assert.AreNotEqual(left, new XLName("different_name"));
+        }
+
+        [Test]
+        public void Sheet_name_is_compared_case_insensitive()
+        {
+            var left = new XLName("sheet", "name");
+            var right = new XLName("SHEET", "NAME");
+
+            Assert.AreEqual(left, right);
+            Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+
+            Assert.AreNotEqual(left, new XLName("Different sheet", "name"));
+            Assert.AreNotEqual(left, new XLName("sheet", "different_name"));
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.Serialization;
-using ClosedXML.Excel;
-using DocumentFormat.OpenXml.Wordprocessing;
+﻿using ClosedXML.Excel;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.Coordinates
@@ -10,7 +7,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
     public class XLSheetAreaTests
     {
         [Test]
-        public void Equality_uses_case_insensitive_comparison_for_sheet_name()
+        public void Sheet_name_is_compared_case_insensitive()
         {
             var upperCase = new XLSheetArea("NAME", new XLSheetRange(1, 2, 3, 4));
             var lowerCase = new XLSheetArea("name", new XLSheetRange(1, 2, 3, 4));
@@ -21,14 +18,14 @@ namespace ClosedXML.Tests.Excel.Coordinates
         [Test]
         public void Intersection_produces_range_intersection_in_same_sheet()
         {
-            var left = new XLSheetArea("THIS", XLSheetRange.Parse("A1:C3"));
-            var rightSameSheet = new XLSheetArea("this", XLSheetRange.Parse("B2:D4"));
-            var rightDifferentSheet = new XLSheetArea("Different", XLSheetRange.Parse("B2:D4"));
+            var sheetArea1 = new XLSheetArea("SHEET", XLSheetRange.Parse("A1:C3"));
+            var sheetArea2 = new XLSheetArea("sheet", XLSheetRange.Parse("B2:D4"));
+            var otherSheetArea = new XLSheetArea("Other", XLSheetRange.Parse("B2:D4"));
 
-            var sameSheetIntersection = left.Intersect(rightSameSheet);
-            Assert.AreEqual(new XLSheetArea("this", XLSheetRange.Parse("B2:C3")), sameSheetIntersection);
+            var sameSheetIntersection = sheetArea1.Intersect(sheetArea2);
+            Assert.AreEqual(new XLSheetArea("sheet", XLSheetRange.Parse("B2:C3")), sameSheetIntersection);
 
-            var differentSheetIntersection = left.Intersect(rightDifferentSheet);
+            var differentSheetIntersection = sheetArea1.Intersect(otherSheetArea);
             Assert.Null(differentSheetIntersection);
         }
     }

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+using ClosedXML.Excel;
+using DocumentFormat.OpenXml.Wordprocessing;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates
+{
+    [TestFixture]
+    public class XLSheetAreaTests
+    {
+        [Test]
+        public void Equality_uses_case_insensitive_comparison_for_sheet_name()
+        {
+            var upperCase = new XLSheetArea("NAME", new XLSheetRange(1, 2, 3, 4));
+            var lowerCase = new XLSheetArea("name", new XLSheetRange(1, 2, 3, 4));
+            Assert.AreEqual(upperCase.GetHashCode(), lowerCase.GetHashCode());
+            Assert.AreEqual(upperCase, lowerCase);
+        }
+
+        [Test]
+        public void Intersection_produces_range_intersection_in_same_sheet()
+        {
+            var left = new XLSheetArea("THIS", XLSheetRange.Parse("A1:C3"));
+            var rightSameSheet = new XLSheetArea("this", XLSheetRange.Parse("B2:D4"));
+            var rightDifferentSheet = new XLSheetArea("Different", XLSheetRange.Parse("B2:D4"));
+
+            var sameSheetIntersection = left.Intersect(rightSameSheet);
+            Assert.AreEqual(new XLSheetArea("this", XLSheetRange.Parse("B2:C3")), sameSheetIntersection);
+
+            var differentSheetIntersection = left.Intersect(rightDifferentSheet);
+            Assert.Null(differentSheetIntersection);
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -44,5 +44,35 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var r = XLSheetRange.Parse(cellRef);
             Assert.AreEqual(expected, r.ToString());
         }
+
+        [TestCase("A1", "A1", "A1")]
+        [TestCase("A1", "B3", "A1:B3")]
+        [TestCase("C2", "B3", "B2:C3")]
+        [TestCase("I6:J9", "L7", "I6:L9")]
+        [TestCase("B2:B4", "A3:C3", "A2:C4")]
+        [TestCase("B2:C3", "E5:F6", "B2:F6")]
+        public void RangeOperation(string leftOperand, string rightOperand, string expectedRange)
+        {
+            var left = XLSheetRange.Parse(leftOperand);
+            var right = XLSheetRange.Parse(rightOperand);
+            var expected = XLSheetRange.Parse(expectedRange);
+
+            Assert.AreEqual(expected, left.Range(right));
+        }
+
+        [TestCase("A1", "A1", "A1")]
+        [TestCase("A1", "A2", null)]
+        [TestCase("B1:B3", "A2:C2", "B2")]
+        [TestCase("A1:A3", "B2:C2", null)]
+        [TestCase("A1:D6", "B2:C3", "B2:C3")]
+        [TestCase("A1:C6", "B4:E10", "B4:C6")]
+        public void IntersectOperation(string leftOperand, string rightOperand, string expectedRange)
+        {
+            var left = XLSheetRange.Parse(leftOperand);
+            var right = XLSheetRange.Parse(rightOperand);
+            var expected = expectedRange is null ? (XLSheetRange?)null : XLSheetRange.Parse(expectedRange);
+
+            Assert.AreEqual(expected, left.Intersect(right));
+        }
     }
 }

--- a/ClosedXML/ClosedXML.csproj.DotSettings
+++ b/ClosedXML/ClosedXML.csproj.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccells/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccolumns/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccoordinates/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Csparkline/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cstyle/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ClosedXML/Excel/CalcEngine/AstNode.cs
+++ b/ClosedXML/Excel/CalcEngine/AstNode.cs
@@ -261,7 +261,6 @@ namespace ClosedXML.Excel.CalcEngine
         public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea)
         {
             Prefix = prefix;
-            Type = GetReferenceType(referenceArea);
             Address = referenceArea.GetDisplayStringA1();
             ReferenceArea = referenceArea;
         }
@@ -270,9 +269,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// An optional prefix for reference item.
         /// </summary>
         public PrefixNode? Prefix { get; }
-
-        public ReferenceItemType Type { get; }
-
+        
         /// <summary>
         /// An address of a reference that corresponds to <see cref="Type"/>. Always without sheet (that is in the prefix).
         /// </summary>
@@ -296,22 +293,7 @@ namespace ClosedXML.Excel.CalcEngine
             // TODO: XLRangeAddress can parse all types of reference item type, utilize known type for faster parsing + cache
             return new Reference(new XLRangeAddress((XLWorksheet)ws!, Address));
         }
-
-        private static ReferenceItemType GetReferenceType(ReferenceArea area)
-        {
-            // If row is not specified, then it's only range of rows.
-            if (area.First.ColumnType == ReferenceAxisType.None)
-                return ReferenceItemType.HRange;
-
-            // If column is not specified, then it's only range of columns.
-            if (area.First.RowType == ReferenceAxisType.None)
-                return ReferenceItemType.VRange;
-
-            return ReferenceItemType.Cell;
-        }
     }
-
-    internal enum ReferenceItemType { Cell, VRange, HRange }
 
     /// <summary>
     /// A name node in the formula. Name can refers to a generic formula, in most cases a reference, but it can be any kind of calculation (e.g. <c>A1+7</c>).

--- a/ClosedXML/Excel/CalcEngine/CellFormulaDependencies.cs
+++ b/ClosedXML/Excel/CalcEngine/CellFormulaDependencies.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// A list of objects a cell formula depends on. If one of them changes,
+    /// the formula value might no longer be accurate and needs to be recalculated.
+    /// </summary>
+    internal class CellFormulaDependencies
+    {
+        private readonly HashSet<XLSheetArea> _areas = new();
+        private readonly HashSet<XLName> _names = new();
+
+        /// <summary>
+        /// List of areas the formula depends on. It is likely a superset of accurate
+        /// result for unusual formulas, but if a value in an areas changes, the dependent
+        /// formula should be marked as dirty.
+        /// </summary>
+        public IReadOnlyCollection<XLSheetArea> Areas => _areas;
+
+        /// <summary>
+        /// A collection of names in the formula. If a name changes (added, deleted),
+        /// the formula dependencies should be refreshed, because new name might refer to
+        /// different references (e.g. a name previously referred to <c>A5</c> and is redefined
+        /// to <c>B7</c> or just value <c>7</c> =&gt; formula no longer depends on <c>A5</c>).
+        /// </summary>
+        public IReadOnlyCollection<XLName> Names => _names;
+        
+        internal void AddAreas(List<XLSheetArea> sheetAreas)
+        {
+            _areas.UnionWith(sheetAreas);
+        }
+
+        internal void AddName(XLName name)
+        {
+            _names.Add(name);
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             var acceptedPrefix = referenceNode.Prefix?.Accept(context, this);
             return !ReferenceEquals(acceptedPrefix, referenceNode.Prefix)
-                ? new ReferenceNode((PrefixNode?)acceptedPrefix, referenceNode.Type, referenceNode.Address)
+                ? new ReferenceNode((PrefixNode?)acceptedPrefix, referenceNode.ReferenceArea)
                 : referenceNode;
         }
 

--- a/ClosedXML/Excel/CalcEngine/DependenciesContext.cs
+++ b/ClosedXML/Excel/CalcEngine/DependenciesContext.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// Context for <see cref="DependenciesVisitor"/>, it is used
+    /// to collect all objects a formula depends on during calculation.
+    /// </summary>
+    internal class DependenciesContext
+    {
+        internal DependenciesContext(XLSheetArea formulaArea)
+        {
+            FormulaArea = formulaArea;
+        }
+
+        /// <summary>
+        /// An area of a formula, in most cases just one cell, for array formulas area of cells.
+        /// </summary>
+        internal XLSheetArea FormulaArea { get; }
+
+        /// <summary>
+        /// The result. Visitor adds all areas/names formula depends on to this.
+        /// </summary>
+        internal CellFormulaDependencies Dependencies { get; } = new();
+
+        /// <summary>
+        /// Add areas to a list of areas the formula depends on. Disregards duplicate entries.
+        /// </summary>
+        internal void AddAreas(List<XLSheetArea> sheetAreas) => Dependencies.AddAreas(sheetAreas);
+
+        /// <summary>
+        /// Add name to a list of names the formula depends on. Disregards duplicate entries.
+        /// </summary>
+        internal void AddName(XLName name) => Dependencies.AddName(name);
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/DependenciesVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/DependenciesVisitor.cs
@@ -1,0 +1,309 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Extensions;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// <para>
+    /// Visit each node and determine all ranges that might affect the formula.
+    /// It uses concrete values (e.g. actual range for structured references) and
+    /// should be refreshed when structured reference or name is changed in a workbook.
+    /// </para>
+    /// <para>
+    /// The areas found by the visitor shouldn't change when data on a worksheet changes,
+    /// so the output is a superset of areas, if necessary.
+    /// </para>
+    /// <para>
+    /// Precedents visitor is not completely accurate, in case of uncertainty, it uses
+    /// a larger area. At worst the end result is unnecessary recalculation. For simple
+    /// cases, it works fine and freaks like <c>A1:IF(Other!B5,B7,Different!G3)</c>
+    /// will be marked as dirty more often than strictly necessary.
+    /// </para>
+    /// <para>
+    /// Each node visitor evaluates, if the output is a reference or a value/array. If
+    /// the result is an array, it propagates to upper nodes, where can be things like
+    /// range operator.
+    /// </para>
+    /// </summary>
+    internal class DependenciesVisitor : IFormulaVisitor<DependenciesContext, List<XLSheetArea>?>
+    {
+        public List<XLSheetArea>? Visit(DependenciesContext context, ScalarNode node)
+        {
+            // Scalar node can't contain sub-nodes or references.
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, ArrayNode node)
+        {
+            // Array node can't contain sub-nodes or references.
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, UnaryNode node)
+        {
+            var sheetAreas = node.Expression.Accept(context, this);
+
+            // If the operand of unary node is not a reference -> end immediately,
+            // operator can't modify non-reference into a reference.
+            if (sheetAreas is null)
+                return null;
+
+            // Operand is a reference
+            if (node.Operation is UnaryOp.ImplicitIntersection or UnaryOp.SpillRange)
+            {
+                // Both operators are ignored for now, because *spill* operators
+                // is part of dynamic arrays (=ignore until they are implemented)
+                // and *Implicit intersection* only makes area smaller and is pretty
+                // rare operators = also skip for now (won't affect correctness).
+
+                // The reference must be propagated upward, because there could be
+                // a range operator (e.g. `B7:@A1:A5`)
+                return sheetAreas;
+            }
+
+            // Some other operator is applied to the reference -> reference is converted
+            // to an array
+            context.AddAreas(sheetAreas);
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, BinaryNode node)
+        {
+            // Only range operations transform ranges
+            var leftAreas = node.LeftExpression.Accept(context, this);
+            var rightAreas = node.RightExpression.Accept(context, this);
+
+            // Reference operation only makes sense, if both sides are references.
+            // Otherwise reference operation results into an error.
+            if (leftAreas is not null && rightAreas is not null)
+            {
+                // Both sides are references - calculate new ranges and propagate
+                if (node.Operation == BinaryOp.Union)
+                {
+                    leftAreas.AddRange(rightAreas);
+                    return leftAreas;
+                }
+
+                if (node.Operation == BinaryOp.Range)
+                {
+                    var rangeResult = new List<XLSheetArea>();
+
+                    // Create a new range from both operands. It must deal with
+                    // situation where there are multiple sheets for both operands,
+                    // e.g. `IF(G4,Sheet1!A1,Sheet2!A2):IF(H3,Sheet2!C4,Sheet1!C5)`
+                    // that creates a valid range.
+                    var sheetGroups = leftAreas.Concat(rightAreas)
+                        .GroupBy(area => area.Name, XLHelper.SheetComparer);
+
+                    // There is no simple way to go through all paths, so try to find
+                    // largest possible ranges that could be the result. For normal
+                    // operands(A1:B2:C3), it will work fine and for freaks, it will
+                    // find largest possible range that is a superset of actual result.
+                    foreach (var sheetGroup in sheetGroups)
+                    {
+                        var sheetAreas = sheetGroup.ToList();
+                        if (sheetAreas.Count == 1)
+                            continue;
+
+                        var rangeArea = sheetAreas[0].Area;
+                        for (var i = 1; i < sheetAreas.Count; ++i)
+                            rangeArea = rangeArea.Range(sheetAreas[i].Area);
+
+                        rangeResult.Add(new XLSheetArea(sheetGroup.Key, rangeArea));
+                    }
+
+                    // It's enough to return result of range operation. Operands can
+                    // be discarded, because they are included in the result.
+                    return rangeResult;
+                }
+
+                if (node.Operation == BinaryOp.Intersection)
+                {
+                    // Intersection makes range smaller, so it's rather hard to optimize
+                    // areas. We make a special case for the most frequent case.
+                    if (leftAreas.Count == 1 && rightAreas.Count == 1)
+                    {
+                        var leftArea = leftAreas[0];
+                        var rightArea = rightAreas[0];
+                        var intersection = leftArea.Intersect(rightArea);
+
+                        // Propagate only the intersection, not operands. Even if operands
+                        // change, it doesn't affect the formula, because cells outside
+                        // intersection are never used.
+                        if (intersection is not null)
+                            return new List<XLSheetArea> { intersection.Value };
+
+                        return null;
+                    }
+
+                    // Anything else is too complicated and thus just propagate all references.
+                    leftAreas.AddRange(rightAreas);
+                    return leftAreas;
+                }
+
+                // Operand is not a reference one, so reference is turned to array of values.
+                context.AddAreas(leftAreas);
+                context.AddAreas(rightAreas);
+                return null;
+            }
+
+            // Both children aren't references or only one is -> binary operation transforms it
+            // to a non-reference, either value or #REF!
+            if (leftAreas is not null)
+                context.AddAreas(leftAreas);
+
+            if (rightAreas is not null)
+                context.AddAreas(rightAreas);
+
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, FunctionNode node)
+        {
+            // According to grammar, ref functions are: CHOOSE, IF, INDEX, INDIRECT, OFFSET
+            // Only these functions are allowed to return references, per grammar.
+            // However, OFFSET and INDIRECT are volatile function that always have to be
+            // recalculated (=are always marked dirty).
+
+            if (XLHelper.FunctionComparer.Equals(node.Name, "IF"))
+            {
+                // Tested value is not propagated, it's evaluated as an argument
+                var testReference = node.Parameters[0].Accept(context, this);
+                if (testReference is not null)
+                    context.AddAreas(testReference);
+
+                // If argument is reference and test is evaluated to TRUE,
+                // the reference is returned => propagate.
+                var valueIfTrueReference = node.Parameters[1].Accept(context, this);
+                var valueIfFalseReference = node.Parameters.Count == 3
+                    ? node.Parameters[2].Accept(context, this)
+                    : null;
+
+                if (valueIfFalseReference is not null && valueIfTrueReference is not null)
+                {
+                    valueIfTrueReference.AddRange(valueIfFalseReference);
+                    return valueIfTrueReference;
+                }
+
+                return valueIfFalseReference ?? valueIfTrueReference;
+            }
+
+            if (XLHelper.FunctionComparer.Equals(node.Name, "INDEX"))
+            {
+                // Add argument references, INDEX can have 2 or 3 arguments
+                for (var i = 1; i < node.Parameters.Count; ++i)
+                {
+                    var argReference = node.Parameters[i].Accept(context, this);
+                    if (argReference is not null)
+                        context.AddAreas(argReference);
+                }
+
+                // If INDEX function indexes into an area, it returns reference,
+                // not a value. Either way, return whole reference that is indexed,
+                // even though it's larger than actual function result.
+                var arrayReference = node.Parameters[0].Accept(context, this);
+                return arrayReference;
+            }
+
+            if (XLHelper.FunctionComparer.Equals(node.Name, "CHOOSE"))
+            {
+                // Index argument is used to select value, so don't propagate
+                var indexReference = node.Parameters[0].Accept(context, this);
+                if (indexReference is not null)
+                    context.AddAreas(indexReference);
+
+                // Any of arguments can be propagated -> propagate all.
+                // Initialize list as null to reduce allocations
+                List<XLSheetArea>? parametersReference = null;
+                for (var i = 1; i < node.Parameters.Count; ++i)
+                {
+                    var parameterReference = node.Parameters[i].Accept(context, this);
+                    if (parameterReference is null)
+                        continue;
+
+                    if (parametersReference is not null)
+                        parametersReference.AddRange(parameterReference);
+                    else
+                        parametersReference = parameterReference;
+                }
+
+                return parametersReference;
+            }
+
+            // All other functions can have references as arguments, but not as an output value.
+            foreach (var parameterNode in node.Parameters)
+            {
+                var paramReference = parameterNode.Accept(context, this);
+                if (paramReference is not null)
+                    context.AddAreas(paramReference);
+            }
+
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, NotSupportedNode node)
+        {
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, ReferenceNode node)
+        {
+            var prefix = node.Prefix;
+            string sheetName;
+            if (prefix is not null)
+            {
+                // We don't support external references, so there is no way to depend on something
+                // in different workbook at the moment.
+                if (prefix.File is not null)
+                    return null;
+
+                // 3D references are not supported yet, so don't propagate anything.
+                if (prefix.FirstSheet is not null || prefix.LastSheet is not null)
+                    return null;
+
+                sheetName = prefix.Sheet ?? throw new InvalidOperationException("Prefix doesn't contain sheet.");
+            }
+            else
+            {
+                sheetName = context.FormulaArea.Name;
+            }
+
+            var sheetRange = node.ReferenceArea.ToSheetRange(context.FormulaArea.Area.FirstPoint);
+            return new List<XLSheetArea> { new(sheetName, sheetRange) };
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, NameNode node)
+        {
+            // External references are not supported for names
+            if (node.Prefix?.File is not null)
+                return null;
+
+            var name = node.Prefix?.Sheet is { } sheetName
+                ? new XLName(sheetName, node.Name)
+                : new XLName(node.Name);
+            context.AddName(name);
+
+            // Dependency tree for the formula should be redone, if name changes.
+            // TODO: Name references should be included in formula areas.
+            return null;
+        }
+
+        public List<XLSheetArea>? Visit(DependenciesContext context, StructuredReferenceNode node)
+        {
+            // TODO: Structured reference should be evaluated into a reference and propagated.
+            return null;
+        }
+
+        public List<XLSheetArea> Visit(DependenciesContext context, PrefixNode node)
+        {
+            throw new InvalidOperationException("Should never be called.");
+        }
+
+        public List<XLSheetArea> Visit(DependenciesContext context, FileNode node)
+        {
+            throw new InvalidOperationException("Should never be called.");
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/DependencyTree.cs
+++ b/ClosedXML/Excel/CalcEngine/DependencyTree.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.CalcEngine
+{
+    /// <summary>
+    /// <para>
+    /// A dependency tree structure to hold all formulas of the workbook and reference
+    /// objects they depend on. The key feature of dependency tree is to propagate
+    /// dirty flag across formulas.
+    /// </para>
+    /// <para>
+    /// When a data in a cell changes, all formulas that depend on it should be marked
+    /// as dirty, but it is hard to find which cells are affected - that is what
+    /// dependency tree does.
+    /// </para>
+    /// <para>
+    /// Dependency tree must be updated, when structure of a workbook is updated:
+    /// <list type="bullet">
+    ///   <item>Sheet is added, renamed or deleted.</item>
+    ///   <item>Name is added or deleted.</item>
+    ///   <item>Table is resized, renamed, added or deleted.</item>
+    /// </list>
+    /// Any such action changes what cells formula depends on and
+    /// the formula dependencies must be updated.
+    /// </para>
+    /// </summary>
+    internal class DependencyTree
+    {
+        private readonly Dictionary<XLCellFormula, CellFormulaDependencies> _dependencies = new();
+        private readonly DependenciesVisitor _visitor;
+        private readonly CalcEngine _engine;
+
+        public DependencyTree(CalcEngine engine)
+        {
+            _visitor = new DependenciesVisitor();
+            _engine = engine;
+        }
+
+        /// <summary>
+        /// Add a formula to the dependency tree.
+        /// </summary>
+        /// <param name="sheet">Sheet where is the formula.</param>
+        /// <param name="formula">The cell formula.</param>
+        /// <returns>Added cell formula dependencies.</returns>
+        /// <exception cref="ArgumentException">Formula already is in the tree.</exception>
+        internal CellFormulaDependencies AddFormula(XLWorksheet sheet, XLCellFormula formula)
+        {
+            var ast = formula.GetAst(_engine);
+            var context = new DependenciesContext(new XLSheetArea(sheet.Name, formula.Range));
+            var rootReference = ast.AstRoot.Accept(context, _visitor);
+
+            // If formula references are propagated to the root, make sure to add them.
+            if (rootReference is not null)
+                context.AddAreas(rootReference);
+
+            _dependencies.Add(formula, context.Dependencies);
+            return context.Dependencies;
+        }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/Formula.cs
+++ b/ClosedXML/Excel/CalcEngine/Formula.cs
@@ -1,8 +1,8 @@
-#nullable disable
-
 namespace ClosedXML.Excel.CalcEngine
 {
-    /// <summary>A non-state representation of a formula that can be used by many cells.</summary>
+    /// <summary>
+    /// A non-state representation of a formula that can be used by many cells.
+    /// </summary>
     internal class Formula
     {
         public Formula(string text, ValueNode root, FormulaFlags flags)

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -108,26 +108,20 @@ namespace ClosedXML.Excel.CalcEngine
 
             public ValueNode Reference(List<FormulaFlags> context, ReferenceArea area)
             {
-                var type = GetReferenceType(area);
-                var address = area.GetDisplayStringA1();
-                return new ReferenceNode(null, type, address);
+                return new ReferenceNode(null, area);
             }
 
             public ValueNode SheetReference(List<FormulaFlags> context, string sheet, ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, sheet, null, null);
-                var type = GetReferenceType(area);
-                var address = area.GetDisplayStringA1();
-                return new ReferenceNode(prefixNode, type, address);
+                return new ReferenceNode(prefixNode, area);
             }
 
             public ValueNode Reference3D(List<FormulaFlags> context, string firstSheet, string lastSheet,
                 ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, null, firstSheet, lastSheet);
-                var type = GetReferenceType(area);
-                var address = area.GetDisplayStringA1();
-                return new ReferenceNode(prefixNode, type, address);
+                return new ReferenceNode(prefixNode, area);
             }
 
             public ValueNode ExternalSheetReference(List<FormulaFlags> context, int workbookIndex, string sheet,
@@ -135,9 +129,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var fileNode = new FileNode(workbookIndex);
                 var prefixNode = new PrefixNode(fileNode, sheet, null, null);
-                var type = GetReferenceType(area);
-                var address = area.GetDisplayStringA1();
-                return new ReferenceNode(prefixNode, type, address);
+                return new ReferenceNode(prefixNode, area);
             }
 
             public ValueNode ExternalReference3D(List<FormulaFlags> context, int workbookIndex, string firstSheet,
@@ -145,9 +137,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var fileNode = new FileNode(workbookIndex);
                 var prefixNode = new PrefixNode(fileNode, null, firstSheet, lastSheet);
-                var type = GetReferenceType(area);
-                var address = area.GetDisplayStringA1();
-                return new ReferenceNode(prefixNode, type, address);
+                return new ReferenceNode(prefixNode, area);
             }
 
             public ValueNode Function(List<FormulaFlags> context, ReadOnlySpan<char> name,
@@ -269,19 +259,6 @@ namespace ClosedXML.Excel.CalcEngine
             public ValueNode Nested(List<FormulaFlags> context, ValueNode node)
             {
                 return node;
-            }
-
-            private static ReferenceItemType GetReferenceType(ReferenceArea area)
-            {
-                // If row is not specified, then it's only range of rows.
-                if (area.First.ColumnType == ReferenceAxisType.None)
-                    return ReferenceItemType.HRange;
-
-                // If column is not specified, then it's only range of columns.
-                if (area.First.RowType == ReferenceAxisType.None)
-                    return ReferenceItemType.VRange;
-
-                return ReferenceItemType.Cell;
             }
 
             private FunctionNode GetFunctionNode(List<FormulaFlags> context, PrefixNode? prefixNode, string functionName,

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -1,11 +1,11 @@
 #nullable disable
 
-using ClosedXML.Excel.CalcEngine;
 using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using ClosedXML.Excel.CalcEngine;
 using Array = ClosedXML.Excel.CalcEngine.Array;
 
 namespace ClosedXML.Excel
@@ -181,7 +181,7 @@ namespace ClosedXML.Excel
                 return true;
             }
 
-            foreach (var precedentCell in precedentCells)
+            foreach (var precedentCell in precedentCells!)
             {
                 // the affecting cell was modified after this one was evaluated
                 // e.g. cell now has a different value than it had at the last evaluation.
@@ -707,5 +707,17 @@ namespace ClosedXML.Excel
             /// </summary>
             internal long Version { get; }
         };
+
+        /// <summary>
+        /// Get a lazy initialized AST for the formula.
+        /// </summary>
+        /// <param name="engine">Engine to parse the formula into AST, if necessary.</param>
+        public Formula GetAst(CalcEngine.CalcEngine engine)
+        {
+            // TODO: Add caching for lazy initialization.
+            var a1 = GetFormulaA1(Range.FirstPoint);
+            var ast = engine.Parse(a1);
+            return ast;
+        }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLName.cs
+++ b/ClosedXML/Excel/Coordinates/XLName.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+
+namespace ClosedXML.Excel
+{
+    /// <summary>
+    /// A name in a worksheet. Unlike <see cref="IXLNamedRange"/>, this is basically only a reference.
+    /// The actual 
+    /// </summary>
+    internal readonly struct XLName : IEquatable<XLName>
+    {
+        /// <summary>
+        /// Name of a sheet. If null, the scope is a workbook. The sheet might not exist, e.g. it
+        /// is only in a formula. The name of a sheet is not escaped.
+        /// </summary>
+        public string? SheetName { get; }
+
+        /// <summary>
+        /// The defined name in the scope. Case insensitive during comparisons.
+        /// </summary>
+        public string Name { get; }
+
+        public XLName(string sheetName, string name)
+        {
+            if (name.Any(char.IsWhiteSpace))
+                throw new ArgumentException("Name can't contain whitespace.");
+
+            SheetName = sheetName;
+            Name = name;
+        }
+
+        public XLName(string name)
+        {
+            if (name.Any(char.IsWhiteSpace))
+                throw new ArgumentException("Name can't contain whitespace.");
+
+            SheetName = null;
+            Name = name;
+        }
+
+        public bool Equals(XLName other)
+        {
+            if (SheetName is null ^ other.SheetName is null)
+                return false;
+
+            if (SheetName is null && other.SheetName is null)
+                return XLHelper.NameComparer.Equals(Name, other.Name);
+
+            return XLHelper.NameComparer.Equals(Name, other.Name) &&
+                   XLHelper.SheetComparer.Equals(SheetName, other.SheetName);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is XLName other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (SheetName is not null ? XLHelper.SheetComparer.GetHashCode(SheetName) : 0) * 397;
+                hashCode ^= XLHelper.NameComparer.GetHashCode(Name);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/Coordinates/XLName.cs
+++ b/ClosedXML/Excel/Coordinates/XLName.cs
@@ -22,6 +22,9 @@ namespace ClosedXML.Excel
 
         public XLName(string sheetName, string name)
         {
+            if (string.IsNullOrEmpty(sheetName))
+                throw new ArgumentException(nameof(sheetName));
+
             if (name.Any(char.IsWhiteSpace))
                 throw new ArgumentException("Name can't contain whitespace.");
 
@@ -40,10 +43,12 @@ namespace ClosedXML.Excel
 
         public bool Equals(XLName other)
         {
-            if (SheetName is null ^ other.SheetName is null)
+            var differentScope = SheetName is null ^ other.SheetName is null;
+            if (differentScope)
                 return false;
 
-            if (SheetName is null && other.SheetName is null)
+            var bothWorkbookScope = SheetName is null && other.SheetName is null;
+            if (bothWorkbookScope)
                 return XLHelper.NameComparer.Equals(Name, other.Name);
 
             return XLHelper.NameComparer.Equals(Name, other.Name) &&

--- a/ClosedXML/Excel/Coordinates/XLSheetArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetArea.cs
@@ -8,7 +8,7 @@ namespace ClosedXML.Excel
     internal readonly struct XLSheetArea : IEquatable<XLSheetArea>
     {
         /// <summary>
-        /// Name of the sheet. Sheet may exist or not (e.g. deleted).
+        /// Name of the sheet. Sheet may exist or not (e.g. deleted). Never null.
         /// </summary>
         public readonly string Name;
 
@@ -19,6 +19,9 @@ namespace ClosedXML.Excel
 
         public XLSheetArea(String name, XLSheetRange area)
         {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(nameof(name));
+
             Name = name;
             Area = area;
         }
@@ -37,7 +40,6 @@ namespace ClosedXML.Excel
         {
             unchecked
             {
-               
                 return (XLHelper.SheetComparer.GetHashCode(Name) * 397) ^ Area.GetHashCode();
             }
         }
@@ -57,6 +59,11 @@ namespace ClosedXML.Excel
                 return null;
 
             return new XLSheetArea(Name, intersectionRange.Value);
+        }
+
+        public override string ToString()
+        {
+            return $"{Name}!{Area}";
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetArea.cs
@@ -8,7 +8,7 @@ namespace ClosedXML.Excel
     internal readonly struct XLSheetArea : IEquatable<XLSheetArea>
     {
         /// <summary>
-        /// Name of the sheet. Sheet may exist or not.
+        /// Name of the sheet. Sheet may exist or not (e.g. deleted).
         /// </summary>
         public readonly string Name;
 
@@ -25,7 +25,7 @@ namespace ClosedXML.Excel
 
         public bool Equals(XLSheetArea other)
         {
-            return Area == other.Area && StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name);
+            return Area == other.Area && XLHelper.SheetComparer.Equals(Name, other.Name);
         }
 
         public override bool Equals(object? obj)
@@ -37,8 +37,26 @@ namespace ClosedXML.Excel
         {
             unchecked
             {
-                return (Name.GetHashCode() * 397) ^ Area.GetHashCode();
+               
+                return (XLHelper.SheetComparer.GetHashCode(Name) * 397) ^ Area.GetHashCode();
             }
+        }
+
+        /// <summary>
+        /// Perform an intersection.
+        /// </summary>
+        /// <param name="other">The area that is being intersected with this one.</param>
+        /// <returns>The intersection (=same sheet and has non-empty intersection) or null if intersection isn't possible.</returns>
+        public XLSheetArea? Intersect(XLSheetArea other)
+        {
+            if (!XLHelper.SheetComparer.Equals(Name, other.Name))
+                return null;
+
+            var intersectionRange = Area.Intersect(other.Area);
+            if (intersectionRange is null)
+                return null;
+
+            return new XLSheetArea(Name, intersectionRange.Value);
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetArea.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace ClosedXML.Excel
+{
+    /// <summary>
+    /// A specification of an area (rectangular range) of a sheet.
+    /// </summary>
+    internal readonly struct XLSheetArea : IEquatable<XLSheetArea>
+    {
+        /// <summary>
+        /// Name of the sheet. Sheet may exist or not.
+        /// </summary>
+        public readonly string Name;
+
+        /// <summary>
+        /// An area in the sheet.
+        /// </summary>
+        public readonly XLSheetRange Area;
+
+        public XLSheetArea(String name, XLSheetRange area)
+        {
+            Name = name;
+            Area = area;
+        }
+
+        public bool Equals(XLSheetArea other)
+        {
+            return Area == other.Area && StringComparer.OrdinalIgnoreCase.Equals(Name, other.Name);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is XLSheetArea other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Name.GetHashCode() * 397) ^ Area.GetHashCode();
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -41,8 +41,26 @@ namespace ClosedXML.Excel
 
         public int Height => LastPoint.Row - FirstPoint.Row + 1;
 
+        /// <summary>
+        /// The left column number of the range. From 1 to <see cref="XLHelper.MaxColumnNumber"/>.
+        /// </summary>
+        public int LeftColumn => FirstPoint.Column;
+
+        /// <summary>
+        /// The right column number of the range. From 1 to <see cref="XLHelper.MaxColumnNumber"/>.
+        /// Greater or equal to <see cref="LeftColumn"/>.
+        /// </summary>
         public int RightColumn => LastPoint.Column;
 
+        /// <summary>
+        /// The top row number of the range. From 1 to <see cref="XLHelper.MaxRowNumber"/>.
+        /// </summary>
+        public int TopRow => FirstPoint.Row;
+
+        /// <summary>
+        /// The bottom row number of the range. From 1 to <see cref="XLHelper.MaxRowNumber"/>.
+        /// Greater or equal to <see cref="TopRow"/>.
+        /// </summary>
         public int BottomRow => LastPoint.Row;
 
         public override bool Equals(object obj)
@@ -194,6 +212,39 @@ namespace ClosedXML.Excel
                 throw new ArgumentOutOfRangeException();
 
             return new XLSheetRange(new XLSheetPoint(FirstPoint.Row, RightColumn - columns + 1), LastPoint);
+        }
+
+        /// <summary>
+        /// Create a new sheet range that is a result of range operator (:)
+        /// of this sheet range and 
+        /// </summary>
+        /// <param name="otherRange">The other range.</param>
+        /// <returns>A range that contains both this range and <paramref name="otherRange"/>.</returns>
+        public XLSheetRange Range(XLSheetRange otherRange)
+        {
+            var topRow = Math.Min(TopRow, otherRange.TopRow);
+            var leftColumn = Math.Min(LeftColumn, otherRange.LeftColumn);
+            var bottomRow = Math.Max(BottomRow, otherRange.BottomRow);
+            var rightColumn = Math.Max(RightColumn, otherRange.RightColumn);
+            return new XLSheetRange(topRow, leftColumn, bottomRow, rightColumn);
+        }
+
+        /// <summary>
+        /// Do an intersection between this range and other range.
+        /// </summary>
+        /// <param name="other">Other range.</param>
+        /// <returns>The intersection if exists or null, if intersection doesn't exist.</returns>
+        public XLSheetRange? Intersect(XLSheetRange other)
+        {
+            var leftColumn = Math.Max(LeftColumn, other.LeftColumn);
+            var rightColumn = Math.Min(RightColumn, other.RightColumn);
+            var topRow = Math.Max(TopRow, other.TopRow);
+            var bottomRow = Math.Min(BottomRow, other.BottomRow);
+
+            if (bottomRow < topRow || rightColumn < leftColumn)
+                return null;
+
+            return new XLSheetRange(topRow, leftColumn, bottomRow, rightColumn);
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -215,8 +215,8 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
-        /// Create a new sheet range that is a result of range operator (:)
-        /// of this sheet range and 
+        /// Create a new sheet range that is a result of range operator (<c>:</c>)
+        /// of this sheet range and <paramref name="otherRange"/>
         /// </summary>
         /// <param name="otherRange">The other range.</param>
         /// <returns>A range that contains both this range and <paramref name="otherRange"/>.</returns>
@@ -233,7 +233,7 @@ namespace ClosedXML.Excel
         /// Do an intersection between this range and other range.
         /// </summary>
         /// <param name="other">Other range.</param>
-        /// <returns>The intersection if exists or null, if intersection doesn't exist.</returns>
+        /// <returns>The intersection range if it exists and is non-empty or null, if intersection doesn't exist.</returns>
         public XLSheetRange? Intersect(XLSheetRange other)
         {
             var leftColumn = Math.Max(LeftColumn, other.LeftColumn);

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using ClosedXML.Excel;
+using ClosedXML.Parser;
+
+namespace ClosedXML.Extensions
+{
+    /// <summary>
+    /// Extensions method for <see cref="ReferenceArea"/>.
+    /// </summary>
+    internal static class ReferenceAreaExtensions
+    {
+        /// <summary>
+        /// Convert area to an absolute sheet range (regardless if the area is A1 or R1C1).
+        /// </summary>
+        /// <param name="area">Area to convert</param>
+        /// <param name="anchor">An anchor address that is the center of R1C1 relative address.</param>
+        /// <returns>Converted absolute range.</returns>
+        public static XLSheetRange ToSheetRange(this ReferenceArea area, XLSheetPoint anchor)
+        {
+            var firstRow = ToAbsolutePosition(area.First.RowType, area.First.RowValue, anchor.Row, XLHelper.MinRowNumber);
+            var firstCol = ToAbsolutePosition(area.First.ColumnType, area.First.ColumnValue, anchor.Column, XLHelper.MinColumnNumber);
+            var lastRow = ToAbsolutePosition(area.Second.RowType, area.Second.RowValue, anchor.Row, XLHelper.MaxRowNumber);
+            var lastCol = ToAbsolutePosition(area.Second.ColumnType, area.Second.ColumnValue, anchor.Column, XLHelper.MaxColumnNumber);
+
+            return new XLSheetRange(firstRow, firstCol, lastRow, lastCol);
+        }
+
+        private static int ToAbsolutePosition(ReferenceAxisType axisType, int position, int anchorPosition, int defaultPosition)
+        {
+            return axisType switch
+            {
+                ReferenceAxisType.Absolute => position,
+                ReferenceAxisType.Relative => anchorPosition + position,
+                ReferenceAxisType.None => defaultPosition,
+                _ => throw new NotSupportedException()
+            };
+        }
+    }
+}

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -26,9 +26,20 @@ namespace ClosedXML.Excel
         internal static readonly NumberStyles NumberStyle = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowExponent;
         internal static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
 
+        /// <summary>
+        /// Comparer used to compare sheet names.
+        /// </summary>
         internal static readonly StringComparer SheetComparer = StringComparer.OrdinalIgnoreCase;
 
+        /// <summary>
+        /// Comparer used to compare defined names.
+        /// </summary>
         internal static readonly StringComparer NameComparer = StringComparer.OrdinalIgnoreCase;
+
+        /// <summary>
+        /// Comparer of function names.
+        /// </summary>
+        internal static readonly StringComparer FunctionComparer = StringComparer.OrdinalIgnoreCase;
 
         internal static readonly Regex RCSimpleRegex = new Regex(
             @"^(r(((-\d)?\d*)|\[(-\d)?\d*\]))?(c(((-\d)?\d*)|\[(-\d)?\d*\]))?$"

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -26,6 +26,8 @@ namespace ClosedXML.Excel
         internal static readonly NumberStyles NumberStyle = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowExponent;
         internal static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
 
+        internal static StringComparer SheetComparer = StringComparer.OrdinalIgnoreCase;
+
         internal static readonly Regex RCSimpleRegex = new Regex(
             @"^(r(((-\d)?\d*)|\[(-\d)?\d*\]))?(c(((-\d)?\d*)|\[(-\d)?\d*\]))?$"
             , RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -26,7 +26,9 @@ namespace ClosedXML.Excel
         internal static readonly NumberStyles NumberStyle = NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowExponent;
         internal static readonly CultureInfo ParseCulture = CultureInfo.InvariantCulture;
 
-        internal static StringComparer SheetComparer = StringComparer.OrdinalIgnoreCase;
+        internal static readonly StringComparer SheetComparer = StringComparer.OrdinalIgnoreCase;
+
+        internal static readonly StringComparer NameComparer = StringComparer.OrdinalIgnoreCase;
 
         internal static readonly Regex RCSimpleRegex = new Regex(
             @"^(r(((-\d)?\d*)|\[(-\d)?\d*\]))?(c(((-\d)?\d*)|\[(-\d)?\d*\]))?$"


### PR DESCRIPTION
First step of CalcEngine revamp - extract areas formula depends on, from simple `A1+4+SIN(Other!B5)` to `IF(G4,Sheet!A1,Other!A2):IF(H3,Other!C4,C5)`.

There already is a similar visitor in `XLCalcEngine`, but `XLCalcEngine` is slated for deletion (keep `CalcEngineΣ).

The whole plan for calc engine revamp consists of 
* Dirty flag maintenance:
  * Extract area dependencies from formulas - **that is this PR**
  * build dependency tree
  * mark formulas as dirty when precedent value changes
* Calculate
  * Create calculation chain
  * stop calculation of formula when dependency is not yet done and reorder formulas in calculation chain, so the *not-yet-done* cell is before current one.