### PR TITLE
Implement 2 missing Excel functions and adapt 2 existing functions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FinancialTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FinancialTests.cs
@@ -43,9 +43,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Fv_ZeroPeriodsReturnsNumError()
+        public void Fv_ZeroPeriodsReturnsPresentValue()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("FV(0.1,0,1000)"));
+            Assert.AreEqual(-100, XLWorkbook.EvaluateExpr("FV(0.1,0,1000, 100)"));
         }
 
         [TestCase("IPMT(0.1/12,1,3*12,8000)", -66.666666666666686)]

--- a/ClosedXML.Tests/Excel/CalcEngine/FinancialTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FinancialTests.cs
@@ -89,6 +89,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("IPMT(0.1,1,-1,1000)"));
         }
 
+        [TestCase(-1)]
+        [TestCase(-1.5)]
+        [TestCase(-100)]
+        public void Ipmt_RateLessOrEqualMinusOneReturnsNumError(double rate)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"IPMT({rate},2,3,1000,10000,1)"));
+        }
+
         [Test]
         public void Ipmt_PeriodOutOfRangeReturnsNumError()
         {
@@ -154,6 +162,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Pmt_ZeroPeriodsReturnsNumError()
         {
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("PMT(0.1,0,1000)"));
+        }
+
+        [TestCase(-1)]
+        [TestCase(-1.5)]
+        [TestCase(-100)]
+        public void Pmt_RateLessOrEqualMinusOneReturnsNumError(double rate)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"PMT({rate},1,1000,5000,1)"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
@@ -179,9 +179,123 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Hlookup()
         {
-            // Range lookup false
-            var value = ws.Evaluate(@"=HLOOKUP(""Total"",Data!$B$2:$I$71,4,FALSE)");
-            Assert.AreEqual(179.64, value);
+            // Since HLOOKUP requires values to be sorted, we can't use created data.
+            using var wb = new XLWorkbook();
+            var sheet = wb.AddWorksheet();
+            sheet.Cell("B2").InsertData(new[]
+            {
+                new object[] { 1, 3, 5, 10 },
+                new object[] { "A", "B", "C", "D" },
+            });
+
+            // Range lookup false = exact match
+            var value = sheet.Evaluate(@"HLOOKUP(3,B2:E3,2,FALSE)");
+            Assert.AreEqual("B", value);
+
+            // Text values are looked up case insensitive.
+            value = sheet.Evaluate(@"HLOOKUP(""c"",B3:E3,1,FALSE)");
+            Assert.AreEqual("C", value);
+
+            // Value not present in the range for exact search
+            // Empty string is not same as blank.
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP("""",A2:E2,1,FALSE)"));
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP(50,B2:E3,1,FALSE)"));
+
+            // Value in approximate search that is lower than first element
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP(-10,B2:E3,2,TRUE)"));
+        }
+
+        [Test]
+        public void Hlookup_UnexpectedArguments()
+        {
+            // Lookup value can't be an error
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"HLOOKUP(#DIV/0!,{1,2},1)"));
+
+            // Text value can't be over 255 chars
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"HLOOKUP(\"{new string('A', 256)}\",{{\"A\"}},1)"));
+
+            // Range can only be array or a reference. If other type, it returns the error #N/A
+            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr(@"HLOOKUP(""value"",1,1)"));
+            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr(@"HLOOKUP(""value"",TRUE,1)"));
+
+            // If range is a non-contiguous range, #N/A
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP(""Units"",(B2:I5,B6:I10),1)"));
+
+            // The row index number must be at most the same as height of the range. It is 5 here, but range is 4 cell high.
+            Assert.AreEqual(XLError.CellReference, ws.Evaluate(@"HLOOKUP(""value"",B2:I5,5,FALSE)"));
+
+            // The row index number must be at least 1. It is 0 here.
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"HLOOKUP(1,{1,2},0,FALSE)"));
+        }
+
+        [Test]
+        public void Hlookup_truncates_row_index_number_parameter()
+        {
+            // If row index number is not a whole number, it is truncated, so here 1.9 is truncated to 1
+            Assert.AreEqual(7, ws.Evaluate(@"HLOOKUP(7,{5,7,9},1.9)"));
+        }
+
+        [Test]
+        public void Hlookup_converts_blank_lookup_value_to_number_zero()
+        {
+            using var wb = new XLWorkbook();
+            var worksheet = wb.AddWorksheet();
+            worksheet.Cell("A1").InsertData(new[]
+            {
+                new object[] { -1, 0, 1 },
+                new object[] { "-one", "zero", "one"},
+            });
+
+            var actual = worksheet.Evaluate("HLOOKUP(IF(TRUE,,),A1:C2,2)");
+
+            Assert.AreEqual("zero", actual);
+        }
+
+        [Test]
+        public void Hlookup_approximate_search_omits_values_with_different_type()
+        {
+            using var wb = new XLWorkbook();
+            var worksheet = wb.AddWorksheet();
+            worksheet.Cell("A1").Value = "0";
+            worksheet.Cell("B1").Value = "1";
+            worksheet.Cell("C1").Value = 1;
+            worksheet.Cell("D1").Value = "0";
+            worksheet.Cell("E1").Value = "text";
+            worksheet.Cell("F1").Value = Blank.Value;
+            worksheet.Cell("G1").Value = 2;
+            worksheet.Cell("A2").InsertData(Enumerable.Range(1, 7).Select(x => $"Column {x}"), true);
+
+            var actual = worksheet.Evaluate("HLOOKUP(1.9,A1:G2,2,TRUE)");
+            Assert.AreEqual("Column 3", actual);
+        }
+
+        [Test]
+        public void Hlookup_with_range_containing_only_cells_with_different_type_returns_NA_error()
+        {
+            using var wb = new XLWorkbook();
+            var sheet = wb.AddWorksheet();
+            sheet.Cell("A1").Value = "text";
+            Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate("HLOOKUP(1,A1,1,TRUE)"));
+        }
+
+        [Test]
+        public void Hlookup_approximate_search_returns_last_column_for_multiple_equal_values()
+        {
+            var wb = new XLWorkbook();
+            var sheet = wb.AddWorksheet();
+            sheet.Cell("A1").InsertData(new object[]
+            {
+                new object[] { 1, 3, 3, 3, 3, 3, 3, 9 },
+                new object[] { "A", "B", "C", "D", "E", "F", "G", "H" },
+            });
+
+            // If there is a section of values with same value, return the value at the highest column
+            var actual = sheet.Evaluate("HLOOKUP(3, A1:H2, 2, TRUE)");
+            Assert.AreEqual("G", actual);
+
+            // If the last value is in the highest column, just return value outright
+            actual = sheet.Evaluate("HLOOKUP(3, B1:G2, 2, TRUE)");
+            Assert.AreEqual("G", actual);
         }
 
         [Test]
@@ -384,7 +498,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Vlookup()
         {
-            // Range lookup false
+            // Range lookup false = exact match
             var value = ws.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,3,FALSE)");
             Assert.AreEqual("Central", value);
 
@@ -398,7 +512,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = ws.Evaluate(@"=VLOOKUP(""central"",Data!D:E,2,FALSE)");
             Assert.AreEqual("Kivell", value);
 
-            // Range lookup true
+            // Range lookup true = approximate match
             value = ws.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,8,TRUE)");
             Assert.AreEqual(179.64, value);
 
@@ -505,7 +619,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Vlookup_OnlyOneValueSurreoundedByIgnoredTypes()
+        public void Vlookup_OnlyOneValueSurroundedByIgnoredTypes()
         {
             using var wb = new XLWorkbook();
             var worksheet = wb.AddWorksheet();

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -17,6 +17,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hiragana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HLOOKUP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IFERROR/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=IPMT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISBLANK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISREF/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formulae/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=furigana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hiragana/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HLOOKUP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IFERROR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISBLANK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISNA/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/Financial.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Financial.cs
@@ -26,10 +26,10 @@ namespace ClosedXML.Excel.CalcEngine
             // DOLLARFR Converts a dollar price, expressed as a decimal number, into a dollar price, expressed as a fraction
             // DURATION Returns the annual duration of a security with periodic interest payments
             // EFFECT Returns the effective annual interest rate
-            ce.RegisterFunction("FV", 3, 5, AdaptLastTwoOptional(Fv), FunctionFlags.Scalar); // Returns the future value of an investment
+            ce.RegisterFunction("FV", 3, 5, AdaptLastTwoOptional(Fv, 0, 0), FunctionFlags.Scalar); // Returns the future value of an investment
             // FVSCHEDULE Returns the future value of an initial principal after applying a series of compound interest rates
             // INTRATE Returns the interest rate for a fully invested security
-            ce.RegisterFunction("IPMT", 4, 6, AdaptLastTwoOptional(Ipmt), FunctionFlags.Scalar); // Returns the interest payment for an investment for a given period
+            ce.RegisterFunction("IPMT", 4, 6, AdaptLastTwoOptional(Ipmt, 0, 0), FunctionFlags.Scalar); // Returns the interest payment for an investment for a given period
             // IRR Returns the internal rate of return for a series of cash flows
             // ISPMT Calculates the interest paid during a specific period of an investment
             // MDURATION Returns the Macauley modified duration for a security with an assumed par value of $100
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
             // ODDLPRICE Returns the price per $100 face value of a security with an odd last period
             // ODDLYIELD Returns the yield of a security with an odd last period
             // PDURATION Returns the number of periods required by an investment to reach a specified value
-            ce.RegisterFunction("PMT", 3, 5, AdaptLastTwoOptional(Pmt), FunctionFlags.Scalar); // Returns the periodic payment for an annuity
+            ce.RegisterFunction("PMT", 3, 5, AdaptLastTwoOptional(Pmt, 0, 0), FunctionFlags.Scalar); // Returns the periodic payment for an annuity
             // PPMT Returns the payment on the principal for an investment for a given period
             // PRICE Returns the price per $100 face value of a security that pays periodic interest
             // PRICEDISC Returns the price per $100 face value of a discounted security
@@ -64,7 +64,7 @@ namespace ClosedXML.Excel.CalcEngine
             // YIELDMAT Returns the annual yield of a security that pays interest at maturity
         }
 
-        private static AnyValue Fv(double rate, double numberOfPayments, double pmt, double presentValue, bool type)
+        private static AnyValue Fv(double rate, double numberOfPayments, double pmt, double presentValue, double type)
         {
             if (numberOfPayments == 0)
                 return XLError.NumberInvalid;
@@ -72,18 +72,18 @@ namespace ClosedXML.Excel.CalcEngine
             return FvInternal(rate, numberOfPayments, pmt, presentValue, type);
         }
 
-        private static double FvInternal(double rate, double numberOfPayments, double pmt, double presentValue, bool type)
+        private static double FvInternal(double rate, double numberOfPayments, double pmt, double presentValue, double type)
         {
             if (rate == 0.0)
                 return -(pmt * numberOfPayments + presentValue);
 
-            if (type)
+            if (type != 0.0)
                 pmt *= (1 + rate);
 
             return -(pmt * (Math.Pow(1 + rate, numberOfPayments) - 1) / rate + presentValue * Math.Pow(1 + rate, numberOfPayments));
         }
 
-        private static AnyValue Ipmt(double rate, double period, double numberOfPayments, double presentValue, double futureValue, bool type)
+        private static AnyValue Ipmt(double rate, double period, double numberOfPayments, double presentValue, double futureValue, double type)
         {
             if (numberOfPayments <= 0)
                 return XLError.NumberInvalid;
@@ -95,13 +95,13 @@ namespace ClosedXML.Excel.CalcEngine
 
             double ipmt = FvInternal(rate, period - 1, PmtInternal(rate, numberOfPayments, presentValue, futureValue, type), presentValue, type) * rate;
 
-            if (type)
+            if (type != 0.0)
                 ipmt /= (1 + rate);
 
             return ipmt;
         }
 
-        private static AnyValue Pmt(double rate, double numberOfPayments, double presentValue, double futureValue, bool type)
+        private static AnyValue Pmt(double rate, double numberOfPayments, double presentValue, double futureValue, double type)
         {
             if (numberOfPayments == 0)
                 return XLError.NumberInvalid;
@@ -109,14 +109,14 @@ namespace ClosedXML.Excel.CalcEngine
             return PmtInternal(rate, numberOfPayments, presentValue, futureValue, type);
         }
 
-        private static double PmtInternal(double rate, double numberOfPayments, double presentValue, double futureValue, bool type)
+        private static double PmtInternal(double rate, double numberOfPayments, double presentValue, double futureValue, double type)
         {
             if (rate == 0.0)
                 return -(presentValue + futureValue) / numberOfPayments;
 
             const int paymentAtTheEndOfPeriod = 0;
             const int paymentAtTheBeginningOfPeriod = 1;
-            var timingOffset = type ? paymentAtTheBeginningOfPeriod : paymentAtTheEndOfPeriod;
+            var timingOffset = type != 0.0 ? paymentAtTheBeginningOfPeriod : paymentAtTheEndOfPeriod;
 
             return (-futureValue - presentValue * Math.Pow(1.0 + rate, numberOfPayments)) /
                (1 + rate * timingOffset) / ((Math.Pow(1.0 + rate, numberOfPayments) - 1) / rate);

--- a/ClosedXML/Excel/CalcEngine/Functions/Financial.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Financial.cs
@@ -85,7 +85,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue Ipmt(double rate, double period, double numberOfPayments, double presentValue, double futureValue, double type)
         {
-            if (numberOfPayments <= 0)
+            if (numberOfPayments <= 0 || rate <= -1)
                 return XLError.NumberInvalid;
 
             numberOfPayments = Math.Ceiling(numberOfPayments);
@@ -103,7 +103,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue Pmt(double rate, double numberOfPayments, double presentValue, double futureValue, double type)
         {
-            if (numberOfPayments == 0)
+            if (numberOfPayments == 0 || rate <= -1)
                 return XLError.NumberInvalid;
 
             return PmtInternal(rate, numberOfPayments, presentValue, futureValue, type);

--- a/ClosedXML/Excel/CalcEngine/Functions/Financial.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Financial.cs
@@ -67,7 +67,7 @@ namespace ClosedXML.Excel.CalcEngine
         private static AnyValue Fv(double rate, double numberOfPayments, double pmt, double presentValue, double type)
         {
             if (numberOfPayments == 0)
-                return XLError.NumberInvalid;
+                return -presentValue;
 
             return FvInternal(rate, numberOfPayments, pmt, presentValue, type);
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
@@ -94,14 +94,16 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (!flagValue.IsBlank && !flagValue.TryCoerceLogicalOrBlankOrNumberOrText(out approximateSearchFlag, out var flagError))
                 return flagError;
 
+            // If TRUE or omitted
             if (approximateSearchFlag)
             {
                 // Bisection in Excel and here differs, so we return different values for unsorted ranges, but same values for sorted ranges.
-                var foundRow = Bisection(array, lookupValue);
-                if (foundRow == -1)
+                var transposedArray = new TransposedArray(array);
+                var foundColumn = Bisection(transposedArray, lookupValue);
+                if (foundColumn == -1)
                     return XLError.NoValueAvailable;
 
-                return array[rowIdx - 1, foundRow].ToAnyValue();
+                return array[rowIdx - 1, foundColumn].ToAnyValue();
             }
             else
             {

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -223,6 +223,50 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, double, bool, AnyValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToNumber(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2Converted = ToNumber(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                var arg3Converted = ToNumber(args[3], ctx);
+                if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                    return err3;
+
+                var arg4Optional = 0d;
+                if (args.Length >= 5)
+                {
+                    var arg4Converted = ToNumber(args[4], ctx);
+                    if (!arg4Converted.TryPickT0(out var arg4, out var err4))
+                        return err4;
+
+                    arg4Optional = arg4;
+                }
+
+                var arg5Optional = false;
+                if (args.Length >= 6)
+                {
+                    var arg5Converted = CoerceToLogical(args[5], ctx);
+                    if (!arg5Converted.TryPickT0(out var arg5, out var err5))
+                        return err5;
+
+                    arg5Optional = arg5;
+                }
+
+                return f(arg0, arg1, arg2, arg3, arg4Optional, arg5Optional);
+            };
+        }
+
         #endregion
 
         #region Value converters

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -183,6 +183,46 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, bool, AnyValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToNumber(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2Converted = ToNumber(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                var arg3Optional = 0d;
+                if (args.Length >= 4)
+                {
+                    var arg3Converted = ToNumber(args[3], ctx);
+                    if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                        return err3;
+
+                    arg3Optional = arg3;
+                }
+
+                var arg4Optional = false;
+                if (args.Length >= 5)
+                {
+                    var arg4Converted = CoerceToLogical(args[4], ctx);
+                    if (!arg4Converted.TryPickT0(out var arg4, out var err4))
+                        return err4;
+
+                    arg4Optional = arg4;
+                }
+
+                return f(arg0, arg1, arg2, arg3Optional, arg4Optional);
+            };
+        }
+
         #endregion
 
         #region Value converters

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace ClosedXML.Excel.CalcEngine.Functions
 {
@@ -176,6 +177,28 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                     return err2;
 
                 var arg3Converted = args.Length >= 4 ? ToScalarValue(args[3], ctx) : ScalarValue.Blank;
+                if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                    return err3;
+
+                return f(ctx, arg0, arg1, arg2, arg3);
+            };
+        }
+
+        public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, ScalarValue, AnyValue, double, bool, AnyValue> f, bool defaultValue0)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToScalarValue(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1 = args[1];
+
+                var arg2Converted = ToNumber(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                var arg3Converted = args.Length >= 4 ? CoerceToLogical(args[3], ctx) : defaultValue0;
                 if (!arg3Converted.TryPickT0(out var arg3, out var err3))
                     return err3;
 

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -206,7 +206,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, bool, AnyValue> f)
+        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, double, AnyValue> f, double defaultValue0, double defaultValue1)
         {
             return (ctx, args) =>
             {
@@ -222,7 +222,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg2Converted.TryPickT0(out var arg2, out var err2))
                     return err2;
 
-                var arg3Optional = 0d;
+                var arg3Optional = defaultValue0;
                 if (args.Length >= 4)
                 {
                     var arg3Converted = ToNumber(args[3], ctx);
@@ -232,10 +232,10 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                     arg3Optional = arg3;
                 }
 
-                var arg4Optional = false;
+                var arg4Optional = defaultValue1;
                 if (args.Length >= 5)
                 {
-                    var arg4Converted = CoerceToLogical(args[4], ctx);
+                    var arg4Converted = ToNumber(args[4], ctx);
                     if (!arg4Converted.TryPickT0(out var arg4, out var err4))
                         return err4;
 
@@ -246,7 +246,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, double, bool, AnyValue> f)
+        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, double, double, AnyValue> f, double defaultValue0, double defaultValue1)
         {
             return (ctx, args) =>
             {
@@ -266,7 +266,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg3Converted.TryPickT0(out var arg3, out var err3))
                     return err3;
 
-                var arg4Optional = 0d;
+                var arg4Optional = defaultValue0;
                 if (args.Length >= 5)
                 {
                     var arg4Converted = ToNumber(args[4], ctx);
@@ -276,10 +276,10 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                     arg4Optional = arg4;
                 }
 
-                var arg5Optional = false;
+                var arg5Optional = defaultValue1;
                 if (args.Length >= 6)
                 {
-                    var arg5Converted = CoerceToLogical(args[5], ctx);
+                    var arg5Converted = ToNumber(args[5], ctx);
                     if (!arg5Converted.TryPickT0(out var arg5, out var err5))
                         return err5;
 

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using ClosedXML.Extensions;
 

--- a/docs/features/functions.rst
+++ b/docs/features/functions.rst
@@ -355,7 +355,7 @@ Standard functions
      - No
 
    * - FV
-     - No
+     - YES
 
    * - FVSCHEDULE
      - No
@@ -364,7 +364,7 @@ Standard functions
      - No
 
    * - IPMT
-     - No
+     - YES
 
    * - IRR
      - No


### PR DESCRIPTION
This branch started with an investigation into some bugs I encountered where under certain circumstances, the `PMT` and `HLOOKUP` functions could get into an infinite calculation loop if they referenced cells that hadn't been calculated yet.

Changing them over to the new `Adapt` function structure solved that issue for me as that auto handles missing values in the new calc-chain system. Adapting `PMT` was very straightforward, and for `HLOOKUP` I basically just copied the implementation for `VLOOKUP`, which had already been changed to `Adapt`, and switched row/column lookups around.

In the same spreadsheet I was also seeing errors because the `IPMT` function was being used in the spreadsheet but hadn't been implemented in ClosedXML, so while I was in there I also implemented `IPMT` and `FV` (which the `IPMT` calculation depends on).