### PR TITLE
Convert InsertData to streaming&bulk

### DIFF
--- a/ClosedXML.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
@@ -30,7 +30,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(2, reader.GetRecordsCount());
+            Assert.AreEqual(2, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
@@ -30,14 +30,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(2, reader.GetData().Count());
+            Assert.AreEqual(2, reader.GetRecords().Count());
         }
 
         [Test]
         public void CanReadValues()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             Assert.AreEqual(1, result.First().First());
             Assert.AreEqual(3, result.First().Last());

--- a/ClosedXML.Tests/Excel/InsertData/DataRecordReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/DataRecordReaderTests.cs
@@ -61,7 +61,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
-            Assert.AreEqual(3, reader.GetRecordsCount());
+            Assert.AreEqual(3, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/DataRecordReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/DataRecordReaderTests.cs
@@ -61,14 +61,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
-            Assert.AreEqual(3, reader.GetData().Count());
+            Assert.AreEqual(3, reader.GetRecords().Count());
         }
 
         [Test]
         public void CanGetData()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
-            var result = reader.GetData().ToArray();
+            var result = reader.GetRecords().ToArray();
 
             Assert.AreEqual("Value 1", result.First().First());
             Assert.AreEqual(100, result.First().Last());

--- a/ClosedXML.Tests/Excel/InsertData/DataRowReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/DataRowReaderTests.cs
@@ -40,14 +40,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(2, reader.GetData().Count());
+            Assert.AreEqual(2, reader.GetRecords().Count());
         }
 
         [Test]
         public void CanReadValue()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             Assert.AreEqual("Smith", result.First().First());
             Assert.AreEqual(33, result.First().Last());

--- a/ClosedXML.Tests/Excel/InsertData/DataRowReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/DataRowReaderTests.cs
@@ -40,7 +40,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(2, reader.GetRecordsCount());
+            Assert.AreEqual(2, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/ObjectReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/ObjectReaderTests.cs
@@ -126,14 +126,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
-            Assert.AreEqual(2, reader.GetData().Count());
+            Assert.AreEqual(2, reader.GetRecords().Count());
         }
 
         [Test]
         public void CanReadValues_FromObject()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             var firstRecord = result.First().ToArray();
             var lastRecord = result.Last().ToArray();
@@ -153,7 +153,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanReadValues_FromStruct()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(Structs);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             var firstRecord = result.First().ToArray();
             var lastRecord = result.Last().ToArray();
@@ -171,7 +171,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanReadValues_FromNullableStruct()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(NullableStructs);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             var firstRecord = result.First().ToArray();
             var lastRecord = result.Last().ToArray();

--- a/ClosedXML.Tests/Excel/InsertData/ObjectReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/ObjectReaderTests.cs
@@ -126,7 +126,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
-            Assert.AreEqual(2, reader.GetRecordsCount());
+            Assert.AreEqual(2, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
@@ -41,14 +41,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetData().Count());
+            Assert.AreEqual(3, reader.GetRecords().Count());
         }
 
         [Test]
         public void CanReadValues()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             Assert.AreEqual(1, result.First().Single());
             Assert.AreEqual(Blank.Value, result.Last().Single());

--- a/ClosedXML.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetRecordsCount());
+            Assert.AreEqual(3, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
@@ -41,14 +41,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetData().Count());
+            Assert.AreEqual(3, reader.GetRecords().Count());
         }
 
         [Test]
         public void CanReadValues()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            var result = reader.GetData();
+            var result = reader.GetRecords();
 
             Assert.AreEqual(1, result.First().Single());
             Assert.AreEqual(3, result.Last().Single());

--- a/ClosedXML.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetRecordsCount());
+            Assert.AreEqual(3, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
@@ -54,7 +54,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(9, reader.GetRecordsCount());
+            Assert.AreEqual(9, reader.GetData().Count());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
@@ -54,7 +54,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(9, reader.GetData().Count());
+            Assert.AreEqual(9, reader.GetRecords().Count());
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
 
-            var result = reader.GetData().ToArray();
+            var result = reader.GetRecords().ToArray();
 
             Assert.AreEqual(new XLCellValue[] { Blank.Value }, result[0]);
             Assert.AreEqual(new XLCellValue[] { "Value 2", "Value 1", 4, 3 }, result[1]);

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -683,7 +683,9 @@ namespace ClosedXML.Tests.Excel
 
             // The non-string data inserted to headers were converted to strings and used as a field names.
             Assert.AreEqual("#VALUE!", table.Field(0).Name);
+            Assert.AreEqual("#VALUE!", ws.Cell("A1").Value);
             Assert.AreEqual("7", table.Field(1).Name);
+            Assert.AreEqual("7", ws.Cell("B1").Value);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -665,6 +665,28 @@ namespace ClosedXML.Tests.Excel
         }
 
         [Test]
+        public void OverwritingTableHeaders()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var table = ws.Cell("A1").InsertTable(new object[]
+            {
+                ("Header 1", "Header 2"),
+                (1, 2)
+            }, true);
+
+            // Overwrite the headers of the table with non-string values
+            ws.Cell("A1").InsertData(new object[]
+            {
+                (XLError.IncompatibleValue, 7)
+            });
+
+            // The non-string data inserted to headers were converted to strings and used as a field names.
+            Assert.AreEqual("#VALUE!", table.Field(0).Name);
+            Assert.AreEqual("7", table.Field(1).Name);
+        }
+
+        [Test]
         public void OverwritingTableTotalsRow()
         {
             using (var wb = new XLWorkbook())

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -135,9 +135,14 @@ namespace ClosedXML.Excel.CalcEngine
 
         internal void MarkDirty(XLWorksheet sheet, XLSheetPoint point)
         {
+            MarkDirty(sheet, new XLSheetRange(point, point));
+        }
+
+        internal void MarkDirty(XLWorksheet sheet, XLSheetRange area)
+        {
             if (_dependencyTree is not null)
             {
-                var bookArea = new XLBookArea(sheet.Name, new XLSheetRange(point, point));
+                var bookArea = new XLBookArea(sheet.Name, area);
                 _dependencyTree.MarkDirty(bookArea);
             }
         }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -273,59 +273,12 @@ namespace ClosedXML.Excel
 
             if (setTableHeader)
             {
-                if (SetTableHeaderValue(value)) return this;
-                if (SetTableTotalsRowLabel(value)) return this;
+                var cellRange = new XLSheetRange(SheetPoint, SheetPoint);
+                foreach (var table in Worksheet.Tables)
+                    table.RefreshFieldsFromCells(cellRange);
             }
 
             return this;
-
-            Boolean SetTableHeaderValue(XLCellValue newFieldName)
-            {
-                foreach (var table in Worksheet.Tables.Where<XLTable>(t => t.ShowHeaderRow))
-                {
-                    if (TryGetField(out var field, table, table.RangeAddress.FirstAddress.RowNumber))
-                    {
-                        field.Name = newFieldName.ToString(CultureInfo.CurrentCulture);
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            Boolean SetTableTotalsRowLabel(XLCellValue value)
-            {
-                foreach (var table in Worksheet.Tables.Where<XLTable>(t => t.ShowTotalsRow))
-                {
-                    if (TryGetField(out var field, table, table.RangeAddress.LastAddress.RowNumber))
-                    {
-                        field.TotalsRowFunction = XLTotalsRowFunction.None;
-                        field.TotalsRowLabel = value.ToString(CultureInfo.CurrentCulture);
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            Boolean TryGetField(out IXLTableField field, IXLTable table, int rowNumber)
-            {
-                var tableRange = table.RangeAddress;
-                var tableInTotalsRow = rowNumber == Address.RowNumber;
-                if (!tableInTotalsRow)
-                {
-                    field = null;
-                    return false;
-                }
-
-                var fieldIndex = Address.ColumnNumber - tableRange.FirstAddress.ColumnNumber;
-                var tableContainsCell = fieldIndex >= 0 && fieldIndex < tableRange.ColumnSpan;
-                if (!tableContainsCell)
-                {
-                    field = null;
-                    return false;
-                }
-                field = table.Field(fieldIndex);
-                return true;
-            }
         }
 
         /// <summary>

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -222,6 +222,18 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
+        /// Create a new range from this one by taking a number of rows from the top row down.
+        /// </summary>
+        /// <param name="rows">How many rows to take, must be at least one.</param>
+        public XLSheetRange SliceFromTop(int rows)
+        {
+            if (rows < 1)
+                throw new ArgumentOutOfRangeException();
+
+            return new XLSheetRange(FirstPoint, new XLSheetPoint(TopRow + rows - 1, LastPoint.Column));
+        }
+
+        /// <summary>
         /// Create a new range from this one by taking a number of rows from the bottom row up.
         /// </summary>
         /// <param name="columns">How many columns to take, must be at least one.</param>

--- a/ClosedXML/Excel/InsertData/ArrayReader.cs
+++ b/ClosedXML/Excel/InsertData/ArrayReader.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel.InsertData
             _data = data ?? throw new ArgumentNullException(nameof(data));
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return _data.Select(item => item.Cast<object>().Select(XLCellValue.FromInsertedObject));
         }

--- a/ClosedXML/Excel/InsertData/ArrayReader.cs
+++ b/ClosedXML/Excel/InsertData/ArrayReader.cs
@@ -32,10 +32,5 @@ namespace ClosedXML.Excel.InsertData
         {
             return null;
         }
-
-        public int GetRecordsCount()
-        {
-            return _data.Count();
-        }
     }
 }

--- a/ClosedXML/Excel/InsertData/DataRecordReader.cs
+++ b/ClosedXML/Excel/InsertData/DataRecordReader.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Excel.InsertData
             _inMemoryData = ReadToEnd(data).ToArray();
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return _inMemoryData;
         }

--- a/ClosedXML/Excel/InsertData/DataRecordReader.cs
+++ b/ClosedXML/Excel/InsertData/DataRecordReader.cs
@@ -44,11 +44,6 @@ namespace ClosedXML.Excel.InsertData
             return _columns[propertyIndex];
         }
 
-        public int GetRecordsCount()
-        {
-            return _inMemoryData.Length;
-        }
-
         private IEnumerable<IEnumerable<XLCellValue>> ReadToEnd(IEnumerable<IDataRecord> data)
         {
             foreach (var dataRecord in data)

--- a/ClosedXML/Excel/InsertData/DataTableReader.cs
+++ b/ClosedXML/Excel/InsertData/DataTableReader.cs
@@ -51,10 +51,5 @@ namespace ClosedXML.Excel.InsertData
 
             return _dataTable.Columns[propertyIndex].Caption;
         }
-
-        public int GetRecordsCount()
-        {
-            return _dataRows.Count();
-        }
     }
 }

--- a/ClosedXML/Excel/InsertData/DataTableReader.cs
+++ b/ClosedXML/Excel/InsertData/DataTableReader.cs
@@ -22,7 +22,7 @@ namespace ClosedXML.Excel.InsertData
             _dataTable = _dataRows.FirstOrDefault()?.Table;
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return _dataRows.Select(r => r.ItemArray.Select(XLCellValue.FromInsertedObject));
         }

--- a/ClosedXML/Excel/InsertData/IInsertDataReader.cs
+++ b/ClosedXML/Excel/InsertData/IInsertDataReader.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel.InsertData
         /// <summary>
         /// Get a collection of records, each as a collection of values, extracted from a source.
         /// </summary>
-        IEnumerable<IEnumerable<XLCellValue>> GetData();
+        IEnumerable<IEnumerable<XLCellValue>> GetRecords();
 
         /// <summary>
         /// Get the number of properties to use as a table with.

--- a/ClosedXML/Excel/InsertData/IInsertDataReader.cs
+++ b/ClosedXML/Excel/InsertData/IInsertDataReader.cs
@@ -23,10 +23,5 @@ namespace ClosedXML.Excel.InsertData
         /// Get the title of the property with the specified index.
         /// </summary>
         string? GetPropertyName(int propertyIndex);
-
-        /// <summary>
-        /// Get the total number of records.
-        /// </summary>
-        int GetRecordsCount();
     }
 }

--- a/ClosedXML/Excel/InsertData/NullDataReader.cs
+++ b/ClosedXML/Excel/InsertData/NullDataReader.cs
@@ -28,10 +28,5 @@ namespace ClosedXML.Excel.InsertData
         {
             return null;
         }
-
-        public int GetRecordsCount()
-        {
-            return _count;
-        }
     }
 }

--- a/ClosedXML/Excel/InsertData/NullDataReader.cs
+++ b/ClosedXML/Excel/InsertData/NullDataReader.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.Excel.InsertData
             _count = nulls.Count();
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return Enumerable.Repeat(_row, _count);
         }

--- a/ClosedXML/Excel/InsertData/ObjectReader.cs
+++ b/ClosedXML/Excel/InsertData/ObjectReader.cs
@@ -62,11 +62,6 @@ namespace ClosedXML.Excel.InsertData
             return fieldName;
         }
 
-        public int GetRecordsCount()
-        {
-            return _data.Count();
-        }
-
         private IEnumerable<object?> GetItemData(object item)
         {
             for (int i = 0; i < _members.Length; i++)

--- a/ClosedXML/Excel/InsertData/ObjectReader.cs
+++ b/ClosedXML/Excel/InsertData/ObjectReader.cs
@@ -36,7 +36,7 @@ namespace ClosedXML.Excel.InsertData
             _staticMembers = _members.Select(ReflectionExtensions.IsStatic).ToArray();
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return _data.Select(item => GetItemData(item).Select(XLCellValue.FromInsertedObject));
         }

--- a/ClosedXML/Excel/InsertData/SimpleNullableTypeReader.cs
+++ b/ClosedXML/Excel/InsertData/SimpleNullableTypeReader.cs
@@ -19,7 +19,7 @@ namespace ClosedXML.Excel.InsertData
             _itemType = data.GetItemType().GetUnderlyingType();
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return _data.Select(item => new[] { item }.Select(XLCellValue.FromInsertedObject));
         }

--- a/ClosedXML/Excel/InsertData/SimpleNullableTypeReader.cs
+++ b/ClosedXML/Excel/InsertData/SimpleNullableTypeReader.cs
@@ -36,10 +36,5 @@ namespace ClosedXML.Excel.InsertData
 
             return _itemType.Name;
         }
-
-        public int GetRecordsCount()
-        {
-            return _data.Count();
-        }
     }
 }

--- a/ClosedXML/Excel/InsertData/SimpleTypeReader.cs
+++ b/ClosedXML/Excel/InsertData/SimpleTypeReader.cs
@@ -19,7 +19,7 @@ namespace ClosedXML.Excel.InsertData
             _itemType = data.GetItemType();
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             return _data.Select(item => new[] { item }.Select(XLCellValue.FromInsertedObject));
         }

--- a/ClosedXML/Excel/InsertData/SimpleTypeReader.cs
+++ b/ClosedXML/Excel/InsertData/SimpleTypeReader.cs
@@ -36,10 +36,5 @@ namespace ClosedXML.Excel.InsertData
 
             return _itemType.Name;
         }
-
-        public int GetRecordsCount()
-        {
-            return _data.Count();
-        }
     }
 }

--- a/ClosedXML/Excel/InsertData/UntypedObjectReader.cs
+++ b/ClosedXML/Excel/InsertData/UntypedObjectReader.cs
@@ -78,11 +78,6 @@ namespace ClosedXML.Excel.InsertData
             return GetFirstNonNullReader()?.GetPropertyName(propertyIndex);
         }
 
-        public int GetRecordsCount()
-        {
-            return _data.Count();
-        }
-
         private IInsertDataReader GetFirstNonNullReader()
         {
             return _readers.FirstOrDefault(r => !(r is NullDataReader));

--- a/ClosedXML/Excel/InsertData/UntypedObjectReader.cs
+++ b/ClosedXML/Excel/InsertData/UntypedObjectReader.cs
@@ -57,11 +57,11 @@ namespace ClosedXML.Excel.InsertData
             }
         }
 
-        public IEnumerable<IEnumerable<XLCellValue>> GetData()
+        public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
             foreach (var reader in _readers)
             {
-                foreach (var item in reader.GetData())
+                foreach (var item in reader.GetRecords())
                 {
                     yield return item;
                 }

--- a/ClosedXML/Excel/Style/XLAlignmentValue.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentValue.cs
@@ -64,5 +64,12 @@ namespace ClosedXML.Excel
         {
             return 990326508 + Key.GetHashCode();
         }
+
+        internal XLAlignmentValue WithWrapText(bool wrapText)
+        {
+            var keyCopy = Key;
+            keyCopy.WrapText = wrapText;
+            return FromKey(ref keyCopy);
+        }
     }
 }

--- a/ClosedXML/Excel/Style/XLNumberFormatValue.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormatValue.cs
@@ -52,5 +52,12 @@ namespace ClosedXML.Excel
         {
             return 1507230172 + Key.GetHashCode();
         }
+
+        internal XLNumberFormatValue WithNumberFormatId(int numberFormatId)
+        {
+            var keyCopy = Key;
+            keyCopy.NumberFormatId = numberFormatId;
+            return FromKey(ref keyCopy);
+        }
     }
 }

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -93,5 +93,31 @@ namespace ClosedXML.Excel
         }
 
         private int? _hashCode;
+
+        internal XLStyleValue WithAlignment(Func<XLAlignmentValue, XLAlignmentValue> modify)
+        {
+            return WithAlignment(modify(Alignment));
+        }
+
+        internal XLStyleValue WithAlignment(XLAlignmentValue alignment)
+        {
+            var keyCopy = Key;
+            keyCopy.Alignment = alignment.Key;
+            return FromKey(ref keyCopy);
+        }
+
+        internal XLStyleValue WithIncludeQuotePrefix(bool includeQuotePrefix)
+        {
+            var keyCopy = Key;
+            keyCopy.IncludeQuotePrefix = includeQuotePrefix;
+            return FromKey(ref keyCopy);
+        }
+
+        internal XLStyleValue WithNumberFormat(XLNumberFormatValue numberFormat)
+        {
+            var keyCopy = Key;
+            keyCopy.NumberFormat = numberFormat.Key;
+            return FromKey(ref keyCopy);
+        }
     }
 }

--- a/ClosedXML/Excel/XLCellValue.cs
+++ b/ClosedXML/Excel/XLCellValue.cs
@@ -386,6 +386,10 @@ namespace ClosedXML.Excel
             return IsNumber && _value.Equals(other);
         }
 
+        /// <summary>
+        /// Is the cell value text and is equal to the <paramref name="other"/>?
+        /// Text comparison is case sensitive.
+        /// </summary>
         public bool Equals(string other)
         {
             return IsText && _text == other;

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1785,7 +1785,7 @@ namespace ClosedXML.Excel
         internal XLRange InsertData(XLSheetPoint origin, IInsertDataReader reader, Boolean addHeadings, Boolean transpose)
         {
             // Prepare data. Heading is basically just another row of data, so unify it.
-            var rows = reader.GetData();
+            var rows = reader.GetRecords();
             var propCount = reader.GetPropertiesCount();
             if (addHeadings)
             {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1784,160 +1784,113 @@ namespace ClosedXML.Excel
 
         internal XLRange InsertData(XLSheetPoint origin, IInsertDataReader reader, Boolean addHeadings, Boolean transpose)
         {
-            if (!transpose)
-            {
-                // Prepare data. Heading is basically just another row of data, so unify it.
-                var rows = reader.GetData();
-                var propCount = reader.GetPropertiesCount();
-                if (addHeadings)
-                {
-                    var headings = new XLCellValue[propCount];
-                    for (var i = 0; i < propCount; i++)
-                        headings[i] = reader.GetPropertyName(i);
-
-                    rows = new[] { headings }.Concat(rows);
-                }
-
-                var valueSlice = Internals.CellsCollection.ValueSlice;
-                var styleSlice = Internals.CellsCollection.StyleSlice;
-
-                // A buffer to avoid multiple enumerations of the source.
-                var rowBuffer = new List<XLCellValue>();
-                var maximumColumn = origin.Column;
-                var rowNumber = origin.Row;
-                foreach (var row in rows)
-                {
-                    rowBuffer.AddRange(row);
-
-                    // InsertData should also clear data and if row doesn't have enough data,
-                    // fill in the rest. Only fill up to the props to be consistent. We can't
-                    // know how long any next row will be, so props are used as a source of truth
-                    // for which columns should be cleared.
-                    for (var i = rowBuffer.Count; i < propCount; ++i)
-                        rowBuffer.Add(Blank.Value);
-
-                    // Each row can have different number of values, so we have to check every row.
-                    maximumColumn = Math.Max(origin.Column + rowBuffer.Count - 1, maximumColumn);
-                    if (maximumColumn > XLHelper.MaxColumnNumber || rowNumber > XLHelper.MaxRowNumber)
-                        throw new ArgumentException("Data would write out of the sheet.");
-
-                    var column = origin.Column;
-                    for (var i = 0; i < rowBuffer.Count; ++i)
-                    {
-                        var value = rowBuffer[i];
-                        var point = new XLSheetPoint(rowNumber, column);
-                        var modifiedStyle = GetStyleForValue(value, point);
-                        if (modifiedStyle is not null)
-                        {
-                            if (value.IsText && value.GetText()[0] == '\'')
-                                value = value.GetText().Substring(1);
-
-                            styleSlice.Set(point, modifiedStyle);
-                        }
-
-                        valueSlice.SetCellValue(point, value);
-                        column++;
-                    }
-
-                    rowBuffer.Clear();
-                    rowNumber++;
-                }
-
-                // If there is no row, rowNumber is kept at origin instead of last row + 1 .
-                var lastRow = Math.Max(rowNumber - 1, origin.Row);
-                var insertedArea = new XLSheetRange(origin, new XLSheetPoint(lastRow, maximumColumn));
-
-                // If inserted area affected a table, we must fix headings and totals, because these values
-                // are duplicated. Basically the table values are the truth and cells are a reflection of the
-                // truth, but here we inserted shadow first.
-                foreach (var table in Tables)
-                    table.RefreshFieldsFromCells(insertedArea);
-
-                // Return area that contains all inserted cells, no matter how jagged were data.
-                return Range(
-                    insertedArea.FirstPoint.Row,
-                    insertedArea.FirstPoint.Column,
-                    insertedArea.LastPoint.Row,
-                    insertedArea.LastPoint.Column);
-            }
-
-            // Only non transposed
-            var currentRowNumber = origin.Row;
-            var currentColumnNumber = origin.Column;
-            var maximumColumnNumber = currentColumnNumber + reader.GetRecordsCount() - 1;
-            var maximumRowNumber = currentRowNumber + reader.GetPropertiesCount() - 1;
-
-            // Inline functions to handle looping with transposing
-            //////////////////////////////////////////////////////
-            void incrementFieldPosition()
-            {
-                maximumRowNumber = Math.Max(maximumRowNumber, currentRowNumber);
-                currentRowNumber++;
-            }
-
-            void incrementRecordPosition()
-            {
-                maximumColumnNumber = Math.Max(maximumColumnNumber, currentColumnNumber);
-                currentColumnNumber++;
-            }
-
-            void resetRecordPosition()
-            {
-                currentRowNumber = origin.Row;
-            }
-            //////////////////////////////////////////////////////
-
-            var empty = maximumRowNumber <= origin.Row ||
-                        maximumColumnNumber <= origin.Column;
-
-            if (!empty)
-            {
-                Range(
-                        origin.Row,
-                        origin.Column,
-                        maximumRowNumber,
-                        maximumColumnNumber)
-                    .Clear();
-            }
-
+            // Prepare data. Heading is basically just another row of data, so unify it.
+            var rows = reader.GetData();
+            var propCount = reader.GetPropertiesCount();
             if (addHeadings)
             {
-                for (int i = 0; i < reader.GetPropertiesCount(); i++)
-                {
-                    var propertyName = reader.GetPropertyName(i);
-                    SetValue(propertyName, currentRowNumber, currentColumnNumber);
-                    incrementFieldPosition();
-                }
+                var headings = new XLCellValue[propCount];
+                for (var i = 0; i < propCount; i++)
+                    headings[i] = reader.GetPropertyName(i);
 
-                incrementRecordPosition();
+                rows = new[] { headings }.Concat(rows);
             }
 
-            var data = reader.GetData();
-
-            foreach (var item in data)
+            if (transpose)
             {
-                resetRecordPosition();
-                foreach (var value in item)
+                // Rather memory inefficient, but the original code also materialized
+                // data through Linq/required multiple enumerations.
+                var destination = new List<List<XLCellValue>>();
+
+                var sourceRow = 1;
+                foreach (var row in rows)
                 {
-                    SetValue(value, currentRowNumber, currentColumnNumber);
-                    incrementFieldPosition();
+                    var sourceColumn = 1;
+                    foreach (var sourceValue in row)
+                    {
+                        // The original has `sourceValue` at [sourceRow, sourceColumn]
+                        var destinationRowCount = destination.Count;
+                        if (sourceColumn > destinationRowCount)
+                            destination.Add(new List<XLCellValue>());
+
+                        // There can be jagged arrays and the destination can have spaces between columns.
+                        var destinationRow = destination[sourceColumn - 1];
+                        while (destinationRow.Count < sourceRow - 1)
+                            destinationRow.Add(Blank.Value);
+
+                        destinationRow.Add(sourceValue);
+                        sourceColumn++;
+                    }
+                    sourceRow++;
                 }
-                incrementRecordPosition();
+
+                rows = destination;
             }
 
-            var range = Range(
-                origin.Row,
-                origin.Column,
-                maximumRowNumber,
-                maximumColumnNumber);
+            var valueSlice = Internals.CellsCollection.ValueSlice;
+            var styleSlice = Internals.CellsCollection.StyleSlice;
 
-            return range;
-        }
+            // A buffer to avoid multiple enumerations of the source.
+            var rowBuffer = new List<XLCellValue>();
+            var maximumColumn = origin.Column;
+            var rowNumber = origin.Row;
+            foreach (var row in rows)
+            {
+                rowBuffer.AddRange(row);
 
-        private void SetValue(XLCellValue value, int ro, int co)
-        {
-            var cell = Cell(ro, co);
-            cell.SetValue(value, setTableHeader: true, checkMergedRanges: false);
+                // InsertData should also clear data and if row doesn't have enough data,
+                // fill in the rest. Only fill up to the props to be consistent. We can't
+                // know how long any next row will be, so props are used as a source of truth
+                // for which columns should be cleared.
+                for (var i = rowBuffer.Count; i < propCount; ++i)
+                    rowBuffer.Add(Blank.Value);
+
+                // Each row can have different number of values, so we have to check every row.
+                maximumColumn = Math.Max(origin.Column + rowBuffer.Count - 1, maximumColumn);
+                if (maximumColumn > XLHelper.MaxColumnNumber || rowNumber > XLHelper.MaxRowNumber)
+                    throw new ArgumentException("Data would write out of the sheet.");
+
+                var column = origin.Column;
+                for (var i = 0; i < rowBuffer.Count; ++i)
+                {
+                    var value = rowBuffer[i];
+                    var point = new XLSheetPoint(rowNumber, column);
+                    var modifiedStyle = GetStyleForValue(value, point);
+                    if (modifiedStyle is not null)
+                    {
+                        if (value.IsText && value.GetText()[0] == '\'')
+                            value = value.GetText().Substring(1);
+
+                        styleSlice.Set(point, modifiedStyle);
+                    }
+
+                    valueSlice.SetCellValue(point, value);
+                    column++;
+                }
+
+                rowBuffer.Clear();
+                rowNumber++;
+            }
+
+            // If there is no row, rowNumber is kept at origin instead of last row + 1 .
+            var lastRow = Math.Max(rowNumber - 1, origin.Row);
+            var insertedArea = new XLSheetRange(origin, new XLSheetPoint(lastRow, maximumColumn));
+
+            // If inserted area affected a table, we must fix headings and totals, because these values
+            // are duplicated. Basically the table values are the truth and cells are a reflection of the
+            // truth, but here we inserted shadow first.
+            foreach (var table in Tables)
+                table.RefreshFieldsFromCells(insertedArea);
+
+            // Invalidate only once, not for every cell.
+            Workbook.CalcEngine.MarkDirty(Worksheet, insertedArea);
+
+            // Return area that contains all inserted cells, no matter how jagged were data.
+            return Range(
+                insertedArea.FirstPoint.Row,
+                insertedArea.FirstPoint.Column,
+                insertedArea.LastPoint.Row,
+                insertedArea.LastPoint.Column);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1784,9 +1784,6 @@ namespace ClosedXML.Excel
 
         internal XLRange InsertData(XLSheetPoint origin, IInsertDataReader reader, Boolean addHeadings, Boolean transpose)
         {
-            if (reader == null)
-                return null;
-
             var currentRowNumber = origin.Row;
             var currentColumnNumber = origin.Column;
             var maximumColumnNumber = currentColumnNumber;


### PR DESCRIPTION
Inserting a data from `IEnumerable` & its ilk is generally done by `IXLCell.InsertData`/`InsertTable` through `IInsertDataReader` that wasn't very streaming friendly and inserted values one by one by setting each cell.

This PR 
* converts data insertion to full streaming (i.e. no multiple enumeration of source, e.g. `GetRecordCount` often did it) 
* sets values directly through slice instead of `XLCell` instantiation
* does check in a bulk fashion (i.e. only once for whole inserted area instead of each cell).

Haven't done detailed benchmark, but inserting 10mil cells took ~21seconds and 715MiB in 0.102.1 versus ~11 seconds 340MiB in the PR.

```csharp
// Code to insert 10mil cells
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();
var sw = Stopwatch.StartNew();
ws.Cell("A1").InsertData(Enumerable.Range(0, 1_000_000).Select(x =>
{
    return Enumerable.Range(0, 10).Select(x => "Hello World");
}));
sw.Stop();
Console.WriteLine($"Elapsed {sw.ElapsedMilliseconds}ms.");
```