### PR TITLE
Write pivot table row/column axes, filter fields and data fields

### DIFF
--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -926,7 +926,7 @@ internal class PivotTableDefinitionPartReader
             foreach (var axisItem in axisItems.Cast<RowItem>())
             {
                 var xlItemType = axisItem.ItemType?.Value.ToClosedXml() ?? XLPivotItemType.Data;
-                var dataFieldIndex = axisItem.Index?.Value; // This is used by 'data' field
+                var dataFieldIndex = axisItem.Index?.Value ?? 0; // This is used by 'data' field
                 var repeatedCount = axisItem.RepeatedItemCount?.Value ?? 0;
                 var fieldIndexes = new List<int>();
                 foreach (var dataIndex in axisItem.ChildElements.Cast<MemberPropertyIndex>())

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -869,7 +869,7 @@ internal class PivotTableDefinitionPartReader
             foreach (var item in items.Cast<Item>())
             {
                 var approximatelyHasChildren = item.ChildItems?.Value ?? false;
-                var isExpanded = item.Expanded?.Value ?? true;
+                var isExpanded = item.Expanded?.Value ?? false;
                 var drillAcrossAttributes = item.DrillAcrossAttributes?.Value ?? true;
                 var calculatedMember = item.Calculated?.Value ?? false;
                 var hidden = item.Hidden?.Value ?? false;

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -942,9 +942,9 @@ internal class PivotTableDefinitionPartReader
                 foreach (var dataIndex in axisItem.ChildElements.Cast<MemberPropertyIndex>())
                     fieldIndexes.Add(dataIndex.Val?.Value ?? 0);
 
-                var allFieldIndexes = previous.Take((int)repeatedCount).Concat(fieldIndexes);
+                var allFieldIndexes = previous.Take((int)repeatedCount).Concat(fieldIndexes).ToList();
                 axis.AddItem(new XLPivotFieldAxisItem(xlItemType, dataFieldIndex, allFieldIndexes));
-                previous = fieldIndexes;
+                previous = allFieldIndexes;
             }
         }
     }

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -248,6 +248,62 @@ internal class PivotTableDefinitionPartWriter2
             xml.WriteEndElement(); // pageFields
         }
 
+        if (pt.DataFields.Count > 0)
+        {
+            xml.WriteStartElement("dataFields", Main2006SsNs);
+            xml.WriteAttribute("count", pt.DataFields.Count);
+            foreach (var dataField in pt.DataFields)
+            {
+                xml.WriteStartElement("dataField", Main2006SsNs);
+                xml.WriteAttributeOptional("name", dataField.DataFieldName);
+                xml.WriteAttribute("fld", dataField.Field);
+                if (dataField.Subtotal != XLPivotSummary.Sum)
+                {
+                    var subtotalAttr = dataField.Subtotal switch
+                    {
+                        XLPivotSummary.Sum => "sum",
+                        XLPivotSummary.Count => "count",
+                        XLPivotSummary.Average => "average",
+                        XLPivotSummary.Minimum => "min",
+                        XLPivotSummary.Maximum => "max",
+                        XLPivotSummary.Product => "product",
+                        XLPivotSummary.CountNumbers => "countNums",
+                        XLPivotSummary.StandardDeviation => "stdDev",
+                        XLPivotSummary.PopulationStandardDeviation => "stdDevp",
+                        XLPivotSummary.Variance => "var",
+                        XLPivotSummary.PopulationVariance => "varp",
+                        _ => throw new UnreachableException(),
+                    };
+                    xml.WriteAttribute("subtotal", subtotalAttr);
+                }
+
+                if (dataField.ShowDataAsFormat != XLPivotCalculation.Normal)
+                {
+                    var showDataAsAttr = dataField.ShowDataAsFormat switch
+                    {
+                        XLPivotCalculation.Normal => "normal",
+                        XLPivotCalculation.DifferenceFrom => "difference",
+                        XLPivotCalculation.PercentageOf => "percent",
+                        XLPivotCalculation.PercentageDifferenceFrom => "percentDiff",
+                        XLPivotCalculation.RunningTotal => "runTotal",
+                        XLPivotCalculation.PercentageOfRow => "percentOfRow",
+                        XLPivotCalculation.PercentageOfColumn => "percentOfCol",
+                        XLPivotCalculation.PercentageOfTotal => "percentOfTotal",
+                        XLPivotCalculation.Index => "index",
+                        _ => throw new UnreachableException(),
+                    };
+                    xml.WriteAttribute("showDataAs", showDataAsAttr);
+                }
+
+                xml.WriteAttributeDefault("baseField", dataField.BaseField, -1);
+                xml.WriteAttributeDefault("baseItem", dataField.BaseItem, 1048832);
+                xml.WriteAttributeOptional("numFmtId", dataField.NumberFormatId);
+                xml.WriteEndElement(); // dataField
+            }
+
+            xml.WriteEndElement(); // dataFields
+        }
+
         xml.WriteEndElement(); // pivotTableDefinition
     }
 

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -26,6 +26,7 @@ internal class PivotTableDefinitionPartWriter2
 
         xml.WriteStartDocument();
         xml.WriteStartElement("pivotTableDefinition", Main2006SsNs);
+        xml.WriteAttributeString("xmlns", Main2006SsNs);
         xml.WriteAttributeString("xmlns", "mc", null, MarkupCompatibilityNs);
 
         // Mark revision as ignorable extension

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -27,11 +27,7 @@ internal class PivotTableDefinitionPartWriter2
         xml.WriteStartDocument();
         xml.WriteStartElement("pivotTableDefinition", Main2006SsNs);
         xml.WriteAttributeString("xmlns", Main2006SsNs);
-        xml.WriteAttributeString("xmlns", "mc", null, MarkupCompatibilityNs);
 
-        // Mark revision as ignorable extension
-        xml.WriteAttributeString("mc", "Ignorable", null, "xr");
-        xml.WriteAttributeString("xmlns", "xr", null, RevisionNs);
         xml.WriteAttribute("name", pt.Name);
         xml.WriteAttribute("cacheId", pt.PivotCache.CacheId!.Value); // TODO: Maybe not nullable?
         xml.WriteAttributeDefault("dataOnRows", pt.DataOnRows, false);

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -230,6 +230,24 @@ internal class PivotTableDefinitionPartWriter2
         WriteAxis(xml, pt.RowAxis, "rowFields", "rowItems");
         WriteAxis(xml, pt.ColumnAxis, "colFields", "colItems");
 
+        if (pt.PageFields.Count > 0)
+        {
+            xml.WriteStartElement("pageFields", Main2006SsNs);
+            xml.WriteAttribute("count", pt.PageFields.Count);
+            foreach (var pageField in pt.PageFields)
+            {
+                xml.WriteStartElement("pageField", Main2006SsNs);
+                xml.WriteAttribute("fld", pageField.Field);
+                xml.WriteAttributeOptional("item", pageField.ItemIndex);
+                xml.WriteAttributeOptional("hier", pageField.HierarchyIndex);
+                xml.WriteAttributeOptional("name", pageField.HierarchyUniqueName);
+                xml.WriteAttributeOptional("cap", pageField.HierarchyDisplayName);
+                xml.WriteEndElement(); // pageField
+            }
+
+            xml.WriteEndElement(); // pageFields
+        }
+
         xml.WriteEndElement(); // pivotTableDefinition
     }
 

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -195,7 +195,7 @@ internal class PivotTableDefinitionPartWriter2
                 xml.WriteAttribute("count", pf.Items.Count);
                 foreach (var pfItem in pf.Items)
                 {
-                    xml.WriteStartElement("item");
+                    xml.WriteStartElement("item", Main2006SsNs);
                     xml.WriteAttributeOptional("n", pfItem.ItemUserCaption);
                     if (pfItem.ItemType != XLPivotItemType.Data)
                     {

--- a/ClosedXML/Excel/PivotTables/XLPivotFieldAxisItem.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFieldAxisItem.cs
@@ -11,11 +11,11 @@ namespace ClosedXML.Excel;
 /// </remarks>
 internal class XLPivotFieldAxisItem
 {
-    public XLPivotFieldAxisItem(XLPivotItemType itemType, uint? dataItem, IEnumerable<int> fieldIndexes)
+    public XLPivotFieldAxisItem(XLPivotItemType itemType, uint dataItem, IEnumerable<int> fieldItems)
     {
         ItemType = itemType;
         DataItem = dataItem;
-        FieldIndexes = fieldIndexes.ToList();
+        FieldItem = fieldItems.ToList();
     }
 
     /// <summary>
@@ -23,7 +23,7 @@ internal class XLPivotFieldAxisItem
     /// <see cref="XLPivotTableAxis.Fields"/>. Value <c>1048832</c> specifies that no item appears
     /// at the position. 
     /// </summary>
-    internal List<int> FieldIndexes { get; }
+    internal List<int> FieldItem { get; }
 
     /// <summary>
     /// Type of item.
@@ -32,8 +32,8 @@ internal class XLPivotFieldAxisItem
 
     /// <summary>
     /// If this item (row/column) contains 'data' field, this contains an index into the <see cref="XLPivotTable._dataFields"/>
-    /// that should be used as a value. The value for 'data' field in the <see cref="FieldIndexes"/> is ignored, but Excel fills
+    /// that should be used as a value. The value for 'data' field in the <see cref="FieldItem"/> is ignored, but Excel fills
     /// same number as this index.
     /// </summary>
-    internal uint? DataItem { get; }
+    internal uint DataItem { get; }
 }

--- a/ClosedXML/Excel/PivotTables/XLPivotFormat.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotFormat.cs
@@ -16,12 +16,14 @@ internal class XLPivotFormat
     internal XLPivotArea PivotArea { get; }
 
     /// <summary>
-    /// Should the formatting (determined by <see cref="DxfId"/>) be applied or not?
+    /// Should the formatting (determined by <see cref="DxfStyle"/>) be applied or not?
     /// </summary>
     internal XLPivotFormatAction Action { get; init; } = XLPivotFormatAction.Formatting;
 
     /// <summary>
-    /// Differential formatting to apply to the <see cref="PivotArea"/>.
+    /// Differential formatting to apply to the <see cref="PivotArea"/>. It can be empty, e.g. if
+    /// <see cref="Action"/> is blank. Empty dxf is represented by <see cref="XLStyle.Default"/>,
+    /// until we get better dxf representation.
     /// </summary>
-    internal uint? DxfId { get; init; }
+    internal XLStyle DxfStyle { get; init; } = XLStyle.Default;
 }

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -75,6 +75,8 @@ namespace ClosedXML.Excel
 
         internal IReadOnlyList<XLPivotPageField> PageFields => _pageFields;
 
+        internal IReadOnlyList<XLPivotDataField> DataFields => _dataFields;
+
         public IXLPivotTable CopyTo(IXLCell targetCell)
         {
             var addressComparer = new XLAddressComparer(ignoreFixed: true);

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -77,6 +77,8 @@ namespace ClosedXML.Excel
 
         internal IReadOnlyList<XLPivotDataField> DataFields => _dataFields;
 
+        internal IReadOnlyList<XLPivotFormat> Formats => _formats;
+
         public IXLPivotTable CopyTo(IXLCell targetCell)
         {
             var addressComparer = new XLAddressComparer(ignoreFixed: true);

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -73,6 +73,8 @@ namespace ClosedXML.Excel
 
         internal XLPivotTableAxis ColumnAxis { get; }
 
+        internal IReadOnlyList<XLPivotPageField> PageFields => _pageFields;
+
         public IXLPivotTable CopyTo(IXLCell targetCell)
         {
             var addressComparer = new XLAddressComparer(ignoreFixed: true);

--- a/ClosedXML/Excel/PivotTables/XLPivotTableAxis.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTableAxis.cs
@@ -36,6 +36,11 @@ internal class XLPivotTableAxis
     internal IReadOnlyList<FieldIndex> Fields => _fields;
 
     /// <summary>
+    /// Individual row/column parts of the axis.
+    /// </summary>
+    internal IReadOnlyList<XLPivotFieldAxisItem> Items => _axisItems;
+
+    /// <summary>
     /// Add field to the axis.
     /// </summary>
     internal void AddField(FieldIndex fieldIndex)

--- a/ClosedXML/Excel/PivotTables/XLPivotTableField.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTableField.cs
@@ -28,6 +28,9 @@ internal class XLPivotTableField
     internal string? Name { get; init; }
 
     /// <summary>
+    /// If the value is set, the field must also be in <c>rowFields</c>/<c>colFields</c>/
+    /// <c>pageFields</c>/<c>dataFields</c> collection in the pivot table part (otherwise Excel
+    /// will consider it a corrupt file).
     /// </summary>
     /// <remarks>
     /// [MS-OI29500] In Office, axisValues shall not be used for the axis attribute.

--- a/ClosedXML/Extensions/XmlWriterExtensions.cs
+++ b/ClosedXML/Extensions/XmlWriterExtensions.cs
@@ -66,6 +66,12 @@ namespace ClosedXML.Extensions
                 w.WriteAttribute(attrName, value.Value);
         }
 
+        public static void WriteAttributeDefault(this XmlWriter w, String attrName, int value, int defaultValue)
+        {
+            if (value != defaultValue)
+                w.WriteAttribute(attrName, value);
+        }
+
         public static void WriteAttributeDefault(this XmlWriter w, String attrName, uint value, uint defaultValue)
         {
             if (value != defaultValue)

--- a/ClosedXML/Extensions/XmlWriterExtensions.cs
+++ b/ClosedXML/Extensions/XmlWriterExtensions.cs
@@ -40,6 +40,12 @@ namespace ClosedXML.Extensions
                 w.WriteAttribute(attrName, value.Value);
         }
 
+        public static void WriteAttributeOptional(this XmlWriter w, String attrName, Int32? value)
+        {
+            if (value is not null)
+                w.WriteAttribute(attrName, value.Value);
+        }
+
         public static void WriteAttribute(this XmlWriter w, String attrName, Double value)
         {
             w.WriteStartAttribute(attrName);


### PR DESCRIPTION
Improve pivot table Writer2 by adding code to write row/column axes, filter fields, data fields and filters/styles. It now can load and write pivot table with style and not crash (at least sometimes). This is further improvement, so we can just load and write PT without crashing/mangling it.

Pivot table styles use differential formatting, but because ClosedXML doesn't yet have support for it, just use XLStyle object for now,  Styles will need a complete rework to support named styles and differential formatting, but that is work for another release in the future.

This is still in Writer2, i.e. unused code paths.