### PR TITLE
Prevent clear of differential formats before saving. This prevent Tab…

### DIFF
--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -191,7 +191,7 @@ namespace ClosedXML.Excel.IO
                 workbookStylesPart.Stylesheet.DifferentialFormats = new DifferentialFormats();
 
             var differentialFormats = workbookStylesPart.Stylesheet.DifferentialFormats;
-            differentialFormats.RemoveAllChildren();
+
             FillDifferentialFormatsCollection(differentialFormats, context.DifferentialFormats);
 
             foreach (var ws in workbook.Worksheets)


### PR DESCRIPTION
Prevent clear of differential formats before saving. This prevent TableStyles warning in Excel after file is saved in ClosedXML