### PR TITLE
Remove IXLStylized.Styles property

### DIFF
--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1092,14 +1092,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-            }
-        }
-
         void IXLStylized.ModifyStyle(Func<XLStyleKey, XLStyleKey> modification)
         {
             //XLCell cannot have children so the base method may be optimized

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -213,16 +213,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                foreach (XLCell c in this)
-                    yield return c.Style;
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -33,19 +33,6 @@ namespace ClosedXML.Excel
             get { return XLRangeType.Column; }
         }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-
-                int column = ColumnNumber();
-
-                foreach (XLCell cell in Worksheet.Internals.CellsCollection.GetCellsInColumn(column))
-                    yield return cell.Style;
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -214,23 +214,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                if (_worksheet != null)
-                    yield return _worksheet.Style;
-                else
-                {
-                    foreach (IXLStyle s in Columns.SelectMany(col => col.Styles))
-                    {
-                        yield return s;
-                    }
-                }
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -171,14 +171,6 @@ namespace ClosedXML.Excel
 
         public Boolean CopyDefaultModify { get; set; }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get { yield break; }

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -207,15 +207,6 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                foreach (IXLCell cell in Cells())
-                    yield return cell.Style;
-            }
-        }
-
         #endregion IXLStylized Members
 
         #endregion Public properties

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -77,24 +77,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
         
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                foreach (XLRangeColumn rng in _ranges)
-                {
-                    yield return rng.Style;
-                    foreach (XLCell r in rng.Worksheet.Internals.CellsCollection.GetCells(
-                        rng.RangeAddress.FirstAddress.RowNumber,
-                        rng.RangeAddress.FirstAddress.ColumnNumber,
-                        rng.RangeAddress.LastAddress.RowNumber,
-                        rng.RangeAddress.LastAddress.ColumnNumber))
-                        yield return r.Style;
-                }
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -77,24 +77,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                foreach (XLRangeRow rng in _ranges)
-                {
-                    yield return rng.Style;
-                    foreach (XLCell r in rng.Worksheet.Internals.CellsCollection.GetCells(
-                        rng.RangeAddress.FirstAddress.RowNumber,
-                        rng.RangeAddress.FirstAddress.ColumnNumber,
-                        rng.RangeAddress.LastAddress.RowNumber,
-                        rng.RangeAddress.LastAddress.ColumnNumber))
-                        yield return r.Style;
-                }
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -219,24 +219,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                foreach (XLRange rng in Ranges)
-                {
-                    yield return rng.Style;
-                    foreach (XLCell r in rng.Worksheet.Internals.CellsCollection.GetCells(
-                        rng.RangeAddress.FirstAddress.RowNumber,
-                        rng.RangeAddress.FirstAddress.ColumnNumber,
-                        rng.RangeAddress.LastAddress.RowNumber,
-                        rng.RangeAddress.LastAddress.ColumnNumber))
-                        yield return r.Style;
-                }
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -38,19 +38,6 @@ namespace ClosedXML.Excel
             get { return XLRangeType.Row; }
         }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-
-                int row = RowNumber();
-
-                foreach (XLCell cell in Worksheet.Internals.CellsCollection.GetCellsInRow(row))
-                    yield return cell.Style;
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -217,23 +217,6 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                if (_worksheet != null)
-                    yield return _worksheet.Style;
-                else
-                {
-                    foreach (IXLStyle s in Rows.SelectMany(row => row.Styles))
-                    {
-                        yield return s;
-                    }
-                }
-            }
-        }
-
         public override IXLRanges RangesUsed
         {
             get

--- a/ClosedXML/Excel/Style/IXLStylized.cs
+++ b/ClosedXML/Excel/Style/IXLStylized.cs
@@ -16,12 +16,6 @@ namespace ClosedXML.Excel
         IXLStyle Style { get; set; }
 
         /// <summary>
-        /// Method that returns all style within the stylized element. That means style of the element itself
-        /// and all its descendants (not just children).
-        /// </summary>
-        IEnumerable<IXLStyle> Styles { get; }
-
-        /// <summary>
         /// Editable style of the workbook element. Modification of this property DOES NOT affect styles of child objects.
         /// Accessing this property causes a new <see cref="XLStyle"/> instance generated so use this property with caution. If you need
         /// only _read_ the style consider using <see cref="StyleValue"/> property instead.

--- a/ClosedXML/Excel/Style/IXLStylized.cs
+++ b/ClosedXML/Excel/Style/IXLStylized.cs
@@ -1,25 +1,59 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// An interface implemented by workbook elements that have a defined <see cref="IXLStyle"/>.
+    /// </summary>
     internal interface IXLStylized
     {
+        /// <summary>
+        /// Editable style of the workbook element. Modification of this property DOES affect styles of child objects as well - they will
+        /// be changed accordingly. Accessing this property causes a new <see cref="XLStyle"/> instance generated so use this property
+        /// with caution. If you need only _read_ the style consider using <see cref="StyleValue"/> property instead.
+        /// </summary>
         IXLStyle Style { get; set; }
 
+        /// <summary>
+        /// Method that returns all style within the stylized element. That means style of the element itself
+        /// and all its descendants (not just children).
+        /// </summary>
         IEnumerable<IXLStyle> Styles { get; }
 
+        /// <summary>
+        /// Editable style of the workbook element. Modification of this property DOES NOT affect styles of child objects.
+        /// Accessing this property causes a new <see cref="XLStyle"/> instance generated so use this property with caution. If you need
+        /// only _read_ the style consider using <see cref="StyleValue"/> property instead.
+        /// </summary>
         IXLStyle InnerStyle { get; set; }
 
+        /// <summary>
+        /// <para>
+        /// Return a collection of ranges that determine outside borders (used by
+        /// <see cref="XLBorder.OutsideBorder"/>).
+        /// </para>
+        /// <para>
+        /// Return ranges represented by elements. For one element (e.g. workbook, cell,
+        /// column), it should return only the element itself. For element that represent a
+        /// collection of other elements, e.g. <see cref="XLRows"/>, <see cref="XLColumns"/>,
+        /// <see cref="XLCells"/>, it should return range for each element in the collection.
+        /// </para>
+        /// </summary>
         IXLRanges RangesUsed { get; }
 
         /// <summary>
-        /// Immutable style
+        /// Style value representing the current style of the stylized element.
+        /// The value is updated when style is modified (<see cref="XLStyleValue"/>
+        /// is immutable).
         /// </summary>
         XLStyleValue StyleValue { get; }
 
+        /// <summary>
+        /// A callback method called when <see cref="Style"/> is changed. It should update
+        /// style of the stylized descendants of the stylized element.
+        /// </summary>
+        /// <param name="modification">A method that changes the style from original to modified.</param>
         void ModifyStyle(Func<XLStyleKey, XLStyleKey> modification);
     }
 }

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace ClosedXML.Excel
 {
+    /// <summary>
+    /// An immutable style value.
+    /// </summary>
     internal sealed class XLStyleValue : IEquatable<XLStyleValue?>
     {
         private static readonly XLStyleRepository Repository = new(key => new XLStyleValue(key));

--- a/ClosedXML/Excel/Style/XLStylizedBase.cs
+++ b/ClosedXML/Excel/Style/XLStylizedBase.cs
@@ -18,27 +18,21 @@ namespace ClosedXML.Excel
         /// Read-only style property.
         /// </summary>
         internal virtual XLStyleValue StyleValue { get; private protected set; }
+
+        /// <inheritdoc cref="IXLStylized.StyleValue"/>
         XLStyleValue IXLStylized.StyleValue
         {
             get { return StyleValue; }
         }
 
-        /// <summary>
-        /// Editable style of the workbook element. Modification of this property DOES affect styles of child objects as well - they will
-        /// be changed accordingly. Accessing this property causes a new <see cref="XLStyle"/> instance generated so use this property
-        /// with caution. If you need only _read_ the style consider using <see cref="StyleValue"/> property instead.
-        /// </summary>
+        /// <inheritdoc cref="IXLStylized.Style"/>
         public IXLStyle Style
         {
             get { return InnerStyle; }
             set { SetStyle(value, true); }
         }
 
-        /// <summary>
-        /// Editable style of the workbook element. Modification of this property DOES NOT affect styles of child objects.
-        /// Accessing this property causes a new <see cref="XLStyle"/> instance generated so use this property with caution. If you need
-        /// only _read_ the style consider using <see cref="StyleValue"/> property instead.
-        /// </summary>
+        /// <inheritdoc cref="IXLStylized.InnerStyle"/>
         public IXLStyle InnerStyle
         {
             get { return new XLStyle(this, StyleValue.Key); }

--- a/ClosedXML/Excel/Style/XLStylizedBase.cs
+++ b/ClosedXML/Excel/Style/XLStylizedBase.cs
@@ -46,8 +46,6 @@ namespace ClosedXML.Excel
 
         public abstract IXLRanges RangesUsed { get; }
 
-        public abstract IEnumerable<IXLStyle> Styles { get; }
-
         #endregion Properties
 
         protected XLStylizedBase(XLStyleValue styleValue)

--- a/ClosedXML/Excel/Style/XLStylizedEmpty.cs
+++ b/ClosedXML/Excel/Style/XLStylizedEmpty.cs
@@ -9,14 +9,6 @@ namespace ClosedXML.Excel
         {
         }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-            }
-        }
-
         public override IXLRanges RangesUsed
         {
             get { return new XLRanges(); }

--- a/ClosedXML/Excel/Tables/XLTableRows.cs
+++ b/ClosedXML/Excel/Tables/XLTableRows.cs
@@ -15,24 +15,6 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return Style;
-                foreach (XLTableRow rng in _ranges)
-                {
-                    yield return rng.Style;
-                    foreach (XLCell r in rng.Worksheet.Internals.CellsCollection.GetCells(
-                        rng.RangeAddress.FirstAddress.RowNumber,
-                        rng.RangeAddress.FirstAddress.ColumnNumber,
-                        rng.RangeAddress.LastAddress.RowNumber,
-                        rng.RangeAddress.LastAddress.ColumnNumber))
-                        yield return r.Style;
-                }
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -126,16 +126,6 @@ namespace ClosedXML.Excel
             get { return _rangeFactory; }
         }
 
-        public override IEnumerable<IXLStyle> Styles
-        {
-            get
-            {
-                yield return GetStyle();
-                foreach (XLCell c in Internals.CellsCollection.GetCells())
-                    yield return c.Style;
-            }
-        }
-
         protected override IEnumerable<XLStylizedBase> Children
         {
             get


### PR DESCRIPTION
The `IXLStylized.Styles` property wasn't used anywhere (plus it has rather unclear semantic), so it is removed as a dead code (don't want to deal with it in pivot table styles)..