### PR TITLE
Fix an edge case when ranges got unmerged when the adjacent range of the same size got deleted

### DIFF
--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1510,6 +1510,7 @@ namespace ClosedXML.Excel
 
             WorksheetRangeShiftedRows(range, rowsShifted);
 
+            bool collapsed = false;
             foreach (var storedRange in rangesToShift)
             {
                 if (storedRange.IsEntireColumn())
@@ -1519,8 +1520,15 @@ namespace ClosedXML.Excel
                     continue;
 
                 storedRange.WorksheetRangeShiftedRows(range, rowsShifted);
+                if (range.RangeAddress == storedRange.RangeAddress)
+                {
+                    collapsed = true;
+                }
             }
-            range.WorksheetRangeShiftedRows(range, rowsShifted);
+            if (!collapsed)
+            {
+                range.WorksheetRangeShiftedRows(range, rowsShifted);
+            }
         }
 
         public void NotifyRangeShiftedColumns(XLRange range, Int32 columnsShifted)
@@ -1532,6 +1540,7 @@ namespace ClosedXML.Excel
 
             WorksheetRangeShiftedColumns(range, columnsShifted);
 
+            bool collapsed = false;
             foreach (var storedRange in rangesToShift)
             {
                 if (storedRange.IsEntireRow())
@@ -1541,8 +1550,15 @@ namespace ClosedXML.Excel
                     continue;
 
                 storedRange.WorksheetRangeShiftedColumns(range, columnsShifted);
+                if (range.RangeAddress == storedRange.RangeAddress)
+                {
+                    collapsed = true;
+                }
             }
-            range.WorksheetRangeShiftedColumns(range, columnsShifted);
+            if (!collapsed)
+            {
+                range.WorksheetRangeShiftedColumns(range, columnsShifted);
+            }
         }
 
         public XLRow Row(Int32 rowNumber, Boolean pingCells)


### PR DESCRIPTION
As @masterworgen discovered by using ClosedXML.Report, there is an edge case causing a range to be unmerged.

Reproduction:
```
            var wb = new XLWorkbook("Template.xlsx");

            var range = wb.Worksheets.First().Range("A5:F5");
            range.Delete(XLShiftDeletedCells.ShiftCellsUp);

            wb.SaveAs("result.xlsx");
```

**Original file:**

![image](https://github.com/ClosedXML/ClosedXML/assets/19576939/f98dcdb3-fb67-44fe-87f4-8eac00809ffb)

**Expected result:**

![image](https://github.com/ClosedXML/ClosedXML/assets/19576939/728f6450-073c-4186-9122-cc55d3c629eb)

**Actual result:**

![image](https://github.com/ClosedXML/ClosedXML/assets/19576939/cd51b317-2ebc-4cf6-b894-1d0149b15bc6)

[Template.xlsx](https://github.com/user-attachments/files/16030367/Template.xlsx)

This happens if there is a merged range of exactly same size just below a range to be deleted (with `ShiftCellsUps` mode), or to the right of it (when `ShiftCellsLeft` mode is used).

The reason of such a behavior is the usage of ranges repository: when all affected ranges are being adjusted in `NotifyRangeShiftedRows`/`NotifyRangeShiftedColumns`, first we update the merged range and it becomes the exact clone of the range to be deleted (therefore, they both are "optimized" by the repository to reference the same instance); and then the deleted range gets destoyed, together with the merged one.

In the PR, I am handling this edge case: if any range becomes identical to the original one then we don't have to process this range outside the loop.