### PR TITLE
Add conditional formatting structure to pivot table

### DIFF
--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -163,7 +163,11 @@ namespace ClosedXML.Excel
 
         public Guid Id { get; internal set; }
 
-        internal Int32 OriginalPriority { get; set; }
+        /// <summary>
+        /// Priority of formatting rule. Lower values have higher priority than higher values.
+        /// Minimum value is 1. It is basically used for ordering of CF during saving.
+        /// </summary>
+        internal Int32 Priority { get; set; }
 
         public Boolean CopyDefaultModify { get; set; }
 

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -4,11 +4,16 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// A container for conditional formatting of a <see cref="XLWorksheet"/>. It contains
+    /// a collection of <see cref="XLConditionalFormat"/>. Doesn't contain pivot table formats,
+    /// they are in pivot table <see cref="XLPivotTable.ConditionalFormats"/>,
+    /// </summary>
     internal class XLConditionalFormats : IXLConditionalFormats
     {
-        private readonly List<IXLConditionalFormat> _conditionalFormats = new List<IXLConditionalFormat>();
+        private readonly List<IXLConditionalFormat> _conditionalFormats = new();
 
-        private static readonly List<XLConditionalFormatType> _conditionalFormatTypesExcludedFromConsolidation = new List<XLConditionalFormatType>()
+        private static readonly List<XLConditionalFormatType> CFTypesExcludedFromConsolidation = new()
         {
             XLConditionalFormatType.DataBar,
             XLConditionalFormatType.ColorScale,
@@ -53,7 +58,7 @@ namespace ClosedXML.Excel
             {
                 var item = formats.First();
 
-                if (!_conditionalFormatTypesExcludedFromConsolidation.Contains(item.ConditionalFormatType))
+                if (!CFTypesExcludedFromConsolidation.Contains(item.ConditionalFormatType))
                 {
                     var rangesToJoin = new XLRanges();
                     item.Ranges.ForEach(r => rangesToJoin.Add(r));

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -135,7 +135,7 @@ namespace ClosedXML.Excel
         /// </summary>
         public void ReorderAccordingToOriginalPriority()
         {
-            var reorderedFormats = _conditionalFormats.OrderBy(cf => ((XLConditionalFormat)cf).OriginalPriority).ToList();
+            var reorderedFormats = _conditionalFormats.OrderBy(cf => ((XLConditionalFormat)cf).Priority).ToList();
             _conditionalFormats.Clear();
             _conditionalFormats.AddRange(reorderedFormats);
         }

--- a/ClosedXML/Excel/EnumConverter.cs
+++ b/ClosedXML/Excel/EnumConverter.cs
@@ -992,7 +992,7 @@ namespace ClosedXML.Excel
         private static readonly IReadOnlyDictionary<PatternValues, XLFillPatternValues> PatternMap =
             new Dictionary<PatternValues, XLFillPatternValues>
             {
-                { PatternValues.DarkDown,  XLFillPatternValues.DarkDown },
+                { PatternValues.DarkDown, XLFillPatternValues.DarkDown },
                 { PatternValues.DarkGray, XLFillPatternValues.DarkGray },
                 { PatternValues.DarkGrid, XLFillPatternValues.DarkGrid },
                 { PatternValues.DarkHorizontal, XLFillPatternValues.DarkHorizontal },
@@ -1032,7 +1032,7 @@ namespace ClosedXML.Excel
                 { BorderStyleValues.MediumDashDotDot, XLBorderStyleValues.MediumDashDotDot },
                 { BorderStyleValues.MediumDashed, XLBorderStyleValues.MediumDashed },
                 { BorderStyleValues.None, XLBorderStyleValues.None },
-                { BorderStyleValues.SlantDashDot,XLBorderStyleValues.SlantDashDot },
+                { BorderStyleValues.SlantDashDot, XLBorderStyleValues.SlantDashDot },
                 { BorderStyleValues.Thick, XLBorderStyleValues.Thick },
                 { BorderStyleValues.Thin, XLBorderStyleValues.Thin },
             };
@@ -1298,7 +1298,7 @@ namespace ClosedXML.Excel
                 { ShowDataAsValues.Difference, XLPivotCalculation.DifferenceFrom },
                 { ShowDataAsValues.Percent, XLPivotCalculation.PercentageOf },
                 { ShowDataAsValues.PercentageDifference, XLPivotCalculation.PercentageDifferenceFrom },
-                { ShowDataAsValues.RunTotal,  XLPivotCalculation.RunningTotal },
+                { ShowDataAsValues.RunTotal, XLPivotCalculation.RunningTotal },
                 { ShowDataAsValues.PercentOfRaw, XLPivotCalculation.PercentageOfRow }, // There's a typo in the OpenXML SDK =)
                 { ShowDataAsValues.PercentOfColumn, XLPivotCalculation.PercentageOfColumn },
                 { ShowDataAsValues.PercentOfTotal, XLPivotCalculation.PercentageOfTotal },
@@ -1614,6 +1614,33 @@ namespace ClosedXML.Excel
         internal static XLPivotFormatAction ToClosedXml(this FormatActionValues value)
         {
             return FormatActionMap[value];
+        }
+
+        private static readonly IReadOnlyDictionary<ScopeValues, XLPivotCfScope> ScopeMap =
+            new Dictionary<ScopeValues, XLPivotCfScope>
+            {
+                { ScopeValues.Selection, XLPivotCfScope.SelectedCells },
+                { ScopeValues.Data, XLPivotCfScope.DataFields },
+                { ScopeValues.Field, XLPivotCfScope.FieldIntersections },
+            };
+
+        internal static XLPivotCfScope ToClosedXml(this ScopeValues value)
+        {
+            return ScopeMap[value];
+        }
+
+        private static readonly IReadOnlyDictionary<RuleValues, XLPivotCfRuleType> RuleMap =
+            new Dictionary<RuleValues, XLPivotCfRuleType>
+            {
+                { RuleValues.None, XLPivotCfRuleType.None },
+                { RuleValues.All, XLPivotCfRuleType.All },
+                { RuleValues.Row, XLPivotCfRuleType.Row },
+                { RuleValues.Column, XLPivotCfRuleType.Column },
+            };
+
+        internal static XLPivotCfRuleType ToClosedXml(this RuleValues value)
+        {
+            return RuleMap[value];
         }
 
         #endregion To ClosedXml

--- a/ClosedXML/Excel/IO/LoadContext.cs
+++ b/ClosedXML/Excel/IO/LoadContext.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Excel.IO;
+
+internal class LoadContext
+{
+    /// <summary>
+    /// Conditional formats for pivot tables, loaded from sheets. Key is sheet name, value is the
+    /// conditional formats.
+    /// </summary>
+    private readonly Dictionary<string, List<XLConditionalFormat>> _pivotCfs = new(XLHelper.SheetComparer);
+
+    internal void AddPivotTableCf(string sheetName, XLConditionalFormat conditionalFormat)
+    {
+        if (!_pivotCfs.TryGetValue(sheetName, out var list))
+        {
+            list = new List<XLConditionalFormat>();
+            _pivotCfs[sheetName] = list;
+        }
+
+        list.Add(conditionalFormat);
+    }
+
+    internal XLConditionalFormat GetPivotCf(string sheetName, uint priority)
+    {
+        if (!_pivotCfs.TryGetValue(sheetName, out var list))
+            throw PartStructureException.ExpectedElementNotFound();
+
+        var pivotCf = list.SingleOrDefault(x => x.OriginalPriority == checked((int)priority));
+        return pivotCf ?? throw PartStructureException.ExpectedElementNotFound();
+    }
+}

--- a/ClosedXML/Excel/IO/LoadContext.cs
+++ b/ClosedXML/Excel/IO/LoadContext.cs
@@ -22,12 +22,12 @@ internal class LoadContext
         list.Add(conditionalFormat);
     }
 
-    internal XLConditionalFormat GetPivotCf(string sheetName, uint priority)
+    internal XLConditionalFormat GetPivotCf(string sheetName, int priority)
     {
         if (!_pivotCfs.TryGetValue(sheetName, out var list))
             throw PartStructureException.ExpectedElementNotFound();
 
-        var pivotCf = list.SingleOrDefault(x => x.Priority == checked((int)priority));
+        var pivotCf = list.SingleOrDefault(x => x.Priority == priority);
         return pivotCf ?? throw PartStructureException.ExpectedElementNotFound();
     }
 }

--- a/ClosedXML/Excel/IO/LoadContext.cs
+++ b/ClosedXML/Excel/IO/LoadContext.cs
@@ -27,7 +27,7 @@ internal class LoadContext
         if (!_pivotCfs.TryGetValue(sheetName, out var list))
             throw PartStructureException.ExpectedElementNotFound();
 
-        var pivotCf = list.SingleOrDefault(x => x.OriginalPriority == checked((int)priority));
+        var pivotCf = list.SingleOrDefault(x => x.Priority == checked((int)priority));
         return pivotCf ?? throw PartStructureException.ExpectedElementNotFound();
     }
 }

--- a/ClosedXML/Excel/IO/LoadContext.cs
+++ b/ClosedXML/Excel/IO/LoadContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ClosedXML.Excel.IO;
@@ -25,9 +26,17 @@ internal class LoadContext
     internal XLConditionalFormat GetPivotCf(string sheetName, int priority)
     {
         if (!_pivotCfs.TryGetValue(sheetName, out var list))
-            throw PartStructureException.ExpectedElementNotFound();
+            throw PivotCfNotFoundException(sheetName, priority);
 
         var pivotCf = list.SingleOrDefault(x => x.Priority == priority);
-        return pivotCf ?? throw PartStructureException.ExpectedElementNotFound();
+        if (pivotCf is null)
+            throw PivotCfNotFoundException(sheetName, priority);
+
+        return pivotCf;
+    }
+
+    private static Exception PivotCfNotFoundException(string sheetName, int priority)
+    {
+        return PartStructureException.ExpectedElementNotFound($"conditional formatting for pivot table in sheet {sheetName} with priority {priority}");
     }
 }

--- a/ClosedXML/Excel/IO/PartStructureException.cs
+++ b/ClosedXML/Excel/IO/PartStructureException.cs
@@ -11,13 +11,19 @@ namespace ClosedXML.Excel.IO
     /// </summary>
     internal class PartStructureException : Exception
     {
-        private PartStructureException(string message) : base(message)
+        private PartStructureException(string message, string? detail = null)
+            : base(detail is null ? message : message[..^1] + " (" + detail + ").")
         {
         }
 
-        internal static Exception ExpectedElementNotFound()
+        /// <summary>
+        /// Create a new exception with info that some element that should be present in a workbook
+        /// is missing.
+        /// </summary>
+        /// <param name="missingElementDesc">optional info about what element is missing.</param>
+        internal static Exception ExpectedElementNotFound(string? missingElementDesc = null)
         {
-            return new PartStructureException("The structure of XML expected a certain kind of element, but it isn't there.");
+            return new PartStructureException("The structure of XML expected a certain kind of element, but it isn't there.", missingElementDesc);
         }
 
         internal static Exception IncorrectElementsCount()

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -611,7 +611,34 @@ internal class PivotTableDefinitionPartReader
             }
         }
 
-        // TODO: conditionalFormats
+        var conditionalFormats = pivotTable.ConditionalFormats;
+        if (conditionalFormats is not null)
+        {
+            foreach (var conditionalFormat in conditionalFormats.Cast<ConditionalFormat>())
+            {
+                var scope = conditionalFormat.Scope?.Value.ToClosedXml() ?? XLPivotCfScope.SelectedCells;
+                var type = conditionalFormat.Type?.Value.ToClosedXml() ?? XLPivotCfRuleType.None;
+                var priority = conditionalFormat.Priority?.Value ?? throw PartStructureException.MissingAttribute();
+                var xlConditionalFormat = new XLPivotConditionalFormat
+                {
+                    Scope = scope,
+                    Type = type,
+                    Priority = priority,
+                };
+                var pivotAreas = conditionalFormat.PivotAreas;
+                if (pivotAreas is not null)
+                {
+                    foreach (var pivotArea in pivotAreas.Cast<PivotArea>())
+                    {
+                        var xlPivotArea = LoadPivotArea(pivotArea);
+                        xlConditionalFormat.AddArea(xlPivotArea);
+                    }
+                }
+
+                xlPivotTable.AddConditionalFormat(xlConditionalFormat);
+            }
+        }
+
         // TODO: chartFormats
         // pivotHierarchies is OLAP and thus for now out of scope.
         var pivotTableStyle = pivotTable.GetFirstChild<PivotTableStyle>();

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -18,7 +18,7 @@ internal class PivotTableDefinitionPartReader
     /// </summary>
     private const int ValuesFieldIndex = -2;
 
-    internal static void Load(WorkbookPart workbookPart, Dictionary<int, DifferentialFormat> differentialFormats, PivotTablePart pivotTablePart, WorksheetPart worksheetPart, XLWorksheet ws)
+    internal static void Load(WorkbookPart workbookPart, Dictionary<int, DifferentialFormat> differentialFormats, PivotTablePart pivotTablePart, WorksheetPart worksheetPart, XLWorksheet ws, LoadContext context)
     {
         var workbook = ws.Workbook;
         var cache = pivotTablePart.PivotTableCacheDefinitionPart;
@@ -46,7 +46,7 @@ internal class PivotTableDefinitionPartReader
 
         if (target != null && pivotSource != null)
         {
-            var pt = LoadPivotTableDefinition(pivotTableDefinition, ws, pivotSource, differentialFormats);
+            var pt = LoadPivotTableDefinition(pivotTableDefinition, ws, pivotSource, differentialFormats, context);
             pt.TargetCell = target;
             ws.PivotTables.Add(pt);
 
@@ -500,7 +500,7 @@ internal class PivotTableDefinitionPartReader
     }
 
 #nullable enable
-    private static XLPivotTable LoadPivotTableDefinition(PivotTableDefinition pivotTable, XLWorksheet sheet, XLPivotCache cache, Dictionary<int, DifferentialFormat> differentialFormats)
+    private static XLPivotTable LoadPivotTableDefinition(PivotTableDefinition pivotTable, XLWorksheet sheet, XLPivotCache cache, Dictionary<int, DifferentialFormat> differentialFormats, LoadContext context)
     {
         // Load base attributes
         var xlPivotTable = LoadPivotTableAttributes(pivotTable, sheet, cache);
@@ -619,7 +619,8 @@ internal class PivotTableDefinitionPartReader
                 var scope = conditionalFormat.Scope?.Value.ToClosedXml() ?? XLPivotCfScope.SelectedCells;
                 var type = conditionalFormat.Type?.Value.ToClosedXml() ?? XLPivotCfRuleType.None;
                 var priority = conditionalFormat.Priority?.Value ?? throw PartStructureException.MissingAttribute();
-                var xlConditionalFormat = new XLPivotConditionalFormat
+                var format = context.GetPivotCf(sheet.Name, priority);
+                var xlConditionalFormat = new XLPivotConditionalFormat(format)
                 {
                     Scope = scope,
                     Type = type,

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartReader.cs
@@ -619,12 +619,11 @@ internal class PivotTableDefinitionPartReader
                 var scope = conditionalFormat.Scope?.Value.ToClosedXml() ?? XLPivotCfScope.SelectedCells;
                 var type = conditionalFormat.Type?.Value.ToClosedXml() ?? XLPivotCfRuleType.None;
                 var priority = conditionalFormat.Priority?.Value ?? throw PartStructureException.MissingAttribute();
-                var format = context.GetPivotCf(sheet.Name, priority);
+                var format = context.GetPivotCf(sheet.Name, checked((int)priority));
                 var xlConditionalFormat = new XLPivotConditionalFormat(format)
                 {
                     Scope = scope,
                     Type = type,
-                    Priority = priority,
                 };
                 var pivotAreas = conditionalFormat.PivotAreas;
                 if (pivotAreas is not null)

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -364,7 +364,7 @@ internal class PivotTableDefinitionPartWriter2
                     xml.WriteAttribute("type", typeAttr);
                 }
 
-                xml.WriteAttribute("priority", conditionalFormat.Priority);
+                xml.WriteAttribute("priority", conditionalFormat.Format.Priority);
                 xml.WriteStartElement("pivotAreas", Main2006SsNs);
                 xml.WriteAttribute("count", conditionalFormat.Areas.Count);
                 foreach (var pivotArea in conditionalFormat.Areas)

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -237,6 +237,16 @@ namespace ClosedXML.Excel.IO
                             AddStyleAsDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, xlStyle.Value, context);
                         }
                     }
+
+                    foreach (var xlConditionalStyle in pt.ConditionalFormats)
+                    {
+                        var xlStyle = ((XLStyle)xlConditionalStyle.Format.Style);
+                        if (xlStyle.Value != XLStyleValue.Default &&
+                            !context.DifferentialFormats.ContainsKey(xlStyle.Value))
+                        {
+                            AddStyleAsDifferentialFormat(workbookStylesPart.Stylesheet.DifferentialFormats, xlStyle.Value, context);
+                        }
+                    }
                 }
             }
 

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -630,10 +630,10 @@ namespace ClosedXML.Excel.IO
             // these situations, set correct unique priority (also required for pivot CF).
             var xlConditionalFormats = xlWorksheet.ConditionalFormats.Cast<XLConditionalFormat>()
                 .Concat(xlSheetPivotCfs)
-                .OrderBy(x => x.OriginalPriority)
+                .OrderBy(x => x.Priority)
                 .ToList();
             for (var i = 0; i < xlConditionalFormats.Count; ++i)
-                xlConditionalFormats[i].OriginalPriority = i + 1;
+                xlConditionalFormats[i].Priority = i + 1;
 
             if (!xlConditionalFormats.Any())
             {
@@ -665,7 +665,7 @@ namespace ClosedXML.Excel.IO
                     };
                     foreach (var cf in cfGroup.CfList)
                     {
-                        var xlCf = XLCFConverters.Convert(cf, cf.OriginalPriority, context);
+                        var xlCf = XLCFConverters.Convert(cf, cf.Priority, context);
                         conditionalFormatting.Append(xlCf);
                     }
                     worksheet.InsertAfter(conditionalFormatting, previousElement);

--- a/ClosedXML/Excel/PivotTables/XLPivotCfRuleType.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotCfRuleType.cs
@@ -1,0 +1,15 @@
+﻿namespace ClosedXML.Excel;
+
+/// <summary>
+/// Specifies how to apply <see cref="XLConditionalFormatType.Top10"/> conditional formatting rule
+/// on a pivot table <see cref="XLPivotConditionalFormat"/>. Avoid if possible, doesn't seem to
+/// work and row/column causes Excel to repair file.
+/// </summary>
+/// <remarks>18.18.84 ST_Type.</remarks>
+internal enum XLPivotCfRuleType
+{
+    All,
+    Column,
+    None,
+    Row
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotCfScope.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotCfScope.cs
@@ -1,0 +1,31 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Defines a scope of conditional formatting applied to <see cref="XLPivotTable"/>. The scope is
+/// more of a "user preference", it doesn't determine actual scope. The actual scope is determined
+/// by <see cref="XLPivotConditionalFormat.Areas"/>. The scope determines what is in GUI and when
+/// reapplied, it updates the <see cref="XLPivotConditionalFormat.Areas"/> according to selected
+/// values.
+/// </summary>
+/// <remarks>18.18.67 ST_Scope</remarks>
+internal enum XLPivotCfScope
+{
+    /// <summary>
+    /// Conditional formatting is applied to selected cells. When scope is applied, CF areas are be
+    /// updated to contain currently selected cells in GUI.
+    /// </summary>
+    SelectedCells,
+
+    /// <summary>
+    /// Conditional formatting is applied to selected data fields. When scope is applied, CF areas
+    /// are be updated to contain data fields of selected cells in GUI.
+    /// </summary>
+    DataFields,
+
+    /// <summary>
+    /// Conditional formatting is applied to selected pivot fields intersections. When scope is
+    /// applied, CF areas are be updated to contain row/column intersection of currently selected
+    /// cell in GUI.
+    /// </summary>
+    FieldIntersections,
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotConditionalFormat.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotConditionalFormat.cs
@@ -27,13 +27,6 @@ internal class XLPivotConditionalFormat
     internal XLPivotCfRuleType Type { get; init; } = XLPivotCfRuleType.None;
 
     /// <summary>
-    /// Specifies priority of CF. Pivot CF is ultimately part of sheet CFs and the priority
-    /// determines order of CF application (note that CF has <see cref="XLConditionalFormat.StopIfTrue"/>
-    /// flag).
-    /// </summary>
-    internal uint Priority { get; init; }
-
-    /// <summary>
     /// Areas of pivot table the rule should be applied. The areas are projected to the sheet
     /// <see cref="XLConditionalFormat.Ranges"/> that Excel actually uses to display CF.
     /// </summary>
@@ -42,6 +35,12 @@ internal class XLPivotConditionalFormat
     /// <summary>
     /// Conditional format applied to the <see cref="Areas"/>.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="XLConditionalFormat.Priority"/> of the format is used as a identifier used
+    /// to connect pivot CF element and sheet CF element. Pivot CF is ultimately part of sheet CFs
+    /// and the priority determines order of CF application (note that CF has
+    /// <see cref="XLConditionalFormat.StopIfTrue"/> flag).
+    /// </remarks>
     internal XLConditionalFormat Format { get; }
 
     internal void AddArea(XLPivotArea pivotArea)

--- a/ClosedXML/Excel/PivotTables/XLPivotConditionalFormat.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotConditionalFormat.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Specification of conditional formatting of a pivot table.
+/// </summary>
+internal class XLPivotConditionalFormat
+{
+    private readonly List<XLPivotArea> _area = new();
+
+    /// <summary>
+    /// An option to display in GUI on how to update <see cref="Areas"/>.
+    /// </summary>
+    internal XLPivotCfScope Scope { get; init; } = XLPivotCfScope.SelectedCells;
+
+    /// <summary>
+    /// A rule that determines how should CF be applied to <see cref="Areas"/>.
+    /// </summary>
+    /// <remarks>Doesn't seem to work, Excel has no dialogue, nothing found on web and Excel tries
+    ///     to repair on row/column values. Avoid if possible.</remarks>
+    internal XLPivotCfRuleType Type { get; init; } = XLPivotCfRuleType.None;
+
+    /// <summary>
+    /// Specifies priority of CF. Pivot CF is ultimately part of sheet CFs and the priority
+    /// determines order of CF application (note that CF has <see cref="XLConditionalFormat.StopIfTrue"/>
+    /// flag).
+    /// </summary>
+    internal uint Priority { get; init; }
+
+    /// <summary>
+    /// Areas of pivot table the rule should be applied. The areas are projected to the sheet
+    /// <see cref="XLConditionalFormat.Ranges"/> that Excel actually uses to display CF.
+    /// </summary>
+    internal IReadOnlyList<XLPivotArea> Areas => _area;
+
+    internal void AddArea(XLPivotArea pivotArea)
+    {
+        _area.Add(pivotArea);
+    }
+}

--- a/ClosedXML/Excel/PivotTables/XLPivotConditionalFormat.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotConditionalFormat.cs
@@ -9,6 +9,11 @@ internal class XLPivotConditionalFormat
 {
     private readonly List<XLPivotArea> _area = new();
 
+    internal XLPivotConditionalFormat(XLConditionalFormat format)
+    {
+        Format = format;
+    }
+
     /// <summary>
     /// An option to display in GUI on how to update <see cref="Areas"/>.
     /// </summary>
@@ -33,6 +38,11 @@ internal class XLPivotConditionalFormat
     /// <see cref="XLConditionalFormat.Ranges"/> that Excel actually uses to display CF.
     /// </summary>
     internal IReadOnlyList<XLPivotArea> Areas => _area;
+
+    /// <summary>
+    /// Conditional format applied to the <see cref="Areas"/>.
+    /// </summary>
+    internal XLConditionalFormat Format { get; }
 
     internal void AddArea(XLPivotArea pivotArea)
     {

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -18,6 +18,7 @@ namespace ClosedXML.Excel
         private readonly List<XLPivotDataField> _dataFields = new();
         private readonly List<XLPivotPageField> _pageFields = new();
         private readonly List<XLPivotFormat> _formats = new();
+        private readonly List<XLPivotConditionalFormat> _conditionalFormats = new();
 
         public XLPivotTable(IXLWorksheet worksheet)
         {
@@ -78,6 +79,8 @@ namespace ClosedXML.Excel
         internal IReadOnlyList<XLPivotDataField> DataFields => _dataFields;
 
         internal IReadOnlyList<XLPivotFormat> Formats => _formats;
+
+        internal IReadOnlyList<XLPivotConditionalFormat> ConditionalFormats => _conditionalFormats;
 
         public IXLPivotTable CopyTo(IXLCell targetCell)
         {
@@ -684,6 +687,11 @@ namespace ClosedXML.Excel
         internal void AddFormat(XLPivotFormat pivotFormat)
         {
             _formats.Add(pivotFormat);
+        }
+
+        internal void AddConditionalFormat(XLPivotConditionalFormat conditionalFormat)
+        {
+            _conditionalFormats.Add(conditionalFormat);
         }
 
         #region location

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1916,7 +1916,7 @@ namespace ClosedXML.Excel
                 // The conditional formatting type is compulsory. If it doesn't exist, skip the entire rule.
                 if (fr.Type == null) continue;
                 conditionalFormat.ConditionalFormatType = fr.Type.Value.ToClosedXml();
-                conditionalFormat.OriginalPriority = fr.Priority?.Value ?? Int32.MaxValue;
+                conditionalFormat.Priority = fr.Priority?.Value ?? Int32.MaxValue;
 
                 // Although formulas are directly used only by CellIs and Expression type, other
                 // format types also write them for evaluation to the workbook, e.g. rule to

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1683,7 +1683,9 @@ namespace ClosedXML.Excel
 
         public IXLRanges MergedRanges { get { return Internals.MergedRanges; } }
 
-        public IXLConditionalFormats ConditionalFormats { get; private set; }
+        IXLConditionalFormats IXLWorksheet.ConditionalFormats => ConditionalFormats;
+
+        internal XLConditionalFormats ConditionalFormats { get; }
 
         public IXLSparklineGroups SparklineGroups => SparklineGroupsInternal;
 


### PR DESCRIPTION
Add structures for conditional formatting to a pivot table and modify sheet conditional formatting , so it can read and write pivot CF. Part of pivot table rewrite, so it supports "pass-through" of pivot tables.

Pivot CF consists of two parts: 
* Pivot table part - it specifies area affected by the CF and a link to sheet CF (through priority)
* Sheet part - CF element in sheet must have a flag `pivot` set to true and same `priority` as the pivot table part. The element in sheet is directly responsible for actual CF rules that should be evaluated.

To make modification easier, both parts are kept together in `XLPivotConditionalFormatting` and are assembled together during loading.

The code for writing is in PivotTableWriter2, so it is still not enabled, but I can read/write very simple CF file and that is enough for now. CF and Dxf are slated for revision in a next release or two.