### PR TITLE
Fix ROUND (and probably others) not handling the result of binary operations on refs

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1419,10 +1419,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // References are treated differently to constant values within calculations by the calc engine,
             // so let's make sure to include a test to validate that everything keeps working in the future
-            ws.Cell("A8").FormulaA1 = "ROUND((A1*A$2+A3*A$4)/(A$5+A$6),0)"; // (1 * 2 + 3 * 4) / (5 + 3) = 1.75
+            ws.Cell("A8").FormulaA1 = "ROUND((-A1*A$2+A3*A$4)/(A$5+A$6),0)"; // (-1 * 2 + 3 * 4) / (5 + 3) = 1.25
             var actual = ws.Cell("A8").Value;
 
-            Assert.AreEqual(2.0, actual);
+            Assert.AreEqual(1.0, actual);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1407,6 +1407,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
+        public void Round_References()
+        {
+            IXLWorksheet ws = new XLWorkbook().AddWorksheet("Sheet1");
+            ws.Cell("A1").SetValue(1);
+            ws.Cell("A2").SetValue(2);
+            ws.Cell("A3").SetValue(3);
+            ws.Cell("A4").SetValue(4);
+            ws.Cell("A5").SetValue(5);
+            ws.Cell("A6").SetValue(2);
+
+            // References are treated differently to constant values within calculations by the calc engine,
+            // so let's make sure to include a test to validate that everything keeps working in the future
+            ws.Cell("A8").FormulaA1 = "ROUND((A1*A$2+A3*A$4)/(A$5+A$6),0)"; // (1 * 2 + 3 * 4) / (5 + 3) = 1.75
+            var actual = ws.Cell("A8").Value;
+
+            Assert.AreEqual(2.0, actual);
+        }
+
+        [Test]
         public void RoundDown()
         {
             object actual = XLWorkbook.EvaluateExpr("RoundDown(3.2, 0)");

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NA/@EntryIndexedValue">NA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RC/@EntryIndexedValue">RC</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofilter/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=broadcasted/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Calibri/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Carlito/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=codepoints/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/AnyValue.cs
+++ b/ClosedXML/Excel/CalcEngine/AnyValue.cs
@@ -508,82 +508,31 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue BinaryOperation(in AnyValue left, in AnyValue right, BinaryFunc func, CalcContext context)
         {
-            var isLeftScalar = left.TryPickScalar(out var leftScalar, out var leftCollection);
-            var isRightScalar = right.TryPickScalar(out var rightScalar, out var rightCollection);
+            var isLeftSingle = left.TryPickSingleOrMultiValue(out var leftSingle, out var leftArray, context);
+            var isRightSingle = right.TryPickSingleOrMultiValue(out var rightSingle, out var rightArray, context);
 
-            if (isLeftScalar && isRightScalar)
-                return func(in leftScalar, in rightScalar, context).ToAnyValue();
+            if (isLeftSingle && isRightSingle)
+                return func(in leftSingle, in rightSingle, context).ToAnyValue();
 
-            if (isLeftScalar)
+            if (isLeftSingle)
             {
-                // Right side is an array
-                if (rightCollection.TryPickT0(out var rightArray, out var rightReference))
-                    return new ScalarArray(leftScalar, rightArray.Width, rightArray.Height).Apply(rightArray, func, context);
-
-                // Right side is a reference
-                if (rightReference.TryGetSingleCellValue(out var rightCellValue, context))
-                    return func(in leftScalar, in rightCellValue, context).ToAnyValue();
-
-                var referenceArrayResult = rightReference.ToArray(context);
-                if (!referenceArrayResult.TryPickT0(out var rightRefArray, out var rightError))
-                    return rightError;
-
-                return new ScalarArray(leftScalar, rightRefArray.Width, rightRefArray.Height).Apply(rightRefArray, func, context);
+                var broadcastedLeftArray = new ScalarArray(leftSingle, rightArray.Width, rightArray.Height);
+                return broadcastedLeftArray.Apply(rightArray, func, context);
             }
 
-            if (isRightScalar)
+            if (isRightSingle)
             {
-                // Left side is an array
-                if (leftCollection.TryPickT0(out var leftArray, out var leftReference))
-                    return leftArray.Apply(new ScalarArray(rightScalar, leftArray.Width, leftArray.Height), func, context);
-
-                // Left side is a reference
-                if (leftReference.TryGetSingleCellValue(out var leftCellValue, context))
-                    return func(leftCellValue, rightScalar, context).ToAnyValue();
-
-                var referenceArrayResult = leftReference.ToArray(context);
-                if (!referenceArrayResult.TryPickT0(out var leftRefArray, out var leftError))
-                    return leftError;
-
-                return leftRefArray.Apply(new ScalarArray(rightScalar, leftRefArray.Width, leftRefArray.Height), func, context);
+                var broadcastedRightArray = new ScalarArray(rightSingle, leftArray.Width, leftArray.Height);
+                return leftArray.Apply(broadcastedRightArray, func, context);
             }
 
-            // Both are aggregates
-            {
-                var isLeftArray = leftCollection.TryPickT0(out var leftArray, out var leftReference);
-                var isRightArray = rightCollection.TryPickT0(out var rightArray, out var rightReference);
+            var unifiedRows = Math.Max(leftArray.Height, rightArray.Height);
+            var unifiedColumns = Math.Max(leftArray.Width, rightArray.Width);
 
-                if (!isLeftArray)
-                {
-                    if (leftReference.Areas.Count > 1)
-                        return XLError.IncompatibleValue;
+            var leftBroadcastedArray = leftArray.Rescale(unifiedRows, unifiedColumns);
+            var rightBroadcastedArray = rightArray.Rescale(unifiedRows, unifiedColumns);
 
-                    leftArray = new ReferenceArray(leftReference.Areas[0], context);
-                }
-
-                if (!isRightArray)
-                {
-                    if (rightReference.Areas.Count > 1)
-                        return XLError.IncompatibleValue;
-
-                    rightArray = new ReferenceArray(rightReference.Areas[0], context);
-                }
-
-                var combinedRows = Math.Max(leftArray.Height, rightArray.Height);
-                var combinedColumns = Math.Max(leftArray.Width, rightArray.Width);
-
-                if (!isLeftArray && !isRightArray && combinedRows == 1 && combinedColumns == 1)
-                {
-                    // We're dealing with 2 references and each reference is referencing only a single cell.
-                    // So we want to treat them like scalars so other calcs that depend on this calc don't have to deal with 1x1 Arrays.
-                    return func(leftArray[0, 0], rightArray[0, 0], context).ToAnyValue();
-                }
-
-                var leftRescaledArray = leftArray.Rescale(combinedRows, combinedColumns);
-                var rightRescaledArray = rightArray.Rescale(combinedRows, combinedColumns);
-
-                return leftRescaledArray.Apply(rightRescaledArray, func, context);
-            }
+            return leftBroadcastedArray.Apply(rightBroadcastedArray, func, context);
         }
 
         private static ScalarValue BinaryArithmeticOp(in ScalarValue left, in ScalarValue right, BinaryNumberFunc func, CalcContext ctx)

--- a/ClosedXML/Excel/CalcEngine/AnyValue.cs
+++ b/ClosedXML/Excel/CalcEngine/AnyValue.cs
@@ -506,8 +506,8 @@ namespace ClosedXML.Excel.CalcEngine
             var unifiedRows = Math.Max(leftArray.Height, rightArray.Height);
             var unifiedColumns = Math.Max(leftArray.Width, rightArray.Width);
 
-            var leftBroadcastedArray = leftArray.Rescale(unifiedRows, unifiedColumns);
-            var rightBroadcastedArray = rightArray.Rescale(unifiedRows, unifiedColumns);
+            var leftBroadcastedArray = leftArray.Broadcast(unifiedRows, unifiedColumns);
+            var rightBroadcastedArray = rightArray.Broadcast(unifiedRows, unifiedColumns);
 
             return leftBroadcastedArray.Apply(rightBroadcastedArray, func, context);
         }

--- a/ClosedXML/Excel/CalcEngine/AnyValue.cs
+++ b/ClosedXML/Excel/CalcEngine/AnyValue.cs
@@ -554,6 +554,13 @@ namespace ClosedXML.Excel.CalcEngine
                 var combinedRows = Math.Max(leftArray.Height, rightArray.Height);
                 var combinedColumns = Math.Max(leftArray.Width, rightArray.Width);
 
+                if (!isLeftArray && !isRightArray && combinedRows == 1 && combinedColumns == 1)
+                {
+                    // We're dealing with 2 references and each reference is referencing only a single cell.
+                    // So we want to treat them like scalars so other calcs that depend on this calc don't have to deal with 1x1 Arrays.
+                    return func(leftArray[0, 0], rightArray[0, 0], context).ToAnyValue();
+                }
+
                 var leftRescaledArray = leftArray.Rescale(combinedRows, combinedColumns);
                 var rightRescaledArray = rightArray.Rescale(combinedRows, combinedColumns);
 

--- a/ClosedXML/Excel/CalcEngine/Array.cs
+++ b/ClosedXML/Excel/CalcEngine/Array.cs
@@ -84,9 +84,9 @@ namespace ClosedXML.Excel.CalcEngine
         }
 
         /// <summary>
-        /// Rescale array for calculation of array formulas.
+        /// Broadcast array for calculation of array formulas.
         /// </summary>
-        public Array Rescale(int rows, int columns)
+        public Array Broadcast(int rows, int columns)
         {
             if (Width == columns && Height == columns)
                 return this;

--- a/ClosedXML/Excel/CalcEngine/FunctionDefinition.cs
+++ b/ClosedXML/Excel/CalcEngine/FunctionDefinition.cs
@@ -90,7 +90,7 @@ namespace ClosedXML.Excel.CalcEngine
                 {
                     arg = argIsSingle
                         ? new ScalarArray(single, totalColumns, totalRows)
-                        : multi.Rescale(totalRows, totalColumns);
+                        : multi.Broadcast(totalRows, totalColumns);
                 }
                 else
                 {

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -537,8 +537,8 @@ namespace ClosedXML.Excel
             var ws = masterCell.Worksheet;
             var formula = GetFormulaA1(masterCell.SheetPoint);
             var resultArray = ws.CalcEngine.EvaluateArrayFormula(formula, masterCell);
-            var rescaledArray = resultArray.Rescale(Range.Height, Range.Width);
-            return rescaledArray;
+            var broadcastedArray = resultArray.Broadcast(Range.Height, Range.Width);
+            return broadcastedArray;
         }
 
         /// <summary>


### PR DESCRIPTION
While testing the latest HEAD of ClosedXML today, I noticed that I was getting some `System.InvalidCastException: Object must implement IConvertible` exceptions.

I tracked it down to a basic calculation in my source Excel file that looked this this: `=ROUND((H18*H$16+M18*M$16)/(H$16+M$16),0)`

This didn't seem like a function call that should be too difficult or cause issues, so after diving into the ClosedXML code, I noticed that the binary operations on the references within the `ROUND` were returning 1x1 Arrays and when the `ROUND` function tried to convert that to a `double` it would throw the exception.

This PR updates the binary operation code to return a scalar instead of an array, when the binary operation is operating on 2 references that only reference 1 cell each. (EDIT: I also found the same problem with unary operations and fixed that as well)

You might have another way of fixing this issue (e.g. maybe adding an implicit conversion from a 1x1 Array to a double would be better?) and not accept my PR, which is all good with me. But this issue not triggering any test failures and just throwing exceptions at runtime doesn't seem ideal so taking my basic test and adding it to the test suite so this gets captured in the future would be awesome