### PR TITLE
Start new pivot table part writer

### DIFF
--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -871,7 +871,7 @@ internal class PivotTableDefinitionPartReader
                 var approximatelyHasChildren = item.ChildItems?.Value ?? false;
                 var isExpanded = item.Expanded?.Value ?? true;
                 var drillAcrossAttributes = item.DrillAcrossAttributes?.Value ?? true;
-                var calculatedMember = item.DrillAcrossAttributes?.Value ?? false;
+                var calculatedMember = item.Calculated?.Value ?? false;
                 var hidden = item.Hidden?.Value ?? false;
                 var missing = item.Missing?.Value ?? false;
                 var itemUserCaption = item.ItemName;

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -505,6 +505,19 @@ internal class PivotTableDefinitionPartReader
         // Load base attributes
         var xlPivotTable = LoadPivotTableAttributes(pivotTable, sheet, cache);
 
+        // Load location
+        var location = pivotTable.Location;
+        if (location is null)
+            throw PartStructureException.ExpectedElementNotFound();
+
+        var referenceText = location.Reference?.Value ?? throw PartStructureException.MissingAttribute();
+        xlPivotTable.Area = XLSheetRange.Parse(referenceText);
+        xlPivotTable.FirstHeaderRow = location.FirstHeaderRow?.Value ?? throw PartStructureException.MissingAttribute();
+        xlPivotTable.FirstDataRow = location.FirstDataRow?.Value ?? throw PartStructureException.MissingAttribute();
+        xlPivotTable.FirstDataCol = location.FirstDataColumn?.Value ?? throw PartStructureException.MissingAttribute();
+        xlPivotTable.RowPageCount = location.RowPageCount?.Value ?? 0;
+        xlPivotTable.ColumnPageCount = location.ColumnsPerPage?.Value ?? 0;
+
         // Load pivot fields
         var pivotFields = pivotTable.PivotFields;
         if (pivotFields is not null)

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -50,72 +50,8 @@ internal class PivotTableDefinitionPartReader
             pt.TargetCell = target;
             ws.PivotTables.Add(pt);
 
-            if (!String.IsNullOrWhiteSpace(
-                    StringValue.ToString(pivotTableDefinition?.ColumnHeaderCaption ?? String.Empty)))
-                pt.SetColumnHeaderCaption(StringValue.ToString(pivotTableDefinition.ColumnHeaderCaption));
-
-            if (!String.IsNullOrWhiteSpace(
-                    StringValue.ToString(pivotTableDefinition?.RowHeaderCaption ?? String.Empty)))
-                pt.SetRowHeaderCaption(StringValue.ToString(pivotTableDefinition.RowHeaderCaption));
-
             pt.RelId = worksheetPart.GetIdOfPart(pivotTablePart);
             pt.CacheDefinitionRelId = pivotTablePart.GetIdOfPart(cache);
-
-            if (pivotTableDefinition.MergeItem != null)
-                pt.MergeAndCenterWithLabels = pivotTableDefinition.MergeItem.Value;
-            if (pivotTableDefinition.Indent != null) pt.RowLabelIndent = (int)pivotTableDefinition.Indent.Value;
-            if (pivotTableDefinition.PageOverThenDown != null)
-                pt.FilterAreaOrder = pivotTableDefinition.PageOverThenDown.Value
-                    ? XLFilterAreaOrder.OverThenDown
-                    : XLFilterAreaOrder.DownThenOver;
-            if (pivotTableDefinition.PageWrap != null)
-                pt.FilterFieldsPageWrap = (int)pivotTableDefinition.PageWrap.Value;
-            if (pivotTableDefinition.UseAutoFormatting != null)
-                pt.AutofitColumns = pivotTableDefinition.UseAutoFormatting.Value;
-            if (pivotTableDefinition.PreserveFormatting != null)
-                pt.PreserveCellFormatting = pivotTableDefinition.PreserveFormatting.Value;
-            if (pivotTableDefinition.RowGrandTotals != null)
-                pt.ShowGrandTotalsRows = pivotTableDefinition.RowGrandTotals.Value;
-            if (pivotTableDefinition.ColumnGrandTotals != null)
-                pt.ShowGrandTotalsColumns = pivotTableDefinition.ColumnGrandTotals.Value;
-            if (pivotTableDefinition.SubtotalHiddenItems != null)
-                pt.FilteredItemsInSubtotals = pivotTableDefinition.SubtotalHiddenItems.Value;
-            if (pivotTableDefinition.MultipleFieldFilters != null)
-                pt.AllowMultipleFilters = pivotTableDefinition.MultipleFieldFilters.Value;
-            if (pivotTableDefinition.CustomListSort != null)
-                pt.UseCustomListsForSorting = pivotTableDefinition.CustomListSort.Value;
-            if (pivotTableDefinition.ShowDrill != null)
-                pt.ShowExpandCollapseButtons = pivotTableDefinition.ShowDrill.Value;
-            if (pivotTableDefinition.ShowDataTips != null)
-                pt.ShowContextualTooltips = pivotTableDefinition.ShowDataTips.Value;
-            if (pivotTableDefinition.ShowMemberPropertyTips != null)
-                pt.ShowPropertiesInTooltips = pivotTableDefinition.ShowMemberPropertyTips.Value;
-            if (pivotTableDefinition.ShowHeaders != null)
-                pt.DisplayCaptionsAndDropdowns = pivotTableDefinition.ShowHeaders.Value;
-            if (pivotTableDefinition.GridDropZones != null)
-                pt.ClassicPivotTableLayout = pivotTableDefinition.GridDropZones.Value;
-            if (pivotTableDefinition.ShowEmptyRow != null)
-                pt.ShowEmptyItemsOnRows = pivotTableDefinition.ShowEmptyRow.Value;
-            if (pivotTableDefinition.ShowEmptyColumn != null)
-                pt.ShowEmptyItemsOnColumns = pivotTableDefinition.ShowEmptyColumn.Value;
-            if (pivotTableDefinition.ShowItems != null)
-                pt.DisplayItemLabels = pivotTableDefinition.ShowItems.Value;
-            if (pivotTableDefinition.FieldListSortAscending != null)
-                pt.SortFieldsAtoZ = pivotTableDefinition.FieldListSortAscending.Value;
-            if (pivotTableDefinition.PrintDrill != null)
-                pt.PrintExpandCollapsedButtons = pivotTableDefinition.PrintDrill.Value;
-            if (pivotTableDefinition.ItemPrintTitles != null)
-                pt.RepeatRowLabels = pivotTableDefinition.ItemPrintTitles.Value;
-            if (pivotTableDefinition.FieldPrintTitles != null)
-                pt.PrintTitles = pivotTableDefinition.FieldPrintTitles.Value;
-            if (pivotTableDefinition.EnableDrill != null)
-                pt.EnableShowDetails = pivotTableDefinition.EnableDrill.Value;
-
-            // if (pivotTableDefinition.ShowMissing != null && pivotTableDefinition.MissingCaption != null)
-            //     pt.EmptyCellReplacement = pivotTableDefinition.MissingCaption.Value;
-
-            if (pivotTableDefinition.ShowError != null && pivotTableDefinition.ErrorCaption != null)
-                pt.ErrorValueReplacement = pivotTableDefinition.ErrorCaption.Value;
 
             var pivotTableDefinitionExtensionList =
                 pivotTableDefinition.GetFirstChild<PivotTableDefinitionExtensionList>();
@@ -775,9 +711,9 @@ internal class PivotTableDefinitionPartReader
             ShowPropertiesInTooltips = showMemberPropertyTips,
             ShowContextualTooltips = showDataTips,
             EnableEditingMechanism = enableWizard,
-            EnableDrillDown = enableDrill,
+            EnableShowDetails = enableDrill,
             EnableFieldProperties = enableFieldProperties,
-            PreserveFormatting = preserveFormatting,
+            PreserveCellFormatting = preserveFormatting,
             AutofitColumns = useAutoFormatting,
             FilterFieldsPageWrap = checked((int)pageWrap),
             FilterAreaOrder = pageOverThenDown ? XLFilterAreaOrder.OverThenDown : XLFilterAreaOrder.DownThenOver,
@@ -789,7 +725,7 @@ internal class PivotTableDefinitionPartReader
             MergeAndCenterWithLabels = mergeItem,
             ShowDropZones = showDropZones,
             PivotCacheCreatedVersion = createdVersion,
-            IndentationForCompactAxis = indent,
+            RowLabelIndent = checked((int)indent),
             ShowEmptyItemsOnRows = showEmptyRow,
             ShowEmptyItemsOnColumns = showEmptyColumn,
             DisplayCaptionsAndDropdowns = showHeaders,

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -1,0 +1,247 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Xml;
+using ClosedXML.Extensions;
+using DocumentFormat.OpenXml.Packaging;
+using static ClosedXML.Excel.IO.OpenXmlConst;
+
+namespace ClosedXML.Excel.IO;
+
+internal class PivotTableDefinitionPartWriter2
+{
+    internal static void WriteContent(PivotTablePart pivotTablePart, XLPivotTable pt)
+    {
+        var settings = new XmlWriterSettings
+        {
+            Encoding = XLHelper.NoBomUTF8
+        };
+
+        using var partStream = pivotTablePart.GetStream(FileMode.Create);
+        using var xml = XmlWriter.Create(partStream, settings);
+
+        xml.WriteStartDocument();
+        xml.WriteStartElement("pivotTableDefinition", Main2006SsNs);
+        xml.WriteAttributeString("xmlns", "mc", null, MarkupCompatibilityNs);
+
+        // Mark revision as ignorable extension
+        xml.WriteAttributeString("mc", "Ignorable", null, "xr");
+        xml.WriteAttributeString("xmlns", "xr", null, RevisionNs);
+        xml.WriteAttribute("name", pt.Name);
+        xml.WriteAttribute("cacheId", pt.PivotCache.CacheId!.Value); // TODO: Maybe not nullable?
+        xml.WriteAttributeDefault("dataOnRows", pt.DataOnRows, false);
+        xml.WriteAttributeOptional("dataPosition", pt.DataPosition);
+        xml.WriteAttributeOptional("autoFormatId", pt.AutoFormatId);
+
+        // Although apply*Formats do have default value `false`, Excel always writes them.
+        xml.WriteAttribute("applyNumberFormats", pt.ApplyNumberFormats);
+        xml.WriteAttribute("applyBorderFormats", pt.ApplyBorderFormats);
+        xml.WriteAttribute("applyFontFormats", pt.ApplyFontFormats);
+        xml.WriteAttribute("applyPatternFormats", pt.ApplyPatternFormats);
+        xml.WriteAttribute("applyAlignmentFormats", pt.ApplyAlignmentFormats);
+        xml.WriteAttribute("applyWidthHeightFormats", pt.ApplyWidthHeightFormats);
+
+        xml.WriteAttribute("dataCaption", pt.DataCaption);
+        xml.WriteAttributeOptional("grandTotalCaption", pt.GrandTotalCaption);
+        xml.WriteAttributeOptional("errorCaption", pt.ErrorValueReplacement);
+        xml.WriteAttributeDefault("showError", pt.ShowError, false);
+        xml.WriteAttributeOptional("missingCaption", pt.MissingCaption);
+        xml.WriteAttributeDefault("showMissing", pt.ShowMissing, true);
+        xml.WriteAttributeOptional("pageStyle", pt.PageStyle);
+        xml.WriteAttributeOptional("pivotTableStyle", pt.PivotTableStyleName);
+        xml.WriteAttributeOptional("vacatedStyle", pt.VacatedStyle);
+        xml.WriteAttributeOptional("tag", pt.Tag);
+        xml.WriteAttributeDefault("updatedVersion", pt.UpdatedVersion, 0);
+        xml.WriteAttributeDefault("minRefreshableVersion", pt.MinRefreshableVersion, 0);
+        xml.WriteAttributeDefault("asteriskTotals", pt.AsteriskTotals, false);
+        xml.WriteAttributeDefault("showItems", pt.DisplayItemLabels, true);
+        xml.WriteAttributeDefault("editData", pt.EditData, false);
+        xml.WriteAttributeDefault("disableFieldList", pt.DisableFieldList, false);
+        xml.WriteAttributeDefault(@"showCalcMbrs", pt.ShowCalculatedMembers, true);
+        xml.WriteAttributeDefault("visualTotals", pt.VisualTotals, true);
+        xml.WriteAttributeDefault("showMultipleLabel", pt.ShowMultipleLabel, true);
+        xml.WriteAttributeDefault("showDataDropDown", pt.ShowDataDropDown, true);
+        xml.WriteAttributeDefault("showDrill", pt.ShowExpandCollapseButtons, true);
+        xml.WriteAttributeDefault("printDrill", pt.PrintExpandCollapsedButtons, false);
+        xml.WriteAttributeDefault("showMemberPropertyTips", pt.ShowPropertiesInTooltips, true);
+        xml.WriteAttributeDefault("showDataTips", pt.ShowContextualTooltips, true);
+        xml.WriteAttributeDefault("enableWizard", pt.EnableEditingMechanism, true);
+        xml.WriteAttributeDefault("enableDrill", pt.EnableShowDetails, true);
+        xml.WriteAttributeDefault("enableFieldProperties", pt.EnableFieldProperties, true);
+        xml.WriteAttributeDefault("preserveFormatting", pt.PreserveCellFormatting, true);
+        xml.WriteAttributeDefault("useAutoFormatting", pt.AutofitColumns, false);
+        xml.WriteAttributeDefault("pageWrap", checked((uint)pt.FilterFieldsPageWrap), 0);
+        xml.WriteAttributeDefault("pageOverThenDown", pt.FilterAreaOrder == XLFilterAreaOrder.OverThenDown, false);
+        xml.WriteAttributeDefault("subtotalHiddenItems", pt.FilteredItemsInSubtotals, false);
+        xml.WriteAttributeDefault("rowGrandTotals", pt.ShowGrandTotalsRows, true);
+        xml.WriteAttributeDefault("colGrandTotals", pt.ShowGrandTotalsColumns, true);
+        xml.WriteAttributeDefault("fieldPrintTitles", pt.PrintTitles, false);
+        xml.WriteAttributeDefault("itemPrintTitles", pt.RepeatRowLabels, false);
+        xml.WriteAttributeDefault("mergeItem", pt.MergeAndCenterWithLabels, false);
+        xml.WriteAttributeDefault("showDropZones", pt.ShowDropZones, true);
+        xml.WriteAttributeDefault("createdVersion", pt.PivotCacheCreatedVersion, 0);
+        xml.WriteAttributeDefault("indent", checked((uint)pt.RowLabelIndent), 1);
+        xml.WriteAttributeDefault("showEmptyRow", pt.ShowEmptyItemsOnRows, false);
+        xml.WriteAttributeDefault("showEmptyCol", pt.ShowEmptyItemsOnColumns, false);
+        xml.WriteAttributeDefault("showHeaders", pt.DisplayCaptionsAndDropdowns, true);
+        xml.WriteAttributeDefault("compact", pt.Compact, true);
+        xml.WriteAttributeDefault("outline", pt.Outline, false);
+        xml.WriteAttributeDefault("outlineData", pt.OutlineData, false);
+        xml.WriteAttributeDefault("compactData", pt.CompactData, true);
+        xml.WriteAttributeDefault("published", pt.Published, false);
+        xml.WriteAttributeDefault("gridDropZones", pt.ClassicPivotTableLayout, false);
+        xml.WriteAttributeDefault("immersive", pt.StopImmersiveUi, true);
+        xml.WriteAttributeDefault("multipleFieldFilters", pt.AllowMultipleFilters, true);
+        xml.WriteAttributeDefault("chartFormat", pt.ChartFormat, 0);
+        xml.WriteAttributeOptional("rowHeaderCaption", pt.RowHeaderCaption);
+        xml.WriteAttributeOptional("colHeaderCaption", pt.ColumnHeaderCaption);
+        xml.WriteAttributeDefault("fieldListSortAscending", pt.SortFieldsAtoZ, false);
+        xml.WriteAttributeDefault(@"mdxSubqueries", pt.MdxSubQueries, false);
+        xml.WriteAttributeDefault("customListSort", pt.UseCustomListsForSorting, true);
+
+        // Location
+        xml.WriteStartElement("location", Main2006SsNs);
+        xml.WriteAttribute("ref", pt.Area.ToString());
+        xml.WriteAttribute("firstHeaderRow", pt.FirstHeaderRow);
+        xml.WriteAttribute("firstDataRow", pt.FirstDataRow);
+        xml.WriteAttribute("firstDataCol", pt.FirstDataCol);
+        xml.WriteAttributeDefault("rowPageCount", pt.RowPageCount, 0);
+        xml.WriteAttributeDefault("colPageCount", pt.ColumnPageCount, 0);
+        xml.WriteEndElement(); // location
+
+        // Pivot Fields
+        xml.WriteStartElement("pivotFields", Main2006SsNs);
+        xml.WriteAttribute("count", pt.PivotFields.Count);
+
+        foreach (var pf in pt.PivotFields)
+        {
+            xml.WriteStartElement("pivotField", Main2006SsNs);
+            xml.WriteAttributeOptional("name", pf.Name);
+
+            if (pf.Axis is not null)
+            {
+                var axisAttr = pf.Axis.Value switch
+                {
+                    XLPivotAxis.AxisRow => "axisRow",
+                    XLPivotAxis.AxisCol => "axisCol",
+                    XLPivotAxis.AxisPage => "axisPage",
+                    XLPivotAxis.AxisValues => "axisValues",
+                    _ => throw new UnreachableException(),
+                };
+                xml.WriteAttribute("axis", axisAttr);
+            }
+
+            xml.WriteAttributeDefault("dataField", pf.DataField, false);
+            xml.WriteAttributeOptional("subtotalCaption", pf.SubtotalCaption);
+            xml.WriteAttributeDefault("showDropDowns", pf.ShowDropDowns, true);
+            xml.WriteAttributeDefault("hiddenLevel", pf.HiddenLevel, false);
+            xml.WriteAttributeOptional("uniqueMemberProperty", pf.UniqueMemberProperty);
+            xml.WriteAttributeDefault("compact", pf.Compact, true);
+            xml.WriteAttributeDefault("allDrilled", pf.AllDrilled, false);
+            xml.WriteAttributeOptional("numFmtId", pf.NumberFormatId);
+            xml.WriteAttributeDefault("outline", pf.Outline, true);
+            xml.WriteAttributeDefault("subtotalTop", pf.SubtotalTop, true);
+            xml.WriteAttributeDefault("dragToRow", pf.DragToRow, true);
+            xml.WriteAttributeDefault("dragToCol", pf.DragToColumn, true);
+            xml.WriteAttributeDefault("multipleItemSelectionAllowed", pf.MultipleItemSelectionAllowed, false);
+            xml.WriteAttributeDefault("dragToPage", pf.DragToPage, true);
+            xml.WriteAttributeDefault("dragToData", pf.DragToData, true);
+            xml.WriteAttributeDefault("dragOff", pf.DragOff, true);
+            xml.WriteAttributeDefault("showAll", pf.ShowAll, true);
+            xml.WriteAttributeDefault("insertBlankRow", pf.InsertBlankRow, false);
+            xml.WriteAttributeDefault("serverField", pf.ServerField, false);
+            xml.WriteAttributeDefault("insertPageBreak", pf.InsertPageBreak, false);
+            xml.WriteAttributeDefault("autoShow", pf.AutoShow, false);
+            xml.WriteAttributeDefault("topAutoShow", pf.TopAutoShow, true);
+            xml.WriteAttributeDefault("hideNewItems", pf.HideNewItems, false);
+            xml.WriteAttributeDefault("measureFilter", pf.MeasureFilter, false);
+            xml.WriteAttributeDefault("includeNewItemsInFilter", pf.IncludeNewItemsInFilter, false);
+            xml.WriteAttributeDefault("itemPageCount", pf.ItemPageCount, 10);
+            if (pf.SortType != XLPivotSortType.Default)
+            {
+                var sortTypeAttr = pf.SortType switch
+                {
+                    XLPivotSortType.Default => "manual",
+                    XLPivotSortType.Ascending => "ascending",
+                    XLPivotSortType.Descending => "descending",
+                    _ => throw new UnreachableException(),
+                };
+                xml.WriteAttribute("sortType", sortTypeAttr);
+            }
+
+            xml.WriteAttributeOptional("dataSourceSort", pf.DataSourceSort);
+            xml.WriteAttributeDefault("nonAutoSortDefault", pf.NonAutoSortDefault, false);
+            xml.WriteAttributeOptional("rankBy", pf.RankBy);
+            xml.WriteAttributeDefault("defaultSubtotal", pf.DefaultSubtotal, true);
+            xml.WriteAttributeDefault("sumSubtotal", pf.SumSubtotal, false);
+            xml.WriteAttributeDefault("countASubtotal", pf.CountASubtotal, false);
+            xml.WriteAttributeDefault("avgSubtotal", pf.AvgSubtotal, false);
+            xml.WriteAttributeDefault("maxSubtotal", pf.MaxSubtotal, false);
+            xml.WriteAttributeDefault("minSubtotal", pf.MinSubtotal, false);
+            xml.WriteAttributeDefault("productSubtotal", pf.ProductSubtotal, false);
+            xml.WriteAttributeDefault("countSubtotal", pf.CountSubtotal, false);
+            xml.WriteAttributeDefault("stdDevSubtotal", pf.StdDevSubtotal, false);
+            xml.WriteAttributeDefault("stdDevPSubtotal", pf.StdDevPSubtotal, false);
+            xml.WriteAttributeDefault("varSubtotal", pf.VarSubtotal, false);
+            xml.WriteAttributeDefault("varPSubtotal", pf.VarPSubtotal, false);
+            xml.WriteAttributeDefault("showPropCell", pf.ShowPropCell, false);
+            xml.WriteAttributeDefault("showPropTip", pf.ShowPropTip, false);
+            xml.WriteAttributeDefault("showPropAsCaption", pf.ShowPropAsCaption, false);
+            xml.WriteAttributeDefault("defaultAttributeDrillState", pf.DefaultAttributeDrillState, false);
+
+            // items
+            if (pf.Items.Count > 0)
+            {
+                xml.WriteStartElement("items", Main2006SsNs);
+                xml.WriteAttribute("count", pf.Items.Count);
+                foreach (var pfItem in pf.Items)
+                {
+                    xml.WriteStartElement("item");
+                    xml.WriteAttributeOptional("n", pfItem.ItemUserCaption);
+                    if (pfItem.ItemType != XLPivotItemType.Data)
+                    {
+                        var itemTypeAttr = pfItem.ItemType switch
+                        {
+                            XLPivotItemType.Avg => "avg",
+                            XLPivotItemType.Blank => "blank",
+                            XLPivotItemType.Count => "count",
+                            XLPivotItemType.CountA => "countA",
+                            XLPivotItemType.Data => "data",
+                            XLPivotItemType.Default => "default",
+                            XLPivotItemType.Grand => "grand",
+                            XLPivotItemType.Max => "max",
+                            XLPivotItemType.Min => "min",
+                            XLPivotItemType.Product => "product",
+                            XLPivotItemType.StdDev => "stdDev",
+                            XLPivotItemType.StdDevP => "stdDevP",
+                            XLPivotItemType.Sum => "sum",
+                            XLPivotItemType.Var => "var",
+                            XLPivotItemType.VarP => "varP",
+                            _ => throw new UnreachableException(),
+                        };
+                        xml.WriteAttribute("t", itemTypeAttr);
+                    }
+
+                    xml.WriteAttributeDefault("h", pfItem.Hidden, false);
+                    xml.WriteAttributeDefault("s", pfItem.ValueIsString, false);
+                    xml.WriteAttributeDefault("sd", pfItem.HideDetails, true);
+                    xml.WriteAttributeDefault("f", pfItem.CalculatedMember, false);
+                    xml.WriteAttributeDefault("m", pfItem.Missing, false);
+                    xml.WriteAttributeDefault("c", pfItem.ApproximatelyHasChildren, false);
+                    xml.WriteAttributeOptional("x", pfItem.ItemIndex);
+                    xml.WriteAttributeDefault("d", pfItem.IsExpanded, false);
+                    xml.WriteAttributeDefault("e", pfItem.DrillAcrossAttributes, true);
+                    xml.WriteEndElement(); // item
+                }
+
+                xml.WriteEndElement(); // items
+            }
+
+            // TODO: autoSortScope, but not yet represented.
+
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement(); // pivotFields
+        xml.WriteEndElement(); // pivotTableDefinition
+    }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -246,8 +246,6 @@ namespace ClosedXML.Excel
             MergeAndCenterWithLabels = value; return this;
         }
 
-        public Int32 RowLabelIndent { get; set; }
-
         public IXLPivotTable SetRowLabelIndent(Int32 value)
         {
             RowLabelIndent = value; return this;
@@ -306,8 +304,6 @@ namespace ClosedXML.Excel
         {
             AutofitColumns = value; return this;
         }
-
-        public Boolean PreserveCellFormatting { get; set; }
 
         public IXLPivotTable SetPreserveCellFormatting()
         {
@@ -500,9 +496,6 @@ namespace ClosedXML.Excel
         {
             PrintTitles = value; return this;
         }
-
-
-        public Boolean EnableShowDetails { get; set; }
 
         public IXLPivotTable SetEnableShowDetails()
         {
@@ -882,7 +875,7 @@ namespace ClosedXML.Excel
         internal bool EnableEditingMechanism { get; set; } = true;
 
         /// <remarks>Likely OLAP only. Do not confuse with collapse/expand buttons.</remarks>
-        internal bool EnableDrillDown { get; init; } = true;
+        public Boolean EnableShowDetails { get; set; } = true;
 
         /// <summary>
         /// A flag indicating whether the user is prevented from displaying PivotField properties.
@@ -895,8 +888,9 @@ namespace ClosedXML.Excel
         /// A flag that indicates whether the formatting applied by the user to the pivot table
         /// cells is preserved on refresh. 
         /// </summary>
-        /// <remarks>Once again, ISO-29500 is buggy and says the opposite.</remarks>
-        internal bool PreserveFormatting { get; init; } = true;
+        /// <remarks>Once again, ISO-29500 is buggy and says the opposite. Also called <em>
+        /// PreserveFormatting</em></remarks>
+        public Boolean PreserveCellFormatting { get; set; } = true;
 
         /// <summary>
         /// A flag that indicates whether legacy auto formatting has been applied to the PivotTable
@@ -982,7 +976,7 @@ namespace ClosedXML.Excel
         /// are characters.
         /// </summary>
         /// <remarks>Also called <em>Indent</em>.</remarks>
-        internal uint IndentationForCompactAxis { get; init; } = 1;
+        public Int32 RowLabelIndent { get; set; } = 1;
 
         /// <summary>
         /// A flag indicating whether to include empty rows in the pivot table (i.e. row axis items

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -680,6 +680,45 @@ namespace ClosedXML.Excel
             _formats.Add(pivotFormat);
         }
 
+        #region location
+
+        /// <summary>
+        /// Area of a pivot table. Area doesn't include page fields, they are above the area with
+        /// one empty row between area and filters. Size of filter area is held in
+        /// <see cref="RowPageCount"/> and <see cref="ColumnPageCount"/>
+        /// </summary>
+        /// <remarks>Not kept in sync with <see cref="TargetCell"/>.</remarks>
+        internal XLSheetRange Area { get; set; }
+
+        /// <summary>
+        /// First row of pivot table header, relative to the <see cref="TargetCell"/>.
+        /// </summary>
+        internal uint FirstHeaderRow { get; set; }
+
+        /// <summary>
+        /// First row of pivot table data area, relative to the <see cref="TargetCell"/>.
+        /// </summary>
+        internal uint FirstDataRow { get; set; }
+
+        /// <summary>
+        /// First column of pivot table data area, relative to the <see cref="TargetCell"/>.
+        /// </summary>
+        internal uint FirstDataCol { get; set; }
+
+        /// <summary>
+        /// Number of rows a filter area occupies. Filter area is above the pivot table and it
+        /// optional (i.e. value <c>0</c> indicates no filter).
+        /// </summary>
+        internal uint RowPageCount { get; set; }
+
+        /// <summary>
+        /// Number of column a filter area occupies. Filter area is above the pivot table and it
+        /// optional (i.e. value <c>0</c> indicates no filter).
+        /// </summary>
+        internal uint ColumnPageCount { get; set; }
+
+        #endregion
+
         #region Attributes of PivotTableDefinition in same order as XSD
 
         internal bool DataOnRows { get; init; } = false;

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -691,28 +691,28 @@ namespace ClosedXML.Excel
         internal XLSheetRange Area { get; set; }
 
         /// <summary>
-        /// First row of pivot table header, relative to the <see cref="TargetCell"/>.
+        /// First row of pivot table header, relative to the <see cref="Area"/>.
         /// </summary>
         internal uint FirstHeaderRow { get; set; }
 
         /// <summary>
-        /// First row of pivot table data area, relative to the <see cref="TargetCell"/>.
+        /// First row of pivot table data area, relative to the <see cref="Area"/>.
         /// </summary>
         internal uint FirstDataRow { get; set; }
 
         /// <summary>
-        /// First column of pivot table data area, relative to the <see cref="TargetCell"/>.
+        /// First column of pivot table data area, relative to the <see cref="Area"/>.
         /// </summary>
         internal uint FirstDataCol { get; set; }
 
         /// <summary>
-        /// Number of rows a filter area occupies. Filter area is above the pivot table and it
+        /// Number of rows occupied by the filter area. Filter area is above the pivot table and it
         /// optional (i.e. value <c>0</c> indicates no filter).
         /// </summary>
         internal uint RowPageCount { get; set; }
 
         /// <summary>
-        /// Number of column a filter area occupies. Filter area is above the pivot table and it
+        /// Number of column occupied by the filter area. Filter area is above the pivot table and it
         /// optional (i.e. value <c>0</c> indicates no filter).
         /// </summary>
         internal uint ColumnPageCount { get; set; }

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -744,7 +744,7 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Initial text of 'data' field.
         /// </summary>
-        internal string? DataCaption { get; init; }
+        internal string DataCaption { get; init; }
 
         internal string? GrandTotalCaption { get; init; }
 

--- a/ClosedXML/Extensions/XmlWriterExtensions.cs
+++ b/ClosedXML/Extensions/XmlWriterExtensions.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Xml;
 using ClosedXML.Excel;
@@ -16,6 +14,12 @@ namespace ClosedXML.Extensions
             w.WriteEndAttribute();
         }
 
+        public static void WriteAttributeOptional(this XmlWriter w, String attrName, String? value)
+        {
+            if (value is not null)
+                w.WriteAttribute(attrName, value);
+        }
+
         public static void WriteAttribute(this XmlWriter w, String attrName, Int32 value)
         {
             w.WriteStartAttribute(attrName);
@@ -30,6 +34,12 @@ namespace ClosedXML.Extensions
             w.WriteEndAttribute();
         }
 
+        public static void WriteAttributeOptional(this XmlWriter w, String attrName, UInt32? value)
+        {
+            if (value is not null)
+                w.WriteAttribute(attrName, value.Value);
+        }
+
         public static void WriteAttribute(this XmlWriter w, String attrName, Double value)
         {
             w.WriteStartAttribute(attrName);
@@ -42,6 +52,24 @@ namespace ClosedXML.Extensions
             w.WriteStartAttribute(attrName);
             w.WriteValue(value ? "1" : "0");
             w.WriteEndAttribute();
+        }
+
+        public static void WriteAttributeDefault(this XmlWriter w, String attrName, Boolean value, Boolean defaultValue)
+        {
+            if (value != defaultValue)
+                w.WriteAttribute(attrName, value);
+        }
+
+        public static void WriteAttributeOptional(this XmlWriter w, String attrName, Boolean? value)
+        {
+            if (value is not null)
+                w.WriteAttribute(attrName, value.Value);
+        }
+
+        public static void WriteAttributeDefault(this XmlWriter w, String attrName, uint value, uint defaultValue)
+        {
+            if (value != defaultValue)
+                w.WriteAttribute(attrName, value);
         }
 
         /// <summary>


### PR DESCRIPTION
This is a part of pivot table rework. There are newly filled structures from pivot table reader (they are very bare bones without any validity checking) and the goal is to be able to "pipe" pivot table through, as long as it's not modified and still create valid pivot table. That should enable things like styles and so on. Being able to pass-through PT is important, because users can at worst create pivot table in Excel and use it in template, but if CXML crashes because it can't read/write table, it's bigger problem.

This PR adds ability to create a empty pivot table part with pivot fields definition from cache (=enough not to crash on load, but table itself is empty). The code is not used in execution paths while it is being worked on.