### PR TITLE
Load cells from workbook using a streaming

### DIFF
--- a/ClosedXML/Excel/Cells/ValueSlice.cs
+++ b/ClosedXML/Excel/Cells/ValueSlice.cs
@@ -237,7 +237,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        private readonly struct XLValueSliceContent
+        private readonly struct XLValueSliceContent : IEquatable<XLValueSliceContent>
         {
             /// <summary>
             /// A cell value in a very compact representation. The value is interpreted depending on a type.
@@ -255,6 +255,27 @@ namespace ClosedXML.Excel
                 Value = value;
                 Type = type;
                 Inline = inline;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is XLValueSliceContent valueContent && Equals(valueContent);
+            }
+
+            public bool Equals(XLValueSliceContent other)
+            {
+                return Value.Equals(other.Value) && Type == other.Type && Inline == other.Inline;
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Value.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (int)Type;
+                    hashCode = (hashCode * 397) ^ Inline.GetHashCode();
+                    return hashCode;
+                }
             }
         }
     }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1818,7 +1818,6 @@ namespace ClosedXML.Excel
 
             // Unified code to load value. Value can be empty and only type specified (e.g. when formula doesn't save values)
             // String type is only for formulas, while shared string/inline string/date is only for pure cell values.
-
             var cellHasValue = reader.IsStartElement("v");
             if (cellHasValue)
             {
@@ -1842,7 +1841,7 @@ namespace ClosedXML.Excel
                 formula.IsDirty = true;
             }
 
-            // Ignore inline string element, 
+            // Inline text is dealt separately, because it is in a separate element.
             var cellHasInlineString = reader.IsStartElement("is");
             if (cellHasInlineString)
             {
@@ -2271,8 +2270,8 @@ namespace ClosedXML.Excel
             if (dyDescent is not null)
                 xlRow.DyDescent = dyDescent.Value;
 
-            var hiddenAttr = attributes.GetBoolAttribute("hidden", false);
-            if (hiddenAttr)
+            var hidden = attributes.GetBoolAttribute("hidden", false);
+            if (hidden)
                 xlRow.Hide();
 
             var collapsed = attributes.GetBoolAttribute("collapsed", false);
@@ -3552,11 +3551,6 @@ namespace ClosedXML.Excel
             }
 
             return false;
-        }
-
-        private static Exception UnexpectedStreamEnd()
-        {
-            throw new InvalidOperationException("The stream should have contain more XML elements, but has ended instead.");
         }
 
         private static Exception MissingRequiredAttr(string attributeName)

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -7,12 +7,14 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using ClosedXML.Excel.IO;
 using Ap = DocumentFormat.OpenXml.ExtendedProperties;
 using Formula = DocumentFormat.OpenXml.Spreadsheet.Formula;
 using Op = DocumentFormat.OpenXml.CustomProperties;
@@ -230,7 +232,7 @@ namespace ClosedXML.Excel
 
                 lastRow = 0;
 
-                using (var reader = OpenXmlReader.Create(worksheetPart))
+                using (var reader = new OpenXmlPartReader(worksheetPart))
                 {
                     Type[] ignoredElements = new Type[]
                     {
@@ -275,8 +277,8 @@ namespace ClosedXML.Excel
                                         (Columns)reader.LoadCurrentElement());
                         else if (reader.ElementType == typeof(Row))
                         {
-                            LoadRows(s, numberingFormats, fills, borders, fonts, ws, sharedStrings, sharedFormulasR1C1,
-                                     styleList, (Row)reader.LoadCurrentElement());
+                            LoadRow(s, numberingFormats, fills, borders, fonts, ws, sharedStrings, sharedFormulasR1C1,
+                                     styleList, reader);
                         }
                         else if (reader.ElementType == typeof(AutoFilter))
                             LoadAutoFilter((AutoFilter)reader.LoadCurrentElement(), ws);
@@ -1752,19 +1754,33 @@ namespace ClosedXML.Excel
 
         private Int32 lastColumnNumber;
 
-        private void LoadCells(SharedStringItem[] sharedStrings, Stylesheet s, NumberingFormats numberingFormats,
-                               Fills fills, Borders borders, Fonts fonts, Dictionary<uint, string> sharedFormulasR1C1,
-                               XLWorksheet ws, Dictionary<Int32, IXLStyle> styleList, Cell cell, Int32 rowIndex)
+        private void LoadCell(SharedStringItem[] sharedStrings, Stylesheet s, NumberingFormats numberingFormats,
+                              Fills fills, Borders borders, Fonts fonts, Dictionary<uint, string> sharedFormulasR1C1,
+                              XLWorksheet ws, Dictionary<Int32, IXLStyle> styleList, OpenXmlPartReader reader, Int32 rowIndex)
         {
-            Int32 styleIndex = cell.StyleIndex != null ? Int32.Parse(cell.StyleIndex.InnerText) : 0;
+            Debug.Assert(reader.LocalName == "c" && reader.IsStartElement);
 
-            var cellAddress = cell.CellReference?.Value is { } cellRef
-                ? XLSheetPoint.Parse(cellRef)
-                : new XLSheetPoint(rowIndex, lastColumnNumber + 1);
+            var attributes = reader.Attributes;
+
+            var styleIndex = attributes.GetIntAttribute("s") ?? 0;
+
+            var cellAddress = attributes.GetCellRefAttribute("r") ?? new XLSheetPoint(rowIndex, lastColumnNumber + 1);
             lastColumnNumber = cellAddress.Column;
 
+            var dataType = attributes.GetAttribute("t") switch
+            {
+                "b" => CellValues.Boolean,
+                "n" => CellValues.Number,
+                "e" => CellValues.Error,
+                "s" => CellValues.SharedString,
+                "str" => CellValues.String,
+                "inlineStr" => CellValues.InlineString,
+                "d" => CellValues.Date,
+                null => CellValues.Number,
+                _ => throw new FormatException($"Unknown cell type.")
+            };
+
             var xlCell = ws.Cell(cellAddress.Row, cellAddress.Column);
-            var dataType = cell.DataType?.Value ?? CellValues.Number;
 
             if (styleList.TryGetValue(styleIndex, out IXLStyle style))
             {
@@ -1775,100 +1791,84 @@ namespace ClosedXML.Excel
                 ApplyStyle(xlCell, styleIndex, s, fills, borders, fonts, numberingFormats);
             }
 
-            if (cell.ShowPhonetic is not null && cell.ShowPhonetic.Value)
+            var showPhonetic = attributes.GetBoolAttribute("ph", false);
+            if (showPhonetic)
                 xlCell.ShowPhonetic = true;
 
-            if (cell.CellMetaIndex is not null)
-                xlCell.CellMetaIndex = cell.CellMetaIndex.Value;
+            var cellMetaIndex = attributes.GetUintAttribute("cm");
+            if (cellMetaIndex is not null)
+                xlCell.CellMetaIndex = cellMetaIndex.Value;
 
-            if (cell.ValueMetaIndex is not null)
-                xlCell.ValueMetaIndex = cell.ValueMetaIndex.Value;
+            var valueMetaIndex = attributes.GetUintAttribute("vm");
+            if (valueMetaIndex is not null)
+                xlCell.ValueMetaIndex = valueMetaIndex.Value;
 
-            if (cell.CellFormula is not null)
+            // Move from cell start element onwards.
+            reader.MoveAhead();
+
+            var cellHasFormula = reader.IsStartElement("f");
+            XLCellFormula formula = null;
+            if (cellHasFormula)
             {
-                var formula = SetCellFormula(ws, cellAddress, cell.CellFormula, sharedFormulasR1C1);
+                formula = SetCellFormula(ws, cellAddress, reader, sharedFormulasR1C1);
 
-                // If the cell doesn't contain value, we should invalidate it, otherwise rely on the stored value.
-                // The value is likely more reliable. It should be set when cellFormula.CalculateCell is set or
-                // when value is missing. Formula can be null in some cases, e.g. slave cells of array formula.
-                if (formula is not null && cell.CellValue?.Text is null)
-                {
-                    formula.IsDirty = true;
-                }
-
+                // Move from end of 'f' element.
+                reader.MoveAhead();
             }
+
             // Unified code to load value. Value can be empty and only type specified (e.g. when formula doesn't save values)
             // String type is only for formulas, while shared string/inline string/date is only for pure cell values.
-            var cellValue = cell.CellValue;
-            if (dataType == CellValues.Number)
-            {
-                // XLCell is by default blank, so no need to set it.
-                if (cellValue is not null && cellValue.TryGetDouble(out var number))
-                {
-                    var numberDataType = GetNumberDataType(xlCell.StyleValue.NumberFormat);
-                    var cellNumber = numberDataType switch
-                    {
-                        XLDataType.DateTime => XLCellValue.FromSerialDateTime(number),
-                        XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(number),
-                        _ => number // Normal number
-                    };
-                    xlCell.SetOnlyValue(cellNumber);
-                }
-            }
-            else if (dataType == CellValues.SharedString)
-            {
-                if (cellValue is not null
-                    && Int32.TryParse(cellValue.Text, XLHelper.NumberStyle, XLHelper.ParseCulture, out Int32 sharedStringId)
-                    && sharedStringId >= 0 && sharedStringId < sharedStrings.Length)
-                {
-                    var sharedString = sharedStrings[sharedStringId];
 
-                    SetCellText(xlCell, sharedString);
-                }
-                else
-                    xlCell.SetOnlyValue(String.Empty);
-            }
-            else if (dataType == CellValues.String) // A plain string that is a result of a formula calculation
+            var cellHasValue = reader.IsStartElement("v");
+            if (cellHasValue)
             {
-                xlCell.SetOnlyValue(cellValue?.Text ?? String.Empty);
+                SetCellValue(dataType, reader.GetText(), xlCell, sharedStrings);
+
+                // Skips all nodes of the 'v' element (has no child nodes) and moves to the first element after.
+                reader.Skip();
             }
-            else if (dataType == CellValues.Boolean)
+            else
             {
-                if (cellValue is not null)
+                // A string cell must contain at least empty string.
+                if (dataType is CellValues.SharedString or CellValues.String)
+                    xlCell.SetOnlyValue(string.Empty);
+            }
+
+            // If the cell doesn't contain value, we should invalidate it, otherwise rely on the stored value.
+            // The value is likely more reliable. It should be set when cellFormula.CalculateCell is set or
+            // when value is missing. Formula can be null in some cases, e.g. slave cells of array formula.
+            if (formula is not null && !cellHasValue)
+            {
+                formula.IsDirty = true;
+            }
+
+            // Ignore inline string element, 
+            var cellHasInlineString = reader.IsStartElement("is");
+            if (cellHasInlineString)
+            {
+                if (dataType == CellValues.InlineString)
                 {
-                    var isTrue = string.Equals(cellValue.Text, "1", StringComparison.Ordinal) ||
-                                 string.Equals(cellValue.Text, "TRUE", StringComparison.OrdinalIgnoreCase);
-                    xlCell.SetOnlyValue(isTrue);
-                }
-            }
-            else if (dataType == CellValues.InlineString)
-            {
-                xlCell.ShareString = false;
-                if (cell.InlineString != null)
-                {
-                    if (cell.InlineString.Text != null)
-                        xlCell.SetOnlyValue(cell.InlineString.Text.Text.FixNewLines());
+                    xlCell.ShareString = false;
+                    var inlineString = (RstType)reader.LoadCurrentElement();
+                    if (inlineString is not null)
+                    {
+                        if (inlineString.Text is not null)
+                            xlCell.SetOnlyValue(inlineString.Text.Text.FixNewLines());
+                        else
+                            SetCellText(xlCell, inlineString);
+                    }
                     else
-                        SetCellText(xlCell, cell.InlineString);
+                    {
+                        xlCell.SetOnlyValue(String.Empty);
+                    }
+
+                    // Move from end 'is' element to the end of a 'c' element.
+                    reader.MoveAhead();
                 }
                 else
-                    xlCell.SetOnlyValue(String.Empty);
-            }
-            else if (dataType == CellValues.Error)
-            {
-                if (cellValue is not null && XLErrorParser.TryParseError(cellValue.InnerText, out var error))
-                    xlCell.SetOnlyValue(error);
-            }
-            else if (dataType == CellValues.Date)
-            {
-                // Technically, cell can contain date as ISO8601 string, but not rarely used due
-                // to inconsistencies between ISO and serial date time representation.
-                if (cellValue is not null)
                 {
-                    var date = DateTime.ParseExact(cellValue.Text, DateCellFormats,
-                        XLHelper.ParseCulture,
-                        DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
-                    xlCell.SetOnlyValue(date);
+                    // Move to the first node after end of 'is' element, which should be end of cell.
+                    reader.Skip();
                 }
             }
 
@@ -1883,30 +1883,40 @@ namespace ClosedXML.Excel
                 styleList.Add(styleIndex, xlCell.Style);
         }
 
-        private static XLCellFormula SetCellFormula(XLWorksheet ws, XLSheetPoint cellAddress, CellFormula cellFormula, Dictionary<uint, string> sharedFormulasR1C1)
+        private static XLCellFormula SetCellFormula(XLWorksheet ws, XLSheetPoint cellAddress, OpenXmlPartReader reader, Dictionary<uint, string> sharedFormulasR1C1)
         {
+            var attributes = reader.Attributes;
             var formulaSlice = ws.Internals.CellsCollection.FormulaSlice;
             var valueSlice = ws.Internals.CellsCollection.ValueSlice;
-            XLCellFormula formula = null;
 
             // bx attribute of cell formula is not ever used, per MS-OI29500 2.1.620
-            var formulaType = cellFormula.FormulaType?.Value ?? CellFormulaValues.Normal;
+            var formulaText = reader.GetText();
+            var formulaType = attributes.GetAttribute("t") switch
+            {
+                "normal" => CellFormulaValues.Normal,
+                "array" => CellFormulaValues.Array,
+                "dataTable" => CellFormulaValues.DataTable,
+                "shared" => CellFormulaValues.Shared,
+                null => CellFormulaValues.Normal,
+                _ => throw new NotSupportedException("Unknown formula type.")
+            };
+
+            // Always set shareString flag to `false`, because the text result of
+            // formula is stored directly in the sheet, not shared string table.
+            XLCellFormula formula = null;
             if (formulaType == CellFormulaValues.Normal)
             {
-                formula = XLCellFormula.NormalA1(cellFormula.Text);
+                formula = XLCellFormula.NormalA1(formulaText);
                 formulaSlice.Set(cellAddress, formula);
                 valueSlice.SetShareString(cellAddress, false);
             }
-            else if
-                (formulaType == CellFormulaValues.Array &&
-                 cellFormula.Reference is not null) // Child cells of an array may have array type, but not ref, that is reserved for master cell
+            else if (formulaType == CellFormulaValues.Array && attributes.GetRefAttribute("ref") is { } arrayArea) // Child cells of an array may have array type, but not ref, that is reserved for master cell
             {
-                var aca = cellFormula.AlwaysCalculateArray?.Value ?? false;
+                var aca = attributes.GetBoolAttribute("aca", false);
 
                 // Because cells are read from top-to-bottom, from left-to-right, none of child cells have
                 // a formula yet. Also, Excel doesn't allow change of array data, only through parent formula.
-                var arrayArea = XLSheetRange.Parse(cellFormula.Reference);
-                formula = XLCellFormula.Array(cellFormula.Text, arrayArea, aca);
+                formula = XLCellFormula.Array(formulaText, arrayArea, aca);
                 formulaSlice.SetArray(arrayArea, formula);
 
                 for (var col = arrayArea.FirstPoint.Column; col <= arrayArea.LastPoint.Column; ++col)
@@ -1917,24 +1927,22 @@ namespace ClosedXML.Excel
                     }
                 }
             }
-            else if (formulaType == CellFormulaValues.Shared && cellFormula.SharedIndex is not null)
+            else if (formulaType == CellFormulaValues.Shared && attributes.GetUintAttribute("si") is { } sharedIndex)
             {
                 // Shared formulas are rather limited in use and parsing, even by Excel
                 // https://stackoverflow.com/questions/54654993. Therefore we accept them,
                 // but don't output them. Shared formula is created, when user in Excel
                 // takes a supported formula and drags it to more cells.
-                var sharedIndex = cellFormula.SharedIndex.Value;
                 if (!sharedFormulasR1C1.TryGetValue(sharedIndex, out var sharedR1C1Formula))
                 {
                     // Spec: The first formula in a group of shared formulas is saved
-                    // in the f element.This is considered the 'master' formula cell.
-                    formula = XLCellFormula.NormalA1(cellFormula.Text);
+                    // in the f element. This is considered the 'master' formula cell.
+                    formula = XLCellFormula.NormalA1(formulaText);
                     formulaSlice.Set(cellAddress, formula);
-                    valueSlice.SetShareString(cellAddress, false);
 
                     // The key reason why Excel hates shared formulas is likely relative addressing and the messy situation it creates
                     var formulaR1C1 = formula.GetFormulaR1C1(cellAddress);
-                    sharedFormulasR1C1.Add(cellFormula.SharedIndex.Value, formulaR1C1);
+                    sharedFormulasR1C1.Add(sharedIndex, formulaR1C1);
                 }
                 else
                 {
@@ -1942,34 +1950,99 @@ namespace ClosedXML.Excel
                     // (and is not the master) shall be ignored, and the master formula shall override.
                     formula = XLCellFormula.NormalR1C1(sharedR1C1Formula);
                     formulaSlice.Set(cellAddress, formula);
-                    valueSlice.SetShareString(cellAddress, false);
                 }
+
+                valueSlice.SetShareString(cellAddress, false);
             }
-            else if (formulaType == CellFormulaValues.DataTable && cellFormula.Reference is not null)
+            else if (formulaType == CellFormulaValues.DataTable && attributes.GetRefAttribute("ref") is { } dataTableArea)
             {
-                var range = XLSheetRange.Parse(cellFormula.Reference);
-                var is2D = cellFormula.DataTable2D?.Value ?? false;
-                var input1Deleted = cellFormula.Input1Deleted?.Value ?? false;
-                var input1 = XLSheetPoint.Parse(cellFormula.R1);
+                var is2D = attributes.GetBoolAttribute("dt2D", false);
+                var input1Deleted = attributes.GetBoolAttribute("del1", false);
+                var input1 = attributes.GetCellRefAttribute("r1") ?? throw MissingRequiredAttr("r1");
                 if (is2D)
                 {
                     // Input 2 is only used for 2D tables
-                    var input2Deleted = cellFormula.Input2Deleted?.Value ?? false;
-                    var input2 = XLSheetPoint.Parse(cellFormula.R2);
-                    formula = XLCellFormula.DataTable2D(range, input1, input1Deleted, input2, input2Deleted);
+                    var input2Deleted = attributes.GetBoolAttribute("del2", false);
+                    var input2 = attributes.GetCellRefAttribute("r2") ?? throw MissingRequiredAttr("r2");
+                    formula = XLCellFormula.DataTable2D(dataTableArea, input1, input1Deleted, input2, input2Deleted);
                     formulaSlice.Set(cellAddress, formula);
                 }
                 else
                 {
-                    var isRowDataTable = cellFormula.DataTableRow?.Value ?? false;
-                    formula = XLCellFormula.DataTable1D(range, input1, input1Deleted, isRowDataTable);
+                    var isRowDataTable = attributes.GetBoolAttribute("dtr", false);
+                    formula = XLCellFormula.DataTable1D(dataTableArea, input1, input1Deleted, isRowDataTable);
                     formulaSlice.Set(cellAddress, formula);
                 }
 
                 valueSlice.SetShareString(cellAddress, false);
             }
 
+            // Go from start of 'f' element to the end of 'f' element.
+            reader.MoveAhead();
+
             return formula;
+        }
+
+        private void SetCellValue(CellValues dataType, string cellValue, XLCell xlCell, SharedStringItem[] sharedStrings)
+        {
+            if (dataType == CellValues.Number)
+            {
+                // XLCell is by default blank, so no need to set it.
+                if (cellValue is not null && double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out var number))
+                {
+                    var numberDataType = GetNumberDataType(xlCell.StyleValue.NumberFormat);
+                    var cellNumber = numberDataType switch
+                    {
+                        XLDataType.DateTime => XLCellValue.FromSerialDateTime(number),
+                        XLDataType.TimeSpan => XLCellValue.FromSerialTimeSpan(number),
+                        _ => number // Normal number
+                    };
+                    xlCell.SetOnlyValue(cellNumber);
+                }
+            }
+            else if (dataType == CellValues.SharedString)
+            {
+                if (cellValue is not null
+                    && Int32.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out Int32 sharedStringId)
+                    && sharedStringId >= 0 && sharedStringId < sharedStrings.Length)
+                {
+                    var sharedString = sharedStrings[sharedStringId];
+
+                    SetCellText(xlCell, sharedString);
+                }
+                else
+                    xlCell.SetOnlyValue(String.Empty);
+            }
+            else if (dataType == CellValues.String) // A plain string that is a result of a formula calculation
+            {
+                xlCell.SetOnlyValue(cellValue ?? String.Empty);
+            }
+            else if (dataType == CellValues.Boolean)
+            {
+                if (cellValue is not null)
+                {
+                    var isTrue = string.Equals(cellValue, "1", StringComparison.Ordinal) ||
+                                 string.Equals(cellValue, "TRUE", StringComparison.OrdinalIgnoreCase);
+                    xlCell.SetOnlyValue(isTrue);
+                }
+            }
+            else if (dataType == CellValues.Error)
+            {
+                if (cellValue is not null && XLErrorParser.TryParseError(cellValue, out var error))
+                    xlCell.SetOnlyValue(error);
+            }
+            else if (dataType == CellValues.Date)
+            {
+                // Technically, cell can contain date as ISO8601 string, but not rarely used due
+                // to inconsistencies between ISO and serial date time representation.
+                if (cellValue is not null)
+                {
+                    var date = DateTime.ParseExact(cellValue, DateCellFormats,
+                        XLHelper.ParseCulture,
+                        DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite);
+                    xlCell.SetOnlyValue(date);
+                }
+            }
         }
 
         private static readonly string[] DateCellFormats =
@@ -2169,16 +2242,24 @@ namespace ClosedXML.Excel
 
         private Int32 lastRow;
 
-        private void LoadRows(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders, Fonts fonts,
+        private void LoadRow(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders, Fonts fonts,
                               XLWorksheet ws, SharedStringItem[] sharedStrings,
                               Dictionary<uint, string> sharedFormulasR1C1, Dictionary<Int32, IXLStyle> styleList,
-                              Row row)
+                              OpenXmlPartReader reader)
         {
-            Int32 rowIndex = row.RowIndex == null ? ++lastRow : (Int32)row.RowIndex.Value;
+            Debug.Assert(reader.LocalName == "row");
+
+            var attributes = reader.Attributes;
+            var rowIndexAttr = attributes.GetAttribute("r");
+            var rowIndex = string.IsNullOrEmpty(rowIndexAttr) ? ++lastRow : int.Parse(rowIndexAttr);
+
             var xlRow = ws.Row(rowIndex, false);
 
-            if (row.Height != null)
-                xlRow.Height = row.Height;
+            var height = attributes.GetDoubleAttribute("ht");
+            if (height is not null)
+            {
+                xlRow.Height = height.Value;
+            }
             else
             {
                 xlRow.Loading = true;
@@ -2186,27 +2267,33 @@ namespace ClosedXML.Excel
                 xlRow.Loading = false;
             }
 
-            if (row.DyDescent != null)
-                xlRow.DyDescent = row.DyDescent.Value;
+            var dyDescent = attributes.GetDoubleAttribute("dyDescent", OpenXmlConst.X14Ac2009SsNs);
+            if (dyDescent is not null)
+                xlRow.DyDescent = dyDescent.Value;
 
-            if (row.Hidden != null && row.Hidden)
+            var hiddenAttr = attributes.GetBoolAttribute("hidden", false);
+            if (hiddenAttr)
                 xlRow.Hide();
 
-            if (row.Collapsed != null && row.Collapsed)
+            var collapsed = attributes.GetBoolAttribute("collapsed", false);
+            if (collapsed)
                 xlRow.Collapsed = true;
 
-            if (row.OutlineLevel != null && row.OutlineLevel > 0)
-                xlRow.OutlineLevel = row.OutlineLevel;
+            var outlineLevel = attributes.GetIntAttribute("outlineLevel");
+            if (outlineLevel is not null && outlineLevel.Value > 0)
+                xlRow.OutlineLevel = outlineLevel.Value;
 
-            if (row.ShowPhonetic != null && row.ShowPhonetic.Value)
+            var showPhonetic = attributes.GetBoolAttribute("ph", false);
+            if (showPhonetic)
                 xlRow.ShowPhonetic = true;
 
-            if (row.CustomFormat != null)
+            var customFormat = attributes.GetBoolAttribute("customFormat", false);
+            if (customFormat)
             {
-                Int32 styleIndex = row.StyleIndex != null ? Int32.Parse(row.StyleIndex.InnerText) : -1;
-                if (styleIndex >= 0)
+                var styleIndex = attributes.GetIntAttribute("s");
+                if (styleIndex is not null)
                 {
-                    ApplyStyle(xlRow, styleIndex, s, fills, borders, fonts, numberingFormats);
+                    ApplyStyle(xlRow, styleIndex.Value, s, fills, borders, fonts, numberingFormats);
                 }
                 else
                 {
@@ -2215,9 +2302,22 @@ namespace ClosedXML.Excel
             }
 
             lastColumnNumber = 0;
-            foreach (Cell cell in row.Elements<Cell>())
-                LoadCells(sharedStrings, s, numberingFormats, fills, borders, fonts, sharedFormulasR1C1, ws, styleList,
-                          cell, rowIndex);
+
+            // Move from the start element of 'row' forward. We can get cell, extList or end of row.
+            reader.MoveAhead();
+
+            while (reader.IsStartElement("c"))
+            {
+                LoadCell(sharedStrings, s, numberingFormats, fills, borders, fonts, sharedFormulasR1C1, ws, styleList,
+                    reader, rowIndex);
+
+                // Move from end element of 'cell' either to next cell, extList start or end of row.
+                reader.MoveAhead();
+            }
+
+            // In theory, row can also contain extList, just skip them.
+            while (reader.IsStartElement("extLst"))
+                reader.Skip();
         }
 
         private void LoadColumns(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders,
@@ -2275,7 +2375,6 @@ namespace ClosedXML.Excel
                 }
             }
         }
-
 
         private static XLDataType GetNumberDataType(XLNumberFormatValue numberFormat)
         {
@@ -3453,6 +3552,16 @@ namespace ClosedXML.Excel
             }
 
             return false;
+        }
+
+        private static Exception UnexpectedStreamEnd()
+        {
+            throw new InvalidOperationException("The stream should have contain more XML elements, but has ended instead.");
+        }
+
+        private static Exception MissingRequiredAttr(string attributeName)
+        {
+            throw new InvalidOperationException($"XML doesn't contain required attribute '{attributeName}'.");
         }
     }
 }

--- a/ClosedXML/Extensions/OpenXmlPartReaderExtensions.cs
+++ b/ClosedXML/Extensions/OpenXmlPartReaderExtensions.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using ClosedXML.Excel;
+using ClosedXML.Excel.IO;
+using DocumentFormat.OpenXml;
+
+namespace ClosedXML.Extensions
+{
+    internal static class OpenXmlPartReaderExtensions
+    {
+        internal static bool IsStartElement(this OpenXmlPartReader reader, string localName)
+        {
+            return reader.LocalName == localName && reader.NamespaceUri == OpenXmlConst.Main2006SsNs && reader.IsStartElement;
+        }
+
+        internal static bool IsEndElement(this OpenXmlPartReader reader, string localName)
+        {
+            return reader.LocalName == localName && reader.NamespaceUri == OpenXmlConst.Main2006SsNs && reader.IsEndElement;
+        }
+
+        internal static void MoveAhead(this OpenXmlPartReader reader)
+        {
+            if (!reader.Read())
+                throw new InvalidOperationException("Unexpected end of stream");
+        }
+
+        internal static string? GetAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)
+        {
+            // Don't use foreach, performance critical
+            var length = attributes.Count;
+            for (var i = 0; i < length; ++i)
+            {
+                var attr = attributes[i];
+                if (attr.LocalName == name && string.IsNullOrEmpty(attr.NamespaceUri))
+                    return attr.Value;
+            }
+
+            return null;
+        }
+
+        internal static string? GetAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name, string namespaceUri)
+        {
+            // Don't use foreach, performance critical
+            var length = attributes.Count;
+            for (var i = 0; i < length; ++i)
+            {
+                var attr = attributes[i];
+                if (attr.LocalName == name && attr.NamespaceUri == namespaceUri)
+                    return attr.Value;
+            }
+
+            return null;
+        }
+
+        internal static bool GetBoolAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name, bool defaultValue)
+        {
+            var attribute = attributes.GetAttribute(name);
+            return ParseBool(attribute, defaultValue);
+        }
+
+        internal static int? GetIntAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)
+        {
+            var attribute = attributes.GetAttribute(name);
+            if (!string.IsNullOrEmpty(attribute))
+                return int.Parse(attribute);
+
+            return null;
+        }
+
+        internal static uint? GetUintAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)
+        {
+            var attribute = attributes.GetAttribute(name);
+            if (!string.IsNullOrEmpty(attribute))
+                return uint.Parse(attribute);
+
+            return null;
+        }
+
+        internal static double? GetDoubleAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name, string namespaceUri)
+        {
+            var attribute = attributes.GetAttribute(name, namespaceUri);
+            if (!string.IsNullOrEmpty(attribute))
+                return double.Parse(attribute, NumberStyles.Float, XLHelper.ParseCulture);
+
+            return null;
+        }
+
+        internal static double? GetDoubleAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)
+        {
+            var attribute = attributes.GetAttribute(name);
+            if (!string.IsNullOrEmpty(attribute))
+                return double.Parse(attribute, NumberStyles.Float, XLHelper.ParseCulture);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get value of attribute with type <c>ST_CellRef</c>.
+        /// </summary>
+        internal static XLSheetPoint? GetCellRefAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)
+        {
+            var attribute = attributes.GetAttribute(name);
+            if (!string.IsNullOrEmpty(attribute))
+                return XLSheetPoint.Parse(attribute);
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get value of attribute with type <c>ST_Ref</c>.
+        /// </summary>
+        internal static XLSheetRange? GetRefAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)
+        {
+            var attribute = attributes.GetAttribute(name);
+            if (!string.IsNullOrEmpty(attribute))
+                return XLSheetRange.Parse(attribute);
+
+            return null;
+        }
+
+        private static bool ParseBool(string? input, bool defaultValue)
+        {
+            if (string.IsNullOrEmpty(input))
+                return defaultValue;
+
+            var isTrue = input == "1" || string.Equals("true", input, StringComparison.OrdinalIgnoreCase);
+            if (isTrue)
+                return true;
+
+            var isFalse = input == "0" || string.Equals("false", input, StringComparison.OrdinalIgnoreCase);
+            if (isFalse)
+                return false;
+
+            throw new FormatException($"Unable to parse '{input}' to bool.");
+        }
+    }
+}

--- a/ClosedXML/Extensions/OpenXmlPartReaderExtensions.cs
+++ b/ClosedXML/Extensions/OpenXmlPartReaderExtensions.cs
@@ -14,15 +14,10 @@ namespace ClosedXML.Extensions
             return reader.LocalName == localName && reader.NamespaceUri == OpenXmlConst.Main2006SsNs && reader.IsStartElement;
         }
 
-        internal static bool IsEndElement(this OpenXmlPartReader reader, string localName)
-        {
-            return reader.LocalName == localName && reader.NamespaceUri == OpenXmlConst.Main2006SsNs && reader.IsEndElement;
-        }
-
         internal static void MoveAhead(this OpenXmlPartReader reader)
         {
             if (!reader.Read())
-                throw new InvalidOperationException("Unexpected end of stream");
+                throw new InvalidOperationException("Unexpected end of stream.");
         }
 
         internal static string? GetAttribute(this ReadOnlyCollection<OpenXmlAttribute> attributes, string name)


### PR DESCRIPTION
Originally, rows of a workbook were loaded into a memory as a mini-DOM and then converted to internal structures.

This PR changes loading code, so it doesn't create mini-DOM for each row, but instead streams each element.

It has modest improvements for a speed 
* load of 250k rows, 15 columns (10 text, 5 numbers) has decreased from 20.5s (0.102.1) to 17.5s.
* For 250k x 15 columns of numbers, it decreased from 17.8s  to 14.6s
* For comparison, Excel loads the file in 5 - 6 seconds.

Honestly, I hoped for more, but it there are no easy pickings anymore. I think replacing parser would bring improvements (not very optimal, lot of checking, doesn't use spans...), but that is just not realistic.

*dotTrace* flame graphs:

![image](https://github.com/ClosedXML/ClosedXML/assets/7634052/359c1a6d-40c8-4c85-b11e-23852f72c03e)
![image](https://github.com/ClosedXML/ClosedXML/assets/7634052/ab48b4d9-906f-4286-bd13-b4d9b99351bc)


[large_file_250_000-numbers.xlsx](https://github.com/ClosedXML/ClosedXML/files/12744266/large_file_250_000-numbers.xlsx)
[large_file_250_000.xlsx](https://github.com/ClosedXML/ClosedXML/files/12744267/large_file_250_000.xlsx)
