### PR TITLE
Fix TimeSpan conversion

### DIFF
--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -444,6 +444,15 @@ namespace ClosedXML.Tests
         }
 
         [Test]
+        public void TryGetValue_TimeSpan_Good2()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            bool success = ws.Cell("A1").SetValue(0.0034722222222222199).TryGetValue(out TimeSpan outValue);
+            Assert.IsTrue(success);
+            Assert.AreEqual(TimeSpan.FromMinutes(5), outValue);
+        }
+
+        [Test]
         public void TryGetValue_TimeSpan_Good_Large()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");

--- a/ClosedXML/Extensions/DoubleExtensions.cs
+++ b/ClosedXML/Extensions/DoubleExtensions.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.Excel
 
         public static TimeSpan ToSerialTimeSpan(this Double value)
         {
-            return new TimeSpan((long)(TimeSpan.TicksPerDay * value));
+            return XLHelper.GetTimeSpan(value);
         }
 
         public static DateTime ToSerialDateTime(this Double value)


### PR DESCRIPTION
closes #1993

reintroduce changes done by #1364 regarding TimeSpan conversion (broken by #1922).