### PR TITLE
Optimise workbook loading by stopping unneeded invalidation

### DIFF
--- a/ClosedXML/Excel/IXLWorksheets.cs
+++ b/ClosedXML/Excel/IXLWorksheets.cs
@@ -1,8 +1,7 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ClosedXML.Excel
 {
@@ -32,7 +31,7 @@ namespace ClosedXML.Excel
 
         void Delete(Int32 position);
 
-        bool TryGetWorksheet(string sheetName, out IXLWorksheet worksheet);
+        bool TryGetWorksheet(string sheetName, [NotNullWhen(true)] out IXLWorksheet? worksheet);
 
         IXLWorksheet Worksheet(String sheetName);
 

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace ClosedXML.Excel
@@ -50,7 +51,7 @@ namespace ClosedXML.Excel
             return _worksheets.ContainsKey(sheetName);
         }
 
-        bool IXLWorksheets.TryGetWorksheet(string sheetName, out IXLWorksheet? worksheet)
+        bool IXLWorksheets.TryGetWorksheet(string sheetName, [NotNullWhen(true)] out IXLWorksheet? worksheet)
         {
             if (TryGetWorksheet(sheetName, out var foundSheet))
             {
@@ -62,7 +63,7 @@ namespace ClosedXML.Excel
             return false;
         }
 
-        internal bool TryGetWorksheet(string sheetName, out XLWorksheet? worksheet)
+        internal bool TryGetWorksheet(string sheetName, [NotNullWhen(true)] out XLWorksheet? worksheet)
         {
             if (_worksheets.TryGetValue(sheetName.UnescapeSheetName(), out worksheet))
             {

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -121,7 +121,7 @@ namespace ClosedXML.Excel
             return Add(sheetName, position, GetNextSheetId());
         }
 
-        internal XLWorksheet Add(String sheetName, Int32 position, UInt32 sheetId, bool notifyWorksheetAdded = true)
+        internal XLWorksheet Add(String sheetName, Int32 position, UInt32 sheetId)
         {
             _worksheets.Values.Where(w => w._position >= position).ForEach(w => w._position += 1);
             _workbook.UnsupportedSheets.Where(w => w.Position >= position).ForEach(w => w.Position += 1);
@@ -129,20 +129,19 @@ namespace ClosedXML.Excel
             // If the loaded sheetId is greater than current, just make sure our next sheetId is even bigger.
             _nextSheetId = Math.Max(_nextSheetId, sheetId + 1);
             var sheet = new XLWorksheet(sheetName, _workbook, sheetId);
-            Add(sheetName, sheet, notifyWorksheetAdded);
+            Add(sheetName, sheet);
             sheet._position = position;
             return sheet;
         }
 
-        private void Add(String sheetName, XLWorksheet sheet, bool notifyWorksheetAdded = true)
+        private void Add(String sheetName, XLWorksheet sheet)
         {
             if (_worksheets.ContainsKey(sheetName))
                 throw new ArgumentException(String.Format("A worksheet with the same name ({0}) has already been added.", sheetName), nameof(sheetName));
 
             _worksheets.Add(sheetName, sheet);
 
-            if (notifyWorksheetAdded)
-                _workbook.NotifyWorksheetAdded(sheet);
+            _workbook.NotifyWorksheetAdded(sheet);
         }
 
         public void Delete(String sheetName)

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -121,7 +121,7 @@ namespace ClosedXML.Excel
             return Add(sheetName, position, GetNextSheetId());
         }
 
-        internal XLWorksheet Add(String sheetName, Int32 position, UInt32 sheetId)
+        internal XLWorksheet Add(String sheetName, Int32 position, UInt32 sheetId, bool notifyWorksheetAdded = true)
         {
             _worksheets.Values.Where(w => w._position >= position).ForEach(w => w._position += 1);
             _workbook.UnsupportedSheets.Where(w => w.Position >= position).ForEach(w => w.Position += 1);
@@ -129,19 +129,20 @@ namespace ClosedXML.Excel
             // If the loaded sheetId is greater than current, just make sure our next sheetId is even bigger.
             _nextSheetId = Math.Max(_nextSheetId, sheetId + 1);
             var sheet = new XLWorksheet(sheetName, _workbook, sheetId);
-            Add(sheetName, sheet);
+            Add(sheetName, sheet, notifyWorksheetAdded);
             sheet._position = position;
             return sheet;
         }
 
-        private void Add(String sheetName, XLWorksheet sheet)
+        private void Add(String sheetName, XLWorksheet sheet, bool notifyWorksheetAdded = true)
         {
             if (_worksheets.ContainsKey(sheetName))
                 throw new ArgumentException(String.Format("A worksheet with the same name ({0}) has already been added.", sheetName), nameof(sheetName));
 
             _worksheets.Add(sheetName, sheet);
 
-            _workbook.NotifyWorksheetAdded(sheet);
+            if (notifyWorksheetAdded)
+                _workbook.NotifyWorksheetAdded(sheet);
         }
 
         public void Delete(String sheetName)


### PR DESCRIPTION
I'm working on an app that uses ClosedXML, and we've recently started testing it on some large spreadsheets, e.g. 1 test spreadsheet that I've been profiling is 27MB, has 132 worksheets, and probably has thousands of calculations.

These larger spreadsheets have been taking over 10 seconds to load in release builds (time of just doing a `new XLWorkbook(workbookFilePath)`), which we would like to get lower if possible, so I've been doing some profiling to see if there are any easy wins. First cab off the rank is this:

<img width="743" alt="CpuUsage1" src="https://github.com/ClosedXML/ClosedXML/assets/1635228/5c34387d-6018-4f46-9bfb-9856db4c761b">

Having 23% of the time being spent just marking formulas as dirty seems like something that could have had some easy wins, so I dug deeper. This percent is from a debug build, and the savings in release builds turned out to be a decent amount smaller, but it is still worth improving.

The crux of the issue here is that every single time that a sheet is added, the calculations of all the previous sheets that have already been added get marked as dirty. In my test workbook, this means that this mark dirty pass gets run 132 times (although the first time it does nothing because nothing has been loaded yet). Also, as it appears to process all added calculations so far each time it runs, the amount of work done might grow exponentially, as each time it runs there might be more and more calculations to enumerate over to mark as dirty.

One potential solution here would be to delay all this mark dirty work until after all the worksheets have been loaded, and then only do it once at the end. However, I think that this also exposes a logic mistake, so this hasn't been what I've done here.

The current load code, after it was added the new worksheet, has the following code that it runs when loading individual cells of a worksheet (in `LoadCell`):

```csharp
// If the cell doesn't contain value, we should invalidate it, otherwise rely on the stored value.
// The value is likely more reliable. It should be set when cellFormula.CalculateCell is set or
// when value is missing. Formula can be null in some cases, e.g. slave cells of array formula.
if (formula is not null && !cellHasValue)
{
    formula.IsDirty = true;
}
```

This code makes it look like the original intent of the loading code was that marking formulas as dirty was only done when needed, and at some point a change was made and now all formulas always all get marked as dirty when loaded. Or, I should be a bit more correct and say that the current logic always marks all formulas dirty for all worksheets except the last worksheet loaded. This means you wouldn't notice this issue at all if your workbook only has 1 worksheet. But in any case, it looks like this current logic likely wasn't intended.

This PR has one potential solution, where through some new method overloads, `NotifyWorksheetAdded` is not called when loading a workbook from a file, but is still called when modifying a workbook after loading or after creating a new workbook in memory.

I might be missing some historical context, or maybe there is a better way to achieve this fix, so I'm happy if this gets fixed/improved another way.

In my testing this took my load times in release builds from about 16 seconds for my test spreadsheet, down to 15 seconds, or about a 6% reduction. That might not sound like a lot, but every bit helps, and this also likely fixes a logic mistake if I'm reading things correctly.

This fix could likely have further savings after the load as this might allow for better utilisation of cached calculation values written to files, whereas at the moment, most calculations in multi-worksheet workbooks will be marked as dirty, likely leading to the cached calculation values written to files not being possible to be used. I haven't looked into this though, as I'm focused on just loading of the workbook for now, so I might be wrong.