### PR TITLE
Added an option to not load defined names

### DIFF
--- a/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
@@ -410,9 +410,10 @@ namespace ClosedXML.Tests.Excel
             {
                 Assert.DoesNotThrow(() =>
                 {
-                    // The value in the file is blank and kept.
+                    // The value in the file is blank and kept. Defined names are loaded (defaulting to load defined names)
                     using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = false });
                     Assert.AreEqual(Blank.Value, wb.Worksheets.Single().Cell("C2").CachedValue);
+                    Assert.AreEqual(1, wb.DefinedNames.Count());
                 });
 
                 Assert.DoesNotThrow(() =>
@@ -422,9 +423,20 @@ namespace ClosedXML.Tests.Excel
                     Assert.AreEqual(3, wb.Worksheets.Single().Cell("C2").CachedValue);
                 });
 
+                Assert.DoesNotThrow(() =>
+                {
+                    // The value in the file is blank, but recalculation sets it to correct 3.
+                    // Not loading defined names.
+                    using var wb = new XLWorkbook(stream, new LoadOptions { LoadWorkbookDefinedNames = false });
+                    Assert.AreEqual(Blank.Value, wb.Worksheets.Single().Cell("C2").CachedValue);
+                    Assert.AreEqual(0, wb.DefinedNames.Count());
+                });
+
                 Assert.AreEqual(30, new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiX);
                 Assert.AreEqual(14, new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiY);
             }
+
+
         }
 
         [Test]

--- a/ClosedXML/Excel/LoadOptions.cs
+++ b/ClosedXML/Excel/LoadOptions.cs
@@ -23,6 +23,12 @@ namespace ClosedXML.Excel
         public Boolean RecalculateAllFormulas { get; set; } = false;
 
         /// <summary>
+        /// Should load the workbook's defined names? Default value is <c>true</c>.
+        /// </summary>
+        public Boolean LoadWorkbookDefinedNames { get; set; } = true;
+
+
+        /// <summary>
         /// Graphic engine used by the workbook.
         /// </summary>
         public IXLGraphicEngine? GraphicEngine { get; set; }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -813,6 +813,7 @@ namespace ClosedXML.Excel
             CustomProperties = new XLCustomProperties(this);
             ShapeIdManager = new XLIdManager();
             Author = Environment.UserName;
+            LoadWorkbookDefinedNames = loadOptions.LoadWorkbookDefinedNames;
         }
 
         #endregion Constructor
@@ -977,6 +978,8 @@ namespace ClosedXML.Excel
         }
 
         public String Author { get; set; }
+
+        public Boolean LoadWorkbookDefinedNames { get; set; }
 
         public Boolean LockStructure
         {

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -534,7 +534,8 @@ namespace ClosedXML.Excel
                     }
                 }
             }
-            LoadDefinedNames(workbook);
+            if (LoadWorkbookDefinedNames)
+                LoadDefinedNames(workbook);
 
             PivotTableCacheDefinitionPartReader.Load(workbookPart, this);
 


### PR DESCRIPTION
In certain cases, the defined names section in an Excel workbook may contain broken links to ranges that no longer exist. While this doesn't prevent users from working with the Excel file directly in Excel, it poses a significant issue when loading these files with the ClosedXML library.

Currently, ClosedXML automatically attempts to load all defined names in the workbook. If it encounters any corrupt defined names or broken links, it throws an `ArgumentOutOfRangeException` exception (see `XLTable.Table`). This behavior prevents users from loading any Excel files with broken defined names, regardless of whether they need to use these for their processing or not.

This update addresses this issue by introducing a new option that allows users to skip the loading of defined names if they are not needed for their processing tasks. This enhancement ensures that users can still work with Excel files that have broken defined names without encountering exceptions.

Key points of this change include:

* Optional Defined Names Loading: Users can now choose to bypass the loading of defined names, which is particularly useful for files with broken links.
* Backward Compatibility: The change is fully backward compatible. By default, the option is set to true, meaning defined names will be loaded unless specified otherwise.
* Improved Flexibility: This new feature provides greater flexibility and robustness in handling a wider variety of Excel files, enhancing the overall user experience with ClosedXML.
This improvement ensures that users can process Excel files more reliably, even when encountering issues with defined names.