### PR TITLE
Optimize setting the value of a cell if the merge state of the cell is known in advance

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -75,6 +75,8 @@ namespace ClosedXML.Excel
 
         public XLAddress Address => new(Worksheet, _rowNumber, _columnNumber, false, false);
 
+        public bool? IsInferiorMergedCellUserDefined { get; set; }
+
         internal XLSheetPoint SheetPoint => new(_rowNumber, _columnNumber);
 
         #region Slice fields
@@ -1997,6 +1999,11 @@ namespace ClosedXML.Excel
 
         internal bool IsInferiorMergedCell()
         {
+            if (this.IsInferiorMergedCellUserDefined.HasValue)
+            {
+                return this.IsInferiorMergedCellUserDefined.Value;
+            }
+
             return this.IsMerged() && !this.Address.Equals(this.MergedRange().RangeAddress.FirstAddress);
         }
 


### PR DESCRIPTION
The scenario:
I need to copy 1 named range from the template 50,000 (or even more) times into the resulting file

When setting the cell value, the `IsInferiorMergedCell()` method is called, which significantly slows down the speed of operation with a large number of merged ranges. Although if I manually make a merge, I know in advance whether I need to set a value in this cell or not

Initially, I thought about making a public method `SetValue(XLCellValue value, bool checkMergedRanges)`, which will avoid this check, but the problem is that the setter `FormulaA1`, which is called in the `SetValue()` method, also contains the `IsInferiorMergedCell()` call.

So I decided to just add the `IsInferiorMergedCellUserDefined` property, which will bypass this check. I admit that the solution is not the best, but it suits me. I wanted to highlight the problem more, maybe someone has a better solution right away

Code for reproduce: https://gist.github.com/Arteeck/32de98b54ec85cc9ae923766b73e7562

Template: [template.xlsx](https://github.com/ClosedXML/ClosedXML/files/14421957/template.xlsx)


Sampling without `IsInferiorMergedCellUserDefined`:
![image](https://github.com/ClosedXML/ClosedXML/assets/49301547/af0811e6-555c-4a23-a4ba-6ed67fe29519)


Sampling with `IsInferiorMergedCellUserDefined`:
![image](https://github.com/ClosedXML/ClosedXML/assets/49301547/e9ae5a13-20a8-40f4-9f94-4d991be6075b)