### PR TITLE
AutoFilter rework - 6/7 - Add tests

### DIFF
--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
@@ -32,6 +32,22 @@ namespace ClosedXML.Tests.Excel.AutoFilters
             return this;
         }
 
+        internal AutoFilterTester AddTrue(params XLCellValue[] values)
+        {
+            foreach (var value in values)
+                Add(value, true);
+
+            return this;
+        }
+
+        internal AutoFilterTester AddFalse(params XLCellValue[] values)
+        {
+            foreach (var value in values)
+                Add(value, false);
+
+            return this;
+        }
+
         internal void AssertVisibility()
         {
             using var wb = new XLWorkbook();

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.AutoFilters
+{
+    internal class AutoFilterTester
+    {
+        private readonly Action<IXLFilterColumn> _setFilter;
+        private readonly List<(XLCellValue Value, Action<IXLStyle> SetStyle, bool ExpectedVisibility)> _values = new();
+
+        internal AutoFilterTester(Action<IXLFilterColumn> setFilter)
+        {
+            _setFilter = setFilter;
+        }
+
+        internal AutoFilterTester Add(XLCellValue value, bool shouldBeVisible)
+        {
+            return Add(value, static (IXLStyle _) => { }, shouldBeVisible);
+        }
+
+        internal AutoFilterTester Add(XLCellValue value, Action<IXLNumberFormat> setNumberFormat, bool shouldBeVisible)
+        {
+            _values.Add((value, s => setNumberFormat(s.NumberFormat), shouldBeVisible));
+            return this;
+        }
+
+        internal AutoFilterTester Add(XLCellValue value, Action<IXLStyle> setStyle, bool shouldBeVisible)
+        {
+            _values.Add((value, setStyle, shouldBeVisible));
+            return this;
+        }
+
+        internal void AssertVisibility()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = "Data";
+            for (var i = 0; i < _values.Count; ++i)
+            {
+                var cell = ws.Cell(i + 2, 1);
+                cell.Value = _values[i].Value;
+                _values[i].SetStyle(cell.Style);
+            }
+
+            var autoFilter = ws.Range(1, 1, _values.Count + 1, 1).SetAutoFilter();
+            _setFilter(autoFilter.Column(1));
+
+            for (var i = 0; i < _values.Count; ++i)
+            {
+                var row = i + 2;
+                var value = ws.Cell(row, 1).CachedValue;
+                var formattedString = ((XLCell)ws.Cell(row, 1)).GetFormattedString(value);
+                var actualVisible = !ws.Row(row).IsHidden;
+                var expectedVisibility = _values[i].ExpectedVisibility;
+                Assert.AreEqual(expectedVisibility, actualVisible, $"Visibility differs at index {i} for value {value}(formatted '{formattedString}')");
+            }
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
@@ -70,7 +70,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 var formattedString = ((XLCell)ws.Cell(row, 1)).GetFormattedString(value);
                 var actualVisible = !ws.Row(row).IsHidden;
                 var expectedVisibility = _values[i].ExpectedVisibility;
-                Assert.AreEqual(expectedVisibility, actualVisible, $"Visibility differs at index {i} for value {value}(formatted '{formattedString}')");
+                Assert.AreEqual(expectedVisibility, actualVisible, $"Visibility differs at index {i} for value {value} (formatted '{formattedString}')");
             }
         }
     }

--- a/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
@@ -21,6 +21,15 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         }
 
         [Test]
+        public void EqualLessThan_with_text_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.EqualOrLessThan("b"))
+                .Add("", true).Add("A", true).Add("b", true).Add("B", true).Add("C", false)
+                .Add(Blank.Value, false).Add(1, false).Add(false, false).Add(XLError.NullValue, false)
+                .AssertVisibility();
+        }
+
+        [Test]
         public void LessThan_with_number_compares_against_values_of_same_type()
         {
             WithOneAndOtherTypes(f => f.LessThan(2))

--- a/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
@@ -156,7 +156,31 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 .AssertVisibility();
         }
 
-        private AutoFilterTester WithOneAndOtherTypes(Action<IXLFilterColumn> filter)
+        [Test]
+        public void Equal_uses_wildcard_matching_for_patterns_against_text_only()
+        {
+            new AutoFilterTester(f => f.EqualTo("1*0"))
+                .AddTrue("1.0", "1 and 0")
+                .AddFalse(1, "A", "B", 2, XLError.DivisionByZero, true, false)
+                .Add(1, nf => nf.SetFormat("1.0"), false)
+                .Add(1, nf => nf.SetNumberFormatId((int)XLPredefinedFormat.Number.Precision2), false)
+                .AssertVisibility();
+        }
+
+        [Test]
+        [SetCulture("cs-CZ")]
+        public void Equal_uses_content_matching_for_filter_values_that_look_like_non_patterns()
+        {
+            // Note the ',' separator that is used detect number. Excel doesn't use invariant culture.
+            new AutoFilterTester(f => f.EqualTo("1,00"))
+                .Add("1,00", true)
+                .Add(1, nf => nf.SetNumberFormatId((int)XLPredefinedFormat.Number.Precision2), true)
+                .Add(99, nf => nf.SetFormat("\"1,00\""), true)
+                .AddFalse(1, "A", "B", 2, XLError.DivisionByZero, true, false)
+                .AssertVisibility();
+        }
+
+        private static AutoFilterTester WithOneAndOtherTypes(Action<IXLFilterColumn> filter)
         {
             // Add equivalent of 1 and other types
             return new AutoFilterTester(filter)

--- a/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.AutoFilters
+{
+    /// <summary>
+    /// Equal/NotEqual operators in custom filter are wildcard filters, *NOT* comparator filter.
+    /// LessThan/EqualOrLessThan/EqualOrGreaterThan/GreaterThan are comparator filters.
+    /// </summary>
+    [TestFixture]
+    public class CustomFilterTests
+    {
+        [Test]
+        public void EqualLessThan_with_number_compares_against_values_of_same_type()
+        {
+            WithOneAndOtherTypes(f => f.EqualOrLessThan(1))
+                .Add(0.9, true)
+                .Add(1.1, false)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void LessThan_with_number_compares_against_values_of_same_type()
+        {
+            WithOneAndOtherTypes(f => f.LessThan(2))
+                .Add(1.1, true)
+                .Add(2, false)
+                .AssertVisibility();
+        }
+        [Test]
+        public void GreaterThan_with_number_compares_against_values_of_same_type()
+        {
+            WithOneAndOtherTypes(f => f.GreaterThan(0))
+                .Add(0.1, true)
+                .Add(-0.1, false)
+                .Add(-1, false)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void EqualOrGreaterThan_with_number_compares_against_values_of_same_type()
+        {
+            WithOneAndOtherTypes(f => f.EqualOrGreaterThan(1))
+                .Add(0.9, false)
+                .Add(1.1, true)
+                .AssertVisibility();
+        }
+
+        private AutoFilterTester WithOneAndOtherTypes(Action<IXLFilterColumn> filter)
+        {
+            // Add equivalent of 1 and other types
+            return new AutoFilterTester(filter)
+                .Add(1, true)
+                .Add(new DateTime(1900, 1, 1), true) // =1 in serial date time
+                .Add(new TimeSpan(1, 0, 0, 0), true) // =1 in serial date time
+                .Add("1", false)
+                .Add(Blank.Value, false)
+                .Add("Hello", false)
+                .Add(true, false)
+                .Add(XLError.NullValue, false); // #NULL! has type value 1
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
@@ -12,6 +12,15 @@ namespace ClosedXML.Tests.Excel.AutoFilters
     public class CustomFilterTests
     {
         [Test]
+        public void EqualLessThan_with_logical_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.EqualOrLessThan(true))
+                .AddTrue(false, true)
+                .AddFalse(Blank.Value, 1, "FALSE", "TRUE", XLError.NullValue)
+                .AssertVisibility();
+        }
+
+        [Test]
         public void EqualLessThan_with_number_compares_against_values_of_same_type()
         {
             WithOneAndOtherTypes(f => f.EqualOrLessThan(1))
@@ -24,8 +33,26 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         public void EqualLessThan_with_text_compares_against_values_of_same_type()
         {
             new AutoFilterTester(f => f.EqualOrLessThan("b"))
-                .Add("", true).Add("A", true).Add("b", true).Add("B", true).Add("C", false)
-                .Add(Blank.Value, false).Add(1, false).Add(false, false).Add(XLError.NullValue, false)
+                .AddTrue("", "A", "b", "B")
+                .AddFalse("C", Blank.Value, 1, false, XLError.NullValue)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void EqualLessThan_with_error_compares_against_numeric_types_of_error()
+        {
+            new AutoFilterTester(f => f.EqualOrLessThan(XLError.CellReference))
+                .AddTrue(XLError.NullValue, XLError.IncompatibleValue, XLError.CellReference)
+                .AddFalse(XLError.NameNotRecognized, 1, "#NULL!", "Test", "", true, false, Blank.Value)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void LessThan_with_logical_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.LessThan(true))
+                .AddTrue(false)
+                .AddFalse(true, -1, Blank.Value, 1, "FALSE", "TRUE", XLError.NullValue)
                 .AssertVisibility();
         }
 
@@ -37,6 +64,34 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 .Add(2, false)
                 .AssertVisibility();
         }
+
+        [Test]
+        public void LessThan_with_text_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.LessThan("b"))
+                .AddTrue("", "A")
+                .AddFalse("b", "B", "C", Blank.Value, 1, false, XLError.NullValue)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void LessThan_with_error_compares_against_numeric_types_of_error()
+        {
+            new AutoFilterTester(f => f.LessThan(XLError.CellReference))
+                .AddTrue(XLError.NullValue, XLError.IncompatibleValue)
+                .AddFalse(XLError.CellReference, XLError.NameNotRecognized, 1, "#NULL!", "Test", "", true, false, Blank.Value)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void GreaterThan_with_logical_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.GreaterThan(false))
+                .AddTrue(true)
+                .AddFalse(false, -1, Blank.Value, 1, "FALSE", "TRUE", XLError.NullValue)
+                .AssertVisibility();
+        }
+
         [Test]
         public void GreaterThan_with_number_compares_against_values_of_same_type()
         {
@@ -48,11 +103,56 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         }
 
         [Test]
+        public void GreaterThan_with_text_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.GreaterThan("b"))
+                .AddTrue("C", "c")
+                .AddFalse("", "A", "b", "B", Blank.Value, 1, false, XLError.NullValue)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void GreaterThan_with_error_compares_against_numeric_types_of_error()
+        {
+            new AutoFilterTester(f => f.GreaterThan(XLError.CellReference))
+                .AddTrue(XLError.NameNotRecognized, XLError.NumberInvalid, XLError.NoValueAvailable)
+                .AddFalse(XLError.CellReference, XLError.IncompatibleValue, XLError.NullValue, 1, "#NULL!", "Test", "", true, false, Blank.Value)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void EqualOrGreaterThan_with_logical_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.EqualOrGreaterThan(false))
+                .AddTrue(false, true)
+                .AddFalse(-1, 0, Blank.Value, 1, "FALSE", "TRUE", XLError.NullValue)
+                .AssertVisibility();
+        }
+
+        [Test]
         public void EqualOrGreaterThan_with_number_compares_against_values_of_same_type()
         {
             WithOneAndOtherTypes(f => f.EqualOrGreaterThan(1))
                 .Add(0.9, false)
                 .Add(1.1, true)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void EqualOrGreaterThan_with_text_compares_against_values_of_same_type()
+        {
+            new AutoFilterTester(f => f.EqualOrGreaterThan("b"))
+                .AddTrue("b", "B", "Ba", "C", "c")
+                .AddFalse("", "A", Blank.Value, 1, false, XLError.NullValue)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void EqualOrGreaterThan_with_error_compares_against_numeric_types_of_error()
+        {
+            new AutoFilterTester(f => f.EqualOrGreaterThan(XLError.CellReference))
+                .AddTrue(XLError.CellReference, XLError.NameNotRecognized, XLError.NumberInvalid, XLError.NoValueAvailable)
+                .AddFalse(XLError.IncompatibleValue, XLError.NullValue, 1, "#NULL!", "Test", "", true, false, Blank.Value)
                 .AssertVisibility();
         }
 

--- a/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
     public class CustomFilterTests
     {
         [Test]
-        public void EqualLessThan_with_logical_compares_against_values_of_same_type()
+        public void EqualOrLessThan_with_logical_compares_against_values_of_same_type()
         {
             new AutoFilterTester(f => f.EqualOrLessThan(true))
                 .AddTrue(false, true)
@@ -21,7 +21,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         }
 
         [Test]
-        public void EqualLessThan_with_number_compares_against_values_of_same_type()
+        public void EqualOrLessThan_with_number_compares_against_values_of_same_type()
         {
             WithOneAndOtherTypes(f => f.EqualOrLessThan(1))
                 .Add(0.9, true)
@@ -30,7 +30,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         }
 
         [Test]
-        public void EqualLessThan_with_text_compares_against_values_of_same_type()
+        public void EqualOrLessThan_with_text_compares_against_values_of_same_type()
         {
             new AutoFilterTester(f => f.EqualOrLessThan("b"))
                 .AddTrue("", "A", "b", "B")
@@ -39,7 +39,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         }
 
         [Test]
-        public void EqualLessThan_with_error_compares_against_numeric_types_of_error()
+        public void EqualOrLessThan_with_error_compares_against_numeric_types_of_error()
         {
             new AutoFilterTester(f => f.EqualOrLessThan(XLError.CellReference))
                 .AddTrue(XLError.NullValue, XLError.IncompatibleValue, XLError.CellReference)
@@ -97,8 +97,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         {
             WithOneAndOtherTypes(f => f.GreaterThan(0))
                 .Add(0.1, true)
-                .Add(-0.1, false)
-                .Add(-1, false)
+                .AddFalse(-0.1, -1)
                 .AssertVisibility();
         }
 
@@ -169,7 +168,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
 
         [Test]
         [SetCulture("cs-CZ")]
-        public void Equal_uses_content_matching_for_filter_values_that_look_like_non_patterns()
+        public void Equal_uses_format_string_matching_for_filter_values_that_look_like_non_patterns()
         {
             // Note the ',' separator that is used detect number. Excel doesn't use invariant culture.
             new AutoFilterTester(f => f.EqualTo("1,00"))

--- a/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/CustomFilterTests.cs
@@ -180,6 +180,36 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 .AssertVisibility();
         }
 
+        [Test]
+        [SetCulture("cs-CZ")]
+        public void NotEqual_matches_detected_type_and_value_of_filter_value_for_non_text_data_types()
+        {
+            // 1,00 is detected as a type number with value 1.
+            new AutoFilterTester(f => f.NotEqualTo("1,00"))
+                .Add(1, false) // Value is equal => hide
+                .Add(1, nf => nf.SetNumberFormatId((int)XLPredefinedFormat.Number.Precision2), false) // Value is equal => hide
+                .Add("1,00", true) // wrong type
+                .Add(99, nf => nf.SetFormat("\"1,00\""), true) // Value is wrong => non-equal
+                .AddTrue("A", "B", 2, XLError.DivisionByZero, true, false) // Wrong type
+                .AssertVisibility();
+        }
+
+        [Test]
+        [SetCulture("cs-CZ")]
+        public void NotEqual_for_detected_wildcard_matches_only_texts()
+        {
+            // NotEqual with text pattern must have text type.
+            new AutoFilterTester(f => f.NotEqualTo("1*0"))
+                .Add(1, true)
+                .Add(1, nf => nf.SetNumberFormatId((int)XLPredefinedFormat.Number.Precision2), true)
+                .Add("1,00", false)
+                .Add("100", false)
+                .Add(100, true)
+                .Add(99, nf => nf.SetFormat("\"1,00\""), true)
+                .AddTrue("A", "B", 2, XLError.DivisionByZero, true, false)
+                .AssertVisibility();
+        }
+
         private static AutoFilterTester WithOneAndOtherTypes(Action<IXLFilterColumn> filter)
         {
             // Add equivalent of 1 and other types

--- a/ClosedXML.Tests/Excel/AutoFilters/DynamicFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/DynamicFilterTests.cs
@@ -1,5 +1,7 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using System.Linq;
+using ClosedXML.Excel;
 
 namespace ClosedXML.Tests.Excel.AutoFilters
 {
@@ -25,6 +27,44 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                     var filterResult = ws.Rows("2:7").Select(row => !row.IsHidden);
                     CollectionAssert.AreEqual(new[] { false, false, false, false, true, true }, filterResult);
                 });
+        }
+
+        [Test]
+        public void BelowAverage_takes_values_under_avg_value()
+        {
+            // The average 2 is not included. 
+            new AutoFilterTester(f => f.BelowAverage())
+                .AddTrue(1)
+                .AddFalse(2, 3)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void AboveAverage_takes_values_over_avg_value()
+        {
+            new AutoFilterTester(f => f.AboveAverage())
+                .AddTrue(3)
+                .AddFalse(2, 1)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Average_ignores_non_unified_numbers()
+        {
+            new AutoFilterTester(f => f.BelowAverage())
+                .AddTrue(new DateTime(1900, 1, 1)) // Serial date time 1
+                .AddFalse(1.1)
+                .AddFalse(1.2)
+                .AddFalse(XLError.NoValueAvailable, true, false, "-100", "Text", Blank.Value)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void All_rows_are_hidden_when_column_has_no_number()
+        {
+            new AutoFilterTester(f => f.AboveAverage())
+                .AddFalse(Blank.Value, true, false, "-100", "Text", XLError.NoValueAvailable)
+                .AssertVisibility();
         }
     }
 }

--- a/ClosedXML.Tests/Excel/AutoFilters/RegularFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/RegularFilterTests.cs
@@ -41,8 +41,8 @@ namespace ClosedXML.Tests.Excel.AutoFilters
         public void Regular_number_value_is_compared_as_text_against_formatted_text()
         {
             new AutoFilterTester(f => f.AddFilter(1.5))
-                .Add(1.5d, true)
-                .Add("1.5f", false)
+                .Add(1.5, true)
+                .Add("1.5", false)
                 .Add("1,5", true)
                 .Add("1,50", false)
                 .Add(1.5, nf => nf.SetNumberFormatId((int)XLPredefinedFormat.Number.PercentPrecision2), false)

--- a/ClosedXML.Tests/Excel/AutoFilters/RegularFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/RegularFilterTests.cs
@@ -35,5 +35,54 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                     CollectionAssert.AreEqual(new[] { true, false, false, true }, dataVisibility);
                 }, false);
         }
+
+        [Test]
+        [SetCulture("cs-CZ")]
+        public void Regular_number_value_is_compared_as_text_against_formatted_text()
+        {
+            new AutoFilterTester(f => f.AddFilter(1.5))
+                .Add(1.5d, true)
+                .Add("1.5f", false)
+                .Add("1,5", true)
+                .Add("1,50", false)
+                .Add(1.5, nf => nf.SetNumberFormatId((int)XLPredefinedFormat.Number.PercentPrecision2), false)
+                .Add(700, nf => nf.SetFormat("\"1,5\""), true)
+                .AssertVisibility();
+        }
+
+        [Test]
+        [SetCulture("cs-CZ")]
+        public void Regular_logical_value_is_compared_as_text_against_formatted_text()
+        {
+            new AutoFilterTester(f => f.AddFilter(false))
+                .Add(false, true)
+                .Add(0, false)
+                .Add("FALSE", true)
+                .Add("TRUE", false)
+                .Add(true, false)
+                .Add(77, nf => nf.SetFormat("\"FALSE\""), true)
+                .AssertVisibility();
+        }
+
+        [Test]
+        [SetCulture("cs-CZ")]
+        public void Regular_error_value_is_compared_as_text_against_formatted_text()
+        {
+            new AutoFilterTester(f => f.AddFilter("#VALUE!"))
+                .Add(XLError.IncompatibleValue, true)
+                .Add(2, false)
+                .Add("#VALUE!", true)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Pattern_is_not_interpreted_as_wildcard()
+        {
+            new AutoFilterTester(f => f.AddFilter("A*"))
+                .Add("A*", true)
+                .Add("A", false)
+                .Add("A something", false)
+                .AssertVisibility();
+        }
     }
 }

--- a/ClosedXML.Tests/Excel/AutoFilters/Top10FilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/Top10FilterTests.cs
@@ -1,5 +1,7 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using System.Linq;
+using ClosedXML.Excel;
 
 namespace ClosedXML.Tests.Excel.AutoFilters
 {
@@ -25,6 +27,120 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                     var filterResult = ws.Rows("2:7").Select(row => !row.IsHidden);
                     CollectionAssert.AreEqual(new[] { true, true, false, false, false, true }, filterResult);
                 });
+        }
+
+        [Test]
+        public void Top_items_filter_excludes_non_unified_numbers()
+        {
+            // Sort and then use cutoff value, it's 4 here and then take all values >= cutoff.
+            new AutoFilterTester(f => f.Top(1))
+                .AddTrue(new DateTime(1900, 2, 10))
+                .AddFalse(11, 10)
+                .AddFalse("-1000", "Text", Blank.Value, true, false, XLError.IncompatibleValue)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Bottom_items_filter_excludes_non_unified_numbers()
+        {
+            new AutoFilterTester(f => f.Bottom(1))
+                .AddTrue(new DateTime(1900, 1, 1))
+                .AddFalse(2, 3)
+                .AddFalse("-1000", "Text", Blank.Value, true, false, XLError.IncompatibleValue)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Top_items_filter_determines_top_items_by_determining_cut_off_value()
+        {
+            // Sort and then use cutoff value, it's 4 here and then take all values <= cutoff.
+            new AutoFilterTester(f => f.Top(2))
+                .AddTrue(5, 4, 4, 4)
+                .AddFalse(3, 2, 1)
+                .AssertVisibility();
+
+            // Cutoff is 5 here.
+            new AutoFilterTester(f => f.Top(2))
+                .AddTrue(5, 5)
+                .AddFalse(4, 4, 4, 3, 2, 1)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Bottom_items_filter_determines_top_items_by_determining_cut_off_value()
+        {
+            // Cutoff is 2
+            new AutoFilterTester(f => f.Bottom(2))
+                .AddTrue(1, 2, 2, 2)
+                .AddFalse(3, 4, 5)
+                .AssertVisibility();
+
+            // Cutoff is 5
+            new AutoFilterTester(f => f.Bottom(2))
+                .AddTrue(1, 1)
+                .AddFalse(2, 2, 2, 3, 4, 5)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Top_percents_uses_inclusive_percent_value()
+        {
+            // Autofilter doesn't include value 750, which is at 75%, i.e. right at the border.
+            new AutoFilterTester(f => f.Top(25, XLTopBottomType.Percent))
+                .AddFalse(Enumerable.Range(1, 750).Select<int, XLCellValue>(x => x).ToArray())
+                .AddTrue(Enumerable.Range(751, 250).Select<int, XLCellValue>(x => x).ToArray())
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Bottom_percents_uses_inclusive_percent_value()
+        {
+            new AutoFilterTester(f => f.Bottom(25, XLTopBottomType.Percent))
+                .AddTrue(Enumerable.Range(1, 250).Select<int, XLCellValue>(x => x).ToArray())
+                .AddFalse(Enumerable.Range(251, 750).Select<int, XLCellValue>(x => x).ToArray())
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Top_percents_always_has_at_least_one_item()
+        {
+            // Top 1% takes one item that is 33% of all items.
+            new AutoFilterTester(f => f.Top(1, XLTopBottomType.Percent))
+                .AddTrue(3)
+                .AddFalse(2, 1)
+                .AssertVisibility();
+        }
+
+        [Test]
+        public void Bottom_percents_always_has_at_least_one_item()
+        {
+            new AutoFilterTester(f => f.Bottom(1, XLTopBottomType.Percent))
+                .AddTrue(1)
+                .AddFalse(2, 3)
+                .AssertVisibility();
+        }
+
+        [TestCase(0, true)]
+        [TestCase(501, true)]
+        [TestCase(0, false)]
+        [TestCase(501, false)]
+        public void Top_and_bottom_filter_value_must_be_between_1_and_500(int value, bool top)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = "Data";
+            ws.Cell("A2").Value = value;
+            var autoFilter = ws.Range("A1:A2").SetAutoFilter();
+            var filterColumn = autoFilter.Column(1);
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                if (top)
+                    filterColumn.Top(value);
+                else
+                    filterColumn.Bottom(value);
+            })!;
+            StringAssert.Contains("Value must be between 1 and 500.", ex.Message);
         }
     }
 }

--- a/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/IXLFilterColumn.cs
@@ -105,8 +105,10 @@ namespace ClosedXML.Excel
         /// <returns>Fluent API allowing to add additional date time group value.</returns>
         IXLFilteredColumn AddDateGroupFilter(DateTime date, XLDateTimeGrouping dateTimeGrouping, bool reapply = true);
 
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="value"/> is out of range 1..500.</exception>
         void Top(Int32 value, XLTopBottomType type = XLTopBottomType.Items, bool reapply = true);
 
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="value"/> is out of range 1..500.</exception>
         void Bottom(Int32 value, XLTopBottomType type = XLTopBottomType.Items, bool reapply = true);
 
         void AboveAverage(bool reapply = true);

--- a/ClosedXML/Excel/AutoFilters/XLFilter.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilter.cs
@@ -126,11 +126,16 @@ namespace ClosedXML.Excel
             // Blanks are rather strange case. Excel parsing logic for custom filter value into
             // XLCellValue is very inconsistent. E.g. 'does not equal' for empty string ignores
             // blanks and empty strings.
-            cellValue = cellValue.IsBlank ? string.Empty : cellValue;
-            filterValue = filterValue.IsBlank ? string.Empty : filterValue;
-
-            if (cellValue.Type != filterValue.Type && cellValue.IsUnifiedNumber != filterValue.IsUnifiedNumber)
+            // For custom compare filters, blank never matches.
+            if (cellValue.IsBlank || filterValue.IsBlank)
                 return false;
+
+            if (cellValue.Type != filterValue.Type)
+            {
+                // Types are different, but could still be unified numbers and thus comparable.
+                if (!(cellValue.IsUnifiedNumber && filterValue.IsUnifiedNumber))
+                    return false;
+            }
 
             // Note that custom filter even error values, basically everything as a number.
             var comparison = cellValue.Type switch

--- a/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
+++ b/ClosedXML/Excel/AutoFilters/XLFilterColumn.cs
@@ -155,6 +155,9 @@ namespace ClosedXML.Excel
 
         private void SetTopBottom(Int32 percentOrItemCount, XLTopBottomType type, Boolean takeTop, Boolean reapply)
         {
+            if (percentOrItemCount is < 1 or > 500)
+                throw new ArgumentOutOfRangeException(nameof(percentOrItemCount), "Value must be between 1 and 500.");
+
             ResetFilter(XLFilterType.TopBottom);
             TopBottomValue = percentOrItemCount;
             TopBottomType = type;
@@ -180,7 +183,9 @@ namespace ClosedXML.Excel
                 case XLTopBottomType.Percent:
                     var percent = value;
                     var materializedNumbers = columnNumbers.ToArray();
-                    var itemCountByPercents = materializedNumbers.Length * percent / 100;
+
+                    // Ceiling, so there is always at least one item.
+                    var itemCountByPercents = (int)Math.Ceiling(materializedNumbers.Length * (double)percent / 100);
                     return materializedNumbers.OrderBy(d => d, comparer).Take(itemCountByPercents).DefaultIfEmpty(Double.NaN).LastOrDefault();
                 default:
                     throw new NotSupportedException();

--- a/docs/migrations/migrate-to-0.104.rst
+++ b/docs/migrations/migrate-to-0.104.rst
@@ -131,6 +131,10 @@ default, it is set to ``true``. The parameter determines if the method should
 immediately reapplied modified filters to the autofilter. This makes it possile
 to configure several filters and only then call ``IXLAutoFilter.Reapply()``.
 
+Method ``IXLFilterColumn.Top`` and ``IXLFilterColumn.Bottom`` now throw and
+``ArgumentOutOfRangeException`` when passed item count or percentage is not
+between 1 and 500.
+
 *******
 IXLCell
 *******

--- a/docs/migrations/migrate-to-0.104.rst
+++ b/docs/migrations/migrate-to-0.104.rst
@@ -131,7 +131,7 @@ default, it is set to ``true``. The parameter determines if the method should
 immediately reapplied modified filters to the autofilter. This makes it possile
 to configure several filters and only then call ``IXLAutoFilter.Reapply()``.
 
-Method ``IXLFilterColumn.Top`` and ``IXLFilterColumn.Bottom`` now throw and
+Method ``IXLFilterColumn.Top`` and ``IXLFilterColumn.Bottom`` now throw an
 ``ArgumentOutOfRangeException`` when passed item count or percentage is not
 between 1 and 500.
 


### PR DESCRIPTION
This is part 6/? of rework of AutoFilter that should bring it to usable state (=documented, correctly working state). Continuation of https://github.com/ClosedXML/ClosedXML/pull/2242.

Added tests and fixed few bugs and align behavior with Excel.