### PR TITLE
Update language level and use polyfill for missing functions.

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>11.0</LangVersion>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <!-- netstandard 2.0 doesn't contain nullable annotations for BCL, so we want to export
          annotations for our consumers, but no warnings for our code. Warnings will be
@@ -40,6 +41,10 @@
     </PackageReference>
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Polyfill" Version="1.29.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="RBush" Version="3.2.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->

--- a/ClosedXML/Extensions/CompatibilityExtensions.cs
+++ b/ClosedXML/Extensions/CompatibilityExtensions.cs
@@ -20,16 +20,4 @@ namespace System.IO
         }
     }
 }
-
-namespace System
-{
-    internal static class StringCompatibilityExtensions
-    {
-        public static bool Contains(this string s, char c)
-        {
-            return s.IndexOf(c) >= 0;
-        }
-    }
-}
-
 #endif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: 0.103.0.{build}
 
-os: Visual Studio 2019
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 environment:
   AppVeyor: APPVEYOR


### PR DESCRIPTION
The Polyfill library is a development only dependency that has *.cs sources in the .nuget directory. The *.cs files are conditionaly compiled along the project depending on the target and thus more modern version use less polyfills.

The main benefit is ability to use struct records (that require IsExternalInit attribute for init properties), though generally it just allows a modern development even for netstandard2.0 and nullability analysis (e.g. `NotNullWhenAttribute` for `TryGet` pattern).

The polyfills are internal and thus don't pollute applications consuming ClosedXML.