### PR TITLE
Fix precedent cells incorrectly accepting file references

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/PrecedentCellsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/PrecedentCellsTests.cs
@@ -1,5 +1,6 @@
 ﻿using ClosedXML.Excel;
 using NUnit.Framework;
+using System;
 using System.IO;
 using System.Linq;
 
@@ -69,12 +70,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void NonexistentSheetsMeanUnreliablePrecednetCells()
+        public void NonexistentSheetsMeanUnreliablePrecedentCells()
         {
             using var wb = new XLWorkbook();
             var ws = (XLWorksheet)wb.AddWorksheet();
             var remotelyReliable = ws.CalcEngine.TryGetPrecedentCells("=Sheet2!A1", ws, out var cells);
             Assert.False(remotelyReliable);
+        }
+
+        [Test]
+        public void PrecedentCellsRejectsFileReferences()
+        {
+            using var wb = new XLWorkbook();
+            var ws = (XLWorksheet)wb.AddWorksheet("Sheet1");
+            Assert.Throws(Is.TypeOf<NotImplementedException>().And.Message.EqualTo("References from other files are not yet implemented."), () => ws.CalcEngine.TryGetPrecedentCells("='[1]Sheet1'!A1", ws, out var cells));
         }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -111,8 +111,8 @@ namespace ClosedXML.Excel.CalcEngine
                 if (node.Prefix is null)
                     return new Reference(new XLRangeAddress(null, node.Address));
 
-                if (ctx.Worksheet.Workbook.TryGetWorksheet(node.Prefix?.Sheet, out var ws))
-                    return new Reference(new XLRangeAddress((XLWorksheet)ws, node.Address));
+                if (node.Prefix.GetWorksheet(ctx.Worksheet.Workbook).TryPickT0(out var ws, out _))
+                    return new Reference(new XLRangeAddress((XLWorksheet)ws!, node.Address));
 
                 ctx.HasReferenceErrors = true;
                 return XLError.CellReference;


### PR DESCRIPTION
Today I came across a bug that caused a stack overflow and crashed my app. One of my test spreadsheets had a cell `'10.Livestock'!X122` with a formula of `=-'[1]10.Livestock'!X122` and with the latest code of ClosedXML from Git, this caused my crash.

I know that ClosedXML doesn't currently support file references, and has previously rejected them with a `NotImplementedException`. With latest HEAD though, the new `PrecedentCells` code was ignoring the file reference prefix entirely, resulting in the cell `'10.Livestock'!X122` basically looking like it had formula of `=-'10.Livestock'!X122`, at least for the code that works out the precedent cells. With a certain setup where the value is out of date, this can cause the precedent cell code to get into an infinite recursion loop, overflowing the stack and crashing the app.

This PR updates the precedent cell code to use a different method of getting the worksheet which checks for file references and throws an exception if detected, which matches up with what the calculation code does. It also adds a new test to make sure that file references are always rejected.