### PR TITLE
AutoFilter rework - 1/? - Regular filter matches string.

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -32,6 +32,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=unhide/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscaled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscales/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vlookup/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/ClosedXML.csproj.DotSettings
+++ b/ClosedXML/ClosedXML.csproj.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cautofilters/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccells/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccolumns/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccoordinates/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/AutoFilters/IXLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLAutoFilter.cs
@@ -12,24 +12,132 @@ namespace ClosedXML.Excel
 
     public enum XLTopBottomPart { Top, Bottom }
 
+    /// <summary>
+    /// <para>
+    /// Autofilter can sort and filter (hide) values in a non-empty area of a sheet. Each table can
+    /// have autofilter and each worksheet can have at most one range with an autofilter. First row
+    /// of the area contains headers, remaining rows contain sorted and filtered data.
+    /// </para>
+    /// <para>
+    /// Sorting of rows is done <see cref="Sort"/> method, using the passed parameters. The sort
+    /// properties (<see cref="SortColumn"/> and <see cref="SortOrder"/>) are updated from
+    /// properties passed to the <see cref="Sort"/> method. Sorting can be done only on values of
+    /// one column.
+    /// </para>
+    /// <para>
+    /// Autofilter can filter rows through <see cref="Reapply"/> method. The filter evaluates
+    /// conditions of the autofilter and leaves visible only rows that satisfy the conditions.
+    /// Rows that don't satisfy filter conditions are marked as <see cref="IXLRow.IsHidden">hidden</see>.
+    /// Filter conditions can be specified for each column (accessible through <see cref="Column(string)"/>
+    /// methods), e.g. <c>sheet.AutoFilter.Column(1).Top(10, XLTopBottomType.Percent)</c>
+    /// creates a filter that displays only rows with values in top 10% percentile.
+    /// </para>
+    /// </summary>
     public interface IXLAutoFilter
     {
+        /// <summary>
+        /// Get rows of <see cref="Range"/> that were hidden because they didn't satisfy filter
+        /// conditions during last filtering.
+        /// </summary>
+        /// <remarks>
+        /// Visibility is automatically updated on filter change.
+        /// </remarks>
         IEnumerable<IXLRangeRow> HiddenRows { get; }
+
+        /// <summary>
+        /// Is autofilter enabled? When autofilter is enabled, it shows the arrow buttons and might
+        /// contain some filter that hide some rows. Disabled autofilter doesn't show arrow buttons
+        /// and all rows are visible.
+        /// </summary>
         Boolean IsEnabled { get; set; }
+
+        /// <summary>
+        /// Range of the autofilter. It consists of a header in first row, followed by data rows.
+        /// It doesn't include totals row for tables.
+        /// </summary>
         IXLRange Range { get; set; }
+
+        /// <summary>
+        /// What column was used during last <see cref="Sort"/>. Contains undefined value for not
+        /// yet <see cref="Sorted"/> autofilter.
+        /// </summary>
         Int32 SortColumn { get; set; }
+
+        /// <summary>
+        /// Are values in the autofilter range sorted? I.e. the values were either already loaded
+        /// sorted or <see cref="Sort"/> has been called at least once.
+        /// </summary>
+        /// <remarks>
+        /// If <c>true</c>, <see cref="SortColumn"/> and <see cref="SortOrder"/> contain valid values.
+        /// </remarks>
         Boolean Sorted { get; set; }
+
+        /// <summary>
+        /// What sorting order was used during last <see cref="Sort"/>. Contains undefined value
+        /// for not yet <see cref="Sorted"/> autofilter.
+        /// </summary>
         XLSortOrder SortOrder { get; set; }
+
+        /// <summary>
+        /// Get rows of <see cref="Range"/> that are visible because they satisfied filter
+        /// conditions during last filtering.
+        /// </summary>
+        /// <remarks>
+        /// Visibility is not updated on filter change.
+        /// </remarks>
         IEnumerable<IXLRangeRow> VisibleRows { get; }
 
+        /// <summary>
+        /// Disable autofilter, remove all filters and unhide all rows of the <see cref="Range"/>.
+        /// </summary>
         IXLAutoFilter Clear();
 
-        IXLFilterColumn Column(String column);
+        /// <summary>
+        /// Get filter configuration for a column.
+        /// </summary>
+        /// <param name="columnLetter">
+        /// Column letter that determines number in the range, from <em>A</em> as the first column
+        /// of a <see cref="Range"/>.
+        /// </param>
+        /// <returns>Filter configuration for the column.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Invalid column.</exception>
+        IXLFilterColumn Column(String columnLetter);
 
-        IXLFilterColumn Column(Int32 column);
+        /// <summary>
+        /// Get filter configuration for a column.
+        /// </summary>
+        /// <param name="columnNumber">Column number in the range, from 1 as the first column of a <see cref="Range"/>.</param>
+        /// <returns>Filter configuration for the column.</returns>
+        IXLFilterColumn Column(Int32 columnNumber);
 
+        /// <summary>
+        /// Apply autofilter filters to the range and show every row that satisfies the conditions
+        /// and hide the ones that don't satisfy conditions.
+        /// </summary>
+        /// <remarks>
+        /// Filter is generally automatically applied on a filter change. This method could be
+        /// called after a cell value change or row deletion.
+        /// </remarks>
         IXLAutoFilter Reapply();
 
+        /// <summary>
+        /// Sort rows of the range using data of one column.
+        /// </summary>
+        /// <remarks>
+        /// This method sets <see cref="Sorted"/>, <see cref="SortColumn"/> and <see cref="SortOrder"/> properties.
+        /// </remarks>
+        /// <param name="columnToSortBy">
+        /// Column number in the range, from 1 to width of the <see cref="Range"/>.
+        /// </param>
+        /// <param name="sortOrder">Should rows be sorted in ascending or descending order?</param>
+        /// <param name="matchCase">
+        /// Should <see cref="XLDataType.Text"/> values on the column be matched case sensitive.
+        /// </param>
+        /// <param name="ignoreBlanks">
+        /// <c>true</c> - rows with blank value in the column will always at the end, regardless of
+        /// sorting order. <c>false</c> - blank will be treated as empty string and sorted
+        /// accordingly.
+        /// </param>
         IXLAutoFilter Sort(Int32 columnToSortBy = 1, XLSortOrder sortOrder = XLSortOrder.Ascending, Boolean matchCase = false, Boolean ignoreBlanks = true);
     }
 }

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -1,6 +1,5 @@
-#nullable disable
-
 using System;
+using ClosedXML.Excel.CalcEngine;
 
 namespace ClosedXML.Excel
 {
@@ -8,6 +7,22 @@ namespace ClosedXML.Excel
 
     public enum XLDateTimeGrouping { Year, Month, Day, Hour, Minute, Second }
 
+    /// <summary>
+    /// <para>
+    /// AutoFilter filter configuration for one column in an autofilter <see cref="IXLAutoFilter.Range">area</see>.
+    /// Filters determine visibility of rows in the autofilter area. Column can have multiple
+    /// filters, each specifying a different condition. Value in the row must satisfy all filters
+    /// in order for row to be visible.
+    /// </para>
+    /// <para>
+    /// <list type="bullet">
+    ///   <item><term>Top/Bottom</term><description>only accept value in any of the highest/lowest values of the column.</description></item>
+    ///   <item><term>Average</term><description>only accept value above/below average of all values in the column.</description></item>
+    ///   <item><term>Text filters</term><description>only accept value whose text representation matches <see cref="Wildcard"/>. It encompasses text equality, <c>start-with</c> ect.</description></item>
+    ///   <item><term>Number</term><description>only accept value whose text representation matches <see cref="Wildcard"/>.</description></item>
+    /// </list>
+    /// </para>
+    /// </summary>
     public interface IXLFilterColumn
     {
         void Clear();

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -10,9 +10,8 @@ namespace ClosedXML.Excel
     /// <summary>
     /// <para>
     /// AutoFilter filter configuration for one column in an autofilter <see cref="IXLAutoFilter.Range">area</see>.
-    /// Filters determine visibility of rows in the autofilter area. Column can have multiple
-    /// filters, each specifying a different condition. Value in the row must satisfy all filters
-    /// in order for row to be visible.
+    /// Filters determine visibility of rows in the autofilter area. Value in the row must satisfy
+    /// all filters in all columns in order for row to be visible, otherwise it is <see cref="IXLRow.IsHidden"/>.
     /// </para>
     /// <para>
     /// Column can have only one type of filter, so it's not possible to combine several different
@@ -22,15 +21,7 @@ namespace ClosedXML.Excel
     /// can be only one).
     /// </para>
     /// <para>
-    /// <para>
     /// Whenever filter configuration changes, the filters are immediately reapplied.
-    /// </para>
-    /// <list type="bullet">
-    ///   <item><term>Top/Bottom</term><description>only accept value in any of the highest/lowest values of the column.</description></item>
-    ///   <item><term>Average</term><description>only accept value above/below average of all values in the column.</description></item>
-    ///   <item><term>Text filters</term><description>only accept value whose text representation matches <see cref="Wildcard"/>. It encompasses text equality, <c>start-with</c> ect.</description></item>
-    ///   <item><term>Number</term><description>only accept value whose text representation matches <see cref="Wildcard"/>.</description></item>
-    /// </list>
     /// </para>
     /// </summary>
     public interface IXLFilterColumn
@@ -38,11 +29,15 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Remove all filters from the column.
         /// </summary>
+        /// <remarks>
+        /// Does not reapply filters, visibility of rows isn't changed.
+        /// </remarks>
         void Clear();
 
         /// <summary>
         /// <para>
-        /// Switch to <see cref="XLFilterType.Regular"/> filter if necessary and add
+        /// Switch to the <see cref="XLFilterType.Regular"/> filter if filter column has a
+        /// different type (for current type <see cref="FilterType"/>) and add
         /// <paramref name="value"/> to a set of allowed values. Excel displays regular filter as
         /// a list of possible values in a column with checkbox next to it and user can check which
         /// one should be displayed.
@@ -50,16 +45,18 @@ namespace ClosedXML.Excel
         /// <para>
         /// From technical perspective, the passed <paramref name="value"/> is converted to
         /// a localized string (using current locale) and the column values satisfy the filter
-        /// condition, when its formatted string matches any filter string.
+        /// condition, when the <see cref="IXLCell.GetFormattedString">formatted string of a cell
+        /// </see> matches any filter string.
         /// </para>
         /// <para>
         /// Examples of less intuitive behavior: filter value is <c>2.5</c> in locale cs-CZ that
         /// uses "<em>,</em>" as a decimal separator. The passed <paramref name="value"/>
-        /// is number 2.5, converted to string <em>2,5</em>. This string is used for comparison
-        /// with values in the column:
+        /// is number 2.5, converted immediately to a string <em>2,5</em>. The string is used for
+        /// comparison with values of cells in the column:
         /// <list type="bullet">
         ///  <item>Number 2.5 formatted with two decimal places as <em>2,50</em> will not match.</item>
-        ///  <item>Number 2.5 with default formatting will be matched, because its string is <em>2,5</em> in cs-CZ locale (but not in others, e.g. en-US locale).</item>
+        ///  <item>Number 2.5 with default formatting will be matched, because its string is
+        ///        <em>2,5</em> in cs-CZ locale (but not in others, e.g. en-US locale).</item>
         ///  <item>Text <em>2,5</em> will be matched.</item>
         /// </list>
         /// </para>
@@ -111,6 +108,9 @@ namespace ClosedXML.Excel
 
         IXLFilterConnector NotContains(String value);
 
+        /// <summary>
+        /// Current filter type used by the filter columns.
+        /// </summary>
         XLFilterType FilterType { get; set; }
         Int32 TopBottomValue { get; set; }
         XLTopBottomType TopBottomType { get; set; }

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -15,6 +15,16 @@ namespace ClosedXML.Excel
     /// in order for row to be visible.
     /// </para>
     /// <para>
+    /// Column can have only one type of filter, so it's not possible to combine several different
+    /// filter types on one column. Methods for adding filters clear other types or remove
+    /// previously set filters when needed. Some types of filters can have multiple conditions (e.g.
+    /// <see cref="XLFilterType.Regular"/> can have many values while <see cref="XLFilterType.Dynamic"/>
+    /// can be only one).
+    /// </para>
+    /// <para>
+    /// <para>
+    /// Whenever filter configuration changes, the filters are immediately reapplied.
+    /// </para>
     /// <list type="bullet">
     ///   <item><term>Top/Bottom</term><description>only accept value in any of the highest/lowest values of the column.</description></item>
     ///   <item><term>Average</term><description>only accept value above/below average of all values in the column.</description></item>
@@ -25,9 +35,43 @@ namespace ClosedXML.Excel
     /// </summary>
     public interface IXLFilterColumn
     {
+        /// <summary>
+        /// Remove all filters from the column.
+        /// </summary>
         void Clear();
 
-        IXLFilteredColumn AddFilter<T>(T value) where T : IComparable<T>;
+        /// <summary>
+        /// <para>
+        /// Switch to <see cref="XLFilterType.Regular"/> filter if necessary and add
+        /// <paramref name="value"/> to a set of allowed values. Excel displays regular filter as
+        /// a list of possible values in a column with checkbox next to it and user can check which
+        /// one should be displayed.
+        /// </para>
+        /// <para>
+        /// From technical perspective, the passed <paramref name="value"/> is converted to
+        /// a localized string (using current locale) and the column values satisfy the filter
+        /// condition, when its formatted string matches any filter string.
+        /// </para>
+        /// <para>
+        /// Examples of less intuitive behavior: filter value is <c>2.5</c> in locale cs-CZ that
+        /// uses "<em>,</em>" as a decimal separator. The passed <paramref name="value"/>
+        /// is number 2.5, converted to string <em>2,5</em>. This string is used for comparison
+        /// with values in the column:
+        /// <list type="bullet">
+        ///  <item>Number 2.5 formatted with two decimal places as <em>2,50</em> will not match.</item>
+        ///  <item>Number 2.5 with default formatting will be matched, because its string is <em>2,5</em> in cs-CZ locale (but not in others, e.g. en-US locale).</item>
+        ///  <item>Text <em>2,5</em> will be matched.</item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// This behavior of course highly depends on locale and working with same file on two
+        /// different locales might lead to different results.
+        /// </remarks>
+        /// <param name="value">Value of the filter. The type is <c>XLCellValue</c>, but that's for
+        /// convenience sake. The value is converted to a string and filter works with string.</param>
+        /// <returns>Fluent API allowing to add additional filter value.</returns>
+        IXLFilteredColumn AddFilter(XLCellValue value);
 
         IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping);
 

--- a/ClosedXML/Excel/AutoFilters/IXLFilterConnector.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterConnector.cs
@@ -1,7 +1,3 @@
-#nullable disable
-
-using System;
-
 namespace ClosedXML.Excel
 {
     public interface IXLFilterConnector

--- a/ClosedXML/Excel/AutoFilters/IXLFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilteredColumn.cs
@@ -1,10 +1,21 @@
-#nullable disable
-
-using System;
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// A fluent API interface for adding another values to a <see cref="XLFilterType.Regular"/>
+    /// filter. It is chained by <see cref="IXLFilterColumn.AddFilter"/> method.
+    /// </summary>
+    /// <para>
+    /// Whenever filter configuration changes, the filters are immediately reapplied.
+    /// </para>
     public interface IXLFilteredColumn
     {
-        IXLFilteredColumn AddFilter<T>(T value) where T : IComparable<T>;
+        /// <summary>
+        /// Add another value to a subset of allowed values for a <see cref="XLFilterType.Regular"/>
+        /// filter. See <see cref="IXLFilterColumn.AddFilter"/> for more details.
+        /// </summary>
+        /// <param name="value">Value of the filter. The type is <c>XLCellValue</c>, but that's for
+        /// convenience sake. The value is converted to a string and filter works with string.</param>
+        /// <returns>Fluent API allowing to add additional filter value.</returns>
+        IXLFilteredColumn AddFilter(XLCellValue value);
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Excel
             Filters = new Dictionary<int, List<XLFilter>>();
         }
 
-        public Dictionary<Int32, List<XLFilter>> Filters { get; private set; }
+        internal Dictionary<Int32, List<XLFilter>> Filters { get; }
 
         #region IXLAutoFilter Members
 
@@ -166,6 +166,17 @@ namespace ClosedXML.Excel
             Reapply();
 
             return this;
+        }
+
+        internal void AddFilter(Int32 column, XLFilter filter)
+        {
+            if (!Filters.TryGetValue(column, out List<XLFilter> columnFilters))
+            {
+                columnFilters = new List<XLFilter>();
+                Filters.Add(column, columnFilters);
+            }
+
+            columnFilters.Add(filter);
         }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -34,24 +34,24 @@ namespace ClosedXML.Excel
             return Clear();
         }
 
-        public IXLFilterColumn Column(String column)
+        public IXLFilterColumn Column(String columnLetter)
         {
-            var columnNumber = XLHelper.GetColumnNumberFromLetter(column);
+            var columnNumber = XLHelper.GetColumnNumberFromLetter(columnLetter);
             if (columnNumber < 1 || columnNumber > XLHelper.MaxColumnNumber)
-                throw new ArgumentOutOfRangeException(nameof(column), "Column '" + column + "' is outside the allowed column range.");
+                throw new ArgumentOutOfRangeException(nameof(columnLetter), "Column '" + columnLetter + "' is outside the allowed column range.");
 
             return Column(columnNumber);
         }
 
-        public IXLFilterColumn Column(Int32 column)
+        public IXLFilterColumn Column(Int32 columnNumber)
         {
-            if (column < 1 || column > XLHelper.MaxColumnNumber)
-                throw new ArgumentOutOfRangeException(nameof(column), "Column " + column + " is outside the allowed column range.");
+            if (columnNumber < 1 || columnNumber > XLHelper.MaxColumnNumber)
+                throw new ArgumentOutOfRangeException(nameof(columnNumber), "Column " + columnNumber + " is outside the allowed column range.");
 
-            if (!_columns.TryGetValue(column, out XLFilterColumn filterColumn))
+            if (!_columns.TryGetValue(columnNumber, out XLFilterColumn filterColumn))
             {
-                filterColumn = new XLFilterColumn(this, column);
-                _columns.Add(column, filterColumn);
+                filterColumn = new XLFilterColumn(this, columnNumber);
+                _columns.Add(columnNumber, filterColumn);
             }
 
             return filterColumn;

--- a/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
@@ -115,7 +115,7 @@ namespace ClosedXML.Excel
         private void ApplyCustomFilter<T>(T value, XLFilterOperator op, Func<Object, Boolean> condition)
             where T : IComparable<T>
         {
-            _autoFilter.Filters[_column].Add(new XLFilter
+            _autoFilter.AddFilter(_column, new XLFilter
             {
                 Value = value,
                 Operator = op,

--- a/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel
         {
             Func<Object, Boolean> condition = date2 => IsMatch(date, (DateTime) date2, dateTimeGrouping);
 
-            _autoFilter.Filters[_column].Add(new XLFilter
+            _autoFilter.AddFilter(_column, new XLFilter
             {
                 Value = date,
                 Condition = condition,

--- a/ClosedXML/Excel/AutoFilters/XLFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilter.cs
@@ -21,5 +21,18 @@ namespace ClosedXML.Excel
         public XLDateTimeGrouping DateTimeGrouping { get; set; }
         public XLFilterOperator Operator { get; set; }
         public Object Value { get; set; }
+
+        internal static XLFilter CreateRegularFilter(XLCellValue value)
+        {
+            // TODO: If user supplies a text that is a wildcard, escape it (e.g. `2*` to `2~*`).
+            var wildcard = value.ToString();
+            return new XLFilter
+            {
+                Value = wildcard,
+                Operator = XLFilterOperator.Equal,
+                Connector = XLConnector.Or,
+                Condition = v => v.ToString().Equals(value.ToString(), StringComparison.OrdinalIgnoreCase)
+            };
+        }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -24,19 +24,13 @@ namespace ClosedXML.Excel
                 _autoFilter.Filters.Remove(_column);
         }
 
-        public IXLFilteredColumn AddFilter<T>(T value) where T : IComparable<T>
+        public IXLFilteredColumn AddFilter(XLCellValue value)
         {
-            if (typeof(T) == typeof(String))
-            {
-                ApplyRegularFilter(value, XLFilterOperator.Equal,
-                                  v =>
-                                  v.ToString().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                ApplyRegularFilter(value, XLFilterOperator.Equal,
-                                  v => v.CastTo<T>().CompareTo(value) == 0);
-            }
+            // TODO: If different filter type, clear them
+            _autoFilter.IsEnabled = true;
+            FilterType = XLFilterType.Regular;
+            _autoFilter.AddFilter(_column, XLFilter.CreateRegularFilter(value));
+            _autoFilter.Reapply();
             return new XLFilteredColumn(_autoFilter, _column);
         }
 
@@ -338,25 +332,6 @@ namespace ClosedXML.Excel
             _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
             _autoFilter.Reapply();
             return new XLFilterConnector(_autoFilter, _column);
-        }
-
-        private void ApplyRegularFilter<T>(T value, XLFilterOperator op, Func<Object, Boolean> condition,
-            XLFilterType filterType = XLFilterType.Regular)
-            where T : IComparable<T>
-        {
-            _autoFilter.IsEnabled = true;
-            if (filterType == XLFilterType.Custom)
-                Clear();
-
-            _autoFilter.AddFilter(_column, new XLFilter
-            {
-                Value = value,
-                Operator = op,
-                Connector = XLConnector.Or,
-                Condition = condition
-            });
-            _autoFilter.Column(_column).FilterType = filterType;
-            _autoFilter.Reapply();
         }
 
         public IXLFilterColumn SetFilterType(XLFilterType value) { FilterType = value; return this; }

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -46,35 +46,14 @@ namespace ClosedXML.Excel
             Func<Object, Boolean> condition = date2 => XLDateTimeGroupFilteredColumn.IsMatch(date, (DateTime)date2, dateTimeGrouping);
 
             _autoFilter.IsEnabled = true;
-
-            if (_autoFilter.Filters.TryGetValue(_column, out List<XLFilter> filterList))
-                filterList.Add(
-                    new XLFilter
-                    {
-                        Value = date,
-                        Operator = XLFilterOperator.Equal,
-                        Connector = XLConnector.Or,
-                        Condition = condition,
-                        DateTimeGrouping = dateTimeGrouping
-                    }
-                );
-            else
+            _autoFilter.AddFilter(_column, new XLFilter
             {
-                _autoFilter.Filters.Add(
-                    _column,
-                    new List<XLFilter>
-                    {
-                        new XLFilter
-                        {
-                            Value = date,
-                            Operator = XLFilterOperator.Equal,
-                            Connector = XLConnector.Or,
-                            Condition = condition,
-                            DateTimeGrouping = dateTimeGrouping
-                        }
-                    }
-                );
-            }
+                Value = date,
+                Operator = XLFilterOperator.Equal,
+                Connector = XLConnector.Or,
+                Condition = condition,
+                DateTimeGrouping = dateTimeGrouping
+            });
 
             _autoFilter.Column(_column).FilterType = XLFilterType.DateTimeGrouping;
             var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
@@ -231,7 +210,6 @@ namespace ClosedXML.Excel
             var values = GetValues(value, type, takeTop).ToArray();
 
             Clear();
-            _autoFilter.Filters.Add(_column, new List<XLFilter>());
 
             Boolean addToList = true;
             var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
@@ -243,7 +221,7 @@ namespace ClosedXML.Excel
                     Func<Object, Boolean> condition = v => ((IComparable)v).CompareTo(val) == 0;
                     if (addToList)
                     {
-                        _autoFilter.Filters[_column].Add(new XLFilter
+                        _autoFilter.AddFilter(_column, new XLFilter
                         {
                             Value = val,
                             Operator = XLFilterOperator.Equal,
@@ -295,7 +273,6 @@ namespace ClosedXML.Excel
             var values = GetAverageValues(aboveAverage).ToArray();
 
             Clear();
-            _autoFilter.Filters.Add(_column, new List<XLFilter>());
 
             Boolean addToList = true;
             var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
@@ -308,7 +285,7 @@ namespace ClosedXML.Excel
                     Func<Object, Boolean> condition = v => ((IComparable)v).CompareTo(val) == 0;
                     if (addToList)
                     {
-                        _autoFilter.Filters[_column].Add(new XLFilter
+                        _autoFilter.AddFilter(_column, new XLFilter
                         {
                             Value = val,
                             Operator = XLFilterOperator.Equal,
@@ -352,45 +329,15 @@ namespace ClosedXML.Excel
         {
             _autoFilter.IsEnabled = true;
             if (filterType == XLFilterType.Custom)
-            {
                 Clear();
-                _autoFilter.Filters.Add(_column,
-                                        new List<XLFilter>
-                                            {
-                                                new XLFilter
-                                                {
-                                                    Value = value,
-                                                    Operator = op,
-                                                    Connector = XLConnector.Or,
-                                                    Condition = condition
-                                                }
-                                            });
-            }
-            else
+
+            _autoFilter.AddFilter(_column, new XLFilter
             {
-                if (_autoFilter.Filters.TryGetValue(_column, out List<XLFilter> filterList))
-                    filterList.Add(new XLFilter
-                    {
-                        Value = value,
-                        Operator = op,
-                        Connector = XLConnector.Or,
-                        Condition = condition
-                    });
-                else
-                {
-                    _autoFilter.Filters.Add(_column,
-                                            new List<XLFilter>
-                                                {
-                                                    new XLFilter
-                                                        {
-                                                            Value = value,
-                                                            Operator = op,
-                                                            Connector = XLConnector.Or,
-                                                            Condition = condition
-                                                        }
-                                                });
-                }
-            }
+                Value = value,
+                Operator = op,
+                Connector = XLConnector.Or,
+                Condition = condition
+            });
             _autoFilter.Column(_column).FilterType = filterType;
             _autoFilter.Reapply();
             return new XLFilterConnector(_autoFilter, _column);

--- a/ClosedXML/Excel/AutoFilters/XLFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilteredColumn.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel
@@ -15,45 +13,11 @@ namespace ClosedXML.Excel
             _column = column;
         }
 
-        #region IXLFilteredColumn Members
-
-        public IXLFilteredColumn AddFilter<T>(T value) where T : IComparable<T>
+        public IXLFilteredColumn AddFilter(XLCellValue value)
         {
-            Func<Object, Boolean> condition;
-            Boolean isText;
-            if (typeof(T) == typeof(String))
-            {
-                condition = v => v.ToString().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase);
-                isText = true;
-            }
-            else
-            {
-                condition = v => v.CastTo<T>().CompareTo(value) == 0;
-                isText = false;
-            }
-
-            _autoFilter.AddFilter(_column, new XLFilter
-            {
-                Value = value,
-                Condition = condition,
-                Operator = XLFilterOperator.Equal,
-                Connector = XLConnector.Or
-            });
-
-            var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
-
-            foreach (IXLRangeRow row in rows)
-            {
-                if ((isText && condition(row.Cell(_column).GetString())) ||
-                    (!isText && row.Cell(_column).DataType == XLDataType.Number &&
-                     condition(row.Cell(_column).GetValue<T>())))
-                {
-                    row.WorksheetRow().Unhide();
-                }
-            }
+            _autoFilter.AddFilter(_column, XLFilter.CreateRegularFilter(value));
+            _autoFilter.Reapply();
             return this;
         }
-
-        #endregion IXLFilteredColumn Members
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilteredColumn.cs
@@ -32,7 +32,7 @@ namespace ClosedXML.Excel
                 isText = false;
             }
 
-            _autoFilter.Filters[_column].Add(new XLFilter
+            _autoFilter.AddFilter(_column, new XLFilter
             {
                 Value = value,
                 Condition = condition,

--- a/docs/api/autofilter.rst
+++ b/docs/api/autofilter.rst
@@ -1,0 +1,5 @@
+AutoFilter
+==========
+
+.. doxygeninterface:: ClosedXML::Excel::IXLAutoFilter
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ ClosedXML allows you to create Excel files without the Excel application. The ty
    :caption: API Reference
 
    api/index
+   api/autofilter
    api/workbook
    api/worksheet
    api/cell

--- a/docs/migrations/migrate-to-0.104.rst
+++ b/docs/migrations/migrate-to-0.104.rst
@@ -82,3 +82,12 @@ Page setup
 ``IXLPageSetup.FirstPageNumber`` and ``IXLPageSetup.SetFirstPageNumber(int)``
 now use ``int`` type instead of ``uint``. First page number can be negative and
 ``int`` is thus better (``-3`` instead of ``4294967293``).
+
+**********
+AutoFilter
+**********
+
+``IXLFilterColumn.AddFilter`` and ``IXLFilteredColumn.AddFilter`` method
+parameter type was changed from a generic ``T : IComparable<T>`` to ``XLCellValue``.
+Semantic of method was also updated to reflect how Excel actually filter column
+values.


### PR DESCRIPTION
This is part 1/? of rework of AutoFilter that should bring it to usable state (=documented, correctly working state). Since sorting should now work with typed values (#1649), AutoFilter can now be worked on.

In this PR, the argument type of regular filter was changed `T : IComparable<T>` to `XLCellValue`. Technically (in Excel) regular filter matches a set of wildcards against formatted string, e.g. number `2.5` formatted as `2.50` won't match regular filter `2.5`. 

Since regular filter matches against wildcard, the passed `XLCellValue` value is immediately turned into string (there is all fun with number conversion to text in different locales, described in detail in the API XML documentation). I though about leaving just string, but user would just specify `number.ToString()` anyway, because what else can to do? So `XLCellValue` so it can seamlessly work with reasonable cases (implicit conversion) and rest of ClosedXML + documentation of behavior in detail. There is no perfect option when anyway, when Excel filters differently based on locale workbook is opened in.

Also added  XML documentation to `IXLAutoFilter`, so people can actually know what each method and property does.