### PR TITLE
Implement a data structure to hold pivot table close to file structure

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -29,6 +29,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Katakana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=OLAP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/EnumConverter.cs
+++ b/ClosedXML/Excel/EnumConverter.cs
@@ -1494,7 +1494,7 @@ namespace ClosedXML.Excel
         {
             return TimePeriodMap[value];
         }
-        
+
         private static readonly IReadOnlyDictionary<PivotAreaValues, XLPivotAreaValues> PivotAreaMap =
             new Dictionary<PivotAreaValues, XLPivotAreaValues>
             {
@@ -1563,6 +1563,57 @@ namespace ClosedXML.Excel
         public static XLPivotSortType ToClosedXml(this FieldSortValues value)
         {
             return FieldSortMap[value];
+        }
+
+        private static readonly IReadOnlyDictionary<PivotTableAxisValues, XLPivotAxis> PivotTableAxisMap =
+            new Dictionary<PivotTableAxisValues, XLPivotAxis>
+            {
+                { PivotTableAxisValues.AxisRow, XLPivotAxis.AxisRow },
+                { PivotTableAxisValues.AxisColumn, XLPivotAxis.AxisCol },
+                { PivotTableAxisValues.AxisPage, XLPivotAxis.AxisPage },
+                { PivotTableAxisValues.AxisValues, XLPivotAxis.AxisValues },
+            };
+
+        internal static XLPivotAxis ToClosedXml(this PivotTableAxisValues value)
+        {
+            return PivotTableAxisMap[value];
+        }
+
+        private static readonly IReadOnlyDictionary<ItemValues, XLPivotItemType> ItemMap =
+            new Dictionary<ItemValues, XLPivotItemType>
+            {
+                { ItemValues.Data, XLPivotItemType.Data },
+                { ItemValues.Default, XLPivotItemType.Default },
+                { ItemValues.Sum, XLPivotItemType.Sum },
+                { ItemValues.CountA, XLPivotItemType.CountA },
+                { ItemValues.Average, XLPivotItemType.Avg },
+                { ItemValues.Maximum, XLPivotItemType.Max },
+                { ItemValues.Minimum, XLPivotItemType.Min },
+                { ItemValues.Product, XLPivotItemType.Product },
+                { ItemValues.Count, XLPivotItemType.Count },
+                { ItemValues.StandardDeviation, XLPivotItemType.StdDev },
+                { ItemValues.StandardDeviationP, XLPivotItemType.StdDevP },
+                { ItemValues.Variance, XLPivotItemType.Var },
+                { ItemValues.VarianceP, XLPivotItemType.VarP },
+                { ItemValues.Grand, XLPivotItemType.Grand },
+                { ItemValues.Blank, XLPivotItemType.Blank },
+            };
+
+        internal static XLPivotItemType ToClosedXml(this ItemValues value)
+        {
+            return ItemMap[value];
+        }
+
+        private static readonly IReadOnlyDictionary<FormatActionValues, XLPivotFormatAction> FormatActionMap =
+            new Dictionary<FormatActionValues, XLPivotFormatAction>
+            {
+                { FormatActionValues.Blank, XLPivotFormatAction.Blank },
+                { FormatActionValues.Formatting, XLPivotFormatAction.Formatting },
+            };
+
+        internal static XLPivotFormatAction ToClosedXml(this FormatActionValues value)
+        {
+            return FormatActionMap[value];
         }
 
         #endregion To ClosedXml

--- a/ClosedXML/Excel/PivotTables/FieldIndex.cs
+++ b/ClosedXML/Excel/PivotTables/FieldIndex.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A type for field index, so there is a better idea what is a semantic content of some
+/// variable/props. Not detrimental to performance, JIT will inline struct to int.
+/// </summary>
+internal readonly record struct FieldIndex
+{
+    internal FieldIndex(int value)
+    {
+        if (value < 0 && value != -2)
+            throw new ArgumentOutOfRangeException();
+
+        Value = value;
+    }
+
+    /// <summary>
+    /// Index of a field in <see cref="XLPivotTable.PivotFields"/>. Can be -2 for 'data' field.
+    /// </summary>
+    public int Value { get; }
+
+    public static implicit operator int(FieldIndex index) => index.Value;
+
+    public static implicit operator FieldIndex(int index) => new(index);
+}

--- a/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValue.cs
+++ b/ClosedXML/Excel/PivotTables/PivotValues/IXLPivotValue.cs
@@ -4,8 +4,17 @@ using System;
 
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// Enum describing how is a pivot field values (i.e. in data area) displayed.
+    /// </summary>
+    /// <remarks>
+    /// [ISO-29500] 18.18.70 ST_ShowDataAs
+    /// </remarks>
     public enum XLPivotCalculation
     {
+        /// <summary>
+        /// Field values are displayed normally.
+        /// </summary>
         Normal,
         DifferenceFrom,
         PercentageOf,
@@ -14,16 +23,36 @@ namespace ClosedXML.Excel
         PercentageOfRow,
         PercentageOfColumn,
         PercentageOfTotal,
+
+        /// <summary>
+        /// Basically a relative importance of a value. Closer the value to 1.0 is, the less
+        /// important it is. Calculated as <c>(value-in-cell * grand-total-of-grand-totals) /
+        /// (grand-total-row * grand-total-column)</c>.
+        /// </summary>
         Index
     }
 
+    /// <summary>
+    /// Some calculation from <see cref="XLPivotCalculation"/> need a value as another an argument
+    /// of a calculation (e.g. difference from). This enum specifies how to find the reference value.
+    /// </summary>
     public enum XLPivotCalculationItem
     {
         Value, Previous, Next
     }
 
+    /// <summary>
+    /// An enum that specifies how are grouped pivot field values summed up in a single cell of a
+    /// pivot table.
+    /// </summary>
+    /// <remarks>
+    /// [ISO-29500] 18.18.17 ST_DataConsolidateFunction
+    /// </remarks>
     public enum XLPivotSummary
     {
+        /// <summary>
+        /// Values are summed up.
+        /// </summary>
         Sum,
         Count,
         Average,

--- a/ClosedXML/Excel/PivotTables/XLPivotArea.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotArea.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A rule describing a subset of pivot table. Used mostly for styling through <see cref="XLPivotFormat"/>.
+/// </summary>
+/// <remarks>
+/// [ISO-29500] 18.3.1.68 PivotArea
+/// </remarks>
+internal class XLPivotArea
+{
+    private readonly List<XLPivotReference> _references = new();
+
+    /// <summary>
+    /// A subset of field values that are part of the pivot area.
+    /// </summary>
+    internal IReadOnlyList<XLPivotReference> References => _references;
+
+    /// <summary>
+    /// Index of the field that this selection rule refers to.
+    /// </summary>
+    internal FieldIndex? Field { get; init; }
+
+    /// <summary>
+    /// An area of aspect of pivot table that is part of the pivot area.
+    /// </summary>
+    internal XLPivotAreaValues Type { get; init; } = XLPivotAreaValues.Normal;
+
+    /// <summary>
+    /// Flag indicating whether only the data values (in the data area of the view) for an item
+    /// selection are selected and does not include the item labels.
+    /// </summary>
+    internal bool DataOnly { get; init; } = true;
+
+    /// <summary>
+    /// Flag indicating whether only the item labels for an item selection are selected and does
+    /// not include the data values(in the data area of the view).
+    /// </summary>
+    internal bool LabelOnly { get; init; } = false;
+
+    /// <summary>
+    /// Flag indicating whether the row grand total is included.
+    /// </summary>
+    internal bool GrandRow { get; init; } = false;
+
+    /// <summary>
+    /// Flag indicating whether the column grand total is included.
+    /// </summary>
+    internal bool GrandCol { get; init; } = false;
+
+    /// <summary>
+    /// Flag indicating whether indexes refer to fields or items in the pivot cache and not the
+    /// view.
+    /// </summary>
+    internal bool CacheIndex { get; init; } = false;
+
+    /// <summary>
+    /// Flag indicating whether the rule refers to an area that is in outline mode.
+    /// </summary>
+    internal bool Outline { get; init; } = true;
+
+    /// <summary>
+    /// A reference that specifies a subset of the selection area. Points are relative to the top
+    /// left of the selection area.
+    /// </summary>
+    internal XLSheetRange? Offset { get; init; }
+
+    /// <summary>
+    /// Flag indicating if collapsed levels/dimensions are considered subtotals.
+    /// </summary>
+    internal bool CollapsedLevelsAreSubtotals { get; init; } = false;
+
+    /// <summary>
+    /// The region of the pivot table to which this rule applies.
+    /// </summary>
+    internal XLPivotAxis? Axis { get; init; }
+
+    /// <summary>
+    /// Position of the field within the axis to which this rule applies.
+    /// </summary>
+    internal uint? FieldPosition { get; init; }
+
+    internal void AddReference(XLPivotReference reference)
+    {
+        _references.Add(reference);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotAreaValues.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotAreaValues.cs
@@ -1,7 +1,11 @@
-#nullable disable
-
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// An area of aspect of pivot table that is part of the <see cref="XLPivotArea.Type"/>.
+    /// </summary>
+    /// <remarks>
+    /// [ISO-29500] 18.18.58 ST_PivotAreaType
+    /// </remarks>
     internal enum XLPivotAreaValues
     {
         None = 0,
@@ -10,6 +14,8 @@ namespace ClosedXML.Excel
         All = 3,
         Origin = 4,
         Button = 5,
+
+        // Top right has been removed between ISO-29500:2006 and ISO-29500:2016.
         TopRight = 6,
         TopEnd = 7
     }

--- a/ClosedXML/Excel/PivotTables/XLPivotAxis.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotAxis.cs
@@ -1,0 +1,16 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Describes an axis of a pivot table. Used to determine which areas should be styled through
+/// <see cref="XLPivotFormat.PivotArea"/>.
+/// </summary>
+/// <remarks>
+/// [ISO-29500] 18.18.1 ST_Axis(PivotTable Axis).
+/// </remarks>
+internal enum XLPivotAxis
+{
+    AxisRow,
+    AxisCol,
+    AxisPage,
+    AxisValues,
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotDataField.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotDataField.cs
@@ -1,0 +1,56 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A field that describes calculation of value to display in the <see cref="XLPivotAreaValues.Data"/>
+/// area of pivot table.
+/// </summary>
+internal class XLPivotDataField
+{
+    public XLPivotDataField(uint field)
+    {
+        Field = field;
+    }
+
+    /// <summary>
+    /// Custom name of the data field (e.g. <em>Sum of Sold</em>).
+    /// </summary>
+    public string? DataFieldName { get; init; }
+
+    /// <summary>
+    /// Field index to <see cref="XLPivotTable.PivotFields"/>.
+    /// </summary>
+    /// <remarks>
+    /// Unlike axis, this field index can't be <c>-2</c> for data fields. That field can't be in
+    /// the data area.
+    /// </remarks>
+    public uint Field { get; }
+
+    /// <summary>
+    /// An aggregation function that calculates the value to display in the data cells of pivot area.
+    /// </summary>
+    public XLPivotSummary Subtotal { get; init; } = XLPivotSummary.Sum;
+
+    /// <summary>
+    /// A calculation takes value calculated by <see cref="Subtotal"/> aggregation and transforms
+    /// it into the final value to display to the user. The calculation might need
+    /// <see cref="BaseField"/> and/or <see cref="BaseItem"/>.
+    /// </summary>
+    public XLPivotCalculation ShowDataAsFormat { get; init; } = XLPivotCalculation.Normal;
+
+    /// <summary>
+    /// Index to the base field (<see cref="XLPivotTable.PivotFields"/>) when
+    /// <see cref="ShowDataAsFormat"/> needs a field for its calculation.
+    /// </summary>
+    public int BaseField { get; init; } = -1;
+
+    /// <summary>
+    /// Index to the base item of <see cref="BaseField"/> when <see cref="ShowDataAsFormat"/> needs
+    /// an item for its calculation.
+    /// </summary>
+    public uint BaseItem { get; init; } = 1048832;
+
+    /// <summary>
+    /// Formatting to apply to the data field. If <see cref="XLPivotFormat"/> disagree, it has precedence.
+    /// </summary>
+    public uint? NumberFormatId { get; init; }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotFieldAxisItem.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFieldAxisItem.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A representation of a single row/column axis values in a <see cref="XLPivotTableAxis"/>.
+/// </summary>
+/// <remarks>
+/// Represents 18.10.1.44 i (Row Items) and 18.10.1.96 x (Member Property Index).
+/// </remarks>
+internal class XLPivotFieldAxisItem
+{
+    public XLPivotFieldAxisItem(XLPivotItemType itemType, uint? dataItem, IEnumerable<int> fieldIndexes)
+    {
+        ItemType = itemType;
+        DataItem = dataItem;
+        FieldIndexes = fieldIndexes.ToList();
+    }
+
+    /// <summary>
+    /// Each item is an index to field items of corresponding field from
+    /// <see cref="XLPivotTableAxis.Fields"/>. Value <c>1048832</c> specifies that no item appears
+    /// at the position. 
+    /// </summary>
+    internal List<int> FieldIndexes { get; }
+
+    /// <summary>
+    /// Type of item.
+    /// </summary>
+    internal XLPivotItemType ItemType { get; }
+
+    /// <summary>
+    /// If this item (row/column) contains 'data' field, this contains an index into the <see cref="XLPivotTable._dataFields"/>
+    /// that should be used as a value. The value for 'data' field in the <see cref="FieldIndexes"/> is ignored, but Excel fills
+    /// same number as this index.
+    /// </summary>
+    internal uint? DataItem { get; }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotFieldItem.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFieldItem.cs
@@ -1,0 +1,71 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Representation of item (basically one value of a field). Each value used somewhere in pivot
+/// table (e.g. data area, row/column labels and so on) must have an entry here. By itself, it
+/// doesn't contain values, it only references shared items of the field in the
+/// <see cref="XLPivotCache"/>.
+/// </summary>
+/// <remarks>
+/// [OI29500] 18.10.1.45 item (PivotTable Field Item). 
+/// </remarks>
+internal class XLPivotFieldItem
+{
+    private readonly XLPivotTableField _pivotField;
+
+    internal XLPivotFieldItem(XLPivotTableField pivotField, uint? itemIndex)
+    {
+        // TODO: Check that index is in shared items of cached fields.
+        _pivotField = pivotField;
+        ItemIndex = itemIndex;
+    }
+
+    /// <summary>
+    /// If present, must be unique within the containing field items.
+    /// </summary>
+    internal string? ItemUserCaption { get; init; }
+
+    internal XLPivotItemType ItemType { get; init; } = XLPivotItemType.Data;
+
+    /// <summary>
+    /// <para>
+    /// Flag indicating that the the item hidden. Used for <see cref="XLPivotPageField"/>. When
+    /// item field is a page field, the hidden flag mean unselected values in the page filter.
+    /// Non-hidden values are selected in the filter.
+    /// </para>
+    /// <para>
+    /// Allowed for non-OLAP pivot tables only.
+    /// </para>
+    /// </summary>
+    internal bool Hidden { get; init; } = false;
+
+    /// <summary>Flag indicating that the item has a character value/</summary>
+    /// <remarks>Allowed for OLAP pivot tables only.</remarks>
+    internal bool ValueIsString { get; init; } = false;
+
+    /// <remarks>Allowed for non-OLAP pivot tables only.</remarks>
+    internal bool HideDetails { get; init; } = true;
+
+    /// <remarks>Allowed for non-OLAP pivot tables only.</remarks>
+    internal bool CalculatedMember { get; init; } = false;
+
+    /// <summary>
+    /// Item itself is missing from the source data
+    /// </summary>
+    /// <remarks>Allowed for non-OLAP pivot tables only.</remarks>
+    internal bool Missing { get; init; } = false;
+
+    /// <remarks>Allowed for OLAP pivot tables only.</remarks>
+    internal bool ApproximatelyHasChildren { get; init; } = false;
+
+    /// <summary>
+    /// Index to an item in the sharedItems of the field. The index must be unique in containing field items. When <see cref="ItemType"/> is <see cref="XLPivotItemType.Data"/>, it must be set.
+    /// </summary>
+    internal uint? ItemIndex { get; }
+
+    /// <remarks>Allowed for OLAP pivot tables only.</remarks>
+    internal bool DrillAcrossAttributes { get; init; }
+
+    /// <remarks>Allowed for OLAP pivot tables only.</remarks>
+    internal bool IsExpanded { get; init; }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotFormat.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFormat.cs
@@ -1,0 +1,27 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A description of formatting that should be applied to a <see cref="XLPivotTable"/>.
+/// </summary>
+internal class XLPivotFormat
+{
+    internal XLPivotFormat(XLPivotArea pivotArea)
+    {
+        PivotArea = pivotArea;
+    }
+
+    /// <summary>
+    /// Pivot area that should be formatted.
+    /// </summary>
+    internal XLPivotArea PivotArea { get; }
+
+    /// <summary>
+    /// Should the formatting (determined by <see cref="DxfId"/>) be applied or not?
+    /// </summary>
+    internal XLPivotFormatAction Action { get; init; } = XLPivotFormatAction.Formatting;
+
+    /// <summary>
+    /// Differential formatting to apply to the <see cref="PivotArea"/>.
+    /// </summary>
+    internal uint? DxfId { get; init; }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotFormatAction.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFormatAction.cs
@@ -1,0 +1,29 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// An enum describing if <see cref="XLPivotFormat"/> applies formatting to the cells of pivot
+/// table or not.
+/// </summary>
+/// <remarks>
+/// <para>
+/// [ISO-29500] 18.18.34 ST_FormatAction
+/// </para>
+/// <para>
+/// [MS-OI29500] 2.1.761 Excel does not support the <c>Drill</c> and <c>Formula</c> values for the
+/// action attribute. Therefore, neither do we, although <c>Drill</c> and <c>Formula</c> values
+/// are present in the ISO <c>ST_FormatAction</c> enum.
+/// </para>
+/// </remarks>
+internal enum XLPivotFormatAction
+{
+    /// <summary>
+    /// No format is applied to the pivot table. This is used when formatting is cleared from
+    /// already formatted cells of pivot table.
+    /// </summary>
+    Blank,
+
+    /// <summary>
+    /// Pivot table has formatting. This is the default value.
+    /// </summary>
+    Formatting,
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotItemType.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotItemType.cs
@@ -1,0 +1,85 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A categorization of <see cref="XLPivotFieldItem"/> or <see cref="XLPivotFieldAxisItem"/>.
+/// </summary>
+/// <remarks>
+/// 18.18.43 ST_ItemType (PivotItem Type).
+/// </remarks>>
+internal enum XLPivotItemType
+{
+    /// <summary>
+    /// The pivot item represents an "average" aggregate function.
+    /// </summary>
+    Avg,
+
+    /// <summary>
+    /// The pivot item represents a blank line.
+    /// </summary>
+    Blank,
+
+    /// <summary>
+    /// The pivot item represents custom the "count" aggregate.
+    /// </summary>
+    Count,
+
+    /// <summary>
+    /// The pivot item represents the "count numbers" aggregate function.
+    /// </summary>
+    CountA,
+
+    /// <summary>
+    /// The pivot item represents data.
+    /// </summary>
+    Data,
+
+    /// <summary>
+    /// The pivot item represents the default type for this pivot table, i.e. the "total" aggregate function.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// The pivot items represents the grand total line.
+    /// </summary>
+    Grand,
+
+    /// <summary>
+    /// The pivot item represents the "maximum" aggregate function.
+    /// </summary>
+    Max,
+
+    /// <summary>
+    /// The pivot item represents the "minimum" aggregate function.
+    /// </summary>
+    Min,
+
+    /// <summary>
+    /// The pivot item represents the "product" function.
+    /// </summary>
+    Product,
+
+    /// <summary>
+    /// The pivot item represents the "standard deviation" aggregate function.
+    /// </summary>
+    StdDev,
+
+    /// <summary>
+    /// The pivot item represents the "standard deviation population" aggregate function.
+    /// </summary>
+    StdDevP,
+
+    /// <summary>
+    /// The pivot item represents the "sum" aggregate value.
+    /// </summary>
+    Sum,
+
+    /// <summary>
+    /// The pivot item represents the "variance" aggregate value.
+    /// </summary>
+    Var,
+
+    /// <summary>
+    /// The pivot item represents the "variance population" aggregate value.
+    /// </summary>
+    VarP
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotPageField.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotPageField.cs
@@ -1,0 +1,34 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A field displayed in the filters part of a pivot table.
+/// </summary>
+internal class XLPivotPageField
+{
+    internal XLPivotPageField(int field)
+    {
+        Field = field;
+    }
+
+    /// <summary>
+    /// Field index to <see cref="XLPivotTable.PivotFields"/>. Can't contain 'data' field <c>-2</c>.
+    /// </summary>
+    internal int Field { get; }
+
+    /// <summary>
+    /// If a single item is selected, item index. Null, if nothing selected or multiple selected.
+    /// Multiple selected values are indicated directly in <see cref="XLPivotTableField.Items"/>
+    /// through <see cref="XLPivotFieldItem.Hidden"/> flags. Items that are not selected are hidden,
+    /// rest isn't.
+    /// </summary>
+    internal uint? ItemIndex { get; init; }
+
+    // OLAP
+    internal int? HierarchyIndex { get; init; }
+
+    // OLAP
+    internal string? HierarchyUniqueName { get; init; }
+
+    // OLAP
+    internal string? HierarchyDisplayName { get; init; }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotReference.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotReference.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Represents a set of selected fields and selected items within those fields. It's used to select
+/// an area for <see cref="XLPivotArea"/>.
+/// </summary>
+internal class XLPivotReference
+{
+    private readonly List<uint> _fieldItems = new();
+
+    /// <summary>
+    /// <para>
+    /// If <see cref="XLPivotArea.CacheIndex"/> is <c>false</c>, then it is index into pivot fields
+    /// items of pivot field <see cref="Field"/> (unless <see cref="ByPosition"/> is <c>true</c>).
+    /// </para>
+    /// <para>
+    /// If <see cref="XLPivotArea.CacheIndex"/> is <c>true</c>, then it is index into shared items
+    /// of a cached field with index <see cref="Field"/> (unless <see cref="ByPosition"/> is
+    /// <c>true</c>).
+    /// </para>
+    /// </summary>
+    internal List<uint> FieldItems => _fieldItems;
+
+    /// <summary>
+    /// Specifies the index of the field to which this filter refers. A value of -2/4294967294
+    /// indicates the 'data' field. It can represent pivot field or cache field, depending on
+    /// <see cref="XLPivotArea.CacheIndex"/>.
+    /// </summary>
+    internal uint? Field { get; init; }
+
+    /// <summary>
+    /// Flag indicating whether this field has selection. This attribute is used when the
+    /// pivot table is in outline view. It is also used when both header and data
+    /// cells have selection.
+    /// </summary>
+    internal bool Selected { get; init; } = true;
+
+    /// <summary>
+    /// Flag indicating whether the item in <see cref="FieldItems"/> is referred to by position rather
+    /// than item index.
+    /// </summary>
+    internal bool ByPosition { get; init; } = false;
+
+    /// <summary>
+    /// Flag indicating whether the item is referred to by a relative reference rather than an
+    /// absolute reference. This attribute is used if posRef is set to true.
+    /// </summary>
+    internal bool Relative { get; init; } = false;
+
+    /// <summary>
+    /// Is the aggregate function included in the filter?
+    /// </summary>
+    internal bool DefaultSubtotal { get; init; } = false;
+
+    internal bool SumSubtotal { get; init; } = false;
+
+    internal bool CountASubtotal { get; init; } = false;
+
+    internal bool AvgSubtotal { get; init; } = false;
+
+    internal bool MaxSubtotal { get; init; } = false;
+
+    internal bool MinSubtotal { get; init; } = false;
+
+    internal bool ProductSubtotal { get; init; } = false;
+
+    internal bool CountSubtotal { get; init; } = false;
+
+    internal bool StdDevSubtotal { get; init; } = false;
+
+    internal bool StdDevPSubtotal { get; init; } = false;
+
+    internal bool VarSubtotal { get; init; } = false;
+
+    internal bool VarPSubtotal { get; init; } = false;
+
+    internal void AddFieldItem(uint fieldItem)
+    {
+        // TODO: Check value by area.CacheIndex and ByPosition
+        _fieldItems.Add(fieldItem);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -14,6 +14,11 @@ namespace ClosedXML.Excel
         private String _name;
         public Guid Guid { get; }
 
+        private readonly List<XLPivotTableField> _fields = new();
+        private readonly List<XLPivotDataField> _dataFields = new();
+        private readonly List<XLPivotPageField> _pageFields = new();
+        private readonly List<XLPivotFormat> _formats = new();
+
         public XLPivotTable(IXLWorksheet worksheet)
         {
             this.Worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
@@ -24,6 +29,8 @@ namespace ClosedXML.Excel
             RowLabels = new XLPivotFields(this);
             Values = new XLPivotValues(this);
             Theme = XLPivotTableTheme.PivotStyleLight16;
+            RowAxis = new XLPivotTableAxis(this);
+            ColumnAxis = new XLPivotTableAxis(this);
 
             SetExcelDefaults();
         }
@@ -51,7 +58,20 @@ namespace ClosedXML.Excel
             }
         }
 
+        /// <summary>
+        /// Table theme this pivot table will use.
+        /// </summary>
         public XLPivotTableTheme Theme { get; set; }
+
+        /// <summary>
+        /// All fields reflected in the pivot cache.
+        /// Order of fields is same as for in the <see cref="PivotCache"/>.
+        /// </summary>
+        internal IReadOnlyList<XLPivotTableField> PivotFields => _fields;
+
+        internal XLPivotTableAxis RowAxis { get; }
+
+        internal XLPivotTableAxis ColumnAxis { get; }
 
         public IXLPivotTable CopyTo(IXLCell targetCell)
         {
@@ -669,6 +689,26 @@ namespace ClosedXML.Excel
                     yield return pivotField.StyleFormats.DataValuesFormat;
                 }
             }
+        }
+
+        internal void AddField(XLPivotTableField field)
+        {
+            _fields.Add(field);
+        }
+
+        internal void AddDataField(XLPivotDataField dataField)
+        {
+            _dataFields.Add(dataField);
+        }
+
+        internal void AddPageField(XLPivotPageField pageField)
+        {
+            _pageFields.Add(pageField);
+        }
+
+        internal void AddFormat(XLPivotFormat pivotFormat)
+        {
+            _formats.Add(pivotFormat);
         }
     }
 }

--- a/ClosedXML/Excel/PivotTables/XLPivotTableAxis.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTableAxis.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A description of one axis (<see cref="XLPivotTable.RowAxis"/>/<see cref="XLPivotTable.ColumnAxis"/>)
+/// of a <see cref="XLPivotTable"/>. It consists of fields in a specific order and values that make up
+/// individual rows/columns of the axis.
+/// </summary>
+/// <remarks>
+/// [ISO-29500] 18.10.1.17 colItems (Column Items), 18.10.1.84 rowItems (Row Items).
+/// </remarks>
+internal class XLPivotTableAxis
+{
+    private readonly List<FieldIndex> _fields = new();
+
+    /// <summary>
+    /// Value of one row/column in an axis.
+    /// </summary>
+    private readonly List<XLPivotFieldAxisItem> _axisItems = new();
+
+    internal XLPivotTableAxis(XLPivotTable pivotTable)
+    {
+        PivotTable = pivotTable;
+    }
+
+    /// <summary>
+    /// Pivot table this axis belongs to.
+    /// </summary>
+    internal XLPivotTable PivotTable { get; }
+
+    /// <summary>
+    /// A list of fields to displayed on the axis. It determines which fields and in what order
+    /// should the fields be displayed.
+    /// </summary>
+    internal IReadOnlyList<FieldIndex> Fields => _fields;
+
+    /// <summary>
+    /// Add field to the axis.
+    /// </summary>
+    internal void AddField(FieldIndex fieldIndex)
+    {
+        _fields.Add(fieldIndex);
+    }
+
+    /// <summary>
+    /// Add a row/column axis values (i.e. values visible on the axis).
+    /// </summary>
+    internal void AddItem(XLPivotFieldAxisItem axisItem)
+    {
+        _axisItems.Add(axisItem);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotTableEnums.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTableEnums.cs
@@ -25,10 +25,27 @@
         Max
     }
 
+    /// <summary>
+    /// An enum describing how are values of a <see cref="XLPivotTableField">pivot field</see> are sorted.
+    /// </summary>
+    /// <remarks>
+    /// [ISO-29500] 18.18.28 ST_FieldSortType.
+    /// </remarks>
     public enum XLPivotSortType
     {
+        /// <summary>
+        /// Field values are sorted manually.
+        /// </summary>
         Default = 0,
+
+        /// <summary>
+        /// Field values are sorted in ascending order.
+        /// </summary>
         Ascending = 1,
+
+        /// <summary>
+        /// Field values are sorted in descending order.
+        /// </summary>
         Descending = 2
     }
 

--- a/ClosedXML/Excel/PivotTables/XLPivotTableField.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTableField.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// One field in a <see cref="XLPivotTable"/>. Pivot table must contain field for each entry of
+/// pivot cache and both are accessed through same index. Pivot field contains items, which are
+/// cache field values referenced anywhere in the pivot table (e.g. caption, axis value ect.).
+/// </summary>
+/// <remarks>
+/// See <em>[OI-29500] 18.10.1.69 pivotField(PivotTable Field)</em> for details.
+/// </remarks>
+internal class XLPivotTableField
+{
+    private readonly List<XLPivotFieldItem> _items = new();
+
+    /// <summary>
+    /// Pivot field item, doesn't contain value, only indexes to <see cref="XLPivotCache"/> shared items.
+    /// </summary>
+    internal IReadOnlyList<XLPivotFieldItem> Items => _items;
+
+    /// <summary>
+    /// Custom name of the field.
+    /// </summary>
+    /// <remarks>
+    /// [MS-OI29500] Office requires @name to be unique for non-OLAP PivotTables.
+    /// </remarks>
+    internal string? Name { get; init; }
+
+    /// <summary>
+    /// </summary>
+    /// <remarks>
+    /// [MS-OI29500] In Office, axisValues shall not be used for the axis attribute.
+    /// </remarks>
+    internal XLPivotAxis? Axis { get; init; }
+
+    internal bool DataField { get; init; } = false;
+
+    internal string? SubtotalCaption { get; init; }
+
+    internal bool ShowDropDowns { get; init; } = true;
+
+    internal bool HiddenLevel { get; init; } = false;
+
+    internal string? UniqueMemberProperty { get; init; }
+
+    internal bool Compact { get; init; } = true;
+
+    internal bool AllDrilled { get; init; } = false;
+
+    internal uint? NumberFormatId { get; init; }
+
+    internal bool Outline { get; init; } = true;
+
+    internal bool SubtotalTop { get; init; } = true;
+
+    internal bool DragToRow { get; init; } = true;
+
+    internal bool DragToColumn { get; init; } = true;
+
+    internal bool MultipleItemSelectionAllowed { get; init; } = false;
+
+    internal bool DragToPage { get; init; } = true;
+
+    internal bool DragToData { get; init; } = true;
+
+    internal bool DragOff { get; init; } = true;
+
+    internal bool ShowAll { get; init; } = true;
+
+    internal bool InsertBlankRow { get; init; } = false;
+
+    internal bool ServerField { get; init; } = false;
+
+    internal bool InsertPageBreak { get; init; } = false;
+
+    internal bool AutoShow { get; init; } = false;
+
+    internal bool TopAutoShow { get; init; } = true;
+
+    internal bool HideNewItems { get; init; } = false;
+
+    internal bool MeasureFilter { get; init; } = false;
+
+    internal bool IncludeNewItemsInFilter { get; init; } = false;
+
+    internal uint ItemPageCount { get; init; } = 10;
+
+    internal XLPivotSortType SortType { get; init; } = XLPivotSortType.Default;
+
+    internal bool? DataSourceSort { get; init; }
+
+    internal bool NonAutoSortDefault { get; init; } = false;
+
+    internal uint? RankBy { get; init; }
+
+    internal bool DefaultSubtotal { get; init; } = true;
+
+    internal bool SumSubtotal { get; init; } = false;
+
+    internal bool CountASubtotal { get; init; } = false;
+
+    internal bool AvgSubtotal { get; init; } = false;
+
+    internal bool MaxSubtotal { get; init; } = false;
+
+    internal bool MinSubtotal { get; init; } = false;
+
+    internal bool ProductSubtotal { get; init; } = false;
+
+    internal bool CountSubtotal { get; init; } = false;
+
+    internal bool StdDevSubtotal { get; init; } = false;
+
+    internal bool StdDevPSubtotal { get; init; } = false;
+
+    internal bool VarSubtotal { get; init; } = false;
+
+    internal bool VarPSubtotal { get; init; } = false;
+
+    internal bool ShowPropCell { get; init; } = false;
+
+    internal bool ShowPropTip { get; init; } = false;
+
+    internal bool ShowPropAsCaption { get; init; } = false;
+
+    internal bool DefaultAttributeDrillState { get; init; } = false;
+
+    /// <summary>
+    /// Add an item when it is used anywhere in the pivot table.
+    /// </summary>
+    /// <param name="item">Item to add.</param>
+    /// <returns>Index of added item.</returns>
+    internal uint AddItem(XLPivotFieldItem item)
+    {
+        var index = _items.Count;
+        _items.Add(item);
+        return (uint)index;
+    }
+}


### PR DESCRIPTION
The current approach faces complexity explosion and is just not feasible. The amount of possible states in file is massive and in current representation is really large. The mapping during loading/saving thus has to deal with both and that's never going to work properly.

Instead, be close to the file structure and move complexity to the API, where ClosedXML is in control (load should deal with any valid pivot table and thus we are not in control there).

This is only part 1 - load most most of elements into a parallel data structure. It doesn't save anything. Other parts have to replace current structure while keeping API and save to file.