### PR TITLE
Convert XLNumberFormatKey and XLAlignmentKey to readonly structs

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
@@ -91,8 +91,8 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void XLNumberFormatKey_GetHashCode_IsCaseSensitive()
         {
-            var numberFormatKey1 = new XLNumberFormatKey { Format = "MM" };
-            var numberFormatKey2 = new XLNumberFormatKey { Format = "mm" };
+            var numberFormatKey1 = XLNumberFormatKey.ForFormat("MM");
+            var numberFormatKey2 = XLNumberFormatKey.ForFormat("mm");
 
             Assert.AreNotEqual(numberFormatKey1.GetHashCode(), numberFormatKey2.GetHashCode());
         }
@@ -100,8 +100,8 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void XLNumberFormatKey_Equals_IsCaseSensitive()
         {
-            var numberFormatKey1 = new XLNumberFormatKey { Format = "MM" };
-            var numberFormatKey2 = new XLNumberFormatKey { Format = "mm" };
+            var numberFormatKey1 = XLNumberFormatKey.ForFormat("MM");
+            var numberFormatKey2 = XLNumberFormatKey.ForFormat("mm");
 
             Assert.IsFalse(numberFormatKey1.Equals(numberFormatKey2));
         }

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -519,29 +519,9 @@ namespace ClosedXML.Excel.IO
 
         private static bool AlignmentsAreEqual(Alignment alignment, XLAlignmentValue xlAlignment)
         {
-            if (alignment != null)
+            if (alignment is not null)
             {
-                var a = XLAlignmentValue.Default.Key;
-                if (alignment.Indent != null)
-                    a.Indent = (Int32)alignment.Indent.Value;
-
-                if (alignment.Horizontal != null)
-                    a.Horizontal = alignment.Horizontal.Value.ToClosedXml();
-                if (alignment.Vertical != null)
-                    a.Vertical = alignment.Vertical.Value.ToClosedXml();
-
-                if (alignment.ReadingOrder != null)
-                    a.ReadingOrder = alignment.ReadingOrder.Value.ToClosedXml();
-                if (alignment.WrapText != null)
-                    a.WrapText = alignment.WrapText.Value;
-                if (alignment.TextRotation != null)
-                    a.TextRotation = OpenXmlHelper.GetClosedXmlTextRotation(alignment);
-                if (alignment.ShrinkToFit != null)
-                    a.ShrinkToFit = alignment.ShrinkToFit.Value;
-                if (alignment.RelativeIndent != null)
-                    a.RelativeIndent = alignment.RelativeIndent.Value;
-                if (alignment.JustifyLastLine != null)
-                    a.JustifyLastLine = alignment.JustifyLastLine.Value;
+                var a = OpenXmlHelper.AlignmentToClosedXml(alignment, XLAlignmentValue.Default.Key);
                 return a.Equals(xlAlignment.Key);
             }
             else

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -115,11 +115,7 @@ namespace ClosedXML.Excel.IO
 
             foreach (var pivotNumberFormat in xlPivotTablesCustomFormats)
             {
-                var numberFormatKey = new XLNumberFormatKey
-                {
-                    NumberFormatId = -1,
-                    Format = pivotNumberFormat
-                };
+                var numberFormatKey = XLNumberFormatKey.ForFormat(pivotNumberFormat);
                 var numberFormat = XLNumberFormatValue.FromKey(ref numberFormatKey);
 
                 customNumberFormats.Add(numberFormat);

--- a/ClosedXML/Excel/Style/XLAlignment.cs
+++ b/ClosedXML/Excel/Style/XLAlignment.cs
@@ -87,7 +87,7 @@ namespace ClosedXML.Excel
                                             || value == XLAlignmentHorizontalValues.Distributed
                                         );
 
-                Modify(k => { k.Horizontal = value; return k; });
+                Modify(k => k with { Horizontal = value });
                 if (updateIndent)
                     Indent = 0;
             }
@@ -96,7 +96,7 @@ namespace ClosedXML.Excel
         public XLAlignmentVerticalValues Vertical
         {
             get { return Key.Vertical; }
-            set { Modify(k => { k.Vertical = value; return k; }); }
+            set { Modify(k => k with { Vertical = value }); }
         }
 
         public Int32 Indent
@@ -119,32 +119,32 @@ namespace ClosedXML.Excel
                             "For indents, only left, right, and distributed horizontal alignments are supported.");
                     }
                 }
-                Modify(k => { k.Indent = value; return k; });
+                Modify(k => k with { Indent = value });
             }
         }
 
         public Boolean JustifyLastLine
         {
             get { return Key.JustifyLastLine; }
-            set { Modify(k => { k.JustifyLastLine = value; return k; }); }
+            set { Modify(k => k with { JustifyLastLine = value }); }
         }
 
         public XLAlignmentReadingOrderValues ReadingOrder
         {
             get { return Key.ReadingOrder; }
-            set { Modify(k => { k.ReadingOrder = value; return k; }); }
+            set { Modify(k => k with { ReadingOrder = value }); }
         }
 
         public Int32 RelativeIndent
         {
             get { return Key.RelativeIndent; }
-            set { Modify(k => { k.RelativeIndent = value; return k; }); }
+            set { Modify(k => k with { RelativeIndent = value }); }
         }
 
         public Boolean ShrinkToFit
         {
             get { return Key.ShrinkToFit; }
-            set { Modify(k => { k.ShrinkToFit = value; return k; }); }
+            set { Modify(k => k with { ShrinkToFit = value }); }
         }
 
         public Int32 TextRotation
@@ -157,14 +157,14 @@ namespace ClosedXML.Excel
                 if (rotation != 255 && (rotation < -90 || rotation > 90))
                     throw new ArgumentException("TextRotation must be between -90 and 90 degrees, or 255.");
 
-                Modify(k => { k.TextRotation = rotation; return k; });
+                Modify(k => k with { TextRotation = rotation });
             }
         }
 
         public Boolean WrapText
         {
             get { return Key.WrapText; }
-            set { Modify(k => { k.WrapText = value; return k; }); }
+            set { Modify(k => k with { WrapText = value }); }
         }
 
         public Boolean TopToBottom

--- a/ClosedXML/Excel/Style/XLAlignmentKey.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentKey.cs
@@ -2,23 +2,23 @@ namespace ClosedXML.Excel;
 
 public readonly record struct XLAlignmentKey
 {
-    public XLAlignmentHorizontalValues Horizontal { get; init; }
+    public required XLAlignmentHorizontalValues Horizontal { get; init; }
 
-    public XLAlignmentVerticalValues Vertical { get; init; }
+    public required XLAlignmentVerticalValues Vertical { get; init; }
 
-    public int Indent { get; init; }
+    public required int Indent { get; init; }
 
-    public bool JustifyLastLine { get; init; }
+    public required bool JustifyLastLine { get; init; }
 
-    public XLAlignmentReadingOrderValues ReadingOrder { get; init; }
+    public required XLAlignmentReadingOrderValues ReadingOrder { get; init; }
 
     public required int RelativeIndent { get; init; }
 
-    public bool ShrinkToFit { get; init; }
+    public required bool ShrinkToFit { get; init; }
 
-    public int TextRotation { get; init; }
+    public required int TextRotation { get; init; }
 
-    public bool WrapText { get; init; }
+    public required bool WrapText { get; init; }
 
     public override string ToString()
     {

--- a/ClosedXML/Excel/Style/XLAlignmentKey.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentKey.cs
@@ -12,7 +12,7 @@ public readonly record struct XLAlignmentKey
 
     public XLAlignmentReadingOrderValues ReadingOrder { get; init; }
 
-    public int RelativeIndent { get; init; }
+    public required int RelativeIndent { get; init; }
 
     public bool ShrinkToFit { get; init; }
 
@@ -20,14 +20,11 @@ public readonly record struct XLAlignmentKey
 
     public bool WrapText { get; init; }
 
-    public bool TopToBottom { get; init; }
-
     public override string ToString()
     {
         return
             $"{Horizontal} {Vertical} {ReadingOrder} Indent: {Indent} RelativeIndent: {RelativeIndent} TextRotation: {TextRotation} " +
             (WrapText ? "WrapText" : "") +
-            (JustifyLastLine ? "JustifyLastLine" : "") +
-            (TopToBottom ? "TopToBottom" : "");
+            (JustifyLastLine ? "JustifyLastLine" : "");
     }
 }

--- a/ClosedXML/Excel/Style/XLAlignmentKey.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentKey.cs
@@ -1,80 +1,33 @@
-#nullable disable
+namespace ClosedXML.Excel;
 
-using System;
-
-namespace ClosedXML.Excel
+public readonly record struct XLAlignmentKey
 {
-    public struct XLAlignmentKey : IEquatable<XLAlignmentKey>
+    public XLAlignmentHorizontalValues Horizontal { get; init; }
+
+    public XLAlignmentVerticalValues Vertical { get; init; }
+
+    public int Indent { get; init; }
+
+    public bool JustifyLastLine { get; init; }
+
+    public XLAlignmentReadingOrderValues ReadingOrder { get; init; }
+
+    public int RelativeIndent { get; init; }
+
+    public bool ShrinkToFit { get; init; }
+
+    public int TextRotation { get; init; }
+
+    public bool WrapText { get; init; }
+
+    public bool TopToBottom { get; init; }
+
+    public override string ToString()
     {
-        public XLAlignmentHorizontalValues Horizontal { get; set; }
-
-        public XLAlignmentVerticalValues Vertical { get; set; }
-
-        public int Indent { get; set; }
-
-        public bool JustifyLastLine { get; set; }
-
-        public XLAlignmentReadingOrderValues ReadingOrder { get; set; }
-
-        public int RelativeIndent { get; set; }
-
-        public bool ShrinkToFit { get; set; }
-
-        public int TextRotation { get; set; }
-
-        public bool WrapText { get; set; }
-
-        public bool TopToBottom { get; set; }
-
-        public bool Equals(XLAlignmentKey other)
-        {
-            return
-                Horizontal == other.Horizontal
-             && Vertical == other.Vertical
-             && Indent == other.Indent
-             && JustifyLastLine == other.JustifyLastLine
-             && ReadingOrder == other.ReadingOrder
-             && RelativeIndent == other.RelativeIndent
-             && ShrinkToFit == other.ShrinkToFit
-             && TextRotation == other.TextRotation
-             && WrapText == other.WrapText
-             && TopToBottom == other.TopToBottom;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is XLAlignment)
-                return Equals((XLAlignment)obj);
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            var hashCode = -596887160;
-            hashCode = hashCode * -1521134295 + (int)Horizontal;
-            hashCode = hashCode * -1521134295 + (int)Vertical;
-            hashCode = hashCode * -1521134295 + Indent;
-            hashCode = hashCode * -1521134295 + JustifyLastLine.GetHashCode();
-            hashCode = hashCode * -1521134295 + (int)ReadingOrder;
-            hashCode = hashCode * -1521134295 + RelativeIndent;
-            hashCode = hashCode * -1521134295 + ShrinkToFit.GetHashCode();
-            hashCode = hashCode * -1521134295 + TextRotation;
-            hashCode = hashCode * -1521134295 + WrapText.GetHashCode();
-            hashCode = hashCode * -1521134295 + TopToBottom.GetHashCode();
-            return hashCode;
-        }
-
-        public override string ToString()
-        {
-            return
-                $"{Horizontal} {Vertical} {ReadingOrder} Indent: {Indent} RelativeIndent: {RelativeIndent} TextRotation: {TextRotation} " +
-                (WrapText ? "WrapText" : "") +
-                (JustifyLastLine ? "JustifyLastLine" : "") +
-                (TopToBottom ? "TopToBottom" : "");
-        }
-
-        public static bool operator ==(XLAlignmentKey left, XLAlignmentKey right) => left.Equals(right);
-
-        public static bool operator !=(XLAlignmentKey left, XLAlignmentKey right) => !(left.Equals(right));
+        return
+            $"{Horizontal} {Vertical} {ReadingOrder} Indent: {Indent} RelativeIndent: {RelativeIndent} TextRotation: {TextRotation} " +
+            (WrapText ? "WrapText" : "") +
+            (JustifyLastLine ? "JustifyLastLine" : "") +
+            (TopToBottom ? "TopToBottom" : "");
     }
 }

--- a/ClosedXML/Excel/Style/XLAlignmentValue.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentValue.cs
@@ -67,8 +67,7 @@ namespace ClosedXML.Excel
 
         internal XLAlignmentValue WithWrapText(bool wrapText)
         {
-            var keyCopy = Key;
-            keyCopy.WrapText = wrapText;
+            var keyCopy = Key with { WrapText = wrapText };
             return FromKey(ref keyCopy);
         }
     }

--- a/ClosedXML/Excel/Style/XLAlignmentValue.cs
+++ b/ClosedXML/Excel/Style/XLAlignmentValue.cs
@@ -48,8 +48,6 @@ namespace ClosedXML.Excel
 
         public bool WrapText { get { return Key.WrapText; } }
 
-        public bool TopToBottom { get { return Key.TopToBottom; } }
-
         private XLAlignmentValue(XLAlignmentKey key)
         {
             Key = key;

--- a/ClosedXML/Excel/Style/XLNumberFormat.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormat.cs
@@ -1,152 +1,148 @@
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal class XLNumberFormat : IXLNumberFormat
 {
-    internal class XLNumberFormat : IXLNumberFormat
+    #region Static members
+
+    internal static XLNumberFormatKey GenerateKey(IXLNumberFormat? defaultNumberFormat)
     {
-        #region Static members
+        if (defaultNumberFormat == null)
+            return XLNumberFormatValue.Default.Key;
 
-        internal static XLNumberFormatKey GenerateKey(IXLNumberFormat? defaultNumberFormat)
+        if (defaultNumberFormat is XLNumberFormat format)
+            return format.Key;
+
+        return new XLNumberFormatKey
         {
-            if (defaultNumberFormat == null)
-                return XLNumberFormatValue.Default.Key;
+            NumberFormatId = defaultNumberFormat.NumberFormatId,
+            Format = defaultNumberFormat.Format
+        };
+    }
 
-            if (defaultNumberFormat is XLNumberFormat format)
-                return format.Key;
+    #endregion Static members
 
-            return new XLNumberFormatKey
+    #region Properties
+
+    private readonly XLStyle _style;
+
+    private XLNumberFormatValue _value;
+
+    internal XLNumberFormatKey Key
+    {
+        get => _value.Key;
+        private set => _value = XLNumberFormatValue.FromKey(ref value);
+    }
+
+    #endregion Properties
+
+    #region Constructors
+
+    /// <summary>
+    /// Create an instance of XLNumberFormat initializing it with the specified value.
+    /// </summary>
+    /// <param name="style">Style to attach the new instance to.</param>
+    /// <param name="value">Style value to use.</param>
+    public XLNumberFormat(XLStyle? style, XLNumberFormatValue value)
+    {
+        _style = style ?? XLStyle.CreateEmptyStyle();
+        _value = value;
+    }
+
+    public XLNumberFormat(XLStyle? style, XLNumberFormatKey key) : this(style, XLNumberFormatValue.FromKey(ref key))
+    {
+    }
+
+    public XLNumberFormat(XLStyle? style = null, IXLNumberFormat? d = null) : this(style, GenerateKey(d))
+    {
+    }
+
+    #endregion Constructors
+
+    #region IXLNumberFormat Members
+
+    public Int32 NumberFormatId
+    {
+        get => Key.NumberFormatId;
+        set
+        {
+            Modify(_ => new XLNumberFormatKey
             {
-                NumberFormatId = defaultNumberFormat.NumberFormatId,
-                Format = defaultNumberFormat.Format
-            };
-        }
-
-        #endregion Static members
-
-        #region Properties
-
-        private readonly XLStyle _style;
-
-        private XLNumberFormatValue _value;
-
-        internal XLNumberFormatKey Key
-        {
-            get { return _value.Key; }
-            private set { _value = XLNumberFormatValue.FromKey(ref value); }
-        }
-
-        #endregion Properties
-
-        #region Constructors
-
-        /// <summary>
-        /// Create an instance of XLNumberFormat initializing it with the specified value.
-        /// </summary>
-        /// <param name="style">Style to attach the new instance to.</param>
-        /// <param name="value">Style value to use.</param>
-        public XLNumberFormat(XLStyle? style, XLNumberFormatValue value)
-        {
-            _style = style ?? XLStyle.CreateEmptyStyle();
-            _value = value;
-        }
-
-        public XLNumberFormat(XLStyle? style, XLNumberFormatKey key) : this(style, XLNumberFormatValue.FromKey(ref key))
-        {
-        }
-
-        public XLNumberFormat(XLStyle? style = null, IXLNumberFormat? d = null) : this(style, GenerateKey(d))
-        {
-        }
-
-        #endregion Constructors
-
-        #region IXLNumberFormat Members
-
-        public Int32 NumberFormatId
-        {
-            get { return Key.NumberFormatId; }
-            set
-            {
-                Modify(k =>
-                {
-                    k.Format = XLNumberFormatValue.Default.Format;
-                    k.NumberFormatId = value;
-                    return k;
-                });
-            }
-        }
-
-        public String Format
-        {
-            get { return Key.Format; }
-            set
-            {
-                Modify(k =>
-                {
-                    k.Format = value;
-                    if (string.IsNullOrWhiteSpace(k.Format))
-                        k.NumberFormatId = XLNumberFormatValue.Default.NumberFormatId;
-                    else
-                        k.NumberFormatId = -1;
-                    return k;
-                });
-            }
-        }
-
-        public IXLStyle SetNumberFormatId(Int32 value)
-        {
-            NumberFormatId = value;
-            return _style;
-        }
-
-        public IXLStyle SetFormat(String value)
-        {
-            Format = value;
-            return _style;
-        }
-
-        #endregion IXLNumberFormat Members
-
-        private void Modify(Func<XLNumberFormatKey, XLNumberFormatKey> modification)
-        {
-            Key = modification(Key);
-
-            _style.Modify(styleKey =>
-            {
-                var numberFormat = styleKey.NumberFormat;
-                styleKey.NumberFormat = modification(numberFormat);
-                return styleKey;
+                Format = XLNumberFormatValue.Default.Format,
+                NumberFormatId = value,
             });
         }
-
-        #region Overridden
-
-        public override string ToString()
-        {
-            return NumberFormatId + "-" + Format;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as IXLNumberFormatBase);
-        }
-
-        public bool Equals(IXLNumberFormatBase? other)
-        {
-            var otherN = other as XLNumberFormat;
-            if (otherN == null)
-                return false;
-
-            return Key == otherN.Key;
-        }
-
-        public override int GetHashCode()
-        {
-            var hashCode = 416600561;
-            hashCode = hashCode * -1521134295 + Key.GetHashCode();
-            return hashCode;
-        }
-
-        #endregion Overridden
     }
+
+    public String Format
+    {
+        get => Key.Format;
+        set
+        {
+            Modify(_ => new XLNumberFormatKey
+            {
+                Format = value,
+                NumberFormatId = string.IsNullOrWhiteSpace(value)
+                    ? XLNumberFormatValue.Default.NumberFormatId
+                    : XLNumberFormatKey.CustomFormatNumberId
+            });
+        }
+    }
+
+    public IXLStyle SetNumberFormatId(Int32 value)
+    {
+        NumberFormatId = value;
+        return _style;
+    }
+
+    public IXLStyle SetFormat(String value)
+    {
+        Format = value;
+        return _style;
+    }
+
+    #endregion IXLNumberFormat Members
+
+    private void Modify(Func<XLNumberFormatKey, XLNumberFormatKey> modification)
+    {
+        Key = modification(Key);
+
+        _style.Modify(styleKey =>
+        {
+            var numberFormat = styleKey.NumberFormat;
+            styleKey.NumberFormat = modification(numberFormat);
+            return styleKey;
+        });
+    }
+
+    #region Overridden
+
+    public override string ToString()
+    {
+        return NumberFormatId + "-" + Format;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as IXLNumberFormatBase);
+    }
+
+    public bool Equals(IXLNumberFormatBase? other)
+    {
+        var otherN = other as XLNumberFormat;
+        if (otherN == null)
+            return false;
+
+        return Key == otherN.Key;
+    }
+
+    public override int GetHashCode()
+    {
+        var hashCode = 416600561;
+        hashCode = hashCode * -1521134295 + Key.GetHashCode();
+        return hashCode;
+    }
+
+    #endregion Overridden
 }

--- a/ClosedXML/Excel/Style/XLNumberFormatKey.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormatKey.cs
@@ -1,48 +1,37 @@
-#nullable disable
-
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal readonly record struct XLNumberFormatKey
 {
-    internal struct XLNumberFormatKey : IEquatable<XLNumberFormatKey>
+    /// <summary>
+    /// The value <c>-1</c> that is set to <see cref="NumberFormatId"/>, if <see cref="Format"/> is
+    /// set to user-defined format (non-empty string).
+    /// </summary>
+    public const int CustomFormatNumberId = -1;
+
+    /// <summary>
+    /// Number format identifier of predefined format, see <see cref="XLPredefinedFormat"/>.
+    /// If -1, the format is custom and stored in the <see cref="Format"/>.
+    /// </summary>
+    public required int NumberFormatId { get; init; }
+
+    public required string Format { get; init; }
+
+    public static XLNumberFormatKey ForFormat(string customFormat)
     {
-        /// <summary>
-        /// Number format identifier of predefined format, see <see cref="XLPredefinedFormat"/>.
-        /// If -1, the format is custom and stored in the <see cref="Format"/>.
-        /// </summary>
-        public int NumberFormatId { get; set; }
+        if (string.IsNullOrEmpty(customFormat))
+            throw new ArgumentException();
 
-        public string Format { get; set; }
-
-        public override int GetHashCode()
+        return new XLNumberFormatKey
         {
-            unchecked
-            {
-                var hashCode = -759193072;
-                hashCode = hashCode * -1521134295 + NumberFormatId;
-                hashCode = hashCode * -1521134295 + (Format == null ? 0 : Format.GetHashCode());
-                return hashCode;
-            }
-        }
+            NumberFormatId = CustomFormatNumberId,
+            Format = customFormat,
+        };
+    }
 
-        public bool Equals(XLNumberFormatKey other)
-        {
-            return NumberFormatId == other.NumberFormatId &&
-                   string.Equals(Format, other.Format);
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is XLNumberFormatKey other && Equals(other);
-        }
-
-        public override string ToString()
-        {
-            return $"{Format}/{NumberFormatId}";
-        }
-
-        public static bool operator ==(XLNumberFormatKey left, XLNumberFormatKey right) => left.Equals(right);
-
-        public static bool operator !=(XLNumberFormatKey left, XLNumberFormatKey right) => !(left.Equals(right));
+    public override string ToString()
+    {
+        return $"{Format}/{NumberFormatId}";
     }
 }

--- a/ClosedXML/Excel/Style/XLNumberFormatValue.cs
+++ b/ClosedXML/Excel/Style/XLNumberFormatValue.cs
@@ -55,8 +55,7 @@ namespace ClosedXML.Excel
 
         internal XLNumberFormatValue WithNumberFormatId(int numberFormatId)
         {
-            var keyCopy = Key;
-            keyCopy.NumberFormatId = numberFormatId;
+            var keyCopy = Key with { NumberFormatId = numberFormatId };
             return FromKey(ref keyCopy);
         }
     }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2592,29 +2592,7 @@ namespace ClosedXML.Excel
             var alignment = cellFormat.Alignment;
             if (alignment != null)
             {
-                var xlAlignment = xlStyle.Alignment;
-                if (alignment.Horizontal != null)
-                    xlAlignment.Horizontal = alignment.Horizontal.Value.ToClosedXml();
-                if (alignment.Indent != null && alignment.Indent != 0)
-                    xlAlignment.Indent = Int32.Parse(alignment.Indent.ToString());
-                if (alignment.JustifyLastLine != null)
-                    xlAlignment.JustifyLastLine = alignment.JustifyLastLine;
-                if (alignment.ReadingOrder != null)
-                {
-                    xlAlignment.ReadingOrder =
-                        (XLAlignmentReadingOrderValues)Int32.Parse(alignment.ReadingOrder.ToString());
-                }
-                if (alignment.RelativeIndent != null)
-                    xlAlignment.RelativeIndent = alignment.RelativeIndent;
-                if (alignment.ShrinkToFit != null)
-                    xlAlignment.ShrinkToFit = alignment.ShrinkToFit;
-                if (alignment.TextRotation != null)
-                    xlAlignment.TextRotation = OpenXmlHelper.GetClosedXmlTextRotation(alignment);
-                if (alignment.Vertical != null)
-                    xlAlignment.Vertical = alignment.Vertical.Value.ToClosedXml();
-                if (alignment.WrapText != null)
-                    xlAlignment.WrapText = alignment.WrapText;
-
+                var xlAlignment = OpenXmlHelper.AlignmentToClosedXml(alignment, xlStyle.Alignment);
                 xlStyle.Alignment = xlAlignment;
             }
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -562,7 +562,7 @@ namespace ClosedXML.Excel
                 }
             }
         }
-        
+
         /// <summary>
         /// Calculate expected column width as a number displayed in the column in Excel from
         /// number of characters that should fit into the width and a font.
@@ -2753,11 +2753,10 @@ namespace ClosedXML.Excel
                 var xlNumberFormat = xlStyle.NumberFormat;
                 if (formatCode.Length > 0)
                 {
-                    xlNumberFormat.Format = formatCode;
-                    xlNumberFormat.NumberFormatId = -1;
+                    xlNumberFormat = XLNumberFormatKey.ForFormat(formatCode);
                 }
                 else
-                    xlNumberFormat.NumberFormatId = (Int32)numberFormatId.Value;
+                    xlNumberFormat = xlNumberFormat with { NumberFormatId = (Int32)numberFormatId.Value };
                 xlStyle.NumberFormat = xlNumberFormat;
             }
         }

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -227,6 +227,24 @@ namespace ClosedXML.Utils
 
 #nullable enable
 
+        public static XLAlignmentKey AlignmentToClosedXml(Alignment alignment, XLAlignmentKey defaultAlignment)
+        {
+            return new XLAlignmentKey
+            {
+                Indent = checked((int?)alignment.Indent?.Value) ?? defaultAlignment.Indent,
+                Horizontal = alignment.Horizontal?.Value.ToClosedXml() ?? defaultAlignment.Horizontal,
+                Vertical = alignment.Vertical?.Value.ToClosedXml() ?? defaultAlignment.Vertical,
+                ReadingOrder = alignment.ReadingOrder?.Value.ToClosedXml() ?? defaultAlignment.ReadingOrder,
+                WrapText = alignment.WrapText?.Value ?? defaultAlignment.WrapText,
+                TextRotation = alignment.TextRotation is not null
+                    ? OpenXmlHelper.GetClosedXmlTextRotation(alignment)
+                    : defaultAlignment.TextRotation,
+                ShrinkToFit = alignment.ShrinkToFit?.Value ?? defaultAlignment.ShrinkToFit,
+                RelativeIndent = alignment.RelativeIndent?.Value ?? defaultAlignment.RelativeIndent,
+                JustifyLastLine = alignment.JustifyLastLine?.Value ?? defaultAlignment.JustifyLastLine,
+            };
+        }
+
         #endregion Public Methods
 
         #region Private Methods


### PR DESCRIPTION
First part of conversion of mutable style key structures to readonly structures, because mutable structs are generally evil (defensive copying around). Will use `readonly record struct`.
The `readonly record struct` operator `with` also nicely aligns with the modification method.