### PR TITLE
Add names areas to dependency tree

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -175,7 +175,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.AreEqual(expectedDirtyFlag, dirtyCell.Formula?.IsDirty);
         }
 
-        private static CellFormulaDependencies GetDependencies(string formula)
+        private static FormulaDependencies GetDependencies(string formula)
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet");

--- a/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
@@ -1,0 +1,192 @@
+﻿using System.Collections.Generic;
+using ClosedXML.Excel;
+using ClosedXML.Extensions;
+using ClosedXML.Parser;
+using NUnit.Framework;
+using static ClosedXML.Parser.ReferenceAxisType;
+
+namespace ClosedXML.Tests.Extensions
+{
+    [TestFixture]
+    internal class ReferenceAreaExtensionsTests
+    {
+        [Test]
+        [TestCaseSource(nameof(A1TestCases))]
+        public void ToSheetPoint_converts_a1_reference_to_sheet_range(ReferenceArea tokenArea, XLSheetRange expectedRange)
+        {
+            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(default, true));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(R1C1TestCases))]
+        public void ToSheetPoint_converts_r1c1_reference_to_sheet_range(XLSheetPoint anchor, ReferenceArea tokenArea, XLSheetRange expectedRange)
+        {
+            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(anchor, false));
+        }
+
+        public static IEnumerable<object[]> A1TestCases()
+        {
+            // C5
+            yield return new object[]
+            {
+                new ReferenceArea(Relative, 3, Relative, 5),
+                new XLSheetRange(5, 3, 5, 3)
+            };
+
+            // C5:E14
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(Relative, 3, Relative, 5), new Reference(Relative, 5, Relative, 14)),
+                new XLSheetRange(5, 3, 14, 5)
+            };
+
+            // $B3:E$10
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(Absolute, 2, Relative, 3), new Reference(Relative, 5, Absolute, 10)),
+                new XLSheetRange(3, 2, 10, 5)
+            };
+
+            // $B$3:$E$10
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(Absolute, 2, Absolute, 3), new Reference(Absolute, 5, Absolute, 10)),
+                new XLSheetRange(3, 2, 10, 5)
+            };
+
+            // B10:E3 points are not in left top corner and bottom right corner
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(Relative, 2, Relative, 10), new Reference(Absolute, 5, Absolute, 3)),
+                new XLSheetRange(3, 2, 10, 5)
+            };
+
+            // C:E
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(Relative, 3, None, 0), new Reference(Relative, 5, None, 0)),
+                new XLSheetRange(XLHelper.MinRowNumber, 3, XLHelper.MaxRowNumber, 5)
+            };
+
+            // E:C
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(Relative, 5, None, 0), new Reference(Relative, 3, None, 0)),
+                new XLSheetRange(XLHelper.MinRowNumber, 3, XLHelper.MaxRowNumber, 5)
+            };
+
+            // 14:30
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(None, 0, Relative, 14), new Reference(None, 0, Relative, 30)),
+                new XLSheetRange(14, XLHelper.MinColumnNumber, 30, XLHelper.MaxColumnNumber)
+            };
+
+            // 30:14
+            yield return new object[]
+            {
+                new ReferenceArea(new Reference(None, 0, Relative, 30), new Reference(None, 0, Relative, 14)),
+                new XLSheetRange(14, XLHelper.MinColumnNumber, 30, XLHelper.MaxColumnNumber)
+            };
+        }
+
+        public static IEnumerable<object[]> R1C1TestCases()
+        {
+            // R2C4
+            yield return new object[]
+            {
+                new XLSheetPoint(1, 1),
+                new ReferenceArea(Absolute, 4, Absolute, 2),
+                new XLSheetRange(2, 4, 2, 4)
+            };
+
+            // R[2]C[4]
+            yield return new object[]
+            {
+                new XLSheetPoint(3, 2), // R3C2
+                new ReferenceArea(Relative, 4, Relative, 2), // R[2]C[4]
+                new XLSheetRange(5, 6, 5, 6)
+            };
+
+            // R[0]C[0] is the identical address
+            yield return new object[]
+            {
+                new XLSheetPoint(3, 2), // R3C2
+                new ReferenceArea(Relative, 0, Relative, 0), // R[0]C[0]
+                new XLSheetRange(3, 2, 3, 2)
+            };
+
+            // No looping: Maximum allowed value for relative column is `XLHelper.MaxColumnNumber-1`.
+            yield return new object[]
+            {
+                new XLSheetPoint(1, 1), // R1C1
+                new ReferenceArea(Relative, 16383, Relative, 0), // R[0]C[16383]
+                new XLSheetRange(1, XLHelper.MaxColumnNumber, 1, XLHelper.MaxColumnNumber)
+            };
+
+            // No looping: Minimum allowed value for relative column is `-XLHelper.MaxColumnNumber+1`.
+            yield return new object[]
+            {
+                new XLSheetPoint(1, XLHelper.MaxColumnNumber), // R1C16384
+                new ReferenceArea(Relative, -16383, Relative, 0), // R[0]C[-16383]
+                new XLSheetRange(1, 1, 1, 1) // R1C1
+            };
+
+            // Looping: when relative column adjusted to anchor is above the max column, it loops back
+            yield return new object[]
+            {
+                new XLSheetPoint(1, 16380), // R1C16380
+                new ReferenceArea(Relative, 16380, Relative, 0), // R[0]C[16380]
+                new XLSheetRange(1, 16376, 1, 16376) // RC16376
+            };
+
+            // Looping: when relative column adjusted to anchor is below the column 1, it loops back
+            yield return new object[]
+            {
+                new XLSheetPoint(1, 10), // R1C10
+                new ReferenceArea(Relative, -16370, Relative, 0), // R[0]C[16370]
+                new XLSheetRange(1, 24, 1, 24) // RC24
+            };
+
+            // Looping: when relative row adjusted to anchor is above the max row, it loops back
+            yield return new object[]
+            {
+                new XLSheetPoint(15, 1), // R15C1
+                new ReferenceArea(Relative, 0, Relative, 1048570), // R[1048570]C[0]
+                new XLSheetRange(9, 1, 9, 1) // R9C1
+            };
+
+            // Looping: when relative row adjusted to anchor is below the row 1, it loops back
+            yield return new object[]
+            {
+                new XLSheetPoint(1048570, 1), // R1048570C1
+                new ReferenceArea(Relative, 0, Relative, -1048573), // R[-1048573]C[0]
+                new XLSheetRange(1048573, 1, 1048573, 1) // R1048573C1
+            };
+
+            // Area absolute
+            yield return new object[]
+            {
+                new XLSheetPoint(754, 5742),
+                new ReferenceArea(new Reference(Absolute, 2, Absolute, 3), new Reference(Absolute, 4, Absolute, 7)),
+                XLSheetRange.Parse("B3:D7")
+            };
+
+            // Area relative
+            yield return new object[]
+            {
+                new XLSheetPoint(3, 6),
+                new ReferenceArea(new Reference(Relative, -1, Relative, 4), new Reference(Relative, 3, Relative, 6)), // R[4]C[-1]:R[6]C[3]
+                new XLSheetRange(7, 5, 9, 9)
+            };
+
+            // Are with corners not in top left and right bottom
+            yield return new object[]
+            {
+                new XLSheetPoint(3, 6),
+                new ReferenceArea(new Reference(Relative, -1, Relative, 6), new Reference(Relative, 3, Relative, 4)), // R[6]C[-1]:R[4]C[3]
+                new XLSheetRange(7, 5, 9, 9)
+            };
+        }
+    }
+}

--- a/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
@@ -14,14 +14,14 @@ namespace ClosedXML.Tests.Extensions
         [TestCaseSource(nameof(A1TestCases))]
         public void ToSheetPoint_converts_a1_reference_to_sheet_range(ReferenceArea tokenArea, XLSheetRange expectedRange)
         {
-            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(default, true));
+            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(default, isA1: true));
         }
 
         [Test]
         [TestCaseSource(nameof(R1C1TestCases))]
         public void ToSheetPoint_converts_r1c1_reference_to_sheet_range(XLSheetPoint anchor, ReferenceArea tokenArea, XLSheetRange expectedRange)
         {
-            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(anchor, false));
+            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(anchor, isA1: false));
         }
 
         public static IEnumerable<object[]> A1TestCases()
@@ -145,7 +145,7 @@ namespace ClosedXML.Tests.Extensions
             {
                 new XLSheetPoint(1, 10), // R1C10
                 new ReferenceArea(Relative, -16370, Relative, 0), // R[0]C[16370]
-                new XLSheetRange(1, 24, 1, 24) // RC24
+                new XLSheetRange(1, 24, 1, 24) // R1C24
             };
 
             // Looping: when relative row adjusted to anchor is above the max row, it loops back

--- a/ClosedXML/Excel/CalcEngine/AstNode.cs
+++ b/ClosedXML/Excel/CalcEngine/AstNode.cs
@@ -258,12 +258,12 @@ namespace ClosedXML.Excel.CalcEngine
     /// </summary>
     internal class ReferenceNode : ValueNode
     {
-        public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, XLReferenceStyle style)
+        public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, bool isA1)
         {
             Prefix = prefix;
             Address = referenceArea.GetDisplayStringA1();
             ReferenceArea = referenceArea;
-            Style = style;
+            IsA1 = isA1;
         }
 
         /// <summary>
@@ -282,9 +282,9 @@ namespace ClosedXML.Excel.CalcEngine
         public ReferenceArea ReferenceArea { get; }
 
         /// <summary>
-        /// Reference style used by <see cref="ReferenceArea"/>.
+        /// Is the reference in A1 style? If <c>false</c>, then it is R1C1.
         /// </summary>
-        public XLReferenceStyle Style { get; }
+        public bool IsA1 { get; }
 
         public override TResult Accept<TContext, TResult>(TContext context, IFormulaVisitor<TContext, TResult> visitor) => visitor.Visit(context, this);
 

--- a/ClosedXML/Excel/CalcEngine/AstNode.cs
+++ b/ClosedXML/Excel/CalcEngine/AstNode.cs
@@ -258,11 +258,12 @@ namespace ClosedXML.Excel.CalcEngine
     /// </summary>
     internal class ReferenceNode : ValueNode
     {
-        public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea)
+        public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, XLReferenceStyle style)
         {
             Prefix = prefix;
             Address = referenceArea.GetDisplayStringA1();
             ReferenceArea = referenceArea;
+            Style = style;
         }
 
         /// <summary>
@@ -279,6 +280,11 @@ namespace ClosedXML.Excel.CalcEngine
         /// An area from a parser.
         /// </summary>
         public ReferenceArea ReferenceArea { get; }
+
+        /// <summary>
+        /// Reference style used by <see cref="ReferenceArea"/>.
+        /// </summary>
+        public XLReferenceStyle Style { get; }
 
         public override TResult Accept<TContext, TResult>(TContext context, IFormulaVisitor<TContext, TResult> visitor) => visitor.Visit(context, this);
 

--- a/ClosedXML/Excel/CalcEngine/AstNode.cs
+++ b/ClosedXML/Excel/CalcEngine/AstNode.cs
@@ -337,10 +337,10 @@ namespace ClosedXML.Excel.CalcEngine
 
         internal bool TryGetNameRange(IXLWorksheet ws, out IXLNamedRange range)
         {
-            if (ws.NamedRanges.TryGetValue(Name, out range))
+            if (ws.NamedRanges.TryGetValue(Name, out range!))
                 return true;
 
-            if (ws.Workbook.NamedRanges.TryGetValue(Name, out range))
+            if (ws.Workbook.NamedRanges.TryGetValue(Name, out range!))
                 return true;
 
             return false;

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Excel.CalcEngine
     {
         private readonly CultureInfo _culture;
         private readonly ExpressionCache _cache;               // cache with parsed expressions
-        private readonly FormulaParser _parser;
+        private readonly FormulaParser _parserA1;
         private readonly CalculationVisitor _visitor;
 
         public CalcEngine(CultureInfo culture)
@@ -25,7 +25,7 @@ namespace ClosedXML.Excel.CalcEngine
             _culture = culture;
             _cache = new ExpressionCache(this);
             var funcRegistry = GetFunctionTable();
-            _parser = new FormulaParser(funcRegistry);
+            _parserA1 = new FormulaParser(funcRegistry);
             _visitor = new CalculationVisitor(funcRegistry);
         }
 
@@ -36,7 +36,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <returns>An <see cref="Expression"/> object that can be evaluated.</returns>
         public Formula Parse(string expression)
         {
-            return _parser.GetAst(expression);
+            return _parserA1.GetAst(expression);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             var acceptedPrefix = referenceNode.Prefix?.Accept(context, this);
             return !ReferenceEquals(acceptedPrefix, referenceNode.Prefix)
-                ? new ReferenceNode((PrefixNode?)acceptedPrefix, referenceNode.ReferenceArea, referenceNode.Style)
+                ? new ReferenceNode((PrefixNode?)acceptedPrefix, referenceNode.ReferenceArea, referenceNode.IsA1)
                 : referenceNode;
         }
 

--- a/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/DefaultFormulaVisitor.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             var acceptedPrefix = referenceNode.Prefix?.Accept(context, this);
             return !ReferenceEquals(acceptedPrefix, referenceNode.Prefix)
-                ? new ReferenceNode((PrefixNode?)acceptedPrefix, referenceNode.ReferenceArea)
+                ? new ReferenceNode((PrefixNode?)acceptedPrefix, referenceNode.ReferenceArea, referenceNode.Style)
                 : referenceNode;
         }
 

--- a/ClosedXML/Excel/CalcEngine/DependenciesContext.cs
+++ b/ClosedXML/Excel/CalcEngine/DependenciesContext.cs
@@ -8,15 +8,18 @@ namespace ClosedXML.Excel.CalcEngine
     /// </summary>
     internal class DependenciesContext
     {
-        internal DependenciesContext(XLSheetArea formulaArea)
+        internal DependenciesContext(XLSheetArea formulaArea, XLWorkbook workbook)
         {
             FormulaArea = formulaArea;
+            Workbook = workbook;
         }
 
         /// <summary>
         /// An area of a formula, in most cases just one cell, for array formulas area of cells.
         /// </summary>
         internal XLSheetArea FormulaArea { get; }
+
+        internal XLWorkbook Workbook { get; }
 
         /// <summary>
         /// The result. Visitor adds all areas/names formula depends on to this.

--- a/ClosedXML/Excel/CalcEngine/DependenciesContext.cs
+++ b/ClosedXML/Excel/CalcEngine/DependenciesContext.cs
@@ -21,7 +21,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <summary>
         /// The result. Visitor adds all areas/names formula depends on to this.
         /// </summary>
-        internal CellFormulaDependencies Dependencies { get; } = new();
+        internal FormulaDependencies Dependencies { get; } = new();
 
         /// <summary>
         /// Add areas to a list of areas the formula depends on. Disregards duplicate entries.

--- a/ClosedXML/Excel/CalcEngine/DependenciesVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/DependenciesVisitor.cs
@@ -270,7 +270,8 @@ namespace ClosedXML.Excel.CalcEngine
                 sheetName = context.FormulaArea.Name;
             }
 
-            var sheetRange = node.ReferenceArea.ToSheetRange(context.FormulaArea.Area.FirstPoint);
+            var anchor = context.FormulaArea.Area.FirstPoint;
+            var sheetRange = node.ReferenceArea.ToSheetRange(anchor, node.IsA1);
             return new List<XLSheetArea> { new(sheetName, sheetRange) };
         }
 

--- a/ClosedXML/Excel/CalcEngine/DependencyTree.cs
+++ b/ClosedXML/Excel/CalcEngine/DependencyTree.cs
@@ -28,6 +28,8 @@ namespace ClosedXML.Excel.CalcEngine
     /// </summary>
     internal class DependencyTree
     {
+        private readonly XLWorkbook _workbook;
+
         /// <summary>
         /// The source of the truth, a storage of formula dependencies. The dependency tree is
         /// constructed from this collection.
@@ -49,10 +51,11 @@ namespace ClosedXML.Excel.CalcEngine
         /// </summary>
         private readonly Dictionary<string, SheetDependencyTree> _sheetTrees = new(XLHelper.SheetComparer);
 
-        public DependencyTree(CalcEngine engine)
+        public DependencyTree(XLWorkbook workbook)
         {
+            _workbook = workbook;
             _visitor = new DependenciesVisitor();
-            _engine = engine;
+            _engine = workbook.CalcEngine;
         }
 
         /// <summary>
@@ -116,7 +119,7 @@ namespace ClosedXML.Excel.CalcEngine
         private FormulaDependencies GetFormulaPrecedents(XLSheetArea formulaArea, XLCellFormula formula)
         {
             var ast = formula.GetAst(_engine);
-            var context = new DependenciesContext(formulaArea);
+            var context = new DependenciesContext(formulaArea, _workbook);
             var rootReference = ast.AstRoot.Accept(context, _visitor);
 
             // If formula references are propagated to the root, make sure to add them.

--- a/ClosedXML/Excel/CalcEngine/DependencyTree.cs
+++ b/ClosedXML/Excel/CalcEngine/DependencyTree.cs
@@ -32,7 +32,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// The source of the truth, a storage of formula dependencies. The dependency tree is
         /// constructed from this collection.
         /// </summary>
-        private readonly Dictionary<XLCellFormula, CellFormulaDependencies> _dependencies = new();
+        private readonly Dictionary<XLCellFormula, FormulaDependencies> _dependencies = new();
 
         /// <summary>
         /// Visitor to extract precedents of formulas.
@@ -62,7 +62,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <param name="formula">The cell formula.</param>
         /// <returns>Added cell formula dependencies.</returns>
         /// <exception cref="ArgumentException">Formula already is in the tree.</exception>
-        internal CellFormulaDependencies AddFormula(XLSheetArea formulaArea, XLCellFormula formula)
+        internal FormulaDependencies AddFormula(XLSheetArea formulaArea, XLCellFormula formula)
         {
             var precedents = GetFormulaPrecedents(formulaArea, formula);
 
@@ -113,7 +113,7 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
-        private CellFormulaDependencies GetFormulaPrecedents(XLSheetArea formulaArea, XLCellFormula formula)
+        private FormulaDependencies GetFormulaPrecedents(XLSheetArea formulaArea, XLCellFormula formula)
         {
             var ast = formula.GetAst(_engine);
             var context = new DependenciesContext(formulaArea);

--- a/ClosedXML/Excel/CalcEngine/FormulaDependencies.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaDependencies.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Excel.CalcEngine
     /// A list of objects a cell formula depends on. If one of them changes,
     /// the formula value might no longer be accurate and needs to be recalculated.
     /// </summary>
-    internal class CellFormulaDependencies
+    internal class FormulaDependencies
     {
         private readonly HashSet<XLSheetArea> _areas = new();
         private readonly HashSet<XLName> _names = new();

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         public FormulaParser(FunctionRegistry functionRegistry)
         {
-            _nodeFactory = new AstFactory(functionRegistry, XLReferenceStyle.A1);
+            _nodeFactory = new AstFactory(functionRegistry, true);
         }
 
         /// <summary>
@@ -56,12 +56,12 @@ namespace ClosedXML.Excel.CalcEngine
             private const string DefaultFunctionNameSpace = "_xlfn";
 
             private readonly FunctionRegistry _functionRegistry;
-            private readonly XLReferenceStyle _style;
+            private readonly bool _isA1;
 
-            internal AstFactory(FunctionRegistry functionRegistry, XLReferenceStyle style)
+            internal AstFactory(FunctionRegistry functionRegistry, bool isA1)
             {
                 _functionRegistry = functionRegistry;
-                _style = style;
+                _isA1 = isA1;
             }
 
             public ScalarValue LogicalValue(List<FormulaFlags> context, bool logical) => logical;
@@ -110,20 +110,20 @@ namespace ClosedXML.Excel.CalcEngine
 
             public ValueNode Reference(List<FormulaFlags> context, ReferenceArea area)
             {
-                return new ReferenceNode(null, area, _style);
+                return new ReferenceNode(null, area, _isA1);
             }
 
             public ValueNode SheetReference(List<FormulaFlags> context, string sheet, ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, sheet, null, null);
-                return new ReferenceNode(prefixNode, area, _style);
+                return new ReferenceNode(prefixNode, area, _isA1);
             }
 
             public ValueNode Reference3D(List<FormulaFlags> context, string firstSheet, string lastSheet,
                 ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, null, firstSheet, lastSheet);
-                return new ReferenceNode(prefixNode, area, _style);
+                return new ReferenceNode(prefixNode, area, _isA1);
             }
 
             public ValueNode ExternalSheetReference(List<FormulaFlags> context, int workbookIndex, string sheet,
@@ -131,7 +131,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var fileNode = new FileNode(workbookIndex);
                 var prefixNode = new PrefixNode(fileNode, sheet, null, null);
-                return new ReferenceNode(prefixNode, area, _style);
+                return new ReferenceNode(prefixNode, area, _isA1);
             }
 
             public ValueNode ExternalReference3D(List<FormulaFlags> context, int workbookIndex, string firstSheet,
@@ -139,7 +139,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var fileNode = new FileNode(workbookIndex);
                 var prefixNode = new PrefixNode(fileNode, null, firstSheet, lastSheet);
-                return new ReferenceNode(prefixNode, area, _style);
+                return new ReferenceNode(prefixNode, area, _isA1);
             }
 
             public ValueNode Function(List<FormulaFlags> context, ReadOnlySpan<char> name,

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -7,11 +7,11 @@ namespace ClosedXML.Excel.CalcEngine
 {
     internal class FormulaParser
     {
-        private readonly AstFactoryA1 _nodeFactory;
+        private readonly AstFactory _nodeFactory;
 
         public FormulaParser(FunctionRegistry functionRegistry)
         {
-            _nodeFactory = new AstFactoryA1(functionRegistry);
+            _nodeFactory = new AstFactory(functionRegistry, XLReferenceStyle.A1);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <summary>
         /// Factory to create abstract syntax tree for a formula in A1 notation.
         /// </summary>
-        private sealed class AstFactoryA1 : IAstFactory<ScalarValue, ValueNode, List<FormulaFlags>>
+        private sealed class AstFactory : IAstFactory<ScalarValue, ValueNode, List<FormulaFlags>>
         {
             /// <summary>
             /// A prefix for so-called future functions. Excel can add functions, but to avoid name collisions,
@@ -56,10 +56,12 @@ namespace ClosedXML.Excel.CalcEngine
             private const string DefaultFunctionNameSpace = "_xlfn";
 
             private readonly FunctionRegistry _functionRegistry;
+            private readonly XLReferenceStyle _style;
 
-            internal AstFactoryA1(FunctionRegistry functionRegistry)
+            internal AstFactory(FunctionRegistry functionRegistry, XLReferenceStyle style)
             {
                 _functionRegistry = functionRegistry;
+                _style = style;
             }
 
             public ScalarValue LogicalValue(List<FormulaFlags> context, bool logical) => logical;
@@ -108,20 +110,20 @@ namespace ClosedXML.Excel.CalcEngine
 
             public ValueNode Reference(List<FormulaFlags> context, ReferenceArea area)
             {
-                return new ReferenceNode(null, area);
+                return new ReferenceNode(null, area, _style);
             }
 
             public ValueNode SheetReference(List<FormulaFlags> context, string sheet, ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, sheet, null, null);
-                return new ReferenceNode(prefixNode, area);
+                return new ReferenceNode(prefixNode, area, _style);
             }
 
             public ValueNode Reference3D(List<FormulaFlags> context, string firstSheet, string lastSheet,
                 ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, null, firstSheet, lastSheet);
-                return new ReferenceNode(prefixNode, area);
+                return new ReferenceNode(prefixNode, area, _style);
             }
 
             public ValueNode ExternalSheetReference(List<FormulaFlags> context, int workbookIndex, string sheet,
@@ -129,7 +131,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var fileNode = new FileNode(workbookIndex);
                 var prefixNode = new PrefixNode(fileNode, sheet, null, null);
-                return new ReferenceNode(prefixNode, area);
+                return new ReferenceNode(prefixNode, area, _style);
             }
 
             public ValueNode ExternalReference3D(List<FormulaFlags> context, int workbookIndex, string firstSheet,
@@ -137,7 +139,7 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var fileNode = new FileNode(workbookIndex);
                 var prefixNode = new PrefixNode(fileNode, null, firstSheet, lastSheet);
-                return new ReferenceNode(prefixNode, area);
+                return new ReferenceNode(prefixNode, area, _style);
             }
 
             public ValueNode Function(List<FormulaFlags> context, ReadOnlySpan<char> name,

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         public FormulaParser(FunctionRegistry functionRegistry)
         {
-            _nodeFactory = new AstFactory(functionRegistry, true);
+            _nodeFactory = new AstFactory(functionRegistry, isA1: true);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/Coordinates/XLName.cs
+++ b/ClosedXML/Excel/Coordinates/XLName.cs
@@ -69,5 +69,11 @@ namespace ClosedXML.Excel
                 return hashCode;
             }
         }
+
+        public override string ToString()
+        {
+            var isWorkbookScoped = SheetName is null;
+            return isWorkbookScoped ? Name : $"{SheetName}!{Name}";
+        }
     }
 }

--- a/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRange.cs
@@ -40,6 +40,14 @@ namespace ClosedXML.Excel
         /// <para>Note: A named range can point to multiple ranges.</para>
         /// </summary>
         IXLRanges Ranges { get; }
+
+        /// <summary>
+        /// A formula of the named range. In most cases, name is just a range (e.g.
+        /// <c>Sheet5!$A$4</c>), but it can be a constant, lambda or other values.
+        /// The name formula can contain a bang reference (e.g. reference without
+        /// a sheet, but with exclamation mark <c>!$A$5</c>), but can't contain plain
+        /// local cell references (i.e. references without a sheet like <c>A5</c>).
+        /// </summary>
         String RefersTo { get; set; }
 
         /// <summary>

--- a/ClosedXML/Excel/NamedRanges/IXLNamedRanges.cs
+++ b/ClosedXML/Excel/NamedRanges/IXLNamedRanges.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -11,13 +9,14 @@ namespace ClosedXML.Excel
         /// Gets the specified named range.
         /// </summary>
         /// <param name="rangeName">Name of the range.</param>
-        IXLNamedRange NamedRange(String rangeName);
-        
+        IXLNamedRange? NamedRange(String rangeName);
+
         /// <summary>
         /// Adds a new named range.
         /// </summary>
         /// <param name="rangeName">Name of the range to add.</param>
         /// <param name="rangeAddress">The range address to add.</param>
+        /// <exception cref="ArgumentException">The name or address is invalid.</exception>
         IXLNamedRange Add(String rangeName, String rangeAddress);
 
         /// <summary>
@@ -25,6 +24,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="rangeName">Name of the range to add.</param>
         /// <param name="range">The range to add.</param>
+        /// <exception cref="ArgumentException">The name is invalid.</exception>
         IXLNamedRange Add(String rangeName, IXLRange range);
 
         /// <summary>
@@ -32,6 +32,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="rangeName">Name of the range to add.</param>
         /// <param name="ranges">The ranges to add.</param>
+        /// <exception cref="ArgumentException">The name is invalid.</exception>
         IXLNamedRange Add(String rangeName, IXLRanges ranges);
 
         /// <summary>
@@ -40,7 +41,8 @@ namespace ClosedXML.Excel
         /// <param name="rangeName">Name of the ranges to add.</param>
         /// <param name="rangeAddress">The range address to add.</param>
         /// <param name="comment">The comment for the new named range.</param>
-        IXLNamedRange Add(String rangeName, String rangeAddress, String comment);
+        /// <exception cref="ArgumentException">The range name or address is invalid.</exception>
+        IXLNamedRange Add(String rangeName, String rangeAddress, String? comment);
 
         /// <summary>
         /// Adds a new named range.
@@ -48,7 +50,8 @@ namespace ClosedXML.Excel
         /// <param name="rangeName">Name of the ranges to add.</param>
         /// <param name="range">The range to add.</param>
         /// <param name="comment">The comment for the new named range.</param>
-        IXLNamedRange Add(String rangeName, IXLRange range, String comment);
+        /// <exception cref="ArgumentException">The range name is invalid.</exception>
+        IXLNamedRange Add(String rangeName, IXLRange range, String? comment);
 
         /// <summary>
         /// Adds a new named range.
@@ -56,7 +59,8 @@ namespace ClosedXML.Excel
         /// <param name="rangeName">Name of the ranges to add.</param>
         /// <param name="ranges">The ranges to add.</param>
         /// <param name="comment">The comment for the new named range.</param>
-        IXLNamedRange Add(String rangeName, IXLRanges ranges, String comment);
+        /// <exception cref="ArgumentException">The range name is invalid.</exception>
+        IXLNamedRange Add(String rangeName, IXLRanges ranges, String? comment);
 
         /// <summary>
         /// Deletes the specified named range (not the cells).
@@ -68,15 +72,15 @@ namespace ClosedXML.Excel
         /// Deletes the specified named range's index (not the cells).
         /// </summary>
         /// <param name="rangeIndex">Index of the named range to delete.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The index is outside of named ranges array.</exception>
         void Delete(Int32 rangeIndex);
-
 
         /// <summary>
         /// Deletes all named ranges (not the cells).
         /// </summary>
         void DeleteAll();
 
-        Boolean TryGetValue(String name, out IXLNamedRange range);
+        Boolean TryGetValue(String name, out IXLNamedRange? range);
 
         Boolean Contains(String name);
 

--- a/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRange.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using ClosedXML.Extensions;
 
 namespace ClosedXML.Excel
 {

--- a/ClosedXML/Excel/NamedRanges/XLNamedRanges.cs
+++ b/ClosedXML/Excel/NamedRanges/XLNamedRanges.cs
@@ -6,6 +6,9 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// A collection of a named ranges, either for workbook or for worksheet.
+    /// </summary>
     internal class XLNamedRanges : IXLNamedRanges
     {
         private readonly Dictionary<String, XLNamedRange> _namedRanges = new(XLHelper.NameComparer);

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -165,10 +165,12 @@ namespace ClosedXML.Excel
             get { return WorksheetsInternal; }
         }
 
+        internal XLNamedRanges NamedRangesInternal { get; }
+
         /// <summary>
         ///   Gets an object to manipulate this workbook's named ranges.
         /// </summary>
-        public IXLNamedRanges NamedRanges { get; private set; }
+        public IXLNamedRanges NamedRanges => NamedRangesInternal;
 
         /// <summary>
         ///   Gets an object to manipulate this workbook's theme.
@@ -750,7 +752,7 @@ namespace ClosedXML.Excel
             ShowZeros = DefaultShowZeros;
             RightToLeft = DefaultRightToLeft;
             WorksheetsInternal = new XLWorksheets(this);
-            NamedRanges = new XLNamedRanges(this);
+            NamedRangesInternal = new XLNamedRanges(this);
             PivotCachesInternal = new XLPivotCaches();
             CustomProperties = new XLCustomProperties(this);
             ShapeIdManager = new XLIdManager();

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -14,26 +14,69 @@ namespace ClosedXML.Extensions
         /// </summary>
         /// <param name="area">Area to convert</param>
         /// <param name="anchor">An anchor address that is the center of R1C1 relative address.</param>
+        /// <param name="isA1">If true, the reference area is in A1 style, otherwise in R1C1 style.</param>
         /// <returns>Converted absolute range.</returns>
-        public static XLSheetRange ToSheetRange(this ReferenceArea area, XLSheetPoint anchor)
+        public static XLSheetRange ToSheetRange(this ReferenceArea area, XLSheetPoint anchor, bool isA1)
         {
-            var firstRow = ToAbsolutePositionA1(area.First.RowType, area.First.RowValue, XLHelper.MinRowNumber);
-            var firstCol = ToAbsolutePositionA1(area.First.ColumnType, area.First.ColumnValue, XLHelper.MinColumnNumber);
-            var lastRow = ToAbsolutePositionA1(area.Second.RowType, area.Second.RowValue, XLHelper.MaxRowNumber);
-            var lastCol = ToAbsolutePositionA1(area.Second.ColumnType, area.Second.ColumnValue, XLHelper.MaxColumnNumber);
+            int col1, row1, col2, row2;
+            if (isA1)
+            {
+                row1 = A1ToPosition(area.First.RowType, area.First.RowValue, XLHelper.MinRowNumber);
+                col1 = A1ToPosition(area.First.ColumnType, area.First.ColumnValue, XLHelper.MinColumnNumber);
+                row2 = A1ToPosition(area.Second.RowType, area.Second.RowValue, XLHelper.MaxRowNumber);
+                col2 = A1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, XLHelper.MaxColumnNumber);
+            }
+            else
+            {
+                row1 = R1C1ToPosition(area.First.RowType, area.First.RowValue, anchor.Row, XLHelper.MinRowNumber, XLHelper.MaxRowNumber);
+                col1 = R1C1ToPosition(area.First.ColumnType, area.First.ColumnValue, anchor.Column, XLHelper.MinColumnNumber, XLHelper.MaxColumnNumber);
+                row2 = R1C1ToPosition(area.Second.RowType, area.Second.RowValue, anchor.Row, XLHelper.MaxRowNumber, XLHelper.MaxRowNumber);
+                col2 = R1C1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, anchor.Column, XLHelper.MaxColumnNumber, XLHelper.MaxColumnNumber);
+            }
 
-            return new XLSheetRange(firstRow, firstCol, lastRow, lastCol);
+            var colStart = Math.Min(col1, col2);
+            var colEnd = Math.Max(col1, col2);
+            var rowStart = Math.Min(row1, row2);
+            var rowEnd = Math.Max(row1, row2);
+            return new XLSheetRange(rowStart, colStart, rowEnd, colEnd);
         }
 
-        private static int ToAbsolutePositionA1(ReferenceAxisType axisType, int position, int defaultPosition)
+        private static int A1ToPosition(ReferenceAxisType axisType, int position, int defaultPosition)
         {
             return axisType switch
             {
-                ReferenceAxisType.Absolute => position,
-                ReferenceAxisType.Relative => position,
-                ReferenceAxisType.None => defaultPosition,
+                ReferenceAxisType.Absolute => position, // $A$1 => R1C1
+                ReferenceAxisType.Relative => position, // A1 => R1C1
+                ReferenceAxisType.None => defaultPosition, // Only other axis specified, e.g. A:B doesn't have row.
                 _ => throw new NotSupportedException()
             };
+        }
+
+        private static int R1C1ToPosition(ReferenceAxisType axisType, int position, int anchor, int defaultPosition, int dimensionSize)
+        {
+            switch (axisType)
+            {
+                case ReferenceAxisType.Absolute: // R2C5
+                    return position;
+
+                case ReferenceAxisType.Relative: // R[2]C[5]
+                    {
+                        var absolutePosition = anchor + position;
+                        if (absolutePosition < 1)
+                            return absolutePosition + dimensionSize;
+
+                        if (absolutePosition > dimensionSize)
+                            return absolutePosition - dimensionSize;
+
+                        return absolutePosition;
+                    }
+
+                case ReferenceAxisType.None:
+                    return defaultPosition; // other axis specified, e.g. R3:R5 doesn't have row.
+
+                default:
+                    throw new NotSupportedException();
+            }
         }
     }
 }

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -34,6 +34,8 @@ namespace ClosedXML.Extensions
                 col2 = R1C1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, anchor.Column, XLHelper.MaxColumnNumber, XLHelper.MaxColumnNumber);
             }
 
+            // Points in the token `area` don't have to be in top left and bottom right corners,
+            // e.g. D4:A1 or D1:A4. Normalize coordinates, so the sheet range has expected corners.
             var colStart = Math.Min(col1, col2);
             var colEnd = Math.Max(col1, col2);
             var rowStart = Math.Min(row1, row2);


### PR DESCRIPTION
Cell formula can use named formulas and named formulas can (but don't have to) reference other named formulas or cells.

Ensure that during construction of dependency tree, each cell formula that uses names also transitively depends on references of the named formula.
