### PR TITLE
Add dependency version range for DocumentFormat.OpenXml

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="[2.16.0,3.0.0)" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.102.1</Version>
+    <Version>0.102.2</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.102.1.{build}
+version: 0.102.2.{build}
 
 os: Visual Studio 2019
 image: Visual Studio 2019


### PR DESCRIPTION
ClosedXML is not compatible with DocumentFormat.OpenXml v3.0.0 yet. Without explicit range of accepted versions, there is no warning if user has explicitly declared dependency on both v3.0 and ClosedXML 0.102*.

User will get a warning about version problems:

![image](https://github.com/ClosedXML/ClosedXML/assets/7634052/18175047-2251-46f8-8d03-b96c9a401071)

Related to #2220 