### PR TITLE
Remove multiple enumerations

### DIFF
--- a/ClosedXML.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using ClosedXML.Excel;
 using ClosedXML.Tests.Excel;
 using NUnit.Framework;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,6 +45,19 @@ namespace ClosedXML.Tests.Extensions
             actualType = obj.GetItemType().ToString();
             Assert.True(actualType.StartsWith(expectedTypeStart));
             Assert.True(actualType.EndsWith(expectedTypeEnd));
+        }
+
+        [Test]
+        public void SkipLast_skips_last_element_of_enumerable()
+        {
+            var empty = Array.Empty<int>().SkipLast();
+            CollectionAssert.IsEmpty(empty);
+
+            var oneElement = new[] { 1 }.SkipLast();
+            CollectionAssert.IsEmpty(oneElement);
+
+            var twoElements = new[] { 1, 2 }.SkipLast();
+            CollectionAssert.AreEqual(new[] { 1 }, twoElements);
         }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -268,27 +268,19 @@ namespace ClosedXML.Excel
         {
             var column = _autoFilter.Range.Column(_column);
             var subColumn = column.Column(2, column.CellCount());
-            var cellsUsed = subColumn.CellsUsed(c => c.DataType == XLDataType.Number);
-            if (takeTop)
-            {
-                if (type == XLTopBottomType.Items)
-                {
-                    return cellsUsed.Select(c => c.GetDouble()).OrderByDescending(d => d).Take(value).Distinct();
-                }
-
-                var numerics1 = cellsUsed.Select(c => c.GetDouble());
-                Int32 valsToTake1 = numerics1.Count() * value / 100;
-                return numerics1.OrderByDescending(d => d).Take(valsToTake1).Distinct();
-            }
+            var columnNumbers = subColumn.CellsUsed(c => c.DataType == XLDataType.Number).Select(c => c.GetDouble());
+            var comparer = takeTop
+                ? Comparer<double>.Create((x, y) => -x.CompareTo(y))
+                : Comparer<double>.Create((x, y) => x.CompareTo(y));
 
             if (type == XLTopBottomType.Items)
             {
-                return cellsUsed.Select(c => c.GetDouble()).OrderBy(d => d).Take(value).Distinct();
+                return columnNumbers.OrderBy(d => d, comparer).Take(value).Distinct();
             }
 
-            var numerics = cellsUsed.Select(c => c.GetDouble());
-            Int32 valsToTake = numerics.Count() * value / 100;
-            return numerics.OrderBy(d => d).Take(valsToTake).Distinct();
+            var numerics1 = columnNumbers;
+            Int32 valsToTake1 = numerics1.Count() * value / 100;
+            return numerics1.OrderBy(d => d, comparer).Take(valsToTake1).Distinct();
         }
 
         private void ShowAverage(Boolean aboveAverage)

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -367,7 +367,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return return_date;
         }
 
-        private static DateTime Workday(DateTime startDate, DateTime testDate, int daysRequired, IEnumerable<DateTime> bankHolidays)
+        private static DateTime Workday(DateTime startDate, DateTime testDate, int daysRequired, IReadOnlyCollection<DateTime> bankHolidays)
         {
             var businessDays = BusinessDaysUntil(startDate, testDate, bankHolidays);
             if (businessDays == daysRequired)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -1073,10 +1073,11 @@ namespace ClosedXML.Excel.CalcEngine
                     i++;
                 return i;
             })
-            .Distinct();
+            .Distinct()
+            .ToArray();
 
             // All parameters should have the same length
-            if (counts.Count() > 1)
+            if (counts.Length > 1)
                 return XLError.NoValueAvailable;
 
             var values = p

--- a/ClosedXML/Excel/ContentManagers/XLBaseContentManager.cs
+++ b/ClosedXML/Excel/ContentManagers/XLBaseContentManager.cs
@@ -5,11 +5,7 @@ using System.Linq;
 
 namespace ClosedXML.Excel.ContentManagers
 {
-    internal abstract class XLBaseContentManager
-    {
-    }
-
-    internal abstract class XLBaseContentManager<T> : XLBaseContentManager
+    internal abstract class XLBaseContentManager<T>
         where T : struct, Enum
 
     {

--- a/ClosedXML/Excel/ContentManagers/XLBaseContentManager.cs
+++ b/ClosedXML/Excel/ContentManagers/XLBaseContentManager.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel.ContentManagers
         where T : struct, Enum
 
     {
-        protected readonly Dictionary<T, OpenXmlElement> contents = new();
+        protected readonly Dictionary<T, OpenXmlElement?> contents = new();
 
         public OpenXmlElement? GetPreviousElementFor(T content)
         {
@@ -21,14 +21,16 @@ namespace ClosedXML.Excel.ContentManagers
             var i = (int)(ValueType)content;
 
             var previousElements = contents
-                .Where(kv => (int)(ValueType)kv.Key < i && kv.Value is not null)
-                .OrderBy(kv => (int)(ValueType)kv.Key)
-                .Select(x => x.Value);
-            var previousElement = previousElements.LastOrDefault();
+                .Where(kv => (int)(ValueType)kv.Key < i && kv.Value is not null);
+
+            // If there is no previous element, return null.
+            var previousElement = previousElements
+                .DefaultIfEmpty(new KeyValuePair<T, OpenXmlElement?>(default, null))
+                .MaxBy(kv => kv.Key).Value;
             return previousElement;
         }
 
-        public void SetElement(T content, OpenXmlElement element)
+        public void SetElement(T content, OpenXmlElement? element)
         {
             contents[content] = element;
         }

--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -126,10 +126,11 @@ namespace ClosedXML.Excel
                 .Where(c => c.RangeAddress.Contains(rangeAddress.FirstAddress) &&
                             c.RangeAddress.Contains(rangeAddress.LastAddress));
 
-            if (!candidates.Any())
+            var candidate = candidates.FirstOrDefault();
+            if (candidate is null)
                 return false;
 
-            dataValidation = candidates.First().DataValidation;
+            dataValidation = candidate.DataValidation;
 
             return true;
         }

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -51,10 +51,8 @@ namespace ClosedXML.Excel.Drawings
 
             // Calculate default picture ID
             var allPictures = worksheet.Workbook.Worksheets.SelectMany(ws => ws.Pictures);
-            if (allPictures.Any())
-                this._id = allPictures.Max(p => p.Id) + 1;
-            else
-                this._id = 1;
+            var freeId = allPictures.Select(x => x.Id).DefaultIfEmpty(0).Max() + 1;
+            _id = freeId;
         }
 
         public IXLCell BottomRightCell

--- a/ClosedXML/Excel/Drawings/XLPictures.cs
+++ b/ClosedXML/Excel/Drawings/XLPictures.cs
@@ -127,10 +127,10 @@ namespace ClosedXML.Excel.Drawings
 
         public bool TryGetPicture(string pictureName, out IXLPicture? picture)
         {
-            var matches = _pictures.Where(p => p.Name.Equals(pictureName, StringComparison.OrdinalIgnoreCase));
-            if (matches.Any())
+            var match = _pictures.FirstOrDefault(p => p.Name.Equals(pictureName, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
             {
-                picture = matches.First();
+                picture = match;
                 return true;
             }
             picture = null;

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -645,8 +645,8 @@ namespace ClosedXML.Excel.IO
                 }
             }
 
-            var exlst = from c in xlWorksheet.ConditionalFormats where c.ConditionalFormatType == XLConditionalFormatType.DataBar && typeof(IXLConditionalFormat).IsAssignableFrom(c.GetType()) select c;
-            if (exlst != null && exlst.Any())
+            var exlst = xlWorksheet.ConditionalFormats.Where(c => c.ConditionalFormatType == XLConditionalFormatType.DataBar).ToArray();
+            if (exlst.Any())
             {
                 if (!worksheet.Elements<WorksheetExtensionList>().Any())
                 {
@@ -1195,7 +1195,7 @@ namespace ClosedXML.Excel.IO
 
                 var rowBreaks = worksheet.Elements<RowBreaks>().First();
 
-                var existingBreaks = rowBreaks.ChildElements.OfType<Break>();
+                var existingBreaks = rowBreaks.ChildElements.OfType<Break>().ToArray();
                 var rowBreaksToDelete = existingBreaks
                     .Where(rb => !rb.Id.HasValue ||
                                  !xlWorksheet.PageSetup.RowBreaks.Contains((int)rb.Id.Value))
@@ -1242,7 +1242,7 @@ namespace ClosedXML.Excel.IO
 
                 var columnBreaks = worksheet.Elements<ColumnBreaks>().First();
 
-                var existingBreaks = columnBreaks.ChildElements.OfType<Break>();
+                var existingBreaks = columnBreaks.ChildElements.OfType<Break>().ToArray();
                 var columnBreaksToDelete = existingBreaks
                     .Where(cb => !cb.Id.HasValue ||
                                  !xlWorksheet.PageSetup.ColumnBreaks.Contains((int)cb.Id.Value))

--- a/ClosedXML/Excel/PageSetup/XLHeaderFooter.cs
+++ b/ClosedXML/Excel/PageSetup/XLHeaderFooter.cs
@@ -73,7 +73,7 @@ namespace ClosedXML.Excel
             public string Text;
         }
 
-        private static IEnumerable<ParsedHeaderFooterElement> ParseFormattedHeaderFooterText(string text)
+        private static List<ParsedHeaderFooterElement> ParseFormattedHeaderFooterText(string text)
         {
             Func<int, bool> IsAtPositionIndicator = i => i < text.Length - 1 && text[i] == '&' && (new char[] { 'L', 'C', 'R' }.Contains(text[i + 1]));
 

--- a/ClosedXML/Excel/Patterns/Quadrant.cs
+++ b/ClosedXML/Excel/Patterns/Quadrant.cs
@@ -21,7 +21,7 @@ namespace ClosedXML.Excel.Patterns
         /// <summary>
         /// Smaller quadrants which the current one is split to. Is NULL until ranges are added to child quadrants.
         /// </summary>
-        public IEnumerable<Quadrant> Children { get; private set; }
+        public IReadOnlyList<Quadrant> Children { get; private set; }
 
         /// <summary>
         /// The level of current quadrant. Top most has level 0, child quadrants has levels (Level + 1).

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -35,7 +35,7 @@ namespace ClosedXML.Excel
             IXLRanges retVal = new XLRanges();
             foreach (var ws in worksheets)
             {
-                var matrix = new XLRangeConsolidationMatrix(ws, _allRanges.Where(r => r.Worksheet == ws));
+                var matrix = new XLRangeConsolidationMatrix(ws, _allRanges.Where(r => r.Worksheet == ws).ToList());
                 var consRanges = matrix.GetConsolidatedRanges();
                 foreach (var consRange in consRanges)
                 {
@@ -69,7 +69,7 @@ namespace ClosedXML.Excel
             /// </summary>
             /// <param name="worksheet">Current worksheet.</param>
             /// <param name="ranges">Ranges to be consolidated. They are expected to belong to the current worksheet, no check is performed.</param>
-            public XLRangeConsolidationMatrix(IXLWorksheet worksheet, IEnumerable<IXLRange> ranges)
+            public XLRangeConsolidationMatrix(IXLWorksheet worksheet, IReadOnlyCollection<IXLRange> ranges)
             {
                 _worksheet = worksheet;
                 PrepareBitMatrix(ranges);

--- a/ClosedXML/Excel/Tables/XLTable.cs
+++ b/ClosedXML/Excel/Tables/XLTable.cs
@@ -873,11 +873,11 @@ namespace ClosedXML.Excel
 
         public IXLRange AppendData(IEnumerable data, bool transpose, Boolean propagateExtraColumns = false)
         {
-            var castedData = data?.Cast<object>();
-            if (!(castedData?.Any() ?? false) || data is String)
+            var castedData = data?.Cast<object>().ToArray() ?? Array.Empty<object>();
+            if (!castedData.Any() || data is String)
                 return null;
 
-            var numberOfNewRows = castedData.Count();
+            var numberOfNewRows = castedData.Length;
 
             var lastRowOfOldRange = this.DataRange.LastRow();
             lastRowOfOldRange.InsertRowsBelow(numberOfNewRows);
@@ -897,10 +897,11 @@ namespace ClosedXML.Excel
 
         public IXLRange AppendData<T>(IEnumerable<T> data, Boolean propagateExtraColumns = false)
         {
-            if (!(data?.Any() ?? false) || data is String)
+            var materializedData = data?.ToArray() ?? Array.Empty<T>();
+            if (!materializedData.Any() || data is String)
                 return null;
 
-            var numberOfNewRows = data.Count();
+            var numberOfNewRows = materializedData.Length;
 
             if (numberOfNewRows == 0)
                 return null;
@@ -909,7 +910,7 @@ namespace ClosedXML.Excel
             lastRowOfOldRange.InsertRowsBelow(numberOfNewRows);
             this.Fields.Cast<XLTableField>().ForEach(f => f.Column = null);
 
-            var insertedRange = lastRowOfOldRange.RowBelow().FirstCell().InsertData(data);
+            var insertedRange = lastRowOfOldRange.RowBelow().FirstCell().InsertData(materializedData);
 
             PropagateExtraColumns(insertedRange.ColumnCount(), lastRowOfOldRange.RowNumber());
 
@@ -923,15 +924,15 @@ namespace ClosedXML.Excel
 
         public IXLRange ReplaceData(IEnumerable data, bool transpose, Boolean propagateExtraColumns = false)
         {
-            var castedData = data?.Cast<object>();
-            if (!(castedData?.Any() ?? false) || data is String)
+            var castedData = data?.Cast<object>().ToArray() ?? Array.Empty<object>();
+            if (!castedData.Any() || data is String)
                 throw new InvalidOperationException("Cannot replace table data with empty enumerable.");
 
             var firstDataRowNumber = this.DataRange.FirstRow().RowNumber();
             var lastDataRowNumber = this.DataRange.LastRow().RowNumber();
 
             // Resize table
-            var sizeDifference = castedData.Count() - this.DataRange.RowCount();
+            var sizeDifference = castedData.Length - this.DataRange.RowCount();
             if (sizeDifference > 0)
                 this.DataRange.LastRow().InsertRowsBelow(sizeDifference);
             else if (sizeDifference < 0)
@@ -966,14 +967,15 @@ namespace ClosedXML.Excel
 
         public IXLRange ReplaceData<T>(IEnumerable<T> data, Boolean propagateExtraColumns = false)
         {
-            if (!(data?.Any() ?? false) || data is String)
+            var materializedData = data?.ToArray() ?? Array.Empty<T>();
+            if (!materializedData.Any() || data is String)
                 throw new InvalidOperationException("Cannot replace table data with empty enumerable.");
 
             var firstDataRowNumber = this.DataRange.FirstRow().RowNumber();
             var lastDataRowNumber = this.DataRange.LastRow().RowNumber();
 
             // Resize table
-            var sizeDifference = data.Count() - this.DataRange.RowCount();
+            var sizeDifference = materializedData.Length - DataRange.RowCount();
             if (sizeDifference > 0)
                 this.DataRange.LastRow().InsertRowsBelow(sizeDifference);
             else if (sizeDifference < 0)
@@ -993,7 +995,7 @@ namespace ClosedXML.Excel
                 // Invalidate table fields' columns
                 this.Fields.Cast<XLTableField>().ForEach(f => f.Column = null);
 
-            var replacedRange = this.DataRange.FirstCell().InsertData(data);
+            var replacedRange = this.DataRange.FirstCell().InsertData(materializedData);
 
             if (propagateExtraColumns)
                 PropagateExtraColumns(replacedRange.ColumnCount(), lastDataRowNumber);

--- a/ClosedXML/Excel/Tables/XLTableField.cs
+++ b/ClosedXML/Excel/Tables/XLTableField.cs
@@ -173,7 +173,7 @@ namespace ClosedXML.Excel
                 .Select(c => c.DataType);
 
             if (this.table.ShowTotalsRow)
-                dataTypes = dataTypes.Take(dataTypes.Count() - 1);
+                dataTypes = dataTypes.SkipLast();
 
             var distinctDataTypes = dataTypes
                 .GroupBy(dt => dt)
@@ -190,7 +190,7 @@ namespace ClosedXML.Excel
                 .Select(c => c.FormulaR1C1);
 
             if (this.table.ShowTotalsRow)
-                formulas = formulas.Take(formulas.Count() - 1);
+                formulas = formulas.SkipLast();
 
             var distinctFormulas = formulas
                 .GroupBy(f => f)
@@ -208,7 +208,7 @@ namespace ClosedXML.Excel
                 .Select(c => c.StyleValue);
 
             if (this.table.ShowTotalsRow)
-                styles = styles.Take(styles.Count() - 1);
+                styles = styles.SkipLast();
 
             var distinctStyles = styles
                 .Distinct();

--- a/ClosedXML/Excel/XLWorkbook_ImageHandling.cs
+++ b/ClosedXML/Excel/XLWorkbook_ImageHandling.cs
@@ -18,11 +18,7 @@ namespace ClosedXML.Excel
                 .Where(wsdr => wsdr.Descendants<Xdr.BlipFill>()
                     .Any(x => x?.Blip?.Embed?.Value.Equals(relId) ?? false)
                 );
-
-            if (!matchingAnchor.Any())
-                return null;
-            else
-                return matchingAnchor.First();
+            return matchingAnchor.FirstOrDefault();
         }
 
         public static OpenXmlElement GetAnchorFromImageIndex(WorksheetPart worksheetPart, Int32 index)
@@ -33,10 +29,7 @@ namespace ClosedXML.Excel
                     .Any(x => x.Id.Value.Equals(Convert.ToUInt32(index + 1)))
                 );
 
-            if (!matchingAnchor.Any())
-                return null;
-            else
-                return matchingAnchor.First();
+            return matchingAnchor.FirstOrDefault();
         }
 
         public static NonVisualDrawingProperties GetPropertiesFromAnchor(OpenXmlElement anchor)

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -28,12 +28,12 @@ namespace ClosedXML.Excel
         {
             var backupCulture = Thread.CurrentThread.CurrentCulture;
 
-            IEnumerable<ValidationErrorInfo> errors;
+            IList<ValidationErrorInfo> errors;
             try
             {
                 Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
                 var validator = new OpenXmlValidator();
-                errors = validator.Validate(package);
+                errors = validator.Validate(package).ToArray();
             }
             finally
             {

--- a/ClosedXML/Extensions/DateTimeExtensions.cs
+++ b/ClosedXML/Extensions/DateTimeExtensions.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel
                    && !bankHolidays.Contains(date);
         }
 
-        public static DateTime NextWorkday(this DateTime date, IEnumerable<DateTime> bankHolidays)
+        public static DateTime NextWorkday(this DateTime date, IReadOnlyList<DateTime> bankHolidays)
         {
             var nextDate = date.AddDays(1);
             while (!nextDate.IsWorkDay(bankHolidays))
@@ -33,7 +33,7 @@ namespace ClosedXML.Excel
             return nextDate;
         }
 
-        public static DateTime PreviousWorkDay(this DateTime date, IEnumerable<DateTime> bankHolidays)
+        public static DateTime PreviousWorkDay(this DateTime date, IReadOnlyCollection<DateTime> bankHolidays)
         {
             var previousDate = date.AddDays(-1);
             while (!previousDate.IsWorkDay(bankHolidays))

--- a/ClosedXML/Extensions/EnumerableExtensions.cs
+++ b/ClosedXML/Extensions/EnumerableExtensions.cs
@@ -33,6 +33,23 @@ namespace ClosedXML.Excel
             return new HashSet<T>(source);
         }
 
+        /// <summary>
+        /// Skip last element of a sequence.
+        /// </summary>
+        public static IEnumerable<T> SkipLast<T>(this IEnumerable<T> source)
+        {
+            using var enumerator = source.GetEnumerator();
+            if (!enumerator.MoveNext())
+                yield break;
+
+            T prev = enumerator.Current;
+            while (enumerator.MoveNext())
+            {
+                yield return prev;
+                prev = enumerator.Current;
+            }
+        }
+
         public static Boolean HasDuplicates<T>(this IEnumerable<T> source)
         {
             HashSet<T> distinctItems = new HashSet<T>();


### PR DESCRIPTION
Reworked PR #1462 (it used materialization even when not necessary + too many conflicts due to age).

The major potential benefit is materialization of data `IXLTable.AppendData`/`IXLTable.ReplaceData` methods. If user supplied IEnumerable directly read from database, it could be read twice from db due to multiple enumerations. Granted, it would be better to read and insert through chunks of rows to not increase memory pressure, but good enough.

