### PR TITLE
Fix incorrect logic check in Array Rescale

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
@@ -1,5 +1,6 @@
 ﻿using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
 
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
@@ -214,6 +215,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         #endregion
 
         #region Array Operations
+
+        [Test]
+        public void ArraysOperation_BinaryOperationBetweenAreaReferenceAndSingleCellReferenceShouldWork()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Test1");
+            ws.Cell("A1").Value = new DateTime(2021, 1, 15);
+            ws.Cell("A2").Value = new DateTime(2021, 1, 10);
+            ws.Cell("B1").Value = new DateTime(2021, 1, 5);
+            Assert.AreEqual(5, ws.Evaluate("MIN(A1:A2-B1)"));
+        }
 
         [Test]
         public void ArraysOperation_MultiAreaReferencesArgumentResultsInScalarError()

--- a/ClosedXML/Excel/CalcEngine/Array.cs
+++ b/ClosedXML/Excel/CalcEngine/Array.cs
@@ -88,7 +88,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// </summary>
         public Array Rescale(int rows, int columns)
         {
-            if (Width == columns && Height == columns)
+            if (Width == columns && Height == rows)
                 return this;
 
             if (Width == 1 && Height == 1)


### PR DESCRIPTION
While tracking down an unexpected result from an Excel calculation I was testing, I came across what looks like a copy-paste mistake that was causing my issue. This PR fixes the bug and adds a basic test for my issue that was failing before but now passes after this fix.