### PR TITLE
disabling moving invalid defined names

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1493,6 +1493,8 @@ namespace ClosedXML.Excel
         {
             foreach (var definedName in definedNames)
             {
+                if (!definedName.IsValid)
+                    continue;
                 var newRangeList =
                     definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaColumns(r, this, range, columnsShifted)).Where(
                         newReference => newReference.Length > 0).ToList();


### PR DESCRIPTION
Currently instering new column when there is an invalid name defined on the workbook level is causing a `Error at char 0 of ": Unexpected token EofSymbolId` error