### PR TITLE
When sheet is renamed, rename it also in defined name formula

### DIFF
--- a/ClosedXML.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -268,6 +268,23 @@ namespace ClosedXML.Tests.Excel
         }
 
         [Test]
+        public void Formula_is_updated_on_sheet_rename()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Old name");
+            var bookScopedName = wb.DefinedNames.Add("TEST", "ABS('Old name'!$B$5)");
+            var sheetScopedName = ws.DefinedNames.Add("TEST1", "'Old name'!$D$7:$F$14");
+
+            ws.Name = "Renamed";
+
+            Assert.AreEqual("ABS(Renamed!$B$5)", bookScopedName.RefersTo);
+            Assert.AreEqual("Renamed!$B$5:$B$5", bookScopedName.Ranges.ToString());
+
+            Assert.AreEqual("Renamed!$D$7:$F$14", sheetScopedName.RefersTo);
+            Assert.AreEqual("Renamed!$D$7:$F$14", sheetScopedName.Ranges.ToString());
+        }
+
+        [Test]
         public void MovingRanges()
         {
             var wb = new XLWorkbook();

--- a/ClosedXML/Excel/Cells/IWorkbookListener.cs
+++ b/ClosedXML/Excel/Cells/IWorkbookListener.cs
@@ -1,0 +1,16 @@
+﻿namespace ClosedXML.Excel;
+
+/// <summary>
+/// Listener for components that need to be notified about structural changes of a workbook
+/// (adding/removing sheet, renaming). See <see cref="ISheetListener"/> for similar listener about
+/// structural changes of a sheet.
+/// </summary>
+internal interface IWorkbookListener
+{
+    /// <summary>
+    /// Method is called when sheet has already been renamed.
+    /// </summary>
+    /// <param name="oldSheetName">Old sheet name.</param>
+    /// <param name="newSheetName">New sheet name, different from old one.</param>
+    void OnSheetRenamed(string oldSheetName, string newSheetName);
+}

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -215,9 +215,28 @@ namespace ClosedXML.Excel
 
             _worksheets.Remove(oldSheetName);
             Add(newSheetName, ws);
+
+            foreach (var listener in GetWorkbookListeners())
+                listener.OnSheetRenamed(oldSheetName, newSheetName);
         }
 
         #region Private members
+
+        private IEnumerable<IWorkbookListener> GetWorkbookListeners()
+        {
+            // All components that should be updated when sheet is added/removed or renamed should
+            // be enumerated here.
+            foreach (var definedName in _workbook.DefinedNamesInternal)
+                yield return definedName;
+
+            foreach (var sheet in _worksheets.Values)
+            {
+                foreach (var definedName in sheet.DefinedNames)
+                {
+                    yield return definedName;
+                }
+            }
+        }
 
         private String GetNextWorksheetName()
         {


### PR DESCRIPTION
When sheet is renamed, rename it also in defined name formula. This PR introduces `IWorkbookListener` that should be later implemented by other components to deal with workbook structural changes.

Resolves #2254.