### PR TITLE
Replace regex-powered code for A1-R1C1 formula conversion with AST-based one

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-    <PackageReference Include="ClosedXML.Parser" Version="1.0.0" />
+    <PackageReference Include="ClosedXML.Parser" Version="[1.1.0,2.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -2,10 +2,8 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using ClosedXML.Excel.CalcEngine;
+using ClosedXML.Parser;
 
 namespace ClosedXML.Excel
 {
@@ -34,16 +32,6 @@ namespace ClosedXML.Excel
         /// First argument is replaced by value from current row, second is replaced by value from current column.
         /// </summary>
         private const string DataTableFormulaFormat = "{{TABLE({0},{1}}}";
-
-        private static readonly Regex A1Regex = new(
-            @"(?<=\W)(\$?[a-zA-Z]{1,3}\$?\d{1,7})(?=\W)" // A1
-            + @"|(?<=\W)(\$?\d{1,7}:\$?\d{1,7})(?=\W)" // 1:1
-            + @"|(?<=\W)(\$?[a-zA-Z]{1,3}:\$?[a-zA-Z]{1,3})(?=\W)", RegexOptions.Compiled); // A:A
-
-        private static readonly Regex R1C1Regex = new(
-            @"(?<=\W)([Rr](?:\[-?\d{0,7}\]|\d{0,7})?[Cc](?:\[-?\d{0,7}\]|\d{0,7})?)(?=\W)" // R1C1
-            + @"|(?<=\W)([Rr]\[?-?\d{0,7}\]?:[Rr]\[?-?\d{0,7}\]?)(?=\W)" // R:R
-            + @"|(?<=\W)([Cc]\[?-?\d{0,5}\]?:[Cc]\[?-?\d{0,5}\]?)(?=\W)", RegexOptions.Compiled); // C:C
 
         private XLSheetPoint _input1;
         private XLSheetPoint _input2;
@@ -166,192 +154,29 @@ namespace ClosedXML.Excel
             if (String.IsNullOrWhiteSpace(strValue))
                 return String.Empty;
 
-            var value = ">" + strValue + "<";
+            // Users and some producers might prefix formula with '=', but that is not a valid
+            // formula, so strip and re-add if present.
+            var formula = strValue.Trim();
+            if (formula.StartsWith('='))
+                formula = formula[1..];
 
-            var regex = conversionType == FormulaConversionType.A1ToR1C1 ? A1Regex : R1C1Regex;
-
-            var sb = new StringBuilder();
-            var lastIndex = 0;
-
-            foreach (var match in regex.Matches(value).Cast<Match>())
+            var converted = conversionType switch
             {
-                var matchString = match.Value;
-                var matchIndex = match.Index;
-                if (value.Substring(0, matchIndex).CharCount('"') % 2 == 0
-                    && value.Substring(0, matchIndex).CharCount('\'') % 2 == 0)
-                {
-                    // Check if the match is in between quotes
-                    sb.Append(value.Substring(lastIndex, matchIndex - lastIndex));
-                    sb.Append(conversionType == FormulaConversionType.A1ToR1C1
-                        ? GetR1C1Address(matchString, cellAddress)
-                        : GetA1Address(matchString, cellAddress));
-                }
-                else
-                    sb.Append(value.Substring(lastIndex, matchIndex - lastIndex + matchString.Length));
-                lastIndex = matchIndex + matchString.Length;
-            }
+                FormulaConversionType.A1ToR1C1 => FormulaConverter.ToR1C1(formula, cellAddress.Row, cellAddress.Column),
+                FormulaConversionType.R1C1ToA1 => FormulaConverter.ToA1(formula, cellAddress.Row, cellAddress.Column),
+                _ => throw new NotSupportedException()
+            };
 
-            if (lastIndex < value.Length)
-                sb.Append(value.Substring(lastIndex));
+            if (formula.Length != strValue.Length)
+                converted = strValue[..^formula.Length] + converted;
 
-            var retVal = sb.ToString();
-            return retVal.Substring(1, retVal.Length - 2);
-        }
-
-        private static string GetA1Address(string r1C1Address, XLSheetPoint cellAddress)
-        {
-            var addressToUse = r1C1Address.ToUpper();
-
-            if (addressToUse.Contains(':'))
-            {
-                var parts = addressToUse.Split(':');
-                var p1 = parts[0];
-                var p2 = parts[1];
-                string leftPart;
-                string rightPart;
-                if (p1.StartsWith("R"))
-                {
-                    leftPart = GetA1Row(p1, cellAddress.Row);
-                    rightPart = GetA1Row(p2, cellAddress.Row);
-                }
-                else
-                {
-                    leftPart = GetA1Column(p1, cellAddress.Column);
-                    rightPart = GetA1Column(p2, cellAddress.Column);
-                }
-
-                return leftPart + ":" + rightPart;
-            }
-
-            try
-            {
-                var rowPart = addressToUse.Substring(0, addressToUse.IndexOf('C'));
-                var rowToReturn = GetA1Row(rowPart, cellAddress.Row);
-
-                var columnPart = addressToUse.Substring(addressToUse.IndexOf('C'));
-                var columnToReturn = GetA1Column(columnPart, cellAddress.Column);
-
-                var retAddress = columnToReturn + rowToReturn;
-                return retAddress;
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                return "#REF!";
-            }
-        }
-
-        private static string GetA1Column(string columnPartRC, int cellColumn)
-        {
-            string columnToReturn;
-            if (columnPartRC == "C")
-                columnToReturn = XLHelper.GetColumnLetterFromNumber(cellColumn);
-            else
-            {
-                var bIndex = columnPartRC.IndexOf('[');
-                var mIndex = columnPartRC.IndexOf('-');
-                if (bIndex >= 0)
-                {
-                    columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        cellColumn +
-                        Int32.Parse(columnPartRC.Substring(bIndex + 1, columnPartRC.Length - bIndex - 2))
-                    );
-                }
-                else if (mIndex >= 0)
-                {
-                    columnToReturn = XLHelper.GetColumnLetterFromNumber(
-                        cellColumn + Int32.Parse(columnPartRC.Substring(mIndex))
-                    );
-                }
-                else
-                {
-                    columnToReturn = "$" +
-                                     XLHelper.GetColumnLetterFromNumber(Int32.Parse(columnPartRC.Substring(1)));
-                }
-            }
-
-            return columnToReturn;
-        }
-
-        private static string GetA1Row(string rowPartRC, int cellRow)
-        {
-            string rowToReturn;
-            if (rowPartRC == "R")
-                rowToReturn = cellRow.ToString();
-            else
-            {
-                var bIndex = rowPartRC.IndexOf('[');
-                if (bIndex >= 0)
-                {
-                    rowToReturn =
-                        (cellRow + Int32.Parse(rowPartRC.Substring(bIndex + 1, rowPartRC.Length - bIndex - 2))).ToString();
-                }
-                else
-                    rowToReturn = "$" + (Int32.Parse(rowPartRC.Substring(1)));
-            }
-
-            return rowToReturn;
-        }
-
-        private static string GetR1C1Address(string a1Address, XLSheetPoint cellAddress)
-        {
-            if (a1Address.Contains(':'))
-            {
-                var parts = a1Address.Split(':');
-                var p1 = parts[0];
-                var p2 = parts[1];
-                if (Int32.TryParse(p1.Replace("$", string.Empty), out Int32 row1))
-                {
-                    var row2 = Int32.Parse(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Row(row1, p1.Contains('$'), cellAddress.Row);
-                    var rightPart = GetR1C1Row(row2, p2.Contains('$'), cellAddress.Row);
-                    return leftPart + ":" + rightPart;
-                }
-                else
-                {
-                    var column1 = XLHelper.GetColumnNumberFromLetter(p1.Replace("$", string.Empty));
-                    var column2 = XLHelper.GetColumnNumberFromLetter(p2.Replace("$", string.Empty));
-                    var leftPart = GetR1C1Column(column1, p1.Contains('$'), cellAddress.Column);
-                    var rightPart = GetR1C1Column(column2, p2.Contains('$'), cellAddress.Column);
-                    return leftPart + ":" + rightPart;
-                }
-            }
-
-            var address = XLAddress.Create(a1Address);
-
-            var rowPart = GetR1C1Row(address.RowNumber, address.FixedRow, cellAddress.Row);
-            var columnPart = GetR1C1Column(address.ColumnNumber, address.FixedColumn, cellAddress.Column);
-
-            return rowPart + columnPart;
-        }
-
-        private static string GetR1C1Row(int rowNumber, bool fixedRow, int cellRow)
-        {
-            string rowPart;
-            var rowDiff = rowNumber - cellRow;
-            if (rowDiff != 0 || fixedRow)
-                rowPart = fixedRow ? "R" + rowNumber : "R[" + rowDiff + "]";
-            else
-                rowPart = "R";
-
-            return rowPart;
-        }
-
-        private static string GetR1C1Column(int columnNumber, bool fixedColumn, int cellColumn)
-        {
-            string columnPart;
-            var columnDiff = columnNumber - cellColumn;
-            if (columnDiff != 0 || fixedColumn)
-                columnPart = fixedColumn ? "C" + columnNumber : "C[" + columnDiff + "]";
-            else
-                columnPart = "C";
-
-            return columnPart;
+            return converted;
         }
 
         /// <summary>
         /// A factory method to create a normal A1 formula. Doesn't affect recalculation version.
         /// </summary>
-        /// <param name="formulaA1">Doesn't start with <c>=</c>.</param>
+        /// <param name="formulaA1">Formula in A1 form. Shouldn't start with <c>=</c>.</param>
         internal static XLCellFormula NormalA1(string formulaA1)
         {
             return new XLCellFormula
@@ -366,7 +191,7 @@ namespace ClosedXML.Excel
         /// <summary>
         /// A factory method to create a normal R1C1 formula. Doesn't affect recalculation version.
         /// </summary>
-        /// <param name="formulaR1C1">Doesn't start with <c>=</c>.</param>
+        /// <param name="formulaR1C1">Formula in R1C1 form. Shouldn't start with <c>=</c>.</param>
         internal static XLCellFormula NormalR1C1(string formulaR1C1)
         {
             return new XLCellFormula

--- a/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
@@ -7,7 +7,7 @@ namespace ClosedXML.Excel
     /// An point (address) in a worksheet, an equivalent of <c>ST_CellRef</c>.
     /// </summary>
     /// <remarks>Unlike the XLAddress, sheet can never be invalid.</remarks>
-    [DebuggerDisplay("{XLHelper.GetColumnLetterFromNumber(Column)}{Row}")]
+    [DebuggerDisplay("{XLHelper.GetColumnLetterFromNumber(Column)+Row}")]
     internal readonly struct XLSheetPoint : IEquatable<XLSheetPoint>, IComparable<XLSheetPoint>
     {
         public XLSheetPoint(Int32 row, Int32 column)


### PR DESCRIPTION
The regex powered conversion for detecting references never actually properly worked, except for some simple cases, so it is being replaces. The replacement is powered by *ClosedParser* and uses AST, so when a reference is found, it is converted.

This is nice because it removes fragile/not-properly working code, but also gives significant possibilities for the future. The conversion factory is ready for other usages, e.g.

* User sets formula using a future functions, e.g. `CONCAT(A1:A2)`, but CONCAT is not a valid function name, the proper name is `_xlfn.CONCAT`, so it should be stored as `_xlfn.CONCAT(A1:A2)`. We should do conversion in setter, but that was really hard to do. Now it is not hard.
* Renaming sheets: when reference refers to a sheet and sheet is renamed, the reference in formula should change, e.g. `SUM(OldSheet!A1:A3)` should be turned into `SUM(NewSheet!A1:A3)`, that was really hard to do, now it's now.
* Renaming defined names, same case as sheets.
* Whole schtick with copying formulas across cells. When cells are copied/moved, the formulas are converted to R1C1 and back at the new place. Granted, it kind of works now, but now it should work significantly better.

I am not sure about stripping the `=` from formulas, it should probably be done consistently, but I didn't want to do it in this PR.