### PR TITLE
Make XLCell GetFormat public

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -378,6 +378,11 @@ namespace ClosedXML.Excel
         String GetFormattedString(CultureInfo culture = null);
 
         /// <summary>
+        /// Gets the format string used by <see cref="GetFormattedString"/> to format and render the numeric value of a cell.
+        /// </summary>
+        String GetFormat();
+
+        /// <summary>
         /// Returns a hyperlink for the cell, if any, or creates a new instance is there is no hyperlink.
         /// </summary>
         XLHyperlink GetHyperlink();

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -494,6 +494,21 @@ namespace ClosedXML.Excel
                 : value.ToString(culture);
         }
 
+        public string GetFormat()
+        {
+            var style = GetStyleForRead();
+            if (String.IsNullOrWhiteSpace(style.NumberFormat.Format))
+            {
+                var formatCodes = XLPredefinedFormat.FormatCodes;
+                if (formatCodes.TryGetValue(style.NumberFormat.NumberFormatId, out string format))
+                    return format;
+                else
+                    return string.Empty;
+            }
+            else
+                return style.NumberFormat.Format;
+        }
+
         public void InvalidateFormula()
         {
             if (Formula is null)
@@ -1148,21 +1163,6 @@ namespace ClosedXML.Excel
         public void DeleteSparkline()
         {
             Clear(XLClearOptions.Sparklines);
-        }
-
-        private string GetFormat()
-        {
-            var style = GetStyleForRead();
-            if (String.IsNullOrWhiteSpace(style.NumberFormat.Format))
-            {
-                var formatCodes = XLPredefinedFormat.FormatCodes;
-                if (formatCodes.TryGetValue(style.NumberFormat.NumberFormatId, out string format))
-                    return format;
-                else
-                    return string.Empty;
-            }
-            else
-                return style.NumberFormat.Format;
         }
 
         public IXLCell CopyFrom(IXLRangeBase rangeObject)


### PR DESCRIPTION
Very small PR: just makes `XLCell.GetFormat` public, and exposes it within the `IXLCell` interface.

This is useful in cases like mine where I have a web backend that handles reading of spreadsheets and calculating cell values, but I want to leave the formatting of the values to a web frontend for speed or culture-specific formatting reasons. In cases like that, I need to be able to read the format value in the backend to pass it to the frontend.