### PR TITLE
Update ClosedXML.Parser to 1.0

### DIFF
--- a/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
@@ -4,6 +4,7 @@ using ClosedXML.Extensions;
 using ClosedXML.Parser;
 using NUnit.Framework;
 using static ClosedXML.Parser.ReferenceAxisType;
+using static ClosedXML.Parser.ReferenceStyle;
 
 namespace ClosedXML.Tests.Extensions
 {
@@ -29,63 +30,63 @@ namespace ClosedXML.Tests.Extensions
             // C5
             yield return new object[]
             {
-                new ReferenceArea(Relative, 3, Relative, 5),
+                new ReferenceArea(Relative, 5, Relative, 3, A1),
                 new XLSheetRange(5, 3, 5, 3)
             };
 
             // C5:E14
             yield return new object[]
             {
-                new ReferenceArea(new Reference(Relative, 3, Relative, 5), new Reference(Relative, 5, Relative, 14)),
+                new ReferenceArea(new RowCol(Relative, 5, Relative, 3, A1), new RowCol(Relative, 14, Relative, 5, A1)),
                 new XLSheetRange(5, 3, 14, 5)
             };
 
             // $B3:E$10
             yield return new object[]
             {
-                new ReferenceArea(new Reference(Absolute, 2, Relative, 3), new Reference(Relative, 5, Absolute, 10)),
+                new ReferenceArea(new RowCol(Relative, 3, Absolute, 2, A1), new RowCol(Absolute, 10, Relative, 5, A1)),
                 new XLSheetRange(3, 2, 10, 5)
             };
 
             // $B$3:$E$10
             yield return new object[]
             {
-                new ReferenceArea(new Reference(Absolute, 2, Absolute, 3), new Reference(Absolute, 5, Absolute, 10)),
+                new ReferenceArea(new RowCol(Absolute, 3, Absolute, 2, A1), new RowCol(Absolute, 10, Absolute, 5, A1)),
                 new XLSheetRange(3, 2, 10, 5)
             };
 
             // B10:E3 points are not in left top corner and bottom right corner
             yield return new object[]
             {
-                new ReferenceArea(new Reference(Relative, 2, Relative, 10), new Reference(Absolute, 5, Absolute, 3)),
+                new ReferenceArea(new RowCol(Relative, 10, Relative, 2, A1), new RowCol(Absolute, 3, Absolute, 5, A1)),
                 new XLSheetRange(3, 2, 10, 5)
             };
 
             // C:E
             yield return new object[]
             {
-                new ReferenceArea(new Reference(Relative, 3, None, 0), new Reference(Relative, 5, None, 0)),
+                new ReferenceArea(new RowCol(None, 0, Relative, 3, A1), new RowCol(None, 0, Relative, 5, A1)),
                 new XLSheetRange(XLHelper.MinRowNumber, 3, XLHelper.MaxRowNumber, 5)
             };
 
             // E:C
             yield return new object[]
             {
-                new ReferenceArea(new Reference(Relative, 5, None, 0), new Reference(Relative, 3, None, 0)),
+                new ReferenceArea(new RowCol(None, 0, Relative, 5, A1), new RowCol(None, 0, Relative, 3, A1)),
                 new XLSheetRange(XLHelper.MinRowNumber, 3, XLHelper.MaxRowNumber, 5)
             };
 
             // 14:30
             yield return new object[]
             {
-                new ReferenceArea(new Reference(None, 0, Relative, 14), new Reference(None, 0, Relative, 30)),
+                new ReferenceArea(new RowCol(Relative, 14, None, 0, A1), new RowCol(Relative, 30, None, 0, A1)),
                 new XLSheetRange(14, XLHelper.MinColumnNumber, 30, XLHelper.MaxColumnNumber)
             };
 
             // 30:14
             yield return new object[]
             {
-                new ReferenceArea(new Reference(None, 0, Relative, 30), new Reference(None, 0, Relative, 14)),
+                new ReferenceArea(new RowCol(Relative, 30, None, 0, A1), new RowCol(Relative, 14, None, 0, A1)),
                 new XLSheetRange(14, XLHelper.MinColumnNumber, 30, XLHelper.MaxColumnNumber)
             };
         }
@@ -96,7 +97,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(1, 1),
-                new ReferenceArea(Absolute, 4, Absolute, 2),
+                new ReferenceArea(Absolute, 2, Absolute, 4, R1C1),
                 new XLSheetRange(2, 4, 2, 4)
             };
 
@@ -104,7 +105,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(3, 2), // R3C2
-                new ReferenceArea(Relative, 4, Relative, 2), // R[2]C[4]
+                new ReferenceArea(Relative, 2, Relative, 4, R1C1), // R[2]C[4]
                 new XLSheetRange(5, 6, 5, 6)
             };
 
@@ -112,7 +113,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(3, 2), // R3C2
-                new ReferenceArea(Relative, 0, Relative, 0), // R[0]C[0]
+                new ReferenceArea(Relative, 0, Relative, 0, R1C1), // R[0]C[0]
                 new XLSheetRange(3, 2, 3, 2)
             };
 
@@ -120,7 +121,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(1, 1), // R1C1
-                new ReferenceArea(Relative, 16383, Relative, 0), // R[0]C[16383]
+                new ReferenceArea(Relative, 0, Relative, 16383, R1C1), // R[0]C[16383]
                 new XLSheetRange(1, XLHelper.MaxColumnNumber, 1, XLHelper.MaxColumnNumber)
             };
 
@@ -128,7 +129,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(1, XLHelper.MaxColumnNumber), // R1C16384
-                new ReferenceArea(Relative, -16383, Relative, 0), // R[0]C[-16383]
+                new ReferenceArea(Relative, 0, Relative, -16383, R1C1), // R[0]C[-16383]
                 new XLSheetRange(1, 1, 1, 1) // R1C1
             };
 
@@ -136,7 +137,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(1, 16380), // R1C16380
-                new ReferenceArea(Relative, 16380, Relative, 0), // R[0]C[16380]
+                new ReferenceArea(Relative, 0, Relative, 16380, R1C1), // R[0]C[16380]
                 new XLSheetRange(1, 16376, 1, 16376) // RC16376
             };
 
@@ -144,7 +145,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(1, 10), // R1C10
-                new ReferenceArea(Relative, -16370, Relative, 0), // R[0]C[16370]
+                new ReferenceArea(Relative, 0, Relative, -16370, R1C1), // R[0]C[16370]
                 new XLSheetRange(1, 24, 1, 24) // R1C24
             };
 
@@ -152,7 +153,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(15, 1), // R15C1
-                new ReferenceArea(Relative, 0, Relative, 1048570), // R[1048570]C[0]
+                new ReferenceArea(Relative, 1048570, Relative, 0, R1C1), // R[1048570]C[0]
                 new XLSheetRange(9, 1, 9, 1) // R9C1
             };
 
@@ -160,7 +161,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(1048570, 1), // R1048570C1
-                new ReferenceArea(Relative, 0, Relative, -1048573), // R[-1048573]C[0]
+                new ReferenceArea(Relative, -1048573, Relative, 0, R1C1), // R[-1048573]C[0]
                 new XLSheetRange(1048573, 1, 1048573, 1) // R1048573C1
             };
 
@@ -168,7 +169,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(754, 5742),
-                new ReferenceArea(new Reference(Absolute, 2, Absolute, 3), new Reference(Absolute, 4, Absolute, 7)),
+                new ReferenceArea(new RowCol(Absolute, 3, Absolute, 2, R1C1), new RowCol(Absolute, 7, Absolute, 4, R1C1)),
                 XLSheetRange.Parse("B3:D7")
             };
 
@@ -176,7 +177,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(3, 6),
-                new ReferenceArea(new Reference(Relative, -1, Relative, 4), new Reference(Relative, 3, Relative, 6)), // R[4]C[-1]:R[6]C[3]
+                new ReferenceArea(new RowCol(Relative, 4, Relative, -1, R1C1), new RowCol(Relative, 6, Relative, 3, R1C1)), // R[4]C[-1]:R[6]C[3]
                 new XLSheetRange(7, 5, 9, 9)
             };
 
@@ -184,7 +185,7 @@ namespace ClosedXML.Tests.Extensions
             yield return new object[]
             {
                 new XLSheetPoint(3, 6),
-                new ReferenceArea(new Reference(Relative, -1, Relative, 6), new Reference(Relative, 3, Relative, 4)), // R[6]C[-1]:R[4]C[3]
+                new ReferenceArea(new RowCol(Relative, 6, Relative, -1, R1C1), new RowCol(Relative, 4, Relative, 3, R1C1)), // R[6]C[-1]:R[4]C[3]
                 new XLSheetRange(7, 5, 9, 9)
             };
         }

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-    <PackageReference Include="ClosedXML.Parser" Version="1.0.0-beta4" />
+    <PackageReference Include="ClosedXML.Parser" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/ClosedXML/Excel/CalcEngine/AstNode.cs
+++ b/ClosedXML/Excel/CalcEngine/AstNode.cs
@@ -261,7 +261,7 @@ namespace ClosedXML.Excel.CalcEngine
         public ReferenceNode(PrefixNode? prefix, ReferenceArea referenceArea, bool isA1)
         {
             Prefix = prefix;
-            Address = referenceArea.GetDisplayStringA1();
+            Address = isA1 ? referenceArea.GetDisplayStringA1() : referenceArea.GetDisplayStringR1C1();
             ReferenceArea = referenceArea;
             IsA1 = isA1;
         }
@@ -270,7 +270,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// An optional prefix for reference item.
         /// </summary>
         public PrefixNode? Prefix { get; }
-        
+
         /// <summary>
         /// An address of a reference that corresponds to <see cref="Type"/>. Always without sheet (that is in the prefix).
         /// </summary>

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -68,69 +68,69 @@ namespace ClosedXML.Excel.CalcEngine
                 _isA1 = isA1;
             }
 
-            public ScalarValue LogicalValue(List<FormulaFlags> context, bool logical) => logical;
+            public ScalarValue LogicalValue(List<FormulaFlags> context, SymbolRange range, bool logical) => logical;
 
-            public ScalarValue NumberValue(List<FormulaFlags> context, double number) => number;
+            public ScalarValue NumberValue(List<FormulaFlags> context, SymbolRange range, double number) => number;
 
-            public ScalarValue TextValue(List<FormulaFlags> context, string text) => text;
+            public ScalarValue TextValue(List<FormulaFlags> context, SymbolRange range, string text) => text;
 
-            public ScalarValue ErrorValue(List<FormulaFlags> context, ReadOnlySpan<char> errorText)
+            public ScalarValue ErrorValue(List<FormulaFlags> context, SymbolRange range, ReadOnlySpan<char> errorText)
             {
                 return GetErrorValue(errorText);
             }
 
-            public ValueNode ArrayNode(List<FormulaFlags> context, int rows, int columns,
+            public ValueNode ArrayNode(List<FormulaFlags> context, SymbolRange range, int rows, int columns,
                 IReadOnlyList<ScalarValue> elements)
             {
                 var array = new LiteralArray(rows, columns, elements);
                 return new ArrayNode(array);
             }
 
-            public ValueNode BlankNode(List<FormulaFlags> context)
+            public ValueNode BlankNode(List<FormulaFlags> context, SymbolRange range)
             {
                 return new ScalarNode(ScalarValue.Blank);
             }
 
-            public ValueNode LogicalNode(List<FormulaFlags> context, bool logical)
+            public ValueNode LogicalNode(List<FormulaFlags> context, SymbolRange range, bool logical)
             {
                 return new ScalarNode(logical);
             }
 
-            public ValueNode ErrorNode(List<FormulaFlags> context, ReadOnlySpan<char> errorText)
+            public ValueNode ErrorNode(List<FormulaFlags> context, SymbolRange range, ReadOnlySpan<char> errorText)
             {
                 var error = GetErrorValue(errorText);
                 return new ScalarNode(error);
             }
 
-            public ValueNode NumberNode(List<FormulaFlags> context, double number)
+            public ValueNode NumberNode(List<FormulaFlags> context, SymbolRange range, double number)
             {
                 return new ScalarNode(number);
             }
 
-            public ValueNode TextNode(List<FormulaFlags> context, string text)
+            public ValueNode TextNode(List<FormulaFlags> context, SymbolRange range, string text)
             {
                 return new ScalarNode(text);
             }
 
-            public ValueNode Reference(List<FormulaFlags> context, ReferenceArea area)
+            public ValueNode Reference(List<FormulaFlags> context, SymbolRange range, ReferenceArea area)
             {
                 return new ReferenceNode(null, area, _isA1);
             }
 
-            public ValueNode SheetReference(List<FormulaFlags> context, string sheet, ReferenceArea area)
+            public ValueNode SheetReference(List<FormulaFlags> context, SymbolRange range, string sheet, ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, sheet, null, null);
                 return new ReferenceNode(prefixNode, area, _isA1);
             }
 
-            public ValueNode Reference3D(List<FormulaFlags> context, string firstSheet, string lastSheet,
+            public ValueNode Reference3D(List<FormulaFlags> context, SymbolRange range, string firstSheet, string lastSheet,
                 ReferenceArea area)
             {
                 var prefixNode = new PrefixNode(null, null, firstSheet, lastSheet);
                 return new ReferenceNode(prefixNode, area, _isA1);
             }
 
-            public ValueNode ExternalSheetReference(List<FormulaFlags> context, int workbookIndex, string sheet,
+            public ValueNode ExternalSheetReference(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string sheet,
                 ReferenceArea area)
             {
                 var fileNode = new FileNode(workbookIndex);
@@ -138,7 +138,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return new ReferenceNode(prefixNode, area, _isA1);
             }
 
-            public ValueNode ExternalReference3D(List<FormulaFlags> context, int workbookIndex, string firstSheet,
+            public ValueNode ExternalReference3D(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string firstSheet,
                 string lastSheet, ReferenceArea area)
             {
                 var fileNode = new FileNode(workbookIndex);
@@ -146,83 +146,83 @@ namespace ClosedXML.Excel.CalcEngine
                 return new ReferenceNode(prefixNode, area, _isA1);
             }
 
-            public ValueNode Function(List<FormulaFlags> context, ReadOnlySpan<char> name,
+            public ValueNode Function(List<FormulaFlags> context, SymbolRange range, ReadOnlySpan<char> name,
                 IReadOnlyList<ValueNode> args)
             {
                 var functionName = name.ToString();
                 return GetFunctionNode(context, null, functionName, args);
             }
 
-            public ValueNode Function(List<FormulaFlags> context, string sheetName, ReadOnlySpan<char> name,
+            public ValueNode Function(List<FormulaFlags> context, SymbolRange range, string sheetName, ReadOnlySpan<char> name,
                 IReadOnlyList<ValueNode> args)
             {
                 var prefixNode = new PrefixNode(null, sheetName, null, null);
                 return GetFunctionNode(context, prefixNode, name.ToString(), args);
             }
 
-            public ValueNode ExternalFunction(List<FormulaFlags> context, int workbookIndex, string sheet,
+            public ValueNode ExternalFunction(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string sheet,
                 ReadOnlySpan<char> name, IReadOnlyList<ValueNode> args)
             {
                 var prefixNode = new PrefixNode(new FileNode(workbookIndex), sheet, null, null);
                 return GetFunctionNode(context, prefixNode, name.ToString(), args);
             }
 
-            public ValueNode ExternalFunction(List<FormulaFlags> context, int workbookIndex, ReadOnlySpan<char> name,
+            public ValueNode ExternalFunction(List<FormulaFlags> context, SymbolRange range, int workbookIndex, ReadOnlySpan<char> name,
                 IReadOnlyList<ValueNode> args)
             {
                 var prefixNode = new PrefixNode(new FileNode(workbookIndex), null, null, null);
                 return GetFunctionNode(context, prefixNode, name.ToString(), args);
             }
 
-            public ValueNode CellFunction(List<FormulaFlags> context, Parser.Reference cell,
+            public ValueNode CellFunction(List<FormulaFlags> context, SymbolRange range, RowCol cell,
                 IReadOnlyList<ValueNode> args)
             {
                 return new NotSupportedNode("Cell functions are not yet supported.");
             }
 
-            public ValueNode StructureReference(List<FormulaFlags> context, StructuredReferenceArea area,
+            public ValueNode StructureReference(List<FormulaFlags> context, SymbolRange range, StructuredReferenceArea area,
                 string? firstColumn, string? lastColumn)
             {
                 return new StructuredReferenceNode(null, null, area, firstColumn, lastColumn);
             }
 
-            public ValueNode StructureReference(List<FormulaFlags> context, string table, StructuredReferenceArea area,
+            public ValueNode StructureReference(List<FormulaFlags> context, SymbolRange range, string table, StructuredReferenceArea area,
                 string? firstColumn, string? lastColumn)
             {
                 return new StructuredReferenceNode(null, table, area, firstColumn, lastColumn);
             }
 
-            public ValueNode ExternalStructureReference(List<FormulaFlags> context, int workbookIndex, string table,
+            public ValueNode ExternalStructureReference(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string table,
                 StructuredReferenceArea area, string? firstColumn, string? lastColumn)
             {
                 return new StructuredReferenceNode(new PrefixNode(new FileNode(workbookIndex), null, null, null), table,
                     area, firstColumn, lastColumn);
             }
 
-            public ValueNode Name(List<FormulaFlags> context, string name)
+            public ValueNode Name(List<FormulaFlags> context, SymbolRange range, string name)
             {
                 return new NameNode(null, name);
             }
 
-            public ValueNode SheetName(List<FormulaFlags> context, string sheet, string name)
+            public ValueNode SheetName(List<FormulaFlags> context, SymbolRange range, string sheet, string name)
             {
                 var prefixNode = new PrefixNode(null, sheet, null, null);
                 return new NameNode(prefixNode, name);
             }
 
-            public ValueNode ExternalName(List<FormulaFlags> context, int workbookIndex, string name)
+            public ValueNode ExternalName(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string name)
             {
                 var prefixNode = new PrefixNode(new FileNode(workbookIndex), null, null, null);
                 return new NameNode(prefixNode, name);
             }
 
-            public ValueNode ExternalSheetName(List<FormulaFlags> context, int workbookIndex, string sheet, string name)
+            public ValueNode ExternalSheetName(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string sheet, string name)
             {
                 var prefixNode = new PrefixNode(new FileNode(workbookIndex), sheet, null, null);
                 return new NameNode(prefixNode, name);
             }
 
-            public ValueNode BinaryNode(List<FormulaFlags> context, BinaryOperation operation, ValueNode leftNode,
+            public ValueNode BinaryNode(List<FormulaFlags> context, SymbolRange range, BinaryOperation operation, ValueNode leftNode,
                 ValueNode rightNode)
             {
                 var op = operation switch
@@ -248,7 +248,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return new BinaryNode(op, leftNode, rightNode);
             }
 
-            public ValueNode Unary(List<FormulaFlags> context, UnaryOperation operation, ValueNode node)
+            public ValueNode Unary(List<FormulaFlags> context, SymbolRange range, UnaryOperation operation, ValueNode node)
             {
                 var op = operation switch
                 {
@@ -262,7 +262,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return new UnaryNode(op, node);
             }
 
-            public ValueNode Nested(List<FormulaFlags> context, ValueNode node)
+            public ValueNode Nested(List<FormulaFlags> context, SymbolRange range, ValueNode node)
             {
                 return node;
             }


### PR DESCRIPTION
Update dependency on ClosedXML.Parser v1.0. 

Main changes are 
* switch of argument position for row and column to be consistent with ClosedXML (first row, then column)
* Reference now contains info if it is R1C1 or A1.
* IAstFactory gets position of token/symbol as an argument.
