### PR TITLE
Fix column/row style combination for non-materialized cells.

### DIFF
--- a/ClosedXML/Excel/Style/XLStyle.cs
+++ b/ClosedXML/Excel/Style/XLStyle.cs
@@ -195,8 +195,7 @@ namespace ClosedXML.Excel
             if (otherS == null)
                 return false;
 
-            return Key == otherS.Key &&
-                   _container == otherS._container;
+            return Key == otherS.Key;
         }
 
         public override bool Equals(object obj)

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -3,16 +3,17 @@ using System;
 
 namespace ClosedXML.Excel
 {
-    internal class XLStyleValue
+    internal sealed class XLStyleValue : IEquatable<XLStyleValue?>
     {
-        private static readonly XLStyleRepository Repository = new XLStyleRepository(key => new XLStyleValue(key));
+        private static readonly XLStyleRepository Repository = new(key => new XLStyleValue(key));
+        private int? _hashCode; // Cached hash key
 
         public static XLStyleValue FromKey(ref XLStyleKey key)
         {
             return Repository.GetOrCreate(ref key);
         }
 
-        private static readonly XLStyleKey DefaultKey = new XLStyleKey
+        private static readonly XLStyleKey DefaultKey = new()
         {
             Alignment = XLAlignmentValue.Default.Key,
             Border = XLBorderValue.Default.Key,
@@ -25,21 +26,21 @@ namespace ClosedXML.Excel
 
         internal static readonly XLStyleValue Default = FromKey(ref DefaultKey);
 
-        public XLStyleKey Key { get; private set; }
+        public XLStyleKey Key { get; }
 
-        public XLAlignmentValue Alignment { get; private set; }
+        public XLAlignmentValue Alignment { get; }
 
-        public XLBorderValue Border { get; private set; }
+        public XLBorderValue Border { get; }
 
-        public XLFillValue Fill { get; private set; }
+        public XLFillValue Fill { get; }
 
-        public XLFontValue Font { get; private set; }
+        public XLFontValue Font { get; }
 
-        public Boolean IncludeQuotePrefix { get; private set; }
+        public Boolean IncludeQuotePrefix { get; }
 
-        public XLNumberFormatValue NumberFormat { get; private set; }
+        public XLNumberFormatValue NumberFormat { get; }
 
-        public XLProtectionValue Protection { get; private set; }
+        public XLProtectionValue Protection { get; }
 
         internal XLStyleValue(XLStyleKey key)
         {
@@ -59,9 +60,18 @@ namespace ClosedXML.Excel
             if (ReferenceEquals(this, obj))
                 return true;
 
-            var cached = obj as XLStyleValue;
-            return cached != null &&
-                   Key.Equals(cached.Key);
+            return Equals(obj as XLStyleValue);
+        }
+
+        public bool Equals(XLStyleValue? other)
+        {
+            if (other is null)
+                return false;
+
+            if (_hashCode.HasValue && other._hashCode.HasValue && _hashCode != other._hashCode)
+                return false;
+
+            return Key.Equals(other.Key);
         }
 
         public override int GetHashCode()
@@ -75,24 +85,16 @@ namespace ClosedXML.Excel
 
         public static bool operator ==(XLStyleValue? left, XLStyleValue? right)
         {
-            if (ReferenceEquals(left, right))
-                return true;
-            if (ReferenceEquals(left, null) && ReferenceEquals(right, null))
-                return true;
-            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
-                return false;
-            if (left._hashCode.HasValue && right._hashCode.HasValue &&
-                left._hashCode != right._hashCode)
-                return false;
-            return left.Key.Equals(right.Key);
+            if (left is null)
+                return right is null;
+
+            return left.Equals(right);
         }
 
         public static bool operator !=(XLStyleValue? left, XLStyleValue? right)
         {
             return !(left == right);
         }
-
-        private int? _hashCode;
 
         internal XLStyleValue WithAlignment(Func<XLAlignmentValue, XLAlignmentValue> modify)
         {

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -26,22 +26,6 @@ namespace ClosedXML.Excel
 
         internal static readonly XLStyleValue Default = FromKey(ref DefaultKey);
 
-        public XLStyleKey Key { get; }
-
-        public XLAlignmentValue Alignment { get; }
-
-        public XLBorderValue Border { get; }
-
-        public XLFillValue Fill { get; }
-
-        public XLFontValue Font { get; }
-
-        public Boolean IncludeQuotePrefix { get; }
-
-        public XLNumberFormatValue NumberFormat { get; }
-
-        public XLProtectionValue Protection { get; }
-
         internal XLStyleValue(XLStyleKey key)
         {
             Key = key;
@@ -54,6 +38,22 @@ namespace ClosedXML.Excel
             NumberFormat = XLNumberFormatValue.FromKey(ref numberFormat);
             Protection = XLProtectionValue.FromKey(ref protection);
         }
+
+        internal XLStyleKey Key { get; }
+
+        internal XLAlignmentValue Alignment { get; }
+
+        internal XLBorderValue Border { get; }
+
+        internal XLFillValue Fill { get; }
+
+        internal XLFontValue Font { get; }
+
+        internal Boolean IncludeQuotePrefix { get; }
+
+        internal XLNumberFormatValue NumberFormat { get; }
+
+        internal XLProtectionValue Protection { get; }
 
         public override bool Equals(object obj)
         {
@@ -94,6 +94,75 @@ namespace ClosedXML.Excel
         public static bool operator !=(XLStyleValue? left, XLStyleValue? right)
         {
             return !(left == right);
+        }
+
+        /// <summary>
+        /// Combine row and column styles into a combined style. This style is used by non-pinged
+        /// cells of a worksheet.
+        /// </summary>
+        internal static XLStyleValue Combine(XLStyleValue sheetStyle, XLStyleValue rowStyle, XLStyleValue colStyle)
+        {
+            var isRowSame = ReferenceEquals(sheetStyle, rowStyle);
+            var isColSame = ReferenceEquals(sheetStyle, colStyle);
+
+            if (isRowSame && isColSame)
+                return sheetStyle;
+
+            // At least one style is different, maybe both.
+            if (isRowSame)
+                return colStyle;
+
+            if (isColSame)
+                return rowStyle;
+
+            // Both styles are different from sheet one, merge. If both style components differ,
+            // row has a preference because Excel gives it preference. Generally, if there is
+            // row/col style conflict, all cells affected by conflict should be materialized (aka
+            // 'pinged') during row/col style modification and have their own style explicitly
+            // specified to avoid ambiguity, so we shouldn't really need to rely on this
+            // resolution, it's just last ditch effort.
+            var alignment = GetExplicitlySet(sheetStyle.Alignment, rowStyle.Alignment, colStyle.Alignment);
+            var border = GetExplicitlySet(sheetStyle.Border, rowStyle.Border, colStyle.Border);
+            var fill = GetExplicitlySet(sheetStyle.Fill, rowStyle.Fill, colStyle.Fill);
+            var font = GetExplicitlySet(sheetStyle.Font, rowStyle.Font, colStyle.Font);
+            var includeQuotePrefix = GetExplicitlySet(sheetStyle.IncludeQuotePrefix, rowStyle.IncludeQuotePrefix, colStyle.IncludeQuotePrefix);
+            var numberFormat = GetExplicitlySet(sheetStyle.NumberFormat, rowStyle.NumberFormat, colStyle.NumberFormat);
+            var protection = GetExplicitlySet(sheetStyle.Protection, rowStyle.Protection, colStyle.Protection);
+
+            var combinedStyleKey = new XLStyleKey
+            {
+                Alignment = alignment.Key,
+                Border = border.Key,
+                Fill = fill.Key,
+                Font = font.Key,
+                IncludeQuotePrefix = includeQuotePrefix,
+                NumberFormat = numberFormat.Key,
+                Protection = protection.Key,
+            };
+            return Repository.GetOrCreate(ref combinedStyleKey);
+
+            static T GetExplicitlySet<T>(T sheetComponent, T rowComponent, T colComponent)
+                where T : notnull
+            {
+                // Use reference equal to speed up the process instead of standard equals.
+                var rowHasSameComponent = typeof(T).IsClass
+                    ? ReferenceEquals(sheetComponent, rowComponent)
+                    : sheetComponent.Equals(rowComponent);
+                var colHasSameComponent = typeof(T).IsClass
+                    ? ReferenceEquals(sheetComponent, colComponent)
+                    : sheetComponent.Equals(colComponent);
+
+                if (rowHasSameComponent && colHasSameComponent)
+                    return sheetComponent;
+
+                // At least one style is different, maybe both.
+                if (rowHasSameComponent)
+                    return colComponent;
+
+                // If col has same component as sheet, we should return row.
+                // If both are different, row component should have precedence.
+                return rowComponent;
+            }
         }
 
         internal XLStyleValue WithAlignment(Func<XLAlignmentValue, XLAlignmentValue> modify)

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -2037,13 +2037,15 @@ namespace ClosedXML.Excel
             // style set when column/row is created to avoid problems with correct which
             // style has precedence. I.e. set column blue, set row red => cell is red.
             // Swap order the the cell is blue.
-            if (Internals.RowsCollection.TryGetValue(point.Row, out var row))
-                return row.StyleValue;
+            var sheetStyle = StyleValue;
+            var rowStyle = Internals.RowsCollection.TryGetValue(point.Row, out var row)
+                ? row.StyleValue
+                : sheetStyle;
+            var colStyle = Internals.ColumnsCollection.TryGetValue(point.Column, out var column)
+                ? column.StyleValue
+                : sheetStyle;
 
-            if (Internals.ColumnsCollection.TryGetValue(point.Column, out var column))
-                return column.StyleValue;
-
-            return StyleValue;
+            return XLStyleValue.Combine(sheetStyle, rowStyle, colStyle);
         }
 
         /// <summary>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,8 @@ ClosedXML allows you to create Excel files without the Excel application. The ty
    migrations/migrate-to-0.100
    migrations/migrate-to-0.101
    migrations/migrate-to-0.102
+   migrations/migrate-to-0.103
+   migrations/migrate-to-0.104
 
 .. toctree::
    :maxdepth: 2

--- a/docs/migrations/migrate-to-0.104.rst
+++ b/docs/migrations/migrate-to-0.104.rst
@@ -146,3 +146,14 @@ IXLCell
 ``IXLCell.GetFormattedString(CultureInfo)`` now has an optional argument for a
 culture. By default, it uses current culture in all cases (was inconsistent),
 but culture can be explicitely specified.
+
+********
+IXLStyle
+********
+
+``IXLStyle.Equals`` method (it's implementor) now compares equality purely by style properties.
+Originally, it also checked the container equality and thus were rarely equal. Because styles are
+internally immutable, the ``IXLStyle`` object must hold a reference to object that contains the
+immutable style in a property (e.g. ``IXLCell`` or ``IXLRow``) so it can change it and that
+reference is called container. The end result is that two IXLStyle objects should be equal when all
+their style properties are equal.


### PR DESCRIPTION
Fix a how is a style determined for a cell that is not yet materialized from row and column styles (possibly sheet style). The style should be calculated by evaluating each style component individually and not just taking row/column style in its entirety.

Resolves #2144.