### PR TITLE
AutoFilter rework - 2/? - fix types for custom filters

### DIFF
--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -32,4 +32,9 @@
     <ProjectReference Include="..\ClosedXML.Examples\ClosedXML.Examples.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="NUnit.Framework.SetCultureAttribute">
+      <_Parameter1>en-US</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -237,9 +237,10 @@ namespace ClosedXML.Tests
             {
                 // Set thread culture to French, which should format numbers using a space as thousands separator
                 var culture = CultureInfo.CreateSpecificCulture("fr-FR");
-                // but use a period instead of a comma as for decimal separator and space as group separator
-                culture.NumberFormat.CurrencyDecimalSeparator = ".";
-                culture.NumberFormat.CurrencyGroupSeparator = " ";
+                // but use a period instead of a comma as for decimal separator and space as group separator.
+                // The value is a number, so use number properties.
+                culture.NumberFormat.NumberDecimalSeparator = ".";
+                culture.NumberFormat.NumberGroupSeparator = " ";
 
                 Thread.CurrentThread.CurrentCulture = culture;
 
@@ -247,7 +248,10 @@ namespace ClosedXML.Tests
                 using (var wb = new XLWorkbook(stream))
                 {
                     var ws = wb.Worksheets.First();
-                    Assert.AreEqual(10000, (ws.AutoFilter as XLAutoFilter).Filters.First().Value.First().Value);
+
+                    // Regular filter compares values as strings, doesn't convert to XLCellValue.
+                    // The cell value should be formatted to same value as the filter.
+                    Assert.AreEqual("10 000.00", ((XLAutoFilter)ws.AutoFilter).Filters.First().Value.First().Value);
                     Assert.AreEqual(2, ws.AutoFilter.VisibleRows.Count());
 
                     ws.AutoFilter.Reapply();

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -237,8 +237,12 @@ namespace ClosedXML.Tests
             {
                 // Set thread culture to French, which should format numbers using a space as thousands separator
                 var culture = CultureInfo.CreateSpecificCulture("fr-FR");
-                // but use a period instead of a comma as for decimal separator and space as group separator.
-                // The value is a number, so use number properties.
+
+                // The value in sheet that will be compared with autofilter value is a number
+                // `10000`. That number will be formatted using culture to `10 000.00` thanks to
+                // modified properties of culture - period instead of a comma for decimal separator
+                // and space as group separator. The formatted number will thus match with the
+                // filter value.
                 culture.NumberFormat.NumberDecimalSeparator = ".";
                 culture.NumberFormat.NumberGroupSeparator = " ";
 
@@ -249,8 +253,8 @@ namespace ClosedXML.Tests
                 {
                     var ws = wb.Worksheets.First();
 
-                    // Regular filter compares values as strings, doesn't convert to XLCellValue.
-                    // The cell value should be formatted to same value as the filter.
+                    // Regular filter compares values as strings, doesn't convert to XLCellValue,
+                    // so the value is read from the file as a text despite looking like a number.
                     Assert.AreEqual("10 000.00", ((XLAutoFilter)ws.AutoFilter).Filters.First().Value.First().Value);
                     Assert.AreEqual(2, ws.AutoFilter.VisibleRows.Count());
 

--- a/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
@@ -426,7 +426,7 @@ namespace ClosedXML.Tests.Excel.Cells
         }
 
         [Test]
-        [Culture("cs-CZ")]
+        [SetCulture("cs-CZ")]
         public void ToString_RespectsCulture()
         {
             XLCellValue v = Blank.Value;

--- a/ClosedXML/Excel/AutoFilters/IXLCustomFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLCustomFilteredColumn.cs
@@ -1,16 +1,14 @@
-#nullable disable
-
 using System;
 namespace ClosedXML.Excel
 {
     public interface IXLCustomFilteredColumn
     {
-        void EqualTo<T>(T value) where T : IComparable<T>;
-        void NotEqualTo<T>(T value) where T : IComparable<T>;
-        void GreaterThan<T>(T value) where T : IComparable<T>;
-        void LessThan<T>(T value) where T : IComparable<T>;
-        void EqualOrGreaterThan<T>(T value) where T : IComparable<T>;
-        void EqualOrLessThan<T>(T value) where T : IComparable<T>;
+        void EqualTo(XLCellValue value);
+        void NotEqualTo(XLCellValue value);
+        void GreaterThan(XLCellValue value);
+        void LessThan(XLCellValue value);
+        void EqualOrGreaterThan(XLCellValue value);
+        void EqualOrLessThan(XLCellValue value);
         void BeginsWith(String value);
         void NotBeginsWith(String value);
         void EndsWith(String value);

--- a/ClosedXML/Excel/AutoFilters/IXLDateTimeGroupFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLDateTimeGroupFilteredColumn.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A fluent API interface for adding another values to a <see cref="XLFilterType.Regular"/>
+/// filter. It is chained by <see cref="IXLFilterColumn.AddDateGroupFilter"/> method.
+/// </summary>
+/// <para>
+/// Whenever filter configuration changes, the filters are immediately reapplied.
+/// </para>
+public interface IXLDateTimeGroupFilteredColumn
+{
+    /// <summary>
+    /// Add another grouping to a set of allowed groupings. See <see cref="IXLFilterColumn.AddDateGroupFilter"/>
+    /// for more details.
+    /// </summary>
+    /// <returns>Fluent API allowing to add additional date group filter.</returns>
+    IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping);
+}

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -95,7 +95,7 @@ namespace ClosedXML.Excel
         /// or any date group filter.
         /// </para>
         /// </summary>
-        /// <param name="date">Date who components are compared with date values of the column.</param>
+        /// <param name="date">Date which components are compared with date values of the column.</param>
         /// <param name="dateTimeGrouping">
         /// Starting component of the grouping. Tested date must match all date components of the
         /// <paramref name="date"/> from this one to the <see cref="XLDateTimeGrouping.Second"/>.

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -1,5 +1,4 @@
 using System;
-using ClosedXML.Excel.CalcEngine;
 
 namespace ClosedXML.Excel
 {
@@ -70,6 +69,38 @@ namespace ClosedXML.Excel
         /// <returns>Fluent API allowing to add additional filter value.</returns>
         IXLFilteredColumn AddFilter(XLCellValue value);
 
+        /// <summary>
+        /// <para>
+        /// Enable autofilter (if needed), switch to the <see cref="XLFilterType.Regular"/> filter
+        /// if filter column has a different type (for current type <see cref="FilterType"/>) and
+        /// add a filter that is satisfied when cell value is a <see cref="XLDataType.DateTime"/>
+        /// and the tested date has same components from <paramref name="dateTimeGrouping"/>
+        /// component down to the <see cref="XLDateTimeGrouping.Second"/> component with same value
+        /// as the <paramref name="dateTimeGrouping"/>.
+        /// </para>
+        /// <para>
+        /// <example>
+        /// Example:
+        /// <code>
+        /// // Filter will be satisfied if the cell value is a XLDataType.DateTime and the month,
+        /// // day, hour, minute and second are same as the passed date.
+        /// AddDateGroupFilter(new DateTime(2023, 7, 15), XLDateTimeGrouping.Month)
+        /// </code>
+        /// </example>
+        /// </para>
+        /// <para>
+        /// There can be multiple date group filters and they are <see cref="XLFilterType.Regular"/>
+        /// filter types, i.e. they don't delete filters from <see cref="AddFilter"/>. The cell
+        /// value is satisfied, if it matches any of the text values from <see cref="AddFilter"/>
+        /// or any date group filter.
+        /// </para>
+        /// </summary>
+        /// <param name="date">Date who components are compared with date values of the column.</param>
+        /// <param name="dateTimeGrouping">
+        /// Starting component of the grouping. Tested date must match all date components of the
+        /// <paramref name="date"/> from this one to the <see cref="XLDateTimeGrouping.Second"/>.
+        /// </param>
+        /// <returns>Fluent API allowing to add additional date time group value.</returns>
         IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping);
 
         void Top(Int32 value, XLTopBottomType type = XLTopBottomType.Items);

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -111,21 +111,21 @@ namespace ClosedXML.Excel
 
         void BelowAverage();
 
-        IXLFilterConnector EqualTo<T>(T value) where T : IComparable<T>;
+        IXLFilterConnector EqualTo(XLCellValue value);
 
-        IXLFilterConnector NotEqualTo<T>(T value) where T : IComparable<T>;
+        IXLFilterConnector NotEqualTo(XLCellValue value);
 
-        IXLFilterConnector GreaterThan<T>(T value) where T : IComparable<T>;
+        IXLFilterConnector GreaterThan(XLCellValue value);
 
-        IXLFilterConnector LessThan<T>(T value) where T : IComparable<T>;
+        IXLFilterConnector LessThan(XLCellValue value);
 
-        IXLFilterConnector EqualOrGreaterThan<T>(T value) where T : IComparable<T>;
+        IXLFilterConnector EqualOrGreaterThan(XLCellValue value);
 
-        IXLFilterConnector EqualOrLessThan<T>(T value) where T : IComparable<T>;
+        IXLFilterConnector EqualOrLessThan(XLCellValue value);
 
-        void Between<T>(T minValue, T maxValue) where T : IComparable<T>;
+        void Between(XLCellValue minValue, XLCellValue maxValue);
 
-        void NotBetween<T>(T minValue, T maxValue) where T : IComparable<T>;
+        void NotBetween(XLCellValue minValue, XLCellValue maxValue);
 
         IXLFilterConnector BeginsWith(String value);
 

--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel
                     foreach (var filter in columnFilters)
                     {
                         var cell = row.Cell(columnIndex);
-                        var filterMatch = filter.NewCondition(cell);
+                        var filterMatch = filter.Condition(cell);
                         if (filter.Connector == XLConnector.And)
                         {
                             columnFilterMatch &= filterMatch;

--- a/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLAutoFilter.cs
@@ -83,29 +83,8 @@ namespace ClosedXML.Excel
 
                     foreach (var filter in columnFilters)
                     {
-                        Boolean filterMatch;
-                        if (filter.NewCondition is null)
-                        {
-                            // TODO: Convert old logic to proper XLCellValue conditions.
-                            var condition = filter.Condition;
-                            var isText = filter.Value is String;
-                            var isDateTime = filter.Value is DateTime;
-
-                            if (isText)
-                                filterMatch = condition(row.Cell(columnIndex).GetFormattedString());
-                            else if (isDateTime)
-                                filterMatch = row.Cell(columnIndex).DataType == XLDataType.DateTime &&
-                                              condition(row.Cell(columnIndex).GetDateTime());
-                            else
-                                filterMatch = row.Cell(columnIndex).TryGetValue(out double number) &&
-                                              condition(number);
-                        }
-                        else
-                        {
-                            var cell = row.Cell(columnIndex);
-                            filterMatch = filter.NewCondition(cell.CachedValue);
-                        }
-
+                        var cell = row.Cell(columnIndex);
+                        var filterMatch = filter.NewCondition(cell);
                         if (filter.Connector == XLConnector.And)
                         {
                             columnFilterMatch &= filterMatch;

--- a/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
@@ -83,7 +83,7 @@ namespace ClosedXML.Excel
 
         private void ApplyWildcardCustomFilter(string pattern, bool match)
         {
-            _autoFilter.AddFilter(_column, XLFilter.CreateCustomWildcardFilter(pattern, match, _connector));
+            _autoFilter.AddFilter(_column, XLFilter.CreateWildcardFilter(pattern, match, _connector));
             _autoFilter.Reapply();
         }
     }

--- a/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
@@ -15,8 +15,6 @@ namespace ClosedXML.Excel
             _connector = connector;
         }
 
-        #region IXLCustomFilteredColumn Members
-
         public void EqualTo(XLCellValue value)
         {
             ApplyCustomFilter(value, XLFilterOperator.Equal);
@@ -49,59 +47,43 @@ namespace ClosedXML.Excel
 
         public void BeginsWith(String value)
         {
-            ApplyCustomFilter(value + "*", XLFilterOperator.Equal,
-                              s => ((string)s).StartsWith(value, StringComparison.InvariantCultureIgnoreCase));
+            ApplyWildcardCustomFilter(value + "*", true);
         }
 
         public void NotBeginsWith(String value)
         {
-            ApplyCustomFilter(value + "*", XLFilterOperator.NotEqual,
-                              s =>
-                              !((string)s).StartsWith(value, StringComparison.InvariantCultureIgnoreCase));
+            ApplyWildcardCustomFilter(value + "*", false);
         }
 
         public void EndsWith(String value)
         {
-            ApplyCustomFilter("*" + value, XLFilterOperator.Equal,
-                              s => ((string)s).EndsWith(value, StringComparison.InvariantCultureIgnoreCase));
+            ApplyWildcardCustomFilter("*" + value, true);
         }
 
         public void NotEndsWith(String value)
         {
-            ApplyCustomFilter("*" + value, XLFilterOperator.NotEqual,
-                              s => !((string)s).EndsWith(value, StringComparison.InvariantCultureIgnoreCase));
+            ApplyWildcardCustomFilter("*" + value, false);
         }
 
         public void Contains(String value)
         {
-            ApplyCustomFilter("*" + value + "*", XLFilterOperator.Equal,
-                              s => ((string)s).ToLower().Contains(value.ToLower()));
+            ApplyWildcardCustomFilter("*" + value + "*", true);
         }
 
         public void NotContains(String value)
         {
-            ApplyCustomFilter("*" + value + "*", XLFilterOperator.Equal,
-                              s => !((string)s).ToLower().Contains(value.ToLower()));
-        }
-
-        #endregion
-
-        private void ApplyCustomFilter<T>(T value, XLFilterOperator op, Func<Object, Boolean> condition)
-            where T : IComparable<T>
-        {
-            _autoFilter.AddFilter(_column, new XLFilter
-            {
-                Value = value,
-                Operator = op,
-                Connector = _connector,
-                Condition = condition
-            });
-            _autoFilter.Reapply();
+            ApplyWildcardCustomFilter("*" + value + "*", false);
         }
 
         private void ApplyCustomFilter(XLCellValue value, XLFilterOperator op)
         {
             _autoFilter.AddFilter(_column, XLFilter.CreateCustomFilter(value, op, _connector));
+            _autoFilter.Reapply();
+        }
+
+        private void ApplyWildcardCustomFilter(string pattern, bool match)
+        {
+            _autoFilter.AddFilter(_column, XLFilter.CreateCustomWildcardFilter(pattern, match, _connector));
             _autoFilter.Reapply();
         }
     }

--- a/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLCustomFilteredColumn.cs
@@ -1,7 +1,4 @@
-#nullable disable
-
 using System;
-using System.Linq;
 
 namespace ClosedXML.Excel
 {
@@ -20,57 +17,34 @@ namespace ClosedXML.Excel
 
         #region IXLCustomFilteredColumn Members
 
-        public void EqualTo<T>(T value) where T: IComparable<T>
+        public void EqualTo(XLCellValue value)
         {
-            if (typeof(T) == typeof(String))
-            {
-                ApplyCustomFilter(value, XLFilterOperator.Equal,
-                                  v =>
-                                  v.ToString().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                ApplyCustomFilter(value, XLFilterOperator.Equal,
-                                  v => v.CastTo<T>().CompareTo(value) == 0);
-            }
+            ApplyCustomFilter(value, XLFilterOperator.Equal);
         }
 
-        public void NotEqualTo<T>(T value) where T: IComparable<T>
+        public void NotEqualTo(XLCellValue value)
         {
-            if (typeof(T) == typeof(String))
-            {
-                ApplyCustomFilter(value, XLFilterOperator.NotEqual,
-                                  v =>
-                                  !v.ToString().Equals(value.ToString(), StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                ApplyCustomFilter(value, XLFilterOperator.NotEqual,
-                                  v => v.CastTo<T>().CompareTo(value) != 0);
-            }
+            ApplyCustomFilter(value, XLFilterOperator.NotEqual);
         }
 
-        public void GreaterThan<T>(T value) where T: IComparable<T>
+        public void GreaterThan(XLCellValue value)
         {
-            ApplyCustomFilter(value, XLFilterOperator.GreaterThan,
-                              v => v.CastTo<T>().CompareTo(value) > 0);
+            ApplyCustomFilter(value, XLFilterOperator.GreaterThan);
         }
 
-        public void LessThan<T>(T value) where T: IComparable<T>
+        public void LessThan(XLCellValue value)
         {
-            ApplyCustomFilter(value, XLFilterOperator.LessThan, v => v.CastTo<T>().CompareTo(value) < 0);
+            ApplyCustomFilter(value, XLFilterOperator.LessThan);
         }
 
-        public void EqualOrGreaterThan<T>(T value) where T: IComparable<T>
+        public void EqualOrGreaterThan(XLCellValue value)
         {
-            ApplyCustomFilter(value, XLFilterOperator.EqualOrGreaterThan,
-                              v => v.CastTo<T>().CompareTo(value) >= 0);
+            ApplyCustomFilter(value, XLFilterOperator.EqualOrGreaterThan);
         }
 
-        public void EqualOrLessThan<T>(T value) where T: IComparable<T>
+        public void EqualOrLessThan(XLCellValue value)
         {
-            ApplyCustomFilter(value, XLFilterOperator.EqualOrLessThan,
-                              v => v.CastTo<T>().CompareTo(value) <= 0);
+            ApplyCustomFilter(value, XLFilterOperator.EqualOrLessThan);
         }
 
         public void BeginsWith(String value)
@@ -122,22 +96,13 @@ namespace ClosedXML.Excel
                 Connector = _connector,
                 Condition = condition
             });
-            var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
-            foreach (IXLRangeRow row in rows)
-            {
-                if (_connector == XLConnector.And)
-                {
-                    if (!row.WorksheetRow().IsHidden)
-                    {
-                        if (condition(row.Cell(_column).GetValue<T>()))
-                            row.WorksheetRow().Unhide();
-                        else
-                            row.WorksheetRow().Hide();
-                    }
-                }
-                else if (condition(row.Cell(_column).GetValue<T>()))
-                    row.WorksheetRow().Unhide();
-            }
+            _autoFilter.Reapply();
+        }
+
+        private void ApplyCustomFilter(XLCellValue value, XLFilterOperator op)
+        {
+            _autoFilter.AddFilter(_column, XLFilter.CreateCustomFilter(value, op, _connector));
+            _autoFilter.Reapply();
         }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel
 
         public IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping)
         {
-            _autoFilter.AddFilter(_column, XLFilter.CreateRegularDateGroupFilter(date, dateTimeGrouping));
+            _autoFilter.AddFilter(_column, XLFilter.CreateDateGroupFilter(date, dateTimeGrouping));
             _autoFilter.Reapply();
             return this;
         }

--- a/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
@@ -1,14 +1,7 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel
 {
-    public interface IXLDateTimeGroupFilteredColumn
-    {
-        IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping);
-    }
-
     internal class XLDateTimeGroupFilteredColumn : IXLDateTimeGroupFilteredColumn
     {
         private readonly XLAutoFilter _autoFilter;

--- a/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
@@ -15,32 +15,9 @@ namespace ClosedXML.Excel
 
         public IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping)
         {
-            Func<Object, Boolean> condition = date2 => IsMatch(date, (DateTime) date2, dateTimeGrouping);
-
-            _autoFilter.AddFilter(_column, new XLFilter
-            {
-                Value = date,
-                Condition = condition,
-                Operator = XLFilterOperator.Equal,
-                Connector = XLConnector.Or,
-                DateTimeGrouping = dateTimeGrouping
-            });
-
+            _autoFilter.AddFilter(_column, XLFilter.CreateRegularDateGroupFilter(date, dateTimeGrouping));
             _autoFilter.Reapply();
             return this;
-        }
-
-        internal static Boolean IsMatch(DateTime date1, DateTime date2, XLDateTimeGrouping dateTimeGrouping)
-        {
-            Boolean isMatch = true;
-            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Year) isMatch &= date1.Year.Equals(date2.Year);
-            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Month) isMatch &= date1.Month.Equals(date2.Month);
-            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Day) isMatch &= date1.Day.Equals(date2.Day);
-            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Hour) isMatch &= date1.Hour.Equals(date2.Hour);
-            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Minute) isMatch &= date1.Minute.Equals(date2.Minute);
-            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Second) isMatch &= date1.Second.Equals(date2.Second);
-
-            return isMatch;
         }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLDateTimeGroupFilteredColumn.cs
@@ -26,13 +26,7 @@ namespace ClosedXML.Excel
                 DateTimeGrouping = dateTimeGrouping
             });
 
-            var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
-            foreach (IXLRangeRow row in rows)
-            {
-                if (row.Cell(_column).DataType == XLDataType.DateTime && condition(row.Cell(_column).GetDateTime()))
-                    row.WorksheetRow().Unhide();
-            }
-
+            _autoFilter.Reapply();
             return this;
         }
 

--- a/ClosedXML/Excel/AutoFilters/XLFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilter.cs
@@ -26,11 +26,11 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Value for <see cref="XLFilterType.Custom"/> that is compared using <see cref="Operator"/>.
         /// </summary>
-        public XLCellValue CustomValue { get; set; }
+        public XLCellValue CustomValue { get; init; }
 
         public Func<XLCellValue, bool> NewCondition { get; set; }
 
-        public XLFilterOperator Operator { get; set; }
+        public XLFilterOperator Operator { get; init; }
 
         /// <summary>
         /// Value for <see cref="XLFilterType.Regular"/> filter.

--- a/ClosedXML/Excel/AutoFilters/XLFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilter.cs
@@ -34,5 +34,30 @@ namespace ClosedXML.Excel
                 Condition = v => v.ToString().Equals(value.ToString(), StringComparison.OrdinalIgnoreCase)
             };
         }
+
+        internal static XLFilter CreateRegularDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping)
+        {
+            return new XLFilter
+            {
+                Value = date,
+                Condition = date2 => IsMatch(date, (DateTime)date2, dateTimeGrouping),
+                Operator = XLFilterOperator.Equal,
+                Connector = XLConnector.Or,
+                DateTimeGrouping = dateTimeGrouping
+            };
+        }
+
+        private static Boolean IsMatch(DateTime date1, DateTime date2, XLDateTimeGrouping dateTimeGrouping)
+        {
+            Boolean isMatch = true;
+            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Year) isMatch &= date1.Year.Equals(date2.Year);
+            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Month) isMatch &= date1.Month.Equals(date2.Month);
+            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Day) isMatch &= date1.Day.Equals(date2.Day);
+            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Hour) isMatch &= date1.Hour.Equals(date2.Hour);
+            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Minute) isMatch &= date1.Minute.Equals(date2.Minute);
+            if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Second) isMatch &= date1.Second.Equals(date2.Second);
+
+            return isMatch;
+        }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilter.cs
@@ -17,11 +17,35 @@ namespace ClosedXML.Excel
         }
 
         public Func<Object, Boolean> Condition { get; set; }
+
         public XLConnector Connector { get; set; }
+
         public XLDateTimeGrouping DateTimeGrouping { get; set; }
+
+        /// <summary>
+        /// Value for <see cref="XLFilterType.Custom"/> that is compared using <see cref="Operator"/>.
+        /// </summary>
+        public XLCellValue CustomValue { get; set; }
+
+        public Func<XLCellValue, bool> NewCondition { get; set; }
+
         public XLFilterOperator Operator { get; set; }
+
         public Object Value { get; set; }
 
+        internal static XLFilter CreateCustomFilter(XLCellValue value, XLFilterOperator op, XLConnector connector)
+        {
+            // Keep in closure, so it doesn't have to be checked for every cell.
+            var comparer = StringComparer.CurrentCultureIgnoreCase;
+            return new XLFilter
+            {
+                CustomValue = value,
+                Operator = op,
+                Connector = connector,
+                NewCondition = cellValue => CustomFilterSatisfied(cellValue, op, value, comparer),
+            };
+        }
+        
         internal static XLFilter CreateRegularFilter(XLCellValue value)
         {
             // TODO: If user supplies a text that is a wildcard, escape it (e.g. `2*` to `2~*`).
@@ -58,6 +82,43 @@ namespace ClosedXML.Excel
             if (isMatch && dateTimeGrouping >= XLDateTimeGrouping.Second) isMatch &= date1.Second.Equals(date2.Second);
 
             return isMatch;
+        }
+
+        private static bool CustomFilterSatisfied(XLCellValue cellValue, XLFilterOperator op, XLCellValue filterValue, StringComparer textComparer)
+        {
+            // Blanks are rather strange case. Excel parsing logic for custom filter value into
+            // XLCellValue is very inconsistent. E.g. 'does not equal' for empty string ignores
+            // blanks and empty strings.
+            cellValue = cellValue.IsBlank ? string.Empty : cellValue;
+            filterValue = filterValue.IsBlank ? string.Empty : filterValue;
+
+            if (cellValue.Type != filterValue.Type && cellValue.IsUnifiedNumber != filterValue.IsUnifiedNumber)
+                return false;
+
+            // Note that custom filter even error values, basically everything as a number.
+            var comparison = cellValue.Type switch
+            {
+                XLDataType.Text => textComparer.Compare(cellValue.GetText(), filterValue.GetText()),
+                XLDataType.Boolean => cellValue.GetBoolean().CompareTo(filterValue.GetBoolean()),
+                XLDataType.Error => cellValue.GetError().CompareTo(filterValue.GetError()),
+                _ => cellValue.GetUnifiedNumber().CompareTo(filterValue.GetUnifiedNumber())
+            };
+
+            // !!! Deviation from Excel !!!
+            // Excel interprets custom filter with `equal` operator (and *only* equal operator) as
+            // comparison of formatted string of a cell value with wildcard represented by custom
+            // value filter value.
+            // We do the sane thing and compare them for equality, so $10 is equal to 10.
+            return op switch
+            {
+                XLFilterOperator.LessThan => comparison < 0,
+                XLFilterOperator.EqualOrLessThan => comparison <= 0,
+                XLFilterOperator.Equal => comparison == 0,
+                XLFilterOperator.NotEqual => comparison != 0,
+                XLFilterOperator.EqualOrGreaterThan => comparison >= 0,
+                XLFilterOperator.GreaterThan => comparison > 0,
+                _ => throw new NotSupportedException(),
+            };
         }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/XLFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilter.cs
@@ -2,7 +2,6 @@
 
 // Keep this file CodeMaid organised and cleaned
 using System;
-using System.Diagnostics;
 using ClosedXML.Excel.CalcEngine;
 
 namespace ClosedXML.Excel
@@ -51,15 +50,14 @@ namespace ClosedXML.Excel
             };
         }
 
-        internal static XLFilter CreateCustomWildcardFilter(string wildcard, XLFilterOperator op, XLConnector connector)
+        internal static XLFilter CreateCustomWildcardFilter(string wildcard, bool match, XLConnector connector)
         {
-            Debug.Assert(op is XLFilterOperator.Equal or XLFilterOperator.NotEqual);
             return new XLFilter
             {
                 CustomValue = wildcard,
-                Operator = op,
+                Operator = match ? XLFilterOperator.Equal : XLFilterOperator.NotEqual,
                 Connector = connector,
-                NewCondition = op == XLFilterOperator.Equal ? c => MatchesWildcard(wildcard, c) : c => !MatchesWildcard(wildcard, c),
+                NewCondition = match ? c => MatchesWildcard(wildcard, c) : c => !MatchesWildcard(wildcard, c),
             };
         }
 

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -165,7 +165,7 @@ namespace ClosedXML.Excel
                 Boolean foundOne = false;
                 foreach (double val in values)
                 {
-                    Func<Object, Boolean> condition = v => ((IComparable)v).CompareTo(val) == 0;
+                    Func<XLCellValue, Boolean> condition = v => v.IsUnifiedNumber && v.GetUnifiedNumber().Equals(val);
                     if (addToList)
                     {
                         _autoFilter.AddFilter(_column, new XLFilter
@@ -173,7 +173,7 @@ namespace ClosedXML.Excel
                             Value = val,
                             Operator = XLFilterOperator.Equal,
                             Connector = XLConnector.Or,
-                            Condition = condition
+                            NewCondition = condition
                         });
                     }
 
@@ -229,7 +229,7 @@ namespace ClosedXML.Excel
                 Boolean foundOne = false;
                 foreach (double val in values)
                 {
-                    Func<Object, Boolean> condition = v => ((IComparable)v).CompareTo(val) == 0;
+                    Func<XLCellValue, Boolean> condition = v => v.IsUnifiedNumber && v.GetUnifiedNumber().Equals(val);
                     if (addToList)
                     {
                         _autoFilter.AddFilter(_column, new XLFilter
@@ -237,7 +237,7 @@ namespace ClosedXML.Excel
                             Value = val,
                             Operator = XLFilterOperator.Equal,
                             Connector = XLConnector.Or,
-                            Condition = condition
+                            NewCondition = condition
                         });
                     }
 

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -106,40 +106,34 @@ namespace ClosedXML.Excel
             LessThan(minValue).Or.GreaterThan(maxValue);
         }
 
-        public static Func<String, Object, Boolean> BeginsWithFunction { get; } = (value, input) => ((string)input).StartsWith(value, StringComparison.InvariantCultureIgnoreCase);
-
         public IXLFilterConnector BeginsWith(String value)
         {
-            return ApplyCustomFilter(value + "*", XLFilterOperator.Equal, s => BeginsWithFunction(value, s));
+            return ApplyWildcardCustomFilter(value + "*", XLFilterOperator.Equal);
         }
 
         public IXLFilterConnector NotBeginsWith(String value)
         {
-            return ApplyCustomFilter(value + "*", XLFilterOperator.NotEqual, s => !BeginsWithFunction(value, s));
+            return ApplyWildcardCustomFilter(value + "*", XLFilterOperator.NotEqual);
         }
-
-        public static Func<String, Object, Boolean> EndsWithFunction { get; } = (value, input) => ((string)input).EndsWith(value, StringComparison.InvariantCultureIgnoreCase);
 
         public IXLFilterConnector EndsWith(String value)
         {
-            return ApplyCustomFilter("*" + value, XLFilterOperator.Equal, s => EndsWithFunction(value, s));
+            return ApplyWildcardCustomFilter("*" + value, XLFilterOperator.Equal);
         }
 
         public IXLFilterConnector NotEndsWith(String value)
         {
-            return ApplyCustomFilter("*" + value, XLFilterOperator.NotEqual, s => !EndsWithFunction(value, s));
+            return ApplyWildcardCustomFilter("*" + value, XLFilterOperator.NotEqual);
         }
-
-        public static Func<String, Object, Boolean> ContainsFunction { get; } = (value, input) => ((string)input).IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
 
         public IXLFilterConnector Contains(String value)
         {
-            return ApplyCustomFilter("*" + value + "*", XLFilterOperator.Equal, s => ContainsFunction(value, s));
+            return ApplyWildcardCustomFilter("*" + value + "*", XLFilterOperator.Equal);
         }
 
         public IXLFilterConnector NotContains(String value)
         {
-            return ApplyCustomFilter("*" + value + "*", XLFilterOperator.NotEqual, s => !ContainsFunction(value, s));
+            return ApplyWildcardCustomFilter("*" + value + "*", XLFilterOperator.NotEqual);
         }
 
         public XLFilterType FilterType { get; set; }
@@ -275,31 +269,24 @@ namespace ClosedXML.Excel
                 ? distinctNumbers.Where(c => c > average)
                 : distinctNumbers.Where(c => c < average);
         }
-
-        private IXLFilterConnector ApplyCustomFilter<T>(T value, XLFilterOperator op, Func<Object, Boolean> condition)
-            where T : IComparable<T>
-        {
-            _autoFilter.IsEnabled = true;
-            Clear();
-
-            _autoFilter.AddFilter(_column, new XLFilter
-            {
-                Value = value,
-                Operator = op,
-                Connector = XLConnector.Or,
-                Condition = condition
-            });
-            _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
-            _autoFilter.Reapply();
-            return new XLFilterConnector(_autoFilter, _column);
-        }
-
+        
         private IXLFilterConnector ApplyCustomFilter(XLCellValue value, XLFilterOperator op)
         {
             _autoFilter.IsEnabled = true;
             Clear();
 
             _autoFilter.AddFilter(_column, XLFilter.CreateCustomFilter(value, op, XLConnector.Or));
+            _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
+            _autoFilter.Reapply();
+            return new XLFilterConnector(_autoFilter, _column);
+        }
+
+        private IXLFilterConnector ApplyWildcardCustomFilter(string wildcard, XLFilterOperator op)
+        {
+            _autoFilter.IsEnabled = true;
+            Clear();
+
+            _autoFilter.AddFilter(_column, XLFilter.CreateCustomWildcardFilter(wildcard, op, XLConnector.Or));
             _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
             _autoFilter.Reapply();
             return new XLFilterConnector(_autoFilter, _column);

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -38,7 +38,7 @@ namespace ClosedXML.Excel
         {
             _autoFilter.IsEnabled = true;
             FilterType = XLFilterType.DateTimeGrouping;
-            _autoFilter.AddFilter(_column, XLFilter.CreateRegularDateGroupFilter(date, dateTimeGrouping));
+            _autoFilter.AddFilter(_column, XLFilter.CreateDateGroupFilter(date, dateTimeGrouping));
             _autoFilter.Reapply();
 
             return new XLDateTimeGroupFilteredColumn(_autoFilter, _column);
@@ -173,7 +173,7 @@ namespace ClosedXML.Excel
                             Value = val,
                             Operator = XLFilterOperator.Equal,
                             Connector = XLConnector.Or,
-                            NewCondition = condition
+                            Condition = condition
                         });
                     }
 
@@ -237,7 +237,7 @@ namespace ClosedXML.Excel
                             Value = val,
                             Operator = XLFilterOperator.Equal,
                             Connector = XLConnector.Or,
-                            NewCondition = condition
+                            Condition = condition
                         });
                     }
 
@@ -286,7 +286,7 @@ namespace ClosedXML.Excel
             _autoFilter.IsEnabled = true;
             Clear();
 
-            _autoFilter.AddFilter(_column, XLFilter.CreateCustomWildcardFilter(pattern, match, XLConnector.Or));
+            _autoFilter.AddFilter(_column, XLFilter.CreateWildcardFilter(pattern, match, XLConnector.Or));
             _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
             _autoFilter.Reapply();
             return new XLFilterConnector(_autoFilter, _column);

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -36,28 +36,10 @@ namespace ClosedXML.Excel
 
         public IXLDateTimeGroupFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping)
         {
-            Func<Object, Boolean> condition = date2 => XLDateTimeGroupFilteredColumn.IsMatch(date, (DateTime)date2, dateTimeGrouping);
-
             _autoFilter.IsEnabled = true;
-            _autoFilter.AddFilter(_column, new XLFilter
-            {
-                Value = date,
-                Operator = XLFilterOperator.Equal,
-                Connector = XLConnector.Or,
-                Condition = condition,
-                DateTimeGrouping = dateTimeGrouping
-            });
-
-            _autoFilter.Column(_column).FilterType = XLFilterType.DateTimeGrouping;
-            var rows = _autoFilter.Range.Rows(2, _autoFilter.Range.RowCount());
-
-            foreach (IXLRangeRow row in rows)
-            {
-                if (row.Cell(_column).DataType == XLDataType.DateTime && condition(row.Cell(_column).GetDateTime()))
-                    row.WorksheetRow().Unhide();
-                else
-                    row.WorksheetRow().Hide();
-            }
+            FilterType = XLFilterType.DateTimeGrouping;
+            _autoFilter.AddFilter(_column, XLFilter.CreateRegularDateGroupFilter(date, dateTimeGrouping));
+            _autoFilter.Reapply();
 
             return new XLDateTimeGroupFilteredColumn(_autoFilter, _column);
         }

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -108,32 +108,32 @@ namespace ClosedXML.Excel
 
         public IXLFilterConnector BeginsWith(String value)
         {
-            return ApplyWildcardCustomFilter(value + "*", XLFilterOperator.Equal);
+            return ApplyCustomFilter(value + "*", true);
         }
 
         public IXLFilterConnector NotBeginsWith(String value)
         {
-            return ApplyWildcardCustomFilter(value + "*", XLFilterOperator.NotEqual);
+            return ApplyCustomFilter(value + "*", false);
         }
 
         public IXLFilterConnector EndsWith(String value)
         {
-            return ApplyWildcardCustomFilter("*" + value, XLFilterOperator.Equal);
+            return ApplyCustomFilter("*" + value, true);
         }
 
         public IXLFilterConnector NotEndsWith(String value)
         {
-            return ApplyWildcardCustomFilter("*" + value, XLFilterOperator.NotEqual);
+            return ApplyCustomFilter("*" + value, false);
         }
 
         public IXLFilterConnector Contains(String value)
         {
-            return ApplyWildcardCustomFilter("*" + value + "*", XLFilterOperator.Equal);
+            return ApplyCustomFilter("*" + value + "*", true);
         }
 
         public IXLFilterConnector NotContains(String value)
         {
-            return ApplyWildcardCustomFilter("*" + value + "*", XLFilterOperator.NotEqual);
+            return ApplyCustomFilter("*" + value + "*", false);
         }
 
         public XLFilterType FilterType { get; set; }
@@ -281,12 +281,12 @@ namespace ClosedXML.Excel
             return new XLFilterConnector(_autoFilter, _column);
         }
 
-        private IXLFilterConnector ApplyWildcardCustomFilter(string wildcard, XLFilterOperator op)
+        private IXLFilterConnector ApplyCustomFilter(string pattern, bool match)
         {
             _autoFilter.IsEnabled = true;
             Clear();
 
-            _autoFilter.AddFilter(_column, XLFilter.CreateCustomWildcardFilter(wildcard, op, XLConnector.Or));
+            _autoFilter.AddFilter(_column, XLFilter.CreateCustomWildcardFilter(pattern, match, XLConnector.Or));
             _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
             _autoFilter.Reapply();
             return new XLFilterConnector(_autoFilter, _column);

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -165,7 +165,7 @@ namespace ClosedXML.Excel
                 Boolean foundOne = false;
                 foreach (double val in values)
                 {
-                    Func<XLCellValue, Boolean> condition = v => v.IsUnifiedNumber && v.GetUnifiedNumber().Equals(val);
+                    Func<IXLCell, Boolean> condition = v => v.CachedValue.IsUnifiedNumber && v.CachedValue.GetUnifiedNumber().Equals(val);
                     if (addToList)
                     {
                         _autoFilter.AddFilter(_column, new XLFilter
@@ -178,7 +178,7 @@ namespace ClosedXML.Excel
                     }
 
                     var cell = row.Cell(_column);
-                    if (cell.DataType != XLDataType.Number || !condition(cell.GetDouble())) continue;
+                    if (!condition(cell)) continue;
                     row.WorksheetRow().Unhide();
                     foundOne = true;
                 }
@@ -229,7 +229,7 @@ namespace ClosedXML.Excel
                 Boolean foundOne = false;
                 foreach (double val in values)
                 {
-                    Func<XLCellValue, Boolean> condition = v => v.IsUnifiedNumber && v.GetUnifiedNumber().Equals(val);
+                    Func<IXLCell, Boolean> condition = v => v.CachedValue.IsUnifiedNumber && v.CachedValue.GetUnifiedNumber().Equals(val);
                     if (addToList)
                     {
                         _autoFilter.AddFilter(_column, new XLFilter
@@ -242,7 +242,7 @@ namespace ClosedXML.Excel
                     }
 
                     var cell = row.Cell(_column);
-                    if (cell.DataType != XLDataType.Number || !condition(cell.GetDouble())) continue;
+                    if (!condition(cell)) continue;
                     row.WorksheetRow().Unhide();
                     foundOne = true;
                 }

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -66,64 +66,42 @@ namespace ClosedXML.Excel
             ShowAverage(false);
         }
 
-        public IXLFilterConnector EqualTo<T>(T value) where T : IComparable<T>
+        public IXLFilterConnector EqualTo(XLCellValue value)
         {
-            if (typeof(T) == typeof(String))
-            {
-                return ApplyCustomFilter(value, XLFilterOperator.Equal,
-                                         v =>
-                                         v.ToString().Equals(value.ToString(),
-                                                             StringComparison.InvariantCultureIgnoreCase));
-            }
-
-            return ApplyCustomFilter(value, XLFilterOperator.Equal,
-                                     v => v.CastTo<T>().CompareTo(value) == 0);
+            return ApplyCustomFilter(value, XLFilterOperator.Equal);
         }
 
-        public IXLFilterConnector NotEqualTo<T>(T value) where T : IComparable<T>
+        public IXLFilterConnector NotEqualTo(XLCellValue value)
         {
-            if (typeof(T) == typeof(String))
-            {
-                return ApplyCustomFilter(value, XLFilterOperator.NotEqual,
-                                         v =>
-                                         !v.ToString().Equals(value.ToString(),
-                                                              StringComparison.InvariantCultureIgnoreCase));
-            }
-
-            return ApplyCustomFilter(value, XLFilterOperator.NotEqual,
-                                        v => v.CastTo<T>().CompareTo(value) != 0);
+            return ApplyCustomFilter(value, XLFilterOperator.NotEqual);
         }
 
-        public IXLFilterConnector GreaterThan<T>(T value) where T : IComparable<T>
+        public IXLFilterConnector GreaterThan(XLCellValue value)
         {
-            return ApplyCustomFilter(value, XLFilterOperator.GreaterThan,
-                                     v => v.CastTo<T>().CompareTo(value) > 0);
+            return ApplyCustomFilter(value, XLFilterOperator.GreaterThan);
         }
 
-        public IXLFilterConnector LessThan<T>(T value) where T : IComparable<T>
+        public IXLFilterConnector LessThan(XLCellValue value)
         {
-            return ApplyCustomFilter(value, XLFilterOperator.LessThan,
-                                     v => v.CastTo<T>().CompareTo(value) < 0);
+            return ApplyCustomFilter(value, XLFilterOperator.LessThan);
         }
 
-        public IXLFilterConnector EqualOrGreaterThan<T>(T value) where T : IComparable<T>
+        public IXLFilterConnector EqualOrGreaterThan(XLCellValue value)
         {
-            return ApplyCustomFilter(value, XLFilterOperator.EqualOrGreaterThan,
-                                     v => v.CastTo<T>().CompareTo(value) >= 0);
+            return ApplyCustomFilter(value, XLFilterOperator.EqualOrGreaterThan);
         }
 
-        public IXLFilterConnector EqualOrLessThan<T>(T value) where T : IComparable<T>
+        public IXLFilterConnector EqualOrLessThan(XLCellValue value)
         {
-            return ApplyCustomFilter(value, XLFilterOperator.EqualOrLessThan,
-                                     v => v.CastTo<T>().CompareTo(value) <= 0);
+            return ApplyCustomFilter(value, XLFilterOperator.EqualOrLessThan);
         }
 
-        public void Between<T>(T minValue, T maxValue) where T : IComparable<T>
+        public void Between(XLCellValue minValue, XLCellValue maxValue)
         {
             EqualOrGreaterThan(minValue).And.EqualOrLessThan(maxValue);
         }
 
-        public void NotBetween<T>(T minValue, T maxValue) where T : IComparable<T>
+        public void NotBetween(XLCellValue minValue, XLCellValue maxValue)
         {
             LessThan(minValue).Or.GreaterThan(maxValue);
         }
@@ -311,6 +289,17 @@ namespace ClosedXML.Excel
                 Connector = XLConnector.Or,
                 Condition = condition
             });
+            _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
+            _autoFilter.Reapply();
+            return new XLFilterConnector(_autoFilter, _column);
+        }
+
+        private IXLFilterConnector ApplyCustomFilter(XLCellValue value, XLFilterOperator op)
+        {
+            _autoFilter.IsEnabled = true;
+            Clear();
+
+            _autoFilter.AddFilter(_column, XLFilter.CreateCustomFilter(value, op, XLConnector.Or));
             _autoFilter.Column(_column).FilterType = XLFilterType.Custom;
             _autoFilter.Reapply();
             return new XLFilterConnector(_autoFilter, _column);

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -1474,8 +1474,9 @@ namespace ClosedXML.Excel.IO
                         var customFilters = new CustomFilters();
                         foreach (var filter in kp.Value)
                         {
-                            var v = filter.Value is not null ? filter.Value.ToString() : filter.CustomValue.ToString(CultureInfo.InvariantCulture);
-                            var customFilter = new CustomFilter { Val = v };
+                            // Since OOXML allows only string, the operand for custom filter must be serialized.
+                            var filterValue = filter.CustomValue.ToString(CultureInfo.InvariantCulture);
+                            var customFilter = new CustomFilter { Val = filterValue };
 
                             if (filter.Operator != XLFilterOperator.Equal)
                                 customFilter.Operator = filter.Operator.ToOpenXml();

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -10,6 +10,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using Break = DocumentFormat.OpenXml.Spreadsheet.Break;
@@ -1473,7 +1474,8 @@ namespace ClosedXML.Excel.IO
                         var customFilters = new CustomFilters();
                         foreach (var filter in kp.Value)
                         {
-                            var customFilter = new CustomFilter { Val = filter.Value.ObjectToInvariantString() };
+                            var v = filter.Value is not null ? filter.Value.ToString() : filter.CustomValue.ToString(CultureInfo.InvariantCulture);
+                            var customFilter = new CustomFilter { Val = v };
 
                             if (filter.Operator != XLFilterOperator.Equal)
                                 customFilter.Operator = filter.Operator.ToOpenXml();

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1655,7 +1655,7 @@ namespace ClosedXML.Excel
                             break;
                         }
                     }
-
+                    
                     foreach (var filter in filterColumn.CustomFilters.OfType<CustomFilter>())
                     {
                         var xlFilter = new XLFilter { Connector = connector };
@@ -1692,13 +1692,21 @@ namespace ClosedXML.Excel
                                     : s => XLFilterColumn.BeginsWithFunction(value, s);
                             }
                             else
-                                xlFilter.Value = filter.Val.Value;
+                            {
+                                var customValue = XLCellValue.FromText(filter.Val.Value, CultureInfo.InvariantCulture);
+                                var op = filter.Operator is not null ? filter.Operator.Value.ToClosedXml() : XLFilterOperator.Equal;
+                                xlFilter = XLFilter.CreateCustomFilter(customValue, op, connector);
+                            }
                         }
                         else
-                            xlFilter.Value = Double.Parse(filter.Val.Value, CultureInfo.InvariantCulture);
+                        {
+                            var customValue = XLCellValue.FromText(filter.Val.Value, CultureInfo.InvariantCulture);
+                            var op = filter.Operator is not null ? filter.Operator.Value.ToClosedXml() : XLFilterOperator.Equal;
+                            xlFilter = XLFilter.CreateCustomFilter(customValue, op, connector);
+                        }
 
                         // Unhandled instances - we should actually improve this
-                        if (xlFilter.Condition == null)
+                        if (xlFilter.Condition == null && xlFilter.NewCondition is null)
                         {
                             Func<Object, Boolean> condition = null;
                             switch (xlFilter.Operator)
@@ -1724,7 +1732,7 @@ namespace ClosedXML.Excel
 
                             xlFilter.Condition = condition;
                         }
-
+                        
                         filterList.Add(xlFilter);
                     }
                 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1676,34 +1676,10 @@ namespace ClosedXML.Excel
 
                     autoFilter.Filters.Add((int)filterColumn.ColumnId.Value + 1, filterList);
 
-                    Boolean isText = false;
                     foreach (var filter in filterColumn.Filters.OfType<Filter>())
                     {
-                        String val = filter.Val.Value;
-                        if (!Double.TryParse(val, NumberStyles.Any, null, out Double dTest))
-                        {
-                            isText = true;
-                            break;
-                        }
-                    }
+                        var xlFilter = XLFilter.CreateRegularFilter(filter.Val.Value);
 
-                    foreach (var filter in filterColumn.Filters.OfType<Filter>())
-                    {
-                        var xlFilter = new XLFilter { Connector = XLConnector.Or, Operator = XLFilterOperator.Equal };
-
-                        Func<Object, Boolean> condition;
-                        if (isText)
-                        {
-                            xlFilter.Value = filter.Val.Value;
-                            condition = o => o.ToString().Equals(xlFilter.Value.ToString(), StringComparison.OrdinalIgnoreCase);
-                        }
-                        else
-                        {
-                            xlFilter.Value = Double.Parse(filter.Val.Value, NumberStyles.Any);
-                            condition = o => (o as IComparable).CompareTo(xlFilter.Value) == 0;
-                        }
-
-                        xlFilter.Condition = condition;
                         filterList.Add(xlFilter);
                     }
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1652,7 +1652,7 @@ namespace ClosedXML.Excel
                         var v = filter.Val.Value;
                         if (op is XLFilterOperator.Equal or XLFilterOperator.NotEqual && v is not null && v.Contains('*'))
                         {
-                            xlFilter = XLFilter.CreateCustomWildcardFilter(v, op, connector);
+                            xlFilter = XLFilter.CreateCustomWildcardFilter(v, op == XLFilterOperator.Equal, connector);
                         }
                         else
                         {

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1643,94 +1643,21 @@ namespace ClosedXML.Excel
                     var filterList = new List<XLFilter>();
                     autoFilter.Column(column).FilterType = XLFilterType.Custom;
                     autoFilter.Filters.Add(column, filterList);
-                    XLConnector connector = filterColumn.CustomFilters.And != null && filterColumn.CustomFilters.And.Value ? XLConnector.And : XLConnector.Or;
+                    var connector = filterColumn.CustomFilters.And is not null && filterColumn.CustomFilters.And.Value ? XLConnector.And : XLConnector.Or;
 
-                    Boolean isText = false;
                     foreach (var filter in filterColumn.CustomFilters.OfType<CustomFilter>())
                     {
-                        String val = filter.Val.Value;
-                        if (!Double.TryParse(val, out Double dTest))
+                        var op = filter.Operator is not null ? filter.Operator.Value.ToClosedXml() : XLFilterOperator.Equal;
+                        XLFilter xlFilter;
+                        var v = filter.Val.Value;
+                        if (op is XLFilterOperator.Equal or XLFilterOperator.NotEqual && v is not null && v.Contains('*'))
                         {
-                            isText = true;
-                            break;
-                        }
-                    }
-                    
-                    foreach (var filter in filterColumn.CustomFilters.OfType<CustomFilter>())
-                    {
-                        var xlFilter = new XLFilter { Connector = connector };
-                        if (filter.Operator != null)
-                            xlFilter.Operator = filter.Operator.Value.ToClosedXml();
-                        else
-                            xlFilter.Operator = XLFilterOperator.Equal;
-
-                        if (isText)
-                        {
-                            // TODO: Treat text BETWEEN functions better
-                            if (filter.Val.Value.StartsWith("*") && filter.Val.Value.EndsWith("*"))
-                            {
-                                var value = filter.Val.Value.Substring(1, filter.Val.Value.Length - 2);
-                                xlFilter.Value = filter.Val.Value;
-                                xlFilter.Condition = xlFilter.Operator == XLFilterOperator.NotEqual
-                                    ? s => !XLFilterColumn.ContainsFunction(value, s)
-                                    : s => XLFilterColumn.ContainsFunction(value, s);
-                            }
-                            else if (filter.Val.Value.StartsWith("*"))
-                            {
-                                var value = filter.Val.Value.Substring(1);
-                                xlFilter.Value = filter.Val.Value;
-                                xlFilter.Condition = xlFilter.Operator == XLFilterOperator.NotEqual
-                                    ? s => !XLFilterColumn.EndsWithFunction(value, s)
-                                    : s => XLFilterColumn.EndsWithFunction(value, s);
-                            }
-                            else if (filter.Val.Value.EndsWith("*"))
-                            {
-                                var value = filter.Val.Value.Substring(0, filter.Val.Value.Length - 1);
-                                xlFilter.Value = filter.Val.Value;
-                                xlFilter.Condition = xlFilter.Operator == XLFilterOperator.NotEqual
-                                    ? s => !XLFilterColumn.BeginsWithFunction(value, s)
-                                    : s => XLFilterColumn.BeginsWithFunction(value, s);
-                            }
-                            else
-                            {
-                                var customValue = XLCellValue.FromText(filter.Val.Value, CultureInfo.InvariantCulture);
-                                var op = filter.Operator is not null ? filter.Operator.Value.ToClosedXml() : XLFilterOperator.Equal;
-                                xlFilter = XLFilter.CreateCustomFilter(customValue, op, connector);
-                            }
+                            xlFilter = XLFilter.CreateCustomWildcardFilter(v, op, connector);
                         }
                         else
                         {
                             var customValue = XLCellValue.FromText(filter.Val.Value, CultureInfo.InvariantCulture);
-                            var op = filter.Operator is not null ? filter.Operator.Value.ToClosedXml() : XLFilterOperator.Equal;
                             xlFilter = XLFilter.CreateCustomFilter(customValue, op, connector);
-                        }
-
-                        // Unhandled instances - we should actually improve this
-                        if (xlFilter.Condition == null && xlFilter.NewCondition is null)
-                        {
-                            Func<Object, Boolean> condition = null;
-                            switch (xlFilter.Operator)
-                            {
-                                case XLFilterOperator.Equal:
-                                    if (isText)
-                                        condition = o => o.ToString().Equals(xlFilter.Value.ToString(), StringComparison.OrdinalIgnoreCase);
-                                    else
-                                        condition = o => (o as IComparable).CompareTo(xlFilter.Value) == 0;
-                                    break;
-
-                                case XLFilterOperator.EqualOrGreaterThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) >= 0; break;
-                                case XLFilterOperator.EqualOrLessThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) <= 0; break;
-                                case XLFilterOperator.GreaterThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) > 0; break;
-                                case XLFilterOperator.LessThan: condition = o => (o as IComparable).CompareTo(xlFilter.Value) < 0; break;
-                                case XLFilterOperator.NotEqual:
-                                    if (isText)
-                                        condition = o => !o.ToString().Equals(xlFilter.Value.ToString(), StringComparison.OrdinalIgnoreCase);
-                                    else
-                                        condition = o => (o as IComparable).CompareTo(xlFilter.Value) != 0;
-                                    break;
-                            }
-
-                            xlFilter.Condition = condition;
                         }
                         
                         filterList.Add(xlFilter);

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1774,80 +1774,73 @@ namespace ClosedXML.Excel
 
                     foreach (var dateGroupItem in filterColumn.Filters.OfType<DateGroupItem>())
                     {
-                        bool valid = true;
-
-                        if (!(dateGroupItem.DateTimeGrouping?.HasValue ?? false))
+                        if (dateGroupItem.DateTimeGrouping is null || !dateGroupItem.DateTimeGrouping.HasValue)
                             continue;
 
-                        var xlDateGroupFilter = new XLFilter
-                        {
-                            Connector = XLConnector.Or,
-                            Operator = XLFilterOperator.Equal,
-                            DateTimeGrouping = dateGroupItem.DateTimeGrouping?.Value.ToClosedXml() ?? XLDateTimeGrouping.Year
-                        };
+                        var xlGrouping = dateGroupItem.DateTimeGrouping.Value.ToClosedXml();
+                        var year = 1900;
+                        var month = 1;
+                        var day = 1;
+                        var hour = 0;
+                        var minute = 0;
+                        var second = 0;
 
-                        int year = 1900;
-                        int month = 1;
-                        int day = 1;
-                        int hour = 0;
-                        int minute = 0;
-                        int second = 0;
+                        var valid = true;
 
-                        if (xlDateGroupFilter.DateTimeGrouping >= XLDateTimeGrouping.Year)
+                        if (xlGrouping >= XLDateTimeGrouping.Year)
                         {
-                            if (dateGroupItem?.Year?.HasValue ?? false)
-                                year = (int)dateGroupItem.Year?.Value;
+                            if (dateGroupItem.Year?.HasValue ?? false)
+                                year = dateGroupItem.Year.Value;
                             else
-                                valid &= false;
+                                valid = false;
                         }
 
-                        if (xlDateGroupFilter.DateTimeGrouping >= XLDateTimeGrouping.Month)
+                        if (xlGrouping >= XLDateTimeGrouping.Month)
                         {
-                            if (dateGroupItem?.Month?.HasValue ?? false)
-                                month = (int)dateGroupItem.Month?.Value;
+                            if (dateGroupItem.Month?.HasValue ?? false)
+                                month = dateGroupItem.Month.Value;
                             else
-                                valid &= false;
+                                valid = false;
                         }
 
-                        if (xlDateGroupFilter.DateTimeGrouping >= XLDateTimeGrouping.Day)
+                        if (xlGrouping >= XLDateTimeGrouping.Day)
                         {
-                            if (dateGroupItem?.Day?.HasValue ?? false)
-                                day = (int)dateGroupItem.Day?.Value;
+                            if (dateGroupItem.Day?.HasValue ?? false)
+                                day = dateGroupItem.Day.Value;
                             else
-                                valid &= false;
+                                valid = false;
                         }
 
-                        if (xlDateGroupFilter.DateTimeGrouping >= XLDateTimeGrouping.Hour)
+                        if (xlGrouping >= XLDateTimeGrouping.Hour)
                         {
-                            if (dateGroupItem?.Hour?.HasValue ?? false)
-                                hour = (int)dateGroupItem.Hour?.Value;
+                            if (dateGroupItem.Hour?.HasValue ?? false)
+                                hour = dateGroupItem.Hour.Value;
                             else
-                                valid &= false;
+                                valid = false;
                         }
 
-                        if (xlDateGroupFilter.DateTimeGrouping >= XLDateTimeGrouping.Minute)
+                        if (xlGrouping >= XLDateTimeGrouping.Minute)
                         {
-                            if (dateGroupItem?.Minute?.HasValue ?? false)
-                                minute = (int)dateGroupItem.Minute?.Value;
+                            if (dateGroupItem.Minute?.HasValue ?? false)
+                                minute = dateGroupItem.Minute.Value;
                             else
-                                valid &= false;
+                                valid = false;
                         }
 
-                        if (xlDateGroupFilter.DateTimeGrouping >= XLDateTimeGrouping.Second)
+                        if (xlGrouping >= XLDateTimeGrouping.Second)
                         {
-                            if (dateGroupItem?.Second?.HasValue ?? false)
-                                second = (int)dateGroupItem.Second?.Value;
+                            if (dateGroupItem.Second?.HasValue ?? false)
+                                second = dateGroupItem.Second.Value;
                             else
-                                valid &= false;
+                                valid = false;
                         }
-
-                        var date = new DateTime(year, month, day, hour, minute, second);
-                        xlDateGroupFilter.Value = date;
-
-                        xlDateGroupFilter.Condition = date2 => XLDateTimeGroupFilteredColumn.IsMatch(date, (DateTime)date2, xlDateGroupFilter.DateTimeGrouping);
 
                         if (valid)
+                        {
+                            var date = new DateTime(year, month, day, hour, minute, second);
+                            var xlDateGroupFilter = XLFilter.CreateRegularDateGroupFilter(date, xlGrouping);
                             filterList.Add(xlDateGroupFilter);
+                        }
                     }
                 }
                 else if (filterColumn.Top10 != null)

--- a/ClosedXML/Extensions/FormatExtensions.cs
+++ b/ClosedXML/Extensions/FormatExtensions.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.Extensions
             if (!nf.IsValid)
                 return format;
 
-            return nf.Format(o, CultureInfo.InvariantCulture);
+            return nf.Format(o, CultureInfo.CurrentCulture);
         }
     }
 }


### PR DESCRIPTION
This is part 2/? of rework of AutoFilter that should bring it to usable state (=documented, correctly working state). Continuation of #2238.

* Remove generics from methods adding a compare filter (e.g. `void GreaterThan<T>(T value) where T : IComparable<T>`) and mostly replace them with `XLCellValue`.
* Encapsulate conditions for filter conditions from two places into `XLFilter`.
* Use `IXLCell` as an argument of filters, instead of `Object`.
* Set culture of whole test assembly to en-US. If test needs a different culture, it should use `SetCultureAttribute`.