### PR TITLE
Evaluate calculation chain

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -155,7 +155,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.That(() => _ = ws.Cell("A2").Value,
                 Throws.TypeOf<InvalidOperationException>()
-                    .With.Message.EqualTo("Cell A2 is a part of circular reference."));
+                    .With.Message.EqualTo("Formula in a cell '$Sheet1'!$A1 is part of a cycle."));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine
+{
+    /// <summary>
+    /// Tests that calc engine adjusts it's internal state in response to changes of workbook structure.
+    /// </summary>
+    [TestFixture]
+    internal class CalcEngineListenerTests
+    {
+        [Test]
+        public void Formulas_dependent_on_specific_sheet_are_dirty_after_sheet_addition()
+        {
+            using var wb = new XLWorkbook();
+            var sutWs = wb.AddWorksheet();
+            sutWs.Cell("A1").FormulaA1 = "new!A1";
+            Assert.AreEqual(XLError.CellReference, sutWs.Cell("A1").Value);
+
+            var newWs = wb.AddWorksheet("new");
+            newWs.Cell("A1").Value = 5;
+
+            // Cell contains last calculated value
+            Assert.AreEqual(XLError.CellReference, sutWs.Cell("A1").CachedValue);
+
+            // But once asked for real value, it calculates it.
+            Assert.True(sutWs.Cell("A1").NeedsRecalculation);
+            Assert.AreEqual(5.0, sutWs.Cell("A1").Value);
+        }
+
+        [Test]
+        public void Formulas_dependent_on_specific_sheet_are_dirty_after_sheet_deletion()
+        {
+            using var wb = new XLWorkbook();
+            var keptWs = wb.AddWorksheet();
+            var deletedWs = wb.AddWorksheet("deleted");
+
+            deletedWs.Cell("A1").Value = 5;
+            keptWs.Cell("A1").FormulaA1 = "deleted!A1";
+            Assert.AreEqual(5.0, keptWs.Cell("A1").Value);
+
+            deletedWs.Delete();
+
+            // Cell contains last calculated value
+            Assert.AreEqual(5.0, keptWs.Cell("A1").CachedValue);
+
+            // But once asked for real value, it calculates it.
+            Assert.True(keptWs.Cell("A1").NeedsRecalculation);
+            Assert.AreEqual(XLError.CellReference, keptWs.Cell("A1").Value);
+        }
+
+        [Test]
+        public void Formulas_are_shifted_when_area_is_added_and_cells_shifted_down()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").FormulaA1 = "B1*2";
+            ws.Cell("B1").FormulaA1 = "C1*2";
+            ws.Cell("C1").FormulaA1 = "1+2";
+
+            ws.RecalculateAllFormulas();
+
+            ws.Range("A1:B1").InsertRowsAbove(2);
+
+            Assert.AreEqual(12.0, ws.Cell("A3").Value);
+            Assert.False(ws.Cell("A3").NeedsRecalculation);
+            Assert.False(ws.Cell("B3").NeedsRecalculation);
+
+            // Dependency tree should pick up change
+            ws.Cell("C1").FormulaA1 = "2+2";
+            Assert.True(ws.Cell("A3").NeedsRecalculation);
+            Assert.True(ws.Cell("B3").NeedsRecalculation);
+            Assert.AreEqual(16.0, ws.Cell("A3").Value);
+        }
+
+        [Test]
+        public void Formulas_are_shifted_when_area_is_added_and_cells_shifted_right()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").FormulaA1 = "A2*2";
+            ws.Cell("A2").FormulaA1 = "A3*2";
+            ws.Cell("A3").FormulaA1 = "1+2";
+
+            ws.RecalculateAllFormulas();
+
+            ws.Cell("A2").InsertCellsBefore(4);
+
+            Assert.AreEqual(12.0, ws.Cell("A1").Value);
+            Assert.False(ws.Cell("E2").NeedsRecalculation);
+
+            // Dependency tree should pick up change
+            ws.Cell("A3").FormulaA1 = "2+2";
+            Assert.True(ws.Cell("E2").NeedsRecalculation);
+            Assert.True(ws.Cell("A1").NeedsRecalculation);
+            Assert.AreEqual(16.0, ws.Cell("A1").Value);
+        }
+
+        [Test]
+        public void Formulas_are_shifted_when_area_is_deleted_and_cells_shifted_up()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A5").FormulaA1 = "1+2";
+            ws.Cell("B5").FormulaA1 = "A5*2";
+            ws.Cell("C5").FormulaA1 = "B5*2";
+
+            ws.RecalculateAllFormulas();
+
+            ws.Range("B2:C4").Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+            Assert.AreEqual(12.0, ws.Cell("C2").Value);
+            Assert.False(ws.Cell("B2").NeedsRecalculation);
+            Assert.False(ws.Cell("A5").NeedsRecalculation);
+
+            // Dependency tree should pick up change
+            ws.Cell("A5").FormulaA1 = "2+2";
+            Assert.True(ws.Cell("B2").NeedsRecalculation);
+            Assert.True(ws.Cell("C2").NeedsRecalculation);
+            Assert.AreEqual(16.0, ws.Cell("C2").Value);
+        }
+
+        [Test]
+        public void Formulas_are_shifted_when_area_is_deleted_and_cells_shifted_left()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("D1").FormulaA1 = "1+2";
+            ws.Cell("E2").FormulaA1 = "D1*2";
+            ws.Cell("D3").FormulaA1 = "E2*2";
+
+            ws.RecalculateAllFormulas();
+
+            ws.Range("A1:C5").Delete(XLShiftDeletedCells.ShiftCellsLeft);
+
+            Assert.AreEqual(12.0, ws.Cell("A3").Value);
+            Assert.False(ws.Cell("B2").NeedsRecalculation);
+            Assert.False(ws.Cell("A1").NeedsRecalculation);
+
+            // Dependency tree should pick up change
+            ws.Cell("A1").FormulaA1 = "2+2";
+            Assert.True(ws.Cell("B2").NeedsRecalculation);
+            Assert.True(ws.Cell("A3").NeedsRecalculation);
+            Assert.AreEqual(16.0, ws.Cell("A3").Value);
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Text;
-using ClosedXML.Excel;
+﻿using ClosedXML.Excel;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
     /// <summary>
-    /// Tests that calc engine adjusts it's internal state in response to changes of workbook structure.
+    /// Tests that calc engine adjusts its internal state in response to changes of workbook structure.
     /// </summary>
     [TestFixture]
     internal class CalcEngineListenerTests
@@ -70,7 +66,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.False(ws.Cell("A3").NeedsRecalculation);
             Assert.False(ws.Cell("B3").NeedsRecalculation);
 
-            // Dependency tree should pick up change
+            // Dependency tree should pick up the change
             ws.Cell("C1").FormulaA1 = "2+2";
             Assert.True(ws.Cell("A3").NeedsRecalculation);
             Assert.True(ws.Cell("B3").NeedsRecalculation);
@@ -93,7 +89,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(12.0, ws.Cell("A1").Value);
             Assert.False(ws.Cell("E2").NeedsRecalculation);
 
-            // Dependency tree should pick up change
+            // Dependency tree should pick up the change
             ws.Cell("A3").FormulaA1 = "2+2";
             Assert.True(ws.Cell("E2").NeedsRecalculation);
             Assert.True(ws.Cell("A1").NeedsRecalculation);
@@ -115,9 +111,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(12.0, ws.Cell("C2").Value);
             Assert.False(ws.Cell("B2").NeedsRecalculation);
-            Assert.False(ws.Cell("A5").NeedsRecalculation);
+            Assert.False(ws.Cell("A2").NeedsRecalculation);
 
-            // Dependency tree should pick up change
+            // Dependency tree should pick up the change
             ws.Cell("A5").FormulaA1 = "2+2";
             Assert.True(ws.Cell("B2").NeedsRecalculation);
             Assert.True(ws.Cell("C2").NeedsRecalculation);
@@ -141,7 +137,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.False(ws.Cell("B2").NeedsRecalculation);
             Assert.False(ws.Cell("A1").NeedsRecalculation);
 
-            // Dependency tree should pick up change
+            // Dependency tree should pick up the change
             ws.Cell("A1").FormulaA1 = "2+2";
             Assert.True(ws.Cell("B2").NeedsRecalculation);
             Assert.True(ws.Cell("A3").NeedsRecalculation);

--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -127,6 +127,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             var tree = new DependencyTree();
+            tree.AddSheetTree(ws);
             var cellFormula = AddFormula(tree, ws, "B3", "=C4");
             Assert.False(tree.IsEmpty);
 
@@ -146,6 +147,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             var tree = new DependencyTree();
+            tree.AddSheetTree(ws);
             var cellFormulaA1 = AddFormula(tree, ws, "A1", "=C4 + B1");
             var cellFormulaA2 = AddFormula(tree, ws, "A2", "=B1 / C4");
             Assert.False(tree.IsEmpty);
@@ -170,6 +172,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
+            tree.AddSheetTree(ws);
             AddFormula(tree, ws, "A2", "=A1");
             AddFormula(tree, ws, "A3", "=A2");
             AddFormula(tree, ws, "A4", "=A3");
@@ -183,14 +186,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
-            var ws1 = wb.AddWorksheet();
-            AddFormula(tree, ws1, "B2", "=B1");
-            AddFormula(tree, ws1, "C1", "=B2");
-            AddFormula(tree, ws1, "C3", "=B2");
-            AddFormula(tree, ws1, "D2", "=C1 + C3");
+            var ws = wb.AddWorksheet();
+            tree.AddSheetTree(ws);
+            AddFormula(tree, ws, "B2", "=B1");
+            AddFormula(tree, ws, "C1", "=B2");
+            AddFormula(tree, ws, "C3", "=B2");
+            AddFormula(tree, ws, "D2", "=C1 + C3");
 
-            MarkDirty(tree, ws1, "B1");
-            AssertDirty(ws1, "B2", "C1", "C3", "D2");
+            MarkDirty(tree, ws, "B1");
+            AssertDirty(ws, "B2", "C1", "C3", "D2");
         }
 
         [Test]
@@ -199,7 +203,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
             var ws1 = wb.AddWorksheet("Sheet1");
+            tree.AddSheetTree(ws1);
             var ws2 = wb.AddWorksheet("Sheet2");
+            tree.AddSheetTree(ws2);
 
             // Make a chain, where each cell is on an opposite sheet
             AddFormula(tree, ws1, "B1", "=Sheet2!A1");
@@ -227,6 +233,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
+            tree.AddSheetTree(ws);
             AddFormula(tree, ws, "A2", "=A1");
             AddFormula(tree, ws, "A3", "=A2");
             AddFormula(tree, ws, "A4", "=A3");
@@ -245,6 +252,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
+            tree.AddSheetTree(ws);
             AddFormula(tree, ws, "B1", "=D1 + A1");
             AddFormula(tree, ws, "C1", "=B1");
             AddFormula(tree, ws, "D1", "=C1");
@@ -262,6 +270,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
+            tree.AddSheetTree(ws);
             AddFormula(tree, ws, "D1", "=A1:B3");
 
             // B3:D4 overlaps with A1:B3 in B3
@@ -275,6 +284,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
+            tree.AddSheetTree(ws);
             AddFormula(tree, ws, "B1", "=A1");
             AddFormula(tree, ws, "B2", "=A2");
             AddFormula(tree, ws, "B3", "=A3");

--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -288,8 +288,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         private static XLCellFormula AddFormula(DependencyTree tree, IXLWorksheet sheet, string address, string formula)
         {
+            // Set directly, so the cell is not marked as a dirty.
             var cell = (XLCell)sheet.Cell(address);
-            cell.FormulaA1 = formula;
+            cell.Formula = XLCellFormula.NormalA1(formula);
             var cellArea = new XLBookArea(sheet.Name, new XLSheetRange(cell.SheetPoint, cell.SheetPoint));
             tree.AddFormula(cellArea, cell.Formula, sheet.Workbook);
             return cell.Formula;

--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -126,7 +126,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var cellFormula = AddFormula(tree, ws, "B3", "=C4");
             Assert.False(tree.IsEmpty);
 
@@ -145,7 +145,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var cellFormulaA1 = AddFormula(tree, ws, "A1", "=C4 + B1");
             var cellFormulaA2 = AddFormula(tree, ws, "A2", "=B1 / C4");
             Assert.False(tree.IsEmpty);
@@ -168,7 +168,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_single_chain_is_fully_marked()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
             AddFormula(tree, ws, "A2", "=A1");
             AddFormula(tree, ws, "A3", "=A2");
@@ -182,7 +182,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_split_and_join_is_fully_marked()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws1 = wb.AddWorksheet();
             AddFormula(tree, ws1, "B2", "=B1");
             AddFormula(tree, ws1, "C1", "=B2");
@@ -197,7 +197,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_uses_correct_sheet()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws1 = wb.AddWorksheet("Sheet1");
             var ws2 = wb.AddWorksheet("Sheet2");
 
@@ -225,7 +225,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_stops_at_dirty_cell()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
             AddFormula(tree, ws, "A2", "=A1");
             AddFormula(tree, ws, "A3", "=A2");
@@ -243,7 +243,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_wont_crash_on_cycle()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
             AddFormula(tree, ws, "B1", "=D1 + A1");
             AddFormula(tree, ws, "C1", "=B1");
@@ -260,7 +260,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_affects_precedents_with_partial_overlap()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
             AddFormula(tree, ws, "D1", "=A1:B3");
 
@@ -273,7 +273,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mark_dirty_can_affect_multiple_chains_at_once()
         {
             using var wb = new XLWorkbook();
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var ws = wb.AddWorksheet();
             AddFormula(tree, ws, "B1", "=A1");
             AddFormula(tree, ws, "B2", "=A2");
@@ -291,7 +291,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var cell = (XLCell)sheet.Cell(address);
             cell.FormulaA1 = formula;
             var cellArea = new XLBookArea(sheet.Name, new XLSheetRange(cell.SheetPoint, cell.SheetPoint));
-            tree.AddFormula(cellArea, cell.Formula);
+            tree.AddFormula(cellArea, cell.Formula, sheet.Workbook);
             return cell.Formula;
         }
 
@@ -327,12 +327,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet");
             init?.Invoke(wb);
-            var tree = new DependencyTree(wb);
+            var tree = new DependencyTree();
             var cell = ws.Cell(formulaAddress);
             cell.SetFormulaA1(formula);
 
             var cellFormula = ((XLCell)cell).Formula;
-            var dependencies = tree.AddFormula(new XLBookArea(ws.Name, cellFormula.Range), cellFormula);
+            var dependencies = tree.AddFormula(new XLBookArea(ws.Name, cellFormula.Range), cellFormula, wb);
             return dependencies;
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1917,6 +1917,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             }
         }
 
+        // TODO: Nuke CellRangeReference along with XObjectExpression. It takes values directly from recursively evaluated cells
         [Test]
         public void SumIf_ReturnsCorrectValues_WhenFormulaBelongToSameRange()
         {
@@ -1940,7 +1941,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.AreEqual(3, value);
             }
         }
-
+        
         [Test]
         public void SumIfs_MultidimensionalRanges()
         {
@@ -1956,7 +1957,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             });
             Assert.AreEqual(30, ws.Evaluate("SUMIFS(C1:D5,A1:B5,\">20\")"));
         }
-
+        
         /// <summary>
         /// refers to Example 2 to SumIf from the Excel documentation.
         /// As SumIfs should behave the same if called with three parameters, we can take that example here again.
@@ -2002,7 +2003,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.AreEqual(expectedResult, actualResult);
             }
         }
-
+        
         /// <summary>
         /// refers to Example 1 to SumIf from the Excel documentation.
         /// As SumIfs should behave the same if called with three parameters, but in a different order
@@ -2159,7 +2160,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var actual = (double)XLWorkbook.EvaluateExpr($"TRUNC({input.ToString(CultureInfo.InvariantCulture)}, {digits})");
             Assert.AreEqual(expectedResult, actual);
         }
-
+        /**/
         private static IXLWorksheet AddWorksheetWithCellValues(XLWorkbook wb, params XLCellValue[] values)
         {
             var ws = wb.AddWorksheet();

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1917,7 +1917,6 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             }
         }
 
-        // TODO: Nuke CellRangeReference along with XObjectExpression. It takes values directly from recursively evaluated cells
         [Test]
         public void SumIf_ReturnsCorrectValues_WhenFormulaBelongToSameRange()
         {
@@ -1941,7 +1940,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.AreEqual(3, value);
             }
         }
-        
+
         [Test]
         public void SumIfs_MultidimensionalRanges()
         {
@@ -1957,7 +1956,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             });
             Assert.AreEqual(30, ws.Evaluate("SUMIFS(C1:D5,A1:B5,\">20\")"));
         }
-        
+
         /// <summary>
         /// refers to Example 2 to SumIf from the Excel documentation.
         /// As SumIfs should behave the same if called with three parameters, we can take that example here again.
@@ -2003,7 +2002,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.AreEqual(expectedResult, actualResult);
             }
         }
-        
+
         /// <summary>
         /// refers to Example 1 to SumIf from the Excel documentation.
         /// As SumIfs should behave the same if called with three parameters, but in a different order
@@ -2160,7 +2159,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var actual = (double)XLWorkbook.EvaluateExpr($"TRUNC({input.ToString(CultureInfo.InvariantCulture)}, {digits})");
             Assert.AreEqual(expectedResult, actual);
         }
-        /**/
+
         private static IXLWorksheet AddWorksheetWithCellValues(XLWorkbook wb, params XLCellValue[] values)
         {
             var ws = wb.AddWorksheet();

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -874,10 +874,10 @@ namespace ClosedXML.Tests
                 A2.FormulaA1 = "A1 + 1";
 
                 Assert.Throws(
-                    Is.TypeOf<InvalidOperationException>().And.Message.Contains("circular"),
+                    Is.TypeOf<InvalidOperationException>().And.Message.Contains("cycle"),
                     () => _ = A1.Value);
                 Assert.Throws(
-                    Is.TypeOf<InvalidOperationException>().And.Message.Contains("circular"),
+                    Is.TypeOf<InvalidOperationException>().And.Message.Contains("cycle"),
                     () => _ = A2.Value);
             }
         }

--- a/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
@@ -385,10 +385,21 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void LoadingOptions()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\ExternalLinks\WorkbookWithExternalLink.xlsx")))
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\Formulas.xlsx")))
             {
-                Assert.DoesNotThrow(() => new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = false }));
-                Assert.Throws<NotImplementedException>(() => new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = true }));
+                Assert.DoesNotThrow(() =>
+                {
+                    // The value in the file is blank and kept.
+                    using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = false });
+                    Assert.AreEqual(Blank.Value, wb.Worksheets.Single().Cell("C2").CachedValue);
+                });
+
+                Assert.DoesNotThrow(() =>
+                {
+                    // The value in the file is blank, but recalculation sets it to correct 3.
+                    using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = true });
+                    Assert.AreEqual(3, wb.Worksheets.Single().Cell("C2").CachedValue);
+                });
 
                 Assert.AreEqual(30, new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiX);
                 Assert.AreEqual(14, new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiY);

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -50,6 +50,9 @@ namespace ClosedXML.Excel.CalcEngine
             return _parser.GetAst(expression, false);
         }
 
+        /// <summary>
+        /// Add an array formula to the calc engine to manage dirty tracking and evaluation.
+        /// </summary>
         internal void AddArrayFormula(XLSheetRange range, XLCellFormula arrayFormula, XLWorksheet sheet)
         {
             if (_chain is not null && _dependencyTree is not null)
@@ -75,6 +78,9 @@ namespace ClosedXML.Excel.CalcEngine
         /// <summary>
         /// Remove formula from dependency tree (=precedents won't mark
         /// it as dirty) and remove <paramref name="point"/> from the chain.
+        /// Note that even if formula is used by many cells (e.g. array formula),
+        /// it is fully removed from dependency tree, but each cells referencing
+        /// the formula must be removed individually from calc chain.
         /// </summary>
         internal void RemoveFormula(XLBookPoint point, XLCellFormula formula)
         {

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -19,8 +19,7 @@ namespace ClosedXML.Excel.CalcEngine
     {
         private readonly CultureInfo _culture;
         private readonly ExpressionCache _cache;               // cache with parsed expressions
-        private readonly FormulaParser _parserA1;
-        private readonly FormulaParser _parserR1C1;
+        private readonly FormulaParser _parser;
         private readonly CalculationVisitor _visitor;
         private DependencyTree? _dependencyTree;
         private XLCalculationChain? _chain;
@@ -30,8 +29,7 @@ namespace ClosedXML.Excel.CalcEngine
             _culture = culture;
             _cache = new ExpressionCache(this);
             var funcRegistry = GetFunctionTable();
-            _parserA1 = new FormulaParser(funcRegistry, isA1: true);
-            _parserR1C1 = new FormulaParser(funcRegistry, isA1: false);
+            _parser = new FormulaParser(funcRegistry);
             _visitor = new CalculationVisitor(funcRegistry);
             _dependencyTree = null;
             _chain = null;
@@ -44,12 +42,12 @@ namespace ClosedXML.Excel.CalcEngine
         /// <returns>An <see cref="Expression"/> object that can be evaluated.</returns>
         public Formula Parse(string expression)
         {
-            return _parserA1.GetAst(expression);
+            return _parser.GetAst(expression, true);
         }
 
         public Formula ParseR1C1(string expression)
         {
-            return _parserR1C1.GetAst(expression);
+            return _parser.GetAst(expression, false);
         }
 
         internal void AddArrayFormula(XLSheetRange range, XLCellFormula arrayFormula, XLWorksheet sheet)

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel.CalcEngine
     /// <para>This class has three extensibility points:</para>
     /// <para>Use the <b>RegisterFunction</b> method to define custom functions.</para>
     /// </remarks>
-    internal class CalcEngine
+    internal class CalcEngine : ISheetListener
     {
         private readonly CultureInfo _culture;
         private readonly ExpressionCache _cache;               // cache with parsed expressions
@@ -93,7 +93,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         internal void OnAddedSheet(XLWorksheet sheet)
         {
-            _dependencyTree?.AddSheetTree(sheet);
+            Purge(sheet.Workbook.WorksheetsInternal);
         }
 
         internal void OnDeletingSheet(XLWorksheet sheet)
@@ -101,9 +101,24 @@ namespace ClosedXML.Excel.CalcEngine
             Purge(sheet.Workbook.WorksheetsInternal);
         }
 
-        public void OnWorksheetShiftedRows(XLRange range, int rowsShifted)
+        public void OnInsertAreaAndShiftDown(XLWorksheet sheet, XLSheetRange area)
         {
-            Purge(range.Worksheet.Workbook.WorksheetsInternal);
+            Purge(sheet.Workbook.WorksheetsInternal);
+        }
+
+        public void OnInsertAreaAndShiftRight(XLWorksheet sheet, XLSheetRange area)
+        {
+            Purge(sheet.Workbook.WorksheetsInternal);
+        }
+
+        public void OnDeleteAreaAndShiftLeft(XLWorksheet sheet, XLSheetRange deletedArea)
+        {
+            Purge(sheet.Workbook.WorksheetsInternal);
+        }
+
+        public void OnDeleteAreaAndShiftUp(XLWorksheet sheet, XLSheetRange deletedArea)
+        {
+            Purge(sheet.Workbook.WorksheetsInternal);
         }
 
         private void Purge(XLWorksheets sheets)

--- a/ClosedXML/Excel/CalcEngine/CalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcEngine.cs
@@ -42,12 +42,12 @@ namespace ClosedXML.Excel.CalcEngine
         /// <returns>An <see cref="Expression"/> object that can be evaluated.</returns>
         public Formula Parse(string expression)
         {
-            return _parser.GetAst(expression, true);
+            return _parser.GetAst(expression, isA1: true);
         }
 
         public Formula ParseR1C1(string expression)
         {
-            return _parser.GetAst(expression, false);
+            return _parser.GetAst(expression, isA1: false);
         }
 
         /// <summary>
@@ -125,15 +125,11 @@ namespace ClosedXML.Excel.CalcEngine
         {
             _dependencyTree = null;
             _chain = null;
+
             // Mark everything as dirty, because there can be stale values
             foreach (var sheet in sheets)
             {
-                using var enumerator =
-                    sheet.Internals.CellsCollection.FormulaSlice.GetForwardEnumerator(XLSheetRange.Full);
-                while (enumerator.MoveNext())
-                {
-                    enumerator.Current!.IsDirty = true;
-                }
+                sheet.Internals.CellsCollection.FormulaSlice.MarkDirty(XLSheetRange.Full);
             }
         }
 
@@ -274,7 +270,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <param name="ws">Worksheet where is formula being evaluated.</param>
         /// <param name="address">Address of formula.</param>
         /// <param name="recursive">Should the data necessary for this formula (not deeper ones)
-        /// be calculated recursively? Used only for non-cell calculations</param>
+        /// be calculated recursively? Used only for non-cell calculations.</param>
         /// <param name="recalculateSheetId">
         /// If set, calculation  will allow dirty reads from other sheets than the passed one.
         /// </param>

--- a/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
+++ b/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
@@ -47,7 +47,7 @@ namespace ClosedXML.Excel.CalcEngine
         // ** implementation
         private object GetValue(IXLCell cell)
         {
-            if (_evaluating || ((XLCell)cell).IsEvaluating)
+            if (_evaluating)
             {
                 throw new InvalidOperationException($"Circular Reference occurred during evaluation. Cell: {cell.Address.ToString(XLReferenceStyle.Default, true)}");
             }

--- a/ClosedXML/Excel/CalcEngine/DependencyTree.cs
+++ b/ClosedXML/Excel/CalcEngine/DependencyTree.cs
@@ -84,8 +84,7 @@ namespace ClosedXML.Excel.CalcEngine
                     }
                     else
                     {
-                        // TODO
-                        throw new NotSupportedException();
+                        // TODO: Implement other formulas. Don't throw on data table or shared formulas.
                     }
                 }
             }
@@ -142,7 +141,7 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
-        public void AddSheetTree(IXLWorksheet sheet)
+        internal void AddSheetTree(IXLWorksheet sheet)
         {
             _sheetTrees.Add(sheet.Name, new SheetDependencyTree());
         }

--- a/ClosedXML/Excel/CalcEngine/DependencyTree.cs
+++ b/ClosedXML/Excel/CalcEngine/DependencyTree.cs
@@ -65,8 +65,7 @@ namespace ClosedXML.Excel.CalcEngine
                 using var enumerator = sheet.Internals.CellsCollection.FormulaSlice.GetForwardEnumerator(XLSheetRange.Full);
                 while (enumerator.MoveNext())
                 {
-                    // Enumerators skips default elements, in this case nulls
-                    var formula = enumerator.Current!;
+                    var formula = enumerator.Current;
                     var point = enumerator.Point;
                     if (formula.Type == FormulaType.Normal)
                     {

--- a/ClosedXML/Excel/CalcEngine/Exceptions/GettingDataException.cs
+++ b/ClosedXML/Excel/CalcEngine/Exceptions/GettingDataException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace ClosedXML.Excel.CalcEngine.Exceptions
+{
+    /// <summary>
+    /// Exception that happens when formula in a cell depends on other cells,
+    /// but the supporting formulas are still dirty.
+    /// </summary>
+    internal class GettingDataException : Exception
+    {
+        public GettingDataException(XLBookPoint point)
+        {
+            Point = point;
+        }
+
+        public XLBookPoint Point { get; }
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -7,19 +7,19 @@ namespace ClosedXML.Excel.CalcEngine
 {
     internal class FormulaParser
     {
-        private readonly AstFactory _nodeFactory;
-        private readonly bool _isA1;
+        private readonly AstFactory _nodeFactoryA1;
+        private readonly AstFactory _nodeFactoryR1C1;
 
-        public FormulaParser(FunctionRegistry functionRegistry, bool isA1)
+        public FormulaParser(FunctionRegistry functionRegistry)
         {
-            _nodeFactory = new AstFactory(functionRegistry, isA1);
-            _isA1 = isA1;
+            _nodeFactoryA1 = new AstFactory(functionRegistry, true);
+            _nodeFactoryR1C1 = new AstFactory(functionRegistry, false);
         }
 
         /// <summary>
         /// Parse a formula into an abstract syntax tree.
         /// </summary>
-        public Formula GetAst(string formula)
+        public Formula GetAst(string formula, bool isA1)
         {
             // Equality sign at the beginning of formula is only visualization in the GUI, real formulas don't have it.
             if (formula.Length > 0 && formula[0] == '=')
@@ -29,9 +29,9 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var ctx = new List<FormulaFlags>();
                 
-                var root = _isA1
-                    ? FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaA1(formula, ctx, _nodeFactory)
-                    : FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaR1C1(formula, ctx, _nodeFactory);
+                var root = isA1
+                    ? FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaA1(formula, ctx, _nodeFactoryA1)
+                    : FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaR1C1(formula, ctx, _nodeFactoryR1C1);
                 var flags = ctx.Contains(FormulaFlags.HasSubtotal)
                     ? FormulaFlags.HasSubtotal
                     : FormulaFlags.None;

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -8,10 +8,12 @@ namespace ClosedXML.Excel.CalcEngine
     internal class FormulaParser
     {
         private readonly AstFactory _nodeFactory;
+        private readonly bool _isA1;
 
-        public FormulaParser(FunctionRegistry functionRegistry)
+        public FormulaParser(FunctionRegistry functionRegistry, bool isA1)
         {
-            _nodeFactory = new AstFactory(functionRegistry, isA1: true);
+            _nodeFactory = new AstFactory(functionRegistry, isA1);
+            _isA1 = isA1;
         }
 
         /// <summary>
@@ -26,8 +28,10 @@ namespace ClosedXML.Excel.CalcEngine
             try
             {
                 var ctx = new List<FormulaFlags>();
-                var root = FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaA1(formula, ctx,
-                    _nodeFactory);
+                
+                var root = _isA1
+                    ? FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaA1(formula, ctx, _nodeFactory)
+                    : FormulaParser<ScalarValue, ValueNode, List<FormulaFlags>>.CellFormulaR1C1(formula, ctx, _nodeFactory);
                 var flags = ctx.Contains(FormulaFlags.HasSubtotal)
                     ? FormulaFlags.HasSubtotal
                     : FormulaFlags.None;

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using ClosedXML.Excel.CalcEngine.Exceptions;
 using static ClosedXML.Excel.CalcEngine.Functions.SignatureAdapter;
 
 namespace ClosedXML.Excel.CalcEngine
@@ -956,18 +957,33 @@ namespace ClosedXML.Excel.CalcEngine
             var criteria = p[1].Evaluate();
 
             var rangeValues = rangeColumn.Cast<object>().ToList();
-            var sumRangeValues = sumRange.Cast<object>().ToList();
+            using var sumRangeEnumerator = sumRange.Cast<object>().GetEnumerator();
 
             // compute total
             var ce = new CalcEngine(CultureInfo.CurrentCulture);
             var tally = new Tally();
-            for (var i = 0; i < Math.Max(rangeValues.Count, sumRangeValues.Count); i++)
+            for (var i = 0; i < rangeValues.Count; i++)
             {
-                var targetValue = i < rangeValues.Count ? rangeValues[i] : string.Empty;
+                // TODO: Replace this mess completely
+                var targetValue = rangeValues[i];
                 if (CalcEngineHelpers.ValueSatisfiesCriteria(targetValue, criteria, ce))
                 {
-                    var value = i < sumRangeValues.Count ? sumRangeValues[i] : 0d;
+                    if (!sumRangeEnumerator.MoveNext())
+                        break;
+                    var value = sumRangeEnumerator.Current!;
                     tally.AddValue(value);
+                }
+                else
+                {
+                    try
+                    {
+                        if (!sumRangeEnumerator.MoveNext())
+                            break;
+                    }
+                    catch (GettingDataException)
+                    {
+                        // The referenced cell uses a dirty formula, but we are not using the value, so eat the exception.
+                    }
                 }
             }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -336,7 +336,7 @@ namespace ClosedXML.Excel.CalcEngine
                             .Select(c => c.GetString())
                             .Where(s => !string.IsNullOrEmpty(s));
                     else
-                        cellValues = ((XLRange)range).CellValues()
+                        cellValues = rangeReference.CellValues()
                             .Select(o => o.ToString(CultureInfo.CurrentCulture));
 
                     values.AddRange(cellValues);

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -105,7 +105,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             return _index switch
             {
-                BlankValue => Excel.Blank.Value,
+                BlankValue => 0, // The result value of a formula calculation can be blank, but result of formula in a cell value is never blank, but 0.
                 LogicalValue => _logical,
                 NumberValue => _number,
                 TextValue => _text,

--- a/ClosedXML/Excel/CalcEngine/XLCalculationChain.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalculationChain.cs
@@ -92,6 +92,21 @@ namespace ClosedXML.Excel.CalcEngine
         internal void AddLast(XLBookPoint point) => AddLast(point, 0);
 
         /// <summary>
+        /// Add all cells from the area to the end of the chain.
+        /// </summary>
+        /// <exception cref="ArgumentException">If chain already contains a cell from the area.</exception>
+        internal void AppendArea(uint sheetId, XLSheetRange range)
+        {
+            for (var row = range.TopRow; row <= range.BottomRow; ++row)
+            {
+                for (var col = range.LeftColumn; col <= range.RightColumn; ++col)
+                {
+                    AddLast(new XLBookPoint(sheetId, new XLSheetPoint(row, col)));
+                }
+            }
+        }
+
+        /// <summary>
         /// Append formula at the end of the chain.
         /// </summary>
         private void AddLast(XLBookPoint point, int lastPosition)

--- a/ClosedXML/Excel/CalcEngine/XLCalculationChain.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalculationChain.cs
@@ -82,9 +82,9 @@ namespace ClosedXML.Excel.CalcEngine
             foreach (var sheet in wb.WorksheetsInternal)
             {
                 var formulaSlice = sheet.Internals.CellsCollection.FormulaSlice;
-                using var e = formulaSlice.GetEnumerator(XLSheetRange.Full);
+                using var e = formulaSlice.GetForwardEnumerator(XLSheetRange.Full);
                 while (e.MoveNext())
-                    chain.AddLast(new XLBookPoint(sheet.SheetId, e.Current));
+                    chain.AddLast(new XLBookPoint(sheet.SheetId, e.Point));
             }
 
             return chain;

--- a/ClosedXML/Excel/Cells/FormulaSlice.cs
+++ b/ClosedXML/Excel/Cells/FormulaSlice.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+
+namespace ClosedXML.Excel
+{
+    internal class FormulaSlice : ISlice
+    {
+        private readonly Slice<XLCellFormula?> _formulas = new();
+
+        public bool IsEmpty => _formulas.IsEmpty;
+
+        public int MaxColumn => _formulas.MaxColumn;
+
+        public int MaxRow => _formulas.MaxRow;
+
+        public Dictionary<int, int>.KeyCollection UsedColumns => _formulas.UsedColumns;
+
+        public IEnumerable<int> UsedRows => _formulas.UsedRows;
+
+        public void Clear(XLSheetRange range)
+        {
+            _formulas.Clear(range);
+        }
+
+        public void DeleteAreaAndShiftLeft(XLSheetRange rangeToDelete)
+        {
+            _formulas.DeleteAreaAndShiftLeft(rangeToDelete);
+        }
+
+        public void DeleteAreaAndShiftUp(XLSheetRange rangeToDelete)
+        {
+            _formulas.DeleteAreaAndShiftUp(rangeToDelete);
+        }
+
+        public IEnumerator<XLSheetPoint> GetEnumerator(XLSheetRange range, bool reverse = false)
+        {
+            return _formulas.GetEnumerator(range, reverse);
+        }
+
+        public void InsertAreaAndShiftDown(XLSheetRange range)
+        {
+            _formulas.InsertAreaAndShiftDown(range);
+        }
+
+        public void InsertAreaAndShiftRight(XLSheetRange range)
+        {
+            _formulas.InsertAreaAndShiftRight(range);
+        }
+
+        public bool IsUsed(XLSheetPoint address)
+        {
+            return _formulas.IsUsed(address);
+        }
+
+        public void Swap(XLSheetPoint sp1, XLSheetPoint sp2)
+        {
+            _formulas.Swap(sp1, sp2);
+        }
+
+        internal XLCellFormula? Get(XLSheetPoint point)
+        {
+            return _formulas[point];
+        }
+
+        internal void Set(XLSheetPoint point, XLCellFormula? formula)
+        {
+            ref readonly var original = ref _formulas[point];
+            if (ReferenceEquals(original, formula))
+                return;
+
+            _formulas.Set(point, formula);
+        }
+    }
+}

--- a/ClosedXML/Excel/Cells/FormulaSlice.cs
+++ b/ClosedXML/Excel/Cells/FormulaSlice.cs
@@ -119,5 +119,22 @@ namespace ClosedXML.Excel
             if (arrayFormula is not null)
                 _engine.AddArrayFormula(range, arrayFormula, _sheet);
         }
+
+        internal Slice<XLCellFormula>.Enumerator GetForwardEnumerator(XLSheetRange range)
+        {
+            return new Slice<XLCellFormula>.Enumerator(_formulas!, range);
+        }
+
+        /// <summary>
+        /// Mark all formulas in a range as dirty.
+        /// </summary>
+        internal void MarkDirty(XLSheetRange range)
+        {
+            using var enumerator = GetForwardEnumerator(range);
+            while (enumerator.MoveNext())
+            {
+                enumerator.Current.IsDirty = true;
+            }
+        }
     }
 }

--- a/ClosedXML/Excel/Cells/ISheetListener.cs
+++ b/ClosedXML/Excel/Cells/ISheetListener.cs
@@ -1,0 +1,36 @@
+﻿namespace ClosedXML.Excel
+{
+    /// <summary>
+    /// An interface for components reacting on changes in a worksheet.
+    /// </summary>
+    internal interface ISheetListener
+    {
+        /// <summary>
+        /// A handler called after the area was put into the sheet and cells shifted down.
+        /// </summary>
+        /// <param name="sheet">Sheet where change happened.</param>
+        /// <param name="area">Area that has been inserted. The original cells were shifted down.</param>
+        void OnInsertAreaAndShiftDown(XLWorksheet sheet, XLSheetRange area);
+
+        /// <summary>
+        /// A handler called after the area was put into the sheet and cells shifted right.
+        /// </summary>
+        /// <param name="sheet">Sheet where change happened.</param>
+        /// <param name="area">Area that has been inserted. The original cells were shifted right.</param>
+        void OnInsertAreaAndShiftRight(XLWorksheet sheet, XLSheetRange area);
+
+        /// <summary>
+        /// A handler called after the area was deleted from the sheet and cells shifted left.
+        /// </summary>
+        /// <param name="sheet">Sheet where change happened.</param>
+        /// <param name="deletedRange">Range that has been deleted and cells to the right were shifted left.</param>
+        void OnDeleteAreaAndShiftLeft(XLWorksheet sheet, XLSheetRange deletedRange);
+
+        /// <summary>
+        /// A handler called after the area was deleted from the sheet and cells shifted up.
+        /// </summary>
+        /// <param name="sheet">Sheet where change happened.</param>
+        /// <param name="deletedRange">Range that has been deleted and cells below were shifted up.</param>
+        void OnDeleteAreaAndShiftUp(XLWorksheet sheet, XLSheetRange deletedRange);
+    }
+}

--- a/ClosedXML/Excel/Cells/Slice.cs
+++ b/ClosedXML/Excel/Cells/Slice.cs
@@ -294,7 +294,7 @@ namespace ClosedXML.Excel
         /// Enumerator that returns used values from a specified range.
         /// </summary>
         [DebuggerDisplay("{Point}:{Current}")]
-        private class Enumerator : IEnumerator<XLSheetPoint>
+        internal class Enumerator : IEnumerator<XLSheetPoint>
         {
             private readonly XLSheetRange _range;
             private Lut<TElement>.LutEnumerator _columnsEnumerator;

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1061,19 +1061,7 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
         /// </summary>
-        public bool NeedsRecalculation
-        {
-            get
-            {
-                if (Formula is null)
-                {
-                    return false;
-                }
-
-                return Formula.IsDirty;
-//                return Formula.NeedsRecalculation(this);
-            }
-        }
+        public bool NeedsRecalculation => Formula is not null && Formula.IsDirty;
 
         public XLCellValue CachedValue => SliceCellValue;
 

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -213,19 +213,16 @@ namespace ClosedXML.Excel
         /// </summary>
         internal XLCellFormula Formula
         {
-            get => _cellsCollection.FormulaSlice[_rowNumber, _columnNumber];
+            get => _cellsCollection.FormulaSlice.Get(SheetPoint);
             set
             {
-                ref readonly var original = ref _cellsCollection.FormulaSlice[_rowNumber, _columnNumber];
-                if (ReferenceEquals(original, value))
-                    return;
+                _cellsCollection.FormulaSlice.Set(SheetPoint, value);
 
                 // Because text values of evaluated formulas are stored in a worksheet part, mark it as inlined string and store in sst.
                 // If we are clearing formula, we should enable shareString back on, because it is a default position.
                 // If we are setting formula, we should disable shareString (=inline), because it must be written to the worksheet part
                 var clearFormula = value is null;
                 ShareString = clearFormula;
-                _cellsCollection.FormulaSlice.Set(_rowNumber, _columnNumber, value);
             }
         }
 

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -595,12 +595,7 @@ namespace ClosedXML.Excel
                 ? value.GetUnifiedNumber().ToExcelFormat(format)
                 : value.ToString(CultureInfo.CurrentCulture);
         }
-
-        /// <summary>
-        /// Flag showing that the cell is in formula evaluation state.
-        /// </summary>
-        internal bool IsEvaluating => Formula is not null && Formula.IsEvaluating;
-
+        
         public void InvalidateFormula()
         {
             Worksheet.Workbook.InvalidateFormulas();
@@ -610,7 +605,7 @@ namespace ClosedXML.Excel
                 return;
             }
 
-            Formula.Invalidate(Worksheet);
+            Formula.IsDirty = true;
         }
 
         /// <summary>
@@ -633,7 +628,9 @@ namespace ClosedXML.Excel
                 return;
             }
 
-            Formula.ApplyFormula(this);
+            // TODO: Only one cell, somehow
+            var wb = Worksheet.Workbook;
+            wb.CalcEngine.Recalculate(wb, null);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -124,7 +124,11 @@ namespace ClosedXML.Excel
         private XLCellValue SliceCellValue
         {
             get => _cellsCollection.ValueSlice.GetCellValue(SheetPoint);
-            set => _cellsCollection.ValueSlice.SetCellValue(SheetPoint, value);
+            set
+            {
+                _cellsCollection.ValueSlice.SetCellValue(SheetPoint, value);
+                Worksheet.Workbook.CalcEngine.MarkDirty(Worksheet, SheetPoint);
+            }
         }
 
         private XLImmutableRichText SliceRichText
@@ -223,6 +227,7 @@ namespace ClosedXML.Excel
                 // If we are setting formula, we should disable shareString (=inline), because it must be written to the worksheet part
                 var clearFormula = value is null;
                 ShareString = clearFormula;
+                Worksheet.Workbook.CalcEngine.MarkDirty(Worksheet, SheetPoint);
             }
         }
 
@@ -1068,7 +1073,8 @@ namespace ClosedXML.Excel
                     return false;
                 }
 
-                return Formula.NeedsRecalculation(this);
+                return Formula.IsDirty;
+//                return Formula.NeedsRecalculation(this);
             }
         }
 

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using ClosedXML.Excel.CalcEngine;
-using Array = ClosedXML.Excel.CalcEngine.Array;
 
 namespace ClosedXML.Excel
 {
@@ -50,27 +49,6 @@ namespace ClosedXML.Excel
         private XLSheetPoint _input2;
         private FormulaFlags _flags;
         private FormulaType _type;
-
-        /// <summary>
-        /// The recalculation status of the last time formula was checked whether it needs to be recalculated.
-        /// </summary>
-        private RecalculationStatus _lastStatus;
-
-        /// <summary>
-        /// The value of <see cref="XLWorkbook.RecalculationCounter"/> that workbook had at the moment of cell formula evaluation.
-        /// If this value equals to <see cref="XLWorkbook.RecalculationCounter"/> it indicates that <see cref="XLCell.CachedValue"/> stores
-        /// correct value and no re-evaluation has to be performed.
-        /// </summary>
-        private long _evaluatedAtVersion;
-
-        private XLCellFormula()
-        {
-            // Formulas from loaded worksheets with values are treated as valid, until something changes (i.e. recalculation version increases)
-            // When a formula is set directly from a cell, it invalidates formula immediately afterwards.
-            _lastStatus = new(false, 0);
-        }
-
-        internal bool IsEvaluating { get; private set; }
 
         /// <summary>
         /// Is this formula dirty, i.e. is it potentially out of date due to changes
@@ -153,72 +131,6 @@ namespace ClosedXML.Excel
         /// This property is meaningless, if called for non-data-table formula.
         /// </summary>
         internal Boolean Input2Deleted => _flags.HasFlag(FormulaFlags.Input2Deleted);
-
-        /// <summary>
-        /// Flag indicating that previously calculated cell value may be not valid anymore and has to be re-evaluated.
-        /// </summary>
-        internal bool NeedsRecalculation(XLCell cell)
-        {
-            var worksheet = cell.Worksheet;
-            var currentVersion = worksheet.Workbook.RecalculationCounter;
-
-            // Nothing changed since last check => answer is still the same
-            if (_lastStatus.Version == currentVersion)
-            {
-                return _lastStatus.NeededRecalculation;
-            }
-
-            var recalculationNeeded = EvaluateStatus(cell);
-            _lastStatus = new(recalculationNeeded, currentVersion);
-            return recalculationNeeded;
-        }
-
-        private bool EvaluateStatus(XLCell cell)
-        {
-            // Cell could have been invalidated or a new formula was set
-            bool cellWasModified = _evaluatedAtVersion < cell.ModifiedAtVersion;
-            if (cellWasModified)
-            {
-                return true;
-            }
-
-            var worksheet = cell.Worksheet;
-            if (!worksheet.CalcEngine.TryGetPrecedentCells(A1, worksheet, out var precedentCells))
-            {
-                // If we are unable to even determine precedent cells, always recalculate
-                return true;
-            }
-
-            foreach (var precedentCell in precedentCells!)
-            {
-                // the affecting cell was modified after this one was evaluated
-                // e.g. cell now has a different value than it had at the last evaluation.
-                if (precedentCell.ModifiedAtVersion > _evaluatedAtVersion)
-                {
-                    return true;
-                }
-
-                // the affecting cell was evaluated after this one (normally this should not happen)
-                if (precedentCell.Formula is not null && precedentCell.Formula._evaluatedAtVersion > _evaluatedAtVersion)
-                {
-                    return true;
-                }
-
-                // the affecting cell needs recalculation (recursion to walk through dependencies)
-                if (precedentCell.NeedsRecalculation)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        internal void Invalidate(XLWorksheet worksheet)
-        {
-            IsDirty = true;
-            _lastStatus = new(true, worksheet.Workbook.RecalculationCounter);
-        }
 
         /// <summary>
         /// Get stored formula in A1 notation. Returned formula doesn't contain equal sign.
@@ -436,116 +348,6 @@ namespace ClosedXML.Excel
             return columnPart;
         }
 
-        internal void ApplyFormula(XLCell cell)
-        {
-            var wb = cell.Worksheet.Workbook;
-            wb.CalcEngine.Evaluate(wb);
-            return;
-            /*
-            if (IsEvaluating)
-            {
-                throw new InvalidOperationException($"Cell {cell.Address} is a part of circular reference.");
-            }
-
-            try
-            {
-                IsEvaluating = true;
-
-                if (Type == FormulaType.Normal)
-                {
-                    var fA1 = GetFormulaA1(cell.SheetPoint);
-                    var result = CalculateNormalFormula(fA1, cell);
-                    cell.SetOnlyValue(result.ToCellValue());
-                }
-                else if (Type == FormulaType.Array)
-                {
-                    var result = CalculateArrayFormula(cell);
-                    for (var rowIdx = 0; rowIdx < result.Height; ++rowIdx)
-                    {
-                        for (var colIdx = 0; colIdx < result.Width; ++colIdx)
-                        {
-                            var cellValue = result[rowIdx, colIdx];
-                            var cellRow = Range.FirstPoint.Row + rowIdx;
-                            var cellColumn = Range.FirstPoint.Column + colIdx;
-                            cell.Worksheet.Cell(cellRow, cellColumn).SetOnlyValue(cellValue.ToCellValue());
-                        }
-                    }
-                }
-                else
-                {
-                    throw new NotImplementedException($"Evaluation of {Type} formula not implemented.");
-                }
-
-                var recalculationCounter = cell.Worksheet.Workbook.RecalculationCounter;
-                _lastStatus = new RecalculationStatus(false, recalculationCounter);
-                _evaluatedAtVersion = recalculationCounter;
-            }
-            finally
-            {
-                IsEvaluating = false;
-            }*/
-        }
-
-        /// <summary>
-        /// Calculate a value of the specified formula.
-        /// </summary>
-        /// <param name="fA1">Cell formula to evaluate in A1 format.</param>
-        /// <param name="cell">Cell whose formula is being evaluated.</param>
-        private ScalarValue CalculateNormalFormula(string fA1, XLCell cell)
-        {
-            var worksheet = cell.Worksheet;
-            string sName;
-            string cAddress;
-            if (fA1.Contains('!'))
-            {
-                sName = fA1.Substring(0, fA1.IndexOf('!'));
-                if (sName[0] == '\'')
-                    sName = sName.Substring(1, sName.Length - 2);
-
-                cAddress = fA1.Substring(fA1.IndexOf('!') + 1);
-            }
-            else
-            {
-                sName = worksheet.Name;
-                cAddress = fA1;
-            }
-
-            if (worksheet.Workbook.Worksheets.Contains(sName)
-                && XLHelper.IsValidA1Address(cAddress))
-            {
-                var referenceCell = worksheet.Workbook.Worksheet(sName).Cell(cAddress);
-                if (referenceCell.IsEmpty(XLCellsUsedOptions.AllContents))
-                    return 0d;
-                else
-                    return referenceCell.Value;
-            }
-
-            if (worksheet.Workbook.Worksheets.Contains(sName)
-                && XLHelper.IsValidA1Address(cAddress))
-            {
-                var referenceCell = worksheet.Workbook.Worksheet(sName).Cell(cAddress);
-                if (referenceCell.IsEmpty(XLCellsUsedOptions.AllContents))
-                    return 0;
-                else
-                    return referenceCell.Value;
-            }
-
-            var retVal = worksheet.CalcEngine.EvaluateFormula(fA1, worksheet.Workbook, worksheet, cell.Address);
-            return retVal;
-        }
-
-        /// <summary>
-        /// Calculate array formula and return an array of the array formula range size.
-        /// </summary>
-        private Array CalculateArrayFormula(XLCell masterCell)
-        {
-            var ws = masterCell.Worksheet;
-            var formula = GetFormulaA1(masterCell.SheetPoint);
-            var resultArray = ws.CalcEngine.EvaluateArrayFormula(formula, masterCell);
-            var broadcastedArray = resultArray.Broadcast(Range.Height, Range.Width);
-            return broadcastedArray;
-        }
-
         /// <summary>
         /// A factory method to create a normal A1 formula. Doesn't affect recalculation version.
         /// </summary>
@@ -702,24 +504,6 @@ namespace ClosedXML.Excel
             /// </summary>
             Input2Deleted = 16,
         }
-
-        private readonly struct RecalculationStatus
-        {
-            public RecalculationStatus(bool neededRecalculation, long version)
-            {
-                NeededRecalculation = neededRecalculation;
-                Version = version;
-            }
-
-            internal bool NeededRecalculation { get; }
-
-            /// <summary>
-            /// The value of <see cref="XLWorkbook.RecalculationCounter"/> that workbook had at the moment of determining whether the cell
-            /// needs re-evaluation (due to it has been edited or some of the affecting cells has). If this value equals to <see cref="XLWorkbook.RecalculationCounter"/>
-            /// it indicates that <see cref="NeededRecalculation"/> stores correct value and no check has to be performed.
-            /// </summary>
-            internal long Version { get; }
-        };
 
         /// <summary>
         /// Get a lazy initialized AST for the formula.

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -216,6 +216,7 @@ namespace ClosedXML.Excel
 
         internal void Invalidate(XLWorksheet worksheet)
         {
+            IsDirty = true;
             _lastStatus = new(true, worksheet.Workbook.RecalculationCounter);
         }
 
@@ -437,6 +438,10 @@ namespace ClosedXML.Excel
 
         internal void ApplyFormula(XLCell cell)
         {
+            var wb = cell.Worksheet.Workbook;
+            wb.CalcEngine.Evaluate(wb);
+            return;
+            /*
             if (IsEvaluating)
             {
                 throw new InvalidOperationException($"Cell {cell.Address} is a part of circular reference.");
@@ -478,7 +483,7 @@ namespace ClosedXML.Excel
             finally
             {
                 IsEvaluating = false;
-            }
+            }*/
         }
 
         /// <summary>
@@ -722,9 +727,9 @@ namespace ClosedXML.Excel
         /// <param name="engine">Engine to parse the formula into AST, if necessary.</param>
         public Formula GetAst(CalcEngine.CalcEngine engine)
         {
-            // TODO: Add caching for lazy initialization.
-            var a1 = GetFormulaA1(Range.FirstPoint);
-            var ast = engine.Parse(a1);
+            var ast = A1 is not null
+                ? engine.Parse(A1)
+                : engine.ParseR1C1(R1C1);
             return ast;
         }
 

--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -68,7 +68,7 @@ namespace ClosedXML.Excel
 
         internal ValueSlice ValueSlice { get; }
 
-        internal Slice<XLCellFormula> FormulaSlice { get; } = new();
+        internal FormulaSlice FormulaSlice { get; } = new();
 
         internal Slice<XLStyleValue?> StyleSlice { get; } = new();
 

--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -13,6 +13,7 @@ namespace ClosedXML.Excel
         {
             _ws = ws;
             ValueSlice = new ValueSlice(ws.Workbook.SharedStringTable);
+            FormulaSlice = new FormulaSlice(ws);
             _slices = new List<ISlice> { ValueSlice, FormulaSlice, StyleSlice, MiscSlice };
         }
 
@@ -68,7 +69,7 @@ namespace ClosedXML.Excel
 
         internal ValueSlice ValueSlice { get; }
 
-        internal FormulaSlice FormulaSlice { get; } = new();
+        internal FormulaSlice FormulaSlice { get; }
 
         internal Slice<XLStyleValue?> StyleSlice { get; } = new();
 

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -6,7 +6,6 @@ namespace ClosedXML.Excel
     /// <summary>
     /// A representation of a <c>ST_Ref</c>, i.e. an area in a sheet (no reference to the sheet).
     /// </summary>
-    [DebuggerDisplay("{XLHelper.GetColumnLetterFromNumber(FirstPoint.Column)}{FirstPoint.Row}:{XLHelper.GetColumnLetterFromNumber(LastPoint.Column)}{LastPoint.Row}")]
     internal readonly struct XLSheetRange : IEquatable<XLSheetRange>
     {
         public XLSheetRange(XLSheetPoint firstPoint, XLSheetPoint lastPoint)
@@ -170,6 +169,26 @@ namespace ClosedXML.Excel
             return new XLSheetRange(
                 new XLSheetPoint(FirstPoint.Row, LastPoint.Column + 1),
                 new XLSheetPoint(LastPoint.Row, XLHelper.MaxColumnNumber));
+        }
+
+        /// <summary>
+        /// Return a range that contains additional number of rows below.
+        /// </summary>
+        internal XLSheetRange ExtendBelow(int rows)
+        {
+            Debug.Assert(rows >= 0);
+            var row = Math.Min(LastPoint.Row + rows, XLHelper.MaxRowNumber);
+            return new XLSheetRange(FirstPoint, new XLSheetPoint(row, LastPoint.Column));
+        }
+
+        /// <summary>
+        /// Return a range that contains additional number of columns to the right.
+        /// </summary>
+        internal XLSheetRange ExtendRight(int columns)
+        {
+            Debug.Assert(columns >= 0);
+            var column = Math.Min(LastPoint.Column + columns, XLHelper.MaxColumnNumber);
+            return new XLSheetRange(FirstPoint, new XLSheetPoint(LastPoint.Row, column));
         }
 
         internal static XLSheetRange FromRangeAddress<T>(T address)

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -447,7 +447,7 @@ namespace ClosedXML.Excel
         XLCellValue Evaluate(String expression, string formulaAddress = null);
 
         /// <summary>
-        /// Force recalculation of all cell formulas.
+        /// Force recalculation of all cell formulas in the sheet while leaving other sheets without change, even if they are dirty.
         /// </summary>
         void RecalculateAllFormulas();
 

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -447,7 +447,7 @@ namespace ClosedXML.Excel
         XLCellValue Evaluate(String expression, string formulaAddress = null);
 
         /// <summary>
-        /// Force recalculation of all cell formulas in the sheet while leaving other sheets without change, even if they are dirty.
+        /// Force recalculation of all cell formulas in the sheet while leaving other sheets without change, even if their dirty cells.
         /// </summary>
         void RecalculateAllFormulas();
 

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -125,12 +125,11 @@ namespace ClosedXML.Excel
                 // If formula evaluates to a text, it is stored directly in a worksheet, not in SST. Thus
                 // when the switch to formula happens, disable shared string and enable when formula is removed.
                 var valueSlice = Worksheet.Internals.CellsCollection.ValueSlice;
-                var clearFormula = value is null;
                 for (var row = range.TopRow; row <= range.BottomRow; ++row)
                 {
                     for (var col = range.LeftColumn; col <= range.RightColumn; ++col)
                     {
-                        valueSlice.SetShareString(new XLSheetPoint(row, col), clearFormula);
+                        valueSlice.SetShareString(new XLSheetPoint(row, col), false);
                     }
                 }
 

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -300,20 +300,6 @@ namespace ClosedXML.Excel
             return Cells(true);
         }
 
-        /// <summary>
-        /// Return the collection of cell values not initializing empty cells.
-        /// </summary>
-        public IEnumerable<XLCellValue> CellValues()
-        {
-            for (int ro = RangeAddress.FirstAddress.RowNumber; ro <= RangeAddress.LastAddress.RowNumber; ro++)
-            {
-                for (int co = RangeAddress.FirstAddress.ColumnNumber; co <= RangeAddress.LastAddress.ColumnNumber; co++)
-                {
-                    yield return Worksheet.GetCellValue(ro, co);
-                }
-            }
-        }
-
         public IXLRange Merge()
         {
             return Merge(true);

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -3,6 +3,7 @@
 using ClosedXML.Excel.CalcEngine;
 using ClosedXML.Graphics;
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -898,8 +899,10 @@ namespace ClosedXML.Excel
         /// </summary>
         public void RecalculateAllFormulas()
         {
-            InvalidateFormulas();
-            Worksheets.ForEach(sheet => sheet.RecalculateAllFormulas());
+            foreach (var sheet in WorksheetsInternal)
+                sheet.Internals.CellsCollection.FormulaSlice.MarkDirty(XLSheetRange.Full);
+
+            CalcEngine.Evaluate(this);
         }
 
         private static XLCalcEngine _calcEngineExpr;
@@ -1031,6 +1034,22 @@ namespace ClosedXML.Excel
         IXLElementProtection IXLProtectable.Unprotect(String password)
         {
             return Unprotect(password);
+        }
+
+        /// <summary>
+        /// Notify various component of a workbook that sheet has been added.
+        /// </summary>
+        internal void NotifyWorksheetAdded(XLWorksheet newSheet)
+        {
+            _calcEngine.OnAddedSheet(newSheet);
+        }
+
+        /// <summary>
+        /// Notify various component of a workbook that sheet is about to be removed.
+        /// </summary>
+        internal void NotifyWorksheetDeleting(XLWorksheet sheet)
+        {
+            _calcEngine.OnDeletingSheet(sheet);
         }
 
         public override string ToString()

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -3,7 +3,6 @@
 using ClosedXML.Excel.CalcEngine;
 using ClosedXML.Graphics;
 using DocumentFormat.OpenXml;
-using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -902,7 +901,7 @@ namespace ClosedXML.Excel
             foreach (var sheet in WorksheetsInternal)
                 sheet.Internals.CellsCollection.FormulaSlice.MarkDirty(XLSheetRange.Full);
 
-            CalcEngine.Evaluate(this);
+            CalcEngine.Recalculate(this, null);
         }
 
         private static XLCalcEngine _calcEngineExpr;

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1193,6 +1193,18 @@ namespace ClosedXML.Excel
             ShiftDataValidationColumns(range, columnsShifted);
             ShiftPageBreaksColumns(range, columnsShifted);
             RemoveInvalidSparklines();
+            if (columnsShifted > 0)
+            {
+                var area = XLSheetRange
+                    .FromRangeAddress(range.RangeAddress)
+                    .ExtendRight(columnsShifted - 1);
+                Workbook.CalcEngine.OnInsertAreaAndShiftRight(range.Worksheet, area);
+            }
+            else if (columnsShifted < 0)
+            {
+                var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
+                Workbook.CalcEngine.OnDeleteAreaAndShiftLeft(range.Worksheet, area);
+            }
         }
 
         private void ShiftPageBreaksColumns(XLRange range, int columnsShifted)
@@ -1323,7 +1335,18 @@ namespace ClosedXML.Excel
             ShiftDataValidationRows(range, rowsShifted);
             RemoveInvalidSparklines();
             ShiftPageBreaksRows(range, rowsShifted);
-            Workbook.CalcEngine.OnWorksheetShiftedRows(range, rowsShifted);
+            if (rowsShifted > 0)
+            {
+                var area = XLSheetRange
+                    .FromRangeAddress(range.RangeAddress)
+                    .ExtendBelow(rowsShifted - 1);
+                Workbook.CalcEngine.OnInsertAreaAndShiftDown(range.Worksheet, area);
+            }
+            else if (rowsShifted < 0)
+            {
+                var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
+                Workbook.CalcEngine.OnDeleteAreaAndShiftUp(range.Worksheet, area);
+            }
         }
 
         private void ShiftPageBreaksRows(XLRange range, int rowsShifted)

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1672,12 +1672,10 @@ namespace ClosedXML.Excel
             return CalcEngine.EvaluateFormula(expression, Workbook, this, address, true).ToCellValue();
         }
 
-        /// <summary>
-        /// Force recalculation of all cell formulas.
-        /// </summary>
         public void RecalculateAllFormulas()
         {
-            CellsUsed().ForEach<XLCell>(cell => cell.Evaluate(true));
+            Internals.CellsCollection.FormulaSlice.MarkDirty(XLSheetRange.Full);
+            Workbook.CalcEngine.Recalculate(Workbook, SheetId);
         }
 
         public String Author { get; set; }

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -128,6 +128,8 @@ namespace ClosedXML.Excel
                 throw new ArgumentException(String.Format("A worksheet with the same name ({0}) has already been added.", sheetName), nameof(sheetName));
 
             _worksheets.Add(sheetName, sheet);
+
+            _workbook.NotifyWorksheetAdded(sheet);
         }
 
         public void Delete(String sheetName)


### PR DESCRIPTION
Replace the evaluation of a formula using a recursive algorithm with a calculation chain. Calculation chain evaluates a single formula at a time and if formula needs data from another formula, it stops evaluation of the current formula and reorders the chain, so the supporting formula is positioned before the dependent formula (that is also reason why first calculation is often slower-order is not yet determined,  and also why is the chain is saved to the file).

Draft/WIP PR, needs TLS, but added, because I like looking at changes on GitHub.

Things that will be fixed later:
* Stopping evaluation of a formula with an exception when it needs a dirty cell value. Exceptions are really slow and are counter to the goal of fast calc engine, but a better a mechanism to stop evaluation of a formula will be in different PR.
* Recreation of a dependency tree and calculation chain when structure of a workbook changes. This will also be fixed in separate PR. For now, recreating both is a working solution.