### PR TITLE
Convert XLBorderKey, XLFillKey, XLFontKey and XLProtectionKey to readonly structs 

### DIFF
--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <LangVersion>11.0</LangVersion>
     <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -5,12 +5,14 @@ namespace ClosedXML.Tests.Excel.Styles
 {
     public class FontTests
     {
+        private readonly XLFontKey _defaultKey = XLFontValue.Default.Key;
+
         [Test]
         public void XLFontKey_GetHashCode_IsCaseInsensitive()
         {
-            var fontKey1 = new XLFontKey { FontName = "Arial" };
-            var fontKey2 = new XLFontKey { FontName = "Times New Roman" };
-            var fontKey3 = new XLFontKey { FontName = "TIMES NEW ROMAN" };
+            var fontKey1 = _defaultKey with { FontName = "Arial" };
+            var fontKey2 = _defaultKey with { FontName = "Times New Roman" };
+            var fontKey3 = _defaultKey with { FontName = "TIMES NEW ROMAN" };
 
             Assert.AreNotEqual(fontKey1.GetHashCode(), fontKey2.GetHashCode());
             Assert.AreEqual(fontKey2.GetHashCode(), fontKey3.GetHashCode());
@@ -19,9 +21,9 @@ namespace ClosedXML.Tests.Excel.Styles
         [Test]
         public void XLFontKey_Equals_IsCaseInsensitive()
         {
-            var fontKey1 = new XLFontKey { FontName = "Arial" };
-            var fontKey2 = new XLFontKey { FontName = "Times New Roman" };
-            var fontKey3 = new XLFontKey { FontName = "TIMES NEW ROMAN" };
+            var fontKey1 = _defaultKey with { FontName = "Arial" };
+            var fontKey2 = _defaultKey with { FontName = "Times New Roman" };
+            var fontKey3 = _defaultKey with { FontName = "TIMES NEW ROMAN" };
 
             Assert.IsFalse(fontKey1.Equals(fontKey2));
             Assert.IsTrue(fontKey2.Equals(fontKey3));

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -54,5 +54,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -630,56 +630,12 @@ namespace ClosedXML.Excel.IO
             return border;
         }
 
-        private static bool BordersAreEqual(Border b, XLBorderValue xlBorder)
+        private static bool BordersAreEqual(Border border, XLBorderValue xlBorder)
         {
-            var nb = XLBorderValue.Default.Key;
-            if (b.DiagonalUp != null)
-                nb.DiagonalUp = b.DiagonalUp.Value;
-
-            if (b.DiagonalDown != null)
-                nb.DiagonalDown = b.DiagonalDown.Value;
-
-            if (b.DiagonalBorder != null)
-            {
-                if (b.DiagonalBorder.Style != null)
-                    nb.DiagonalBorder = b.DiagonalBorder.Style.Value.ToClosedXml();
-                if (b.DiagonalBorder.Color != null)
-                    nb.DiagonalBorderColor = b.DiagonalBorder.Color.ToClosedXMLColor().Key;
-            }
-
-            if (b.LeftBorder != null)
-            {
-                if (b.LeftBorder.Style != null)
-                    nb.LeftBorder = b.LeftBorder.Style.Value.ToClosedXml();
-                if (b.LeftBorder.Color != null)
-                    nb.LeftBorderColor = b.LeftBorder.Color.ToClosedXMLColor().Key;
-            }
-
-            if (b.RightBorder != null)
-            {
-                if (b.RightBorder.Style != null)
-                    nb.RightBorder = b.RightBorder.Style.Value.ToClosedXml();
-                if (b.RightBorder.Color != null)
-                    nb.RightBorderColor = b.RightBorder.Color.ToClosedXMLColor().Key;
-            }
-
-            if (b.TopBorder != null)
-            {
-                if (b.TopBorder.Style != null)
-                    nb.TopBorder = b.TopBorder.Style.Value.ToClosedXml();
-                if (b.TopBorder.Color != null)
-                    nb.TopBorderColor = b.TopBorder.Color.ToClosedXMLColor().Key;
-            }
-
-            if (b.BottomBorder != null)
-            {
-                if (b.BottomBorder.Style != null)
-                    nb.BottomBorder = b.BottomBorder.Style.Value.ToClosedXml();
-                if (b.BottomBorder.Color != null)
-                    nb.BottomBorderColor = b.BottomBorder.Color.ToClosedXMLColor().Key;
-            }
-
-            return nb.Equals(xlBorder.Key);
+            var convertedBorder = OpenXmlHelper.BorderToClosedXml(
+                border,
+                XLBorderValue.Default.Key);
+            return convertedBorder.Equals(xlBorder.Key);
         }
 
         private static Dictionary<XLFillValue, FillInfo> ResolveFills(WorkbookStylesPart workbookStylesPart,

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -857,38 +857,12 @@ namespace ClosedXML.Excel.IO
             return font;
         }
 
-        private static bool FontsAreEqual(Font f, XLFontValue xlFont)
+        private static bool FontsAreEqual(Font font, XLFontValue xlFont)
         {
-            var nf = XLFontValue.Default.Key;
-            nf.Bold = f.Bold != null;
-            nf.Italic = f.Italic != null;
-
-            if (f.Underline != null)
-            {
-                nf.Underline = f.Underline.Val != null
-                    ? f.Underline.Val.Value.ToClosedXml()
-                    : XLFontUnderlineValues.Single;
-            }
-            nf.Strikethrough = f.Strike != null;
-            if (f.VerticalTextAlignment != null)
-            {
-                nf.VerticalAlignment = f.VerticalTextAlignment.Val != null
-                    ? f.VerticalTextAlignment.Val.Value.ToClosedXml()
-                    : XLFontVerticalTextAlignmentValues.Baseline;
-            }
-            nf.Shadow = f.Shadow != null;
-            if (f.FontSize != null)
-                nf.FontSize = f.FontSize.Val;
-            if (f.Color != null)
-                nf.FontColor = f.Color.ToClosedXMLColor().Key;
-            if (f.FontName != null)
-                nf.FontName = f.FontName.Val;
-            if (f.FontFamilyNumbering != null)
-                nf.FontFamilyNumbering = (XLFontFamilyNumberingValues)f.FontFamilyNumbering.Val.Value;
-            if (f.FontScheme?.Val != null)
-                nf.FontScheme = f.FontScheme.Val.Value.ToClosedXml();
-
-            return nf.Equals(xlFont.Key);
+            var convertedFont = OpenXmlHelper.FontToClosedXml(
+                font,
+                XLFontValue.Default.Key);
+            return convertedFont.Equals(xlFont.Key);
         }
 
         private static Dictionary<XLNumberFormatValue, NumberFormatInfo> ResolveNumberFormats(

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -502,12 +502,13 @@ namespace ClosedXML.Excel.IO
         private static bool ProtectionsAreEqual(Protection protection, XLProtectionValue xlProtection)
         {
             var p = XLProtectionValue.Default.Key;
-            if (protection != null)
+            if (protection is not null)
             {
-                if (protection.Locked != null)
-                    p.Locked = protection.Locked.Value;
-                if (protection.Hidden != null)
-                    p.Hidden = protection.Hidden.Value;
+                if (protection.Locked is not null)
+                    p = p with { Locked = protection.Locked.Value };
+
+                if (protection.Hidden is not null)
+                    p = p with { Hidden = protection.Hidden.Value };
             }
             return p.Equals(xlProtection.Key);
         }

--- a/ClosedXML/Excel/Style/XLBorder.cs
+++ b/ClosedXML/Excel/Style/XLBorder.cs
@@ -92,13 +92,12 @@ namespace ClosedXML.Excel
 
                 if (_container is XLWorksheet || _container is XLConditionalFormat)
                 {
-                    Modify(k =>
+                    Modify(k => k with
                     {
-                        k.TopBorder =
-                        k.BottomBorder =
-                        k.LeftBorder =
-                        k.RightBorder = value;
-                        return k;
+                        TopBorder = value,
+                        BottomBorder = value,
+                        LeftBorder = value,
+                        RightBorder = value,
                     });
                 }
                 else
@@ -122,13 +121,12 @@ namespace ClosedXML.Excel
 
                 if (_container is XLWorksheet || _container is XLConditionalFormat)
                 {
-                    Modify(k =>
+                    Modify(k => k with
                     {
-                        k.TopBorderColor =
-                        k.BottomBorderColor =
-                        k.LeftBorderColor =
-                        k.RightBorderColor = value.Key;
-                        return k;
+                        TopBorderColor = value.Key,
+                        BottomBorderColor = value.Key,
+                        LeftBorderColor = value.Key,
+                        RightBorderColor = value.Key,
                     });
                 }
                 else
@@ -153,13 +151,12 @@ namespace ClosedXML.Excel
                 var wsContainer = _container as XLWorksheet;
                 if (wsContainer != null)
                 {
-                    Modify(k =>
+                    Modify(k => k with
                     {
-                        k.TopBorder =
-                        k.BottomBorder =
-                        k.LeftBorder =
-                        k.RightBorder = value;
-                        return k;
+                        TopBorder = value,
+                        BottomBorder = value,
+                        LeftBorder = value,
+                        RightBorder = value,
                     });
                 }
                 else
@@ -171,13 +168,12 @@ namespace ClosedXML.Excel
                             foreach (var cell in r.Cells())
                             {
                                 (cell.Style.Border as XLBorder)
-                                    .Modify(k =>
+                                    .Modify(k => k with
                                     {
-                                        k.TopBorder =
-                                        k.BottomBorder =
-                                        k.LeftBorder =
-                                        k.RightBorder = value;
-                                        return k;
+                                        TopBorder = value,
+                                        BottomBorder = value,
+                                        LeftBorder = value,
+                                        RightBorder = value,
                                     });
                             }
                         }
@@ -195,13 +191,12 @@ namespace ClosedXML.Excel
                 var wsContainer = _container as XLWorksheet;
                 if (wsContainer != null)
                 {
-                    Modify(k =>
+                    Modify(k => k with
                     {
-                        k.TopBorderColor =
-                        k.BottomBorderColor =
-                        k.LeftBorderColor =
-                        k.RightBorderColor = value.Key;
-                        return k;
+                        TopBorderColor = value.Key,
+                        BottomBorderColor = value.Key,
+                        LeftBorderColor = value.Key,
+                        RightBorderColor = value.Key,
                     });
                 }
                 else
@@ -213,13 +208,12 @@ namespace ClosedXML.Excel
                             foreach (var cell in r.Cells())
                             {
                                 (cell.Style.Border as XLBorder)
-                                    .Modify(k =>
+                                    .Modify(k => k with
                                     {
-                                        k.TopBorderColor =
-                                        k.BottomBorderColor =
-                                        k.LeftBorderColor =
-                                        k.RightBorderColor = value.Key;
-                                        return k;
+                                        TopBorderColor = value.Key,
+                                        BottomBorderColor = value.Key,
+                                        LeftBorderColor = value.Key,
+                                        RightBorderColor = value.Key,
                                     });
                             }
                         }
@@ -231,7 +225,7 @@ namespace ClosedXML.Excel
         public XLBorderStyleValues LeftBorder
         {
             get { return Key.LeftBorder; }
-            set { Modify(k => { k.LeftBorder = value; return k; }); }
+            set { Modify(k => k with { LeftBorder = value }); }
         }
 
         public XLColor LeftBorderColor
@@ -246,14 +240,14 @@ namespace ClosedXML.Excel
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
 
-                Modify(k => { k.LeftBorderColor = value.Key; return k; });
+                Modify(k => k with { LeftBorderColor = value.Key });
             }
         }
 
         public XLBorderStyleValues RightBorder
         {
             get { return Key.RightBorder; }
-            set { Modify(k => { k.RightBorder = value; return k; }); }
+            set { Modify(k => k with { RightBorder = value }); }
         }
 
         public XLColor RightBorderColor
@@ -268,14 +262,14 @@ namespace ClosedXML.Excel
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
 
-                Modify(k => { k.RightBorderColor = value.Key; return k; });
+                Modify(k => k with { RightBorderColor = value.Key });
             }
         }
 
         public XLBorderStyleValues TopBorder
         {
             get { return Key.TopBorder; }
-            set { Modify(k => { k.TopBorder = value; return k; }); }
+            set { Modify(k => k with { TopBorder = value }); }
         }
 
         public XLColor TopBorderColor
@@ -290,14 +284,14 @@ namespace ClosedXML.Excel
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
 
-                Modify(k => { k.TopBorderColor = value.Key; return k; });
+                Modify(k => k with { TopBorderColor = value.Key });
             }
         }
 
         public XLBorderStyleValues BottomBorder
         {
             get { return Key.BottomBorder; }
-            set { Modify(k => { k.BottomBorder = value; return k; }); }
+            set { Modify(k => k with { BottomBorder = value }); }
         }
 
         public XLColor BottomBorderColor
@@ -312,14 +306,14 @@ namespace ClosedXML.Excel
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
 
-                Modify(k => { k.BottomBorderColor = value.Key; return k; });
+                Modify(k => k with { BottomBorderColor = value.Key });
             }
         }
 
         public XLBorderStyleValues DiagonalBorder
         {
             get { return Key.DiagonalBorder; }
-            set { Modify(k => { k.DiagonalBorder = value; return k; }); }
+            set { Modify(k => k with { DiagonalBorder = value }); }
         }
 
         public XLColor DiagonalBorderColor
@@ -334,20 +328,20 @@ namespace ClosedXML.Excel
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
 
-                Modify(k => { k.DiagonalBorderColor = value.Key; return k; });
+                Modify(k => k with { DiagonalBorderColor = value.Key });
             }
         }
 
         public Boolean DiagonalUp
         {
             get { return Key.DiagonalUp; }
-            set { Modify(k => { k.DiagonalUp = value; return k; }); }
+            set { Modify(k => k with { DiagonalUp = value }); }
         }
 
         public Boolean DiagonalDown
         {
             get { return Key.DiagonalDown; }
-            set { Modify(k => { k.DiagonalDown = value; return k; }); }
+            set { Modify(k => k with { DiagonalDown = value }); }
         }
 
         public IXLStyle SetOutsideBorder(XLBorderStyleValues value)
@@ -563,32 +557,28 @@ namespace ClosedXML.Excel
             private void DisposeManaged()
             {
                 _topBorders.ForEach(kp => (_range.FirstRow().Cell(kp.Key).Style
-                    .Border as XLBorder).Modify(k =>
+                    .Border as XLBorder).Modify(k => k with
                     {
-                        k.TopBorder = kp.Value.TopBorder;
-                        k.TopBorderColor = kp.Value.TopBorderColor;
-                        return k;
+                        TopBorder = kp.Value.TopBorder,
+                        TopBorderColor = kp.Value.TopBorderColor,
                     }));
                 _bottomBorders.ForEach(kp => (_range.LastRow().Cell(kp.Key).Style
-                    .Border as XLBorder).Modify(k =>
+                    .Border as XLBorder).Modify(k => k with
                     {
-                        k.BottomBorder = kp.Value.BottomBorder;
-                        k.BottomBorderColor = kp.Value.BottomBorderColor;
-                        return k;
+                        BottomBorder = kp.Value.BottomBorder,
+                        BottomBorderColor = kp.Value.BottomBorderColor,
                     }));
                 _leftBorders.ForEach(kp => (_range.FirstColumn().Cell(kp.Key).Style
-                    .Border as XLBorder).Modify(k =>
+                    .Border as XLBorder).Modify(k => k with
                     {
-                        k.LeftBorder = kp.Value.LeftBorder;
-                        k.LeftBorderColor = kp.Value.LeftBorderColor;
-                        return k;
+                        LeftBorder = kp.Value.LeftBorder,
+                        LeftBorderColor = kp.Value.LeftBorderColor,
                     }));
                 _rightBorders.ForEach(kp => (_range.LastColumn().Cell(kp.Key).Style
-                    .Border as XLBorder).Modify(k =>
+                    .Border as XLBorder).Modify(k => k with
                     {
-                        k.RightBorder = kp.Value.RightBorder;
-                        k.RightBorderColor = kp.Value.RightBorderColor;
-                        return k;
+                        RightBorder = kp.Value.RightBorder,
+                        RightBorderColor = kp.Value.RightBorderColor,
                     }));
             }
 

--- a/ClosedXML/Excel/Style/XLBorderKey.cs
+++ b/ClosedXML/Excel/Style/XLBorderKey.cs
@@ -1,99 +1,85 @@
-#nullable disable
-
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal readonly record struct XLBorderKey
 {
-    internal struct XLBorderKey : IEquatable<XLBorderKey>
+    public required XLBorderStyleValues LeftBorder { get; init; }
+
+    public required XLColorKey LeftBorderColor { get; init; }
+
+    public required XLBorderStyleValues RightBorder { get; init; }
+
+    public required XLColorKey RightBorderColor { get; init; }
+
+    public required XLBorderStyleValues TopBorder { get; init; }
+
+    public required XLColorKey TopBorderColor { get; init; }
+
+    public required XLBorderStyleValues BottomBorder { get; init; }
+
+    public required XLColorKey BottomBorderColor { get; init; }
+
+    public required XLBorderStyleValues DiagonalBorder { get; init; }
+
+    public required XLColorKey DiagonalBorderColor { get; init; }
+
+    public required bool DiagonalUp { get; init; }
+
+    public required bool DiagonalDown { get; init; }
+
+    public override int GetHashCode()
     {
-        public XLBorderStyleValues LeftBorder { get; set; }
+        var hash = new HashCode();
+        hash.Add(LeftBorder);
+        hash.Add(RightBorder);
+        hash.Add(TopBorder);
+        hash.Add(BottomBorder);
+        hash.Add(DiagonalBorder);
+        hash.Add(DiagonalUp);
+        hash.Add(DiagonalDown);
 
-        public XLColorKey LeftBorderColor { get; set; }
+        if (LeftBorder != XLBorderStyleValues.None)
+            hash.Add(LeftBorderColor);
+        if (RightBorder != XLBorderStyleValues.None)
+            hash.Add(RightBorderColor);
+        if (TopBorder != XLBorderStyleValues.None)
+            hash.Add(TopBorderColor);
+        if (BottomBorder != XLBorderStyleValues.None)
+            hash.Add(BottomBorderColor);
+        if (DiagonalBorder != XLBorderStyleValues.None)
+            hash.Add(DiagonalBorderColor);
 
-        public XLBorderStyleValues RightBorder { get; set; }
+        return hash.ToHashCode();
+    }
 
-        public XLColorKey RightBorderColor { get; set; }
+    public bool Equals(XLBorderKey other)
+    {
+        return
+            AreEquivalent(LeftBorder, LeftBorderColor, other.LeftBorder, other.LeftBorderColor)
+            && AreEquivalent(RightBorder, RightBorderColor, other.RightBorder, other.RightBorderColor)
+            && AreEquivalent(TopBorder, TopBorderColor, other.TopBorder, other.TopBorderColor)
+            && AreEquivalent(BottomBorder, BottomBorderColor, other.BottomBorder, other.BottomBorderColor)
+            && AreEquivalent(DiagonalBorder, DiagonalBorderColor, other.DiagonalBorder, other.DiagonalBorderColor)
+            && DiagonalUp == other.DiagonalUp
+            && DiagonalDown == other.DiagonalDown;
+    }
 
-        public XLBorderStyleValues TopBorder { get; set; }
+    private bool AreEquivalent(
+        XLBorderStyleValues borderStyle1, XLColorKey color1,
+        XLBorderStyleValues borderStyle2, XLColorKey color2)
+    {
+        return (borderStyle1 == XLBorderStyleValues.None &&
+                borderStyle2 == XLBorderStyleValues.None) ||
+               borderStyle1 == borderStyle2 &&
+               color1 == color2;
+    }
 
-        public XLColorKey TopBorderColor { get; set; }
-
-        public XLBorderStyleValues BottomBorder { get; set; }
-
-        public XLColorKey BottomBorderColor { get; set; }
-
-        public XLBorderStyleValues DiagonalBorder { get; set; }
-
-        public XLColorKey DiagonalBorderColor { get; set; }
-
-        public bool DiagonalUp { get; set; }
-
-        public bool DiagonalDown { get; set; }
-
-        public override int GetHashCode()
-        {
-            var hashCode = -198124310;
-            hashCode = hashCode * -1521134295 + (int)LeftBorder;
-            hashCode = hashCode * -1521134295 + (int)RightBorder;
-            hashCode = hashCode * -1521134295 + (int)TopBorder;
-            hashCode = hashCode * -1521134295 + (int)BottomBorder;
-            hashCode = hashCode * -1521134295 + (int)DiagonalBorder;
-            hashCode = hashCode * -1521134295 + DiagonalUp.GetHashCode();
-            hashCode = hashCode * -1521134295 + DiagonalDown.GetHashCode();
-
-            if (LeftBorder != XLBorderStyleValues.None)
-                hashCode = hashCode * -1521134295 + LeftBorderColor.GetHashCode();
-            if (RightBorder != XLBorderStyleValues.None)
-                hashCode = hashCode * -1521134295 + RightBorderColor.GetHashCode();
-            if (TopBorder != XLBorderStyleValues.None)
-                hashCode = hashCode * -1521134295 + TopBorderColor.GetHashCode();
-            if (BottomBorder != XLBorderStyleValues.None)
-                hashCode = hashCode * -1521134295 + BottomBorderColor.GetHashCode();
-            if (DiagonalBorder != XLBorderStyleValues.None)
-                hashCode = hashCode * -1521134295 + DiagonalBorderColor.GetHashCode();
-
-            return hashCode;
-        }
-
-        public bool Equals(XLBorderKey other)
-        {
-            return
-                   AreEquivalent(LeftBorder, LeftBorderColor, other.LeftBorder, other.LeftBorderColor)
-                && AreEquivalent(RightBorder, RightBorderColor, other.RightBorder, other.RightBorderColor)
-                && AreEquivalent(TopBorder, TopBorderColor, other.TopBorder, other.TopBorderColor)
-                && AreEquivalent(BottomBorder, BottomBorderColor, other.BottomBorder, other.BottomBorderColor)
-                && AreEquivalent(DiagonalBorder, DiagonalBorderColor, other.DiagonalBorder, other.DiagonalBorderColor)
-                && DiagonalUp == other.DiagonalUp
-                && DiagonalDown == other.DiagonalDown;
-        }
-
-        private bool AreEquivalent(
-            XLBorderStyleValues borderStyle1, XLColorKey color1,
-            XLBorderStyleValues borderStyle2, XLColorKey color2)
-        {
-            return (borderStyle1 == XLBorderStyleValues.None &&
-                    borderStyle2 == XLBorderStyleValues.None) ||
-                   borderStyle1 == borderStyle2 &&
-                   color1 == color2;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is XLBorderKey)
-                return Equals((XLBorderKey)obj);
-            return base.Equals(obj);
-        }
-
-        public override string ToString()
-        {
-            return $"{LeftBorder} {LeftBorderColor} {RightBorder} {RightBorderColor} {TopBorder} {TopBorderColor} " +
-                   $"{BottomBorder} {BottomBorderColor} {DiagonalBorder} {DiagonalBorderColor} " +
-                   (DiagonalUp ? "DiagonalUp" : "") +
-                   (DiagonalDown ? "DiagonalDown" : "");
-        }
-
-        public static bool operator ==(XLBorderKey left, XLBorderKey right) => left.Equals(right);
-
-        public static bool operator !=(XLBorderKey left, XLBorderKey right) => !(left.Equals(right));
+    public override string ToString()
+    {
+        return $"{LeftBorder} {LeftBorderColor} {RightBorder} {RightBorderColor} {TopBorder} {TopBorderColor} " +
+               $"{BottomBorder} {BottomBorderColor} {DiagonalBorder} {DiagonalBorderColor} " +
+               (DiagonalUp ? "DiagonalUp" : "") +
+               (DiagonalDown ? "DiagonalDown" : "");
     }
 }

--- a/ClosedXML/Excel/Style/XLFill.cs
+++ b/ClosedXML/Excel/Style/XLFill.cs
@@ -99,15 +99,14 @@ namespace ClosedXML.Excel
                     && XLColor.IsNullOrTransparent(BackgroundColor))
                 {
                     var patternType = value.HasValue ? XLFillPatternValues.Solid : XLFillPatternValues.None;
-                    Modify(k =>
+                    Modify(k => k with
                     {
-                        k.BackgroundColor = value.Key;
-                        k.PatternType = patternType;
-                        return k;
+                        BackgroundColor = value.Key,
+                        PatternType = patternType,
                     });
                 }
                 else
-                    Modify(k => { k.BackgroundColor = value.Key; return k; });
+                    Modify(k => k with { BackgroundColor = value.Key });
             }
         }
 
@@ -123,7 +122,7 @@ namespace ClosedXML.Excel
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
 
-                Modify(k => { k.PatternColor = value.Key; return k; });
+                Modify(k => k with { PatternColor = value.Key });
             }
         }
 
@@ -137,15 +136,14 @@ namespace ClosedXML.Excel
                 {
                     // If fill was empty and the pattern changes to non-empty we have to specify a background color too.
                     // Otherwise the fill will be considered empty and pattern won't update (the cached empty fill will be used).
-                    Modify(k =>
+                    Modify(k => k with
                     {
-                        k.BackgroundColor = XLColor.FromTheme(XLThemeColor.Text1).Key;
-                        k.PatternType = value;
-                        return k;
+                        BackgroundColor = XLColor.FromTheme(XLThemeColor.Text1).Key,
+                        PatternType = value,
                     });
                 }
                 else
-                    Modify(k => { k.PatternType = value; return k; });
+                    Modify(k => k with { PatternType = value });
             }
         }
 

--- a/ClosedXML/Excel/Style/XLFillKey.cs
+++ b/ClosedXML/Excel/Style/XLFillKey.cs
@@ -1,70 +1,56 @@
-#nullable disable
-
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal readonly record struct XLFillKey
 {
-    internal struct XLFillKey : IEquatable<XLFillKey>
+    public required XLColorKey BackgroundColor { get; init; }
+
+    public required XLColorKey PatternColor { get; init; }
+
+    public required XLFillPatternValues PatternType { get; init; }
+
+    public override int GetHashCode()
     {
-        public XLColorKey BackgroundColor { get; set; }
+        var hash = new HashCode();
 
-        public XLColorKey PatternColor { get; set; }
+        if (HasNoFill()) return hash.ToHashCode();
 
-        public XLFillPatternValues PatternType { get; set; }
+        hash.Add(PatternType);
+        hash.Add(BackgroundColor);
 
-        public override int GetHashCode()
-        {
-            var hashCode = 2043579837;
-
-            if (HasNoFill()) return hashCode;
-
-            hashCode = hashCode * -1521134295 + (int)PatternType;
-            hashCode = hashCode * -1521134295 + BackgroundColor.GetHashCode();
-
-            if (HasNoForeground()) return hashCode;
+        if (HasNoForeground()) return hash.ToHashCode();
                 
-            hashCode = hashCode * -1521134295 + PatternColor.GetHashCode();
+        hash.Add(PatternColor);
             
-            return hashCode;
-        }
+        return hash.ToHashCode();
+    }
 
-        public bool Equals(XLFillKey other)
-        {
-            if (HasNoFill() && other.HasNoFill())
-                return true;
+    public bool Equals(XLFillKey other)
+    {
+        if (HasNoFill() && other.HasNoFill())
+            return true;
 
-            return BackgroundColor == other.BackgroundColor
-                   && PatternType == other.PatternType
-                   && (HasNoForeground() && other.HasNoForeground() ||
-                       PatternColor == other.PatternColor);
-        }
+        return BackgroundColor == other.BackgroundColor
+               && PatternType == other.PatternType
+               && (HasNoForeground() && other.HasNoForeground() ||
+                   PatternColor == other.PatternColor);
+    }
 
-        private bool HasNoFill()
-        {
-            return PatternType == XLFillPatternValues.None
-                || (PatternType == XLFillPatternValues.Solid && XLColor.IsTransparent(BackgroundColor));
-        }
+    private bool HasNoFill()
+    {
+        return PatternType == XLFillPatternValues.None
+               || (PatternType == XLFillPatternValues.Solid && XLColor.IsTransparent(BackgroundColor));
+    }
 
-        private bool HasNoForeground()
-        {
-            return PatternType == XLFillPatternValues.Solid ||
-                   PatternType == XLFillPatternValues.None;
-        }
+    private bool HasNoForeground()
+    {
+        return PatternType == XLFillPatternValues.Solid ||
+               PatternType == XLFillPatternValues.None;
+    }
 
-        public override bool Equals(object obj)
-        {
-            if (obj is XLFillKey)
-                return Equals((XLFillKey)obj);
-            return base.Equals(obj);
-        }
-
-        public override string ToString()
-        {
-            return $"{PatternType} {BackgroundColor}/{PatternColor}";
-        }
-
-        public static bool operator ==(XLFillKey left, XLFillKey right) => left.Equals(right);
-
-        public static bool operator !=(XLFillKey left, XLFillKey right) => !(left.Equals(right));
+    public override string ToString()
+    {
+        return $"{PatternType} {BackgroundColor}/{PatternColor}";
     }
 }

--- a/ClosedXML/Excel/Style/XLFont.cs
+++ b/ClosedXML/Excel/Style/XLFont.cs
@@ -127,7 +127,7 @@ namespace ClosedXML.Excel
             get { return Key.Bold; }
             set
             {
-                Modify(k => { k.Bold = value; return k; });
+                Modify(k => k with { Bold = value });
             }
         }
 
@@ -136,7 +136,7 @@ namespace ClosedXML.Excel
             get { return Key.Italic; }
             set
             {
-                Modify(k => { k.Italic = value; return k; });
+                Modify(k => k with { Italic = value });
             }
         }
 
@@ -145,7 +145,7 @@ namespace ClosedXML.Excel
             get { return Key.Underline; }
             set
             {
-                Modify(k => { k.Underline = value; return k; });
+                Modify(k => k with { Underline = value });
             }
         }
 
@@ -154,7 +154,7 @@ namespace ClosedXML.Excel
             get { return Key.Strikethrough; }
             set
             {
-                Modify(k => { k.Strikethrough = value; return k; });
+                Modify(k => k with { Strikethrough = value });
             }
         }
 
@@ -163,7 +163,7 @@ namespace ClosedXML.Excel
             get { return Key.VerticalAlignment; }
             set
             {
-                Modify(k => { k.VerticalAlignment = value; return k; });
+                Modify(k => k with { VerticalAlignment = value });
             }
         }
 
@@ -172,7 +172,7 @@ namespace ClosedXML.Excel
             get { return Key.Shadow; }
             set
             {
-                Modify(k => { k.Shadow = value; return k; });
+                Modify(k => k with { Shadow = value });
             }
         }
 
@@ -181,7 +181,7 @@ namespace ClosedXML.Excel
             get { return Key.FontSize; }
             set
             {
-                Modify(k => { k.FontSize = value; return k; });
+                Modify(k => k with { FontSize = value });
             }
         }
 
@@ -196,7 +196,7 @@ namespace ClosedXML.Excel
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value), "Color cannot be null");
-                Modify(k => { k.FontColor = value.Key; return k; });
+                Modify(k => k with { FontColor = value.Key });
             }
         }
 
@@ -205,7 +205,7 @@ namespace ClosedXML.Excel
             get { return Key.FontName; }
             set
             {
-                Modify(k => { k.FontName = value; return k; });
+                Modify(k => k with { FontName = value });
             }
         }
 
@@ -214,7 +214,7 @@ namespace ClosedXML.Excel
             get { return Key.FontFamilyNumbering; }
             set
             {
-                Modify(k => { k.FontFamilyNumbering = value; return k; });
+                Modify(k => k with { FontFamilyNumbering = value });
             }
         }
 
@@ -223,7 +223,7 @@ namespace ClosedXML.Excel
             get { return Key.FontCharSet; }
             set
             {
-                Modify(k => { k.FontCharSet = value; return k; });
+                Modify(k => k with { FontCharSet = value });
             }
         }
 
@@ -232,7 +232,7 @@ namespace ClosedXML.Excel
             get { return Key.FontScheme; }
             set
             {
-                Modify(k => { k.FontScheme = value; return k; });
+                Modify(k => k with { FontScheme = value });
             }
         }
 

--- a/ClosedXML/Excel/Style/XLFontKey.cs
+++ b/ClosedXML/Excel/Style/XLFontKey.cs
@@ -1,85 +1,73 @@
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal readonly record struct XLFontKey
 {
-    internal struct XLFontKey : IEquatable<XLFontKey>
+    public bool Bold { get; init; }
+
+    public bool Italic { get; init; }
+
+    public XLFontUnderlineValues Underline { get; init; }
+
+    public bool Strikethrough { get; init; }
+
+    public XLFontVerticalTextAlignmentValues VerticalAlignment { get; init; }
+
+    public bool Shadow { get; init; }
+
+    public double FontSize { get; init; }
+
+    public XLColorKey FontColor { get; init; }
+
+    public string FontName { get; init; }
+
+    public XLFontFamilyNumberingValues FontFamilyNumbering { get; init; }
+
+    public XLFontCharSet FontCharSet { get; init; }
+
+    public XLFontScheme FontScheme { get; init; }
+
+    public bool Equals(XLFontKey other)
     {
-        public bool Bold { get; set; }
+        return
+            Bold == other.Bold
+            && Italic == other.Italic
+            && Underline == other.Underline
+            && Strikethrough == other.Strikethrough
+            && VerticalAlignment == other.VerticalAlignment
+            && Shadow == other.Shadow
+            && FontSize.Equals(other.FontSize)
+            && FontColor == other.FontColor
+            && FontFamilyNumbering == other.FontFamilyNumbering
+            && FontCharSet == other.FontCharSet
+            && FontScheme == other.FontScheme
+            && string.Equals(FontName, other.FontName, StringComparison.OrdinalIgnoreCase);
+    }
 
-        public bool Italic { get; set; }
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Bold);
+        hash.Add(Italic);
+        hash.Add(Underline);
+        hash.Add(Strikethrough);
+        hash.Add(VerticalAlignment);
+        hash.Add(Shadow);
+        hash.Add(FontSize);
+        hash.Add(FontColor);
+        hash.Add(FontName, StringComparer.OrdinalIgnoreCase);
+        hash.Add(FontFamilyNumbering);
+        hash.Add(FontCharSet);
+        hash.Add(FontScheme);
+        return hash.ToHashCode();
+    }
 
-        public XLFontUnderlineValues Underline { get; set; }
-
-        public bool Strikethrough { get; set; }
-
-        public XLFontVerticalTextAlignmentValues VerticalAlignment { get; set; }
-
-        public bool Shadow { get; set; }
-
-        public double FontSize { get; set; }
-
-        public XLColorKey FontColor { get; set; }
-
-        public string FontName { get; set; }
-
-        public XLFontFamilyNumberingValues FontFamilyNumbering { get; set; }
-
-        public XLFontCharSet FontCharSet { get; set; }
-
-        public XLFontScheme FontScheme { get; set; }
-
-        public bool Equals(XLFontKey other)
-        {
-            return
-                Bold == other.Bold
-             && Italic == other.Italic
-             && Underline == other.Underline
-             && Strikethrough == other.Strikethrough
-             && VerticalAlignment == other.VerticalAlignment
-             && Shadow == other.Shadow
-             && FontSize.Equals(other.FontSize)
-             && FontColor == other.FontColor
-             && FontFamilyNumbering == other.FontFamilyNumbering
-             && FontCharSet == other.FontCharSet
-             && FontScheme == other.FontScheme
-             && string.Equals(FontName, other.FontName, StringComparison.OrdinalIgnoreCase);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is XLFontKey)
-                return Equals((XLFontKey)obj);
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            var hashCode = 1158783753;
-            hashCode = hashCode * -1521134295 + Bold.GetHashCode();
-            hashCode = hashCode * -1521134295 + Italic.GetHashCode();
-            hashCode = hashCode * -1521134295 + (int)Underline;
-            hashCode = hashCode * -1521134295 + Strikethrough.GetHashCode();
-            hashCode = hashCode * -1521134295 + (int)VerticalAlignment;
-            hashCode = hashCode * -1521134295 + Shadow.GetHashCode();
-            hashCode = hashCode * -1521134295 + FontSize.GetHashCode();
-            hashCode = hashCode * -1521134295 + FontColor.GetHashCode();
-            hashCode = hashCode * -1521134295 + StringComparer.OrdinalIgnoreCase.GetHashCode(FontName);
-            hashCode = hashCode * -1521134295 + (int)FontFamilyNumbering;
-            hashCode = hashCode * -1521134295 + (int)FontCharSet;
-            hashCode = hashCode * -1521134295 + (int)FontScheme;
-            return hashCode;
-        }
-
-        public override string ToString()
-        {
-            return $"{FontName} {FontSize}pt {FontColor} " +
-                   (Bold ? "Bold" : "") + (Italic ? "Italic" : "") + (Strikethrough ? "Strikethrough" : "") +
-                   (Underline == XLFontUnderlineValues.None ? "" : Underline.ToString()) +
-                   $"{FontFamilyNumbering} {FontCharSet} {FontScheme}";
-        }
-
-        public static bool operator ==(XLFontKey left, XLFontKey right) => left.Equals(right);
-
-        public static bool operator !=(XLFontKey left, XLFontKey right) => !(left.Equals(right));
+    public override string ToString()
+    {
+        return $"{FontName} {FontSize}pt {FontColor} " +
+               (Bold ? "Bold" : "") + (Italic ? "Italic" : "") + (Strikethrough ? "Strikethrough" : "") +
+               (Underline == XLFontUnderlineValues.None ? "" : Underline.ToString()) +
+               $"{FontFamilyNumbering} {FontCharSet} {FontScheme}";
     }
 }

--- a/ClosedXML/Excel/Style/XLFontKey.cs
+++ b/ClosedXML/Excel/Style/XLFontKey.cs
@@ -4,29 +4,29 @@ namespace ClosedXML.Excel;
 
 internal readonly record struct XLFontKey
 {
-    public bool Bold { get; init; }
+    public required bool Bold { get; init; }
 
-    public bool Italic { get; init; }
+    public required bool Italic { get; init; }
 
-    public XLFontUnderlineValues Underline { get; init; }
+    public required XLFontUnderlineValues Underline { get; init; }
 
-    public bool Strikethrough { get; init; }
+    public required bool Strikethrough { get; init; }
 
-    public XLFontVerticalTextAlignmentValues VerticalAlignment { get; init; }
+    public required XLFontVerticalTextAlignmentValues VerticalAlignment { get; init; }
 
-    public bool Shadow { get; init; }
+    public required bool Shadow { get; init; }
 
-    public double FontSize { get; init; }
+    public required double FontSize { get; init; }
 
-    public XLColorKey FontColor { get; init; }
+    public required XLColorKey FontColor { get; init; }
 
-    public string FontName { get; init; }
+    public required string FontName { get; init; }
 
-    public XLFontFamilyNumberingValues FontFamilyNumbering { get; init; }
+    public required XLFontFamilyNumberingValues FontFamilyNumbering { get; init; }
 
-    public XLFontCharSet FontCharSet { get; init; }
+    public required XLFontCharSet FontCharSet { get; init; }
 
-    public XLFontScheme FontScheme { get; init; }
+    public required XLFontScheme FontScheme { get; init; }
 
     public bool Equals(XLFontKey other)
     {

--- a/ClosedXML/Excel/Style/XLFontValue.cs
+++ b/ClosedXML/Excel/Style/XLFontValue.cs
@@ -21,6 +21,7 @@ namespace ClosedXML.Excel
             Underline = XLFontUnderlineValues.None,
             Strikethrough = false,
             VerticalAlignment = XLFontVerticalTextAlignmentValues.Baseline,
+            Shadow = false,
             FontSize = 11,
             FontColor = XLColor.FromArgb(0, 0, 0).Key,
             FontName = "Calibri",

--- a/ClosedXML/Excel/Style/XLProtection.cs
+++ b/ClosedXML/Excel/Style/XLProtection.cs
@@ -66,7 +66,7 @@ namespace ClosedXML.Excel
             get { return Key.Locked; }
             set
             {
-                Modify(k => { k.Locked = value; return k; });
+                Modify(k => k with { Locked = value });
             }
         }
 
@@ -75,7 +75,7 @@ namespace ClosedXML.Excel
             get { return Key.Hidden; }
             set
             {
-                Modify(k => { k.Hidden = value; return k; });
+                Modify(k => k with { Hidden = value });
             }
         }
 

--- a/ClosedXML/Excel/Style/XLProtectionKey.cs
+++ b/ClosedXML/Excel/Style/XLProtectionKey.cs
@@ -1,44 +1,13 @@
-#nullable disable
+namespace ClosedXML.Excel;
 
-using System;
-
-namespace ClosedXML.Excel
+internal readonly record struct XLProtectionKey
 {
-    internal struct XLProtectionKey : IEquatable<XLProtectionKey>
+    public required bool Locked { get; init; }
+
+    public required bool Hidden { get; init; }
+
+    public override string ToString()
     {
-        public bool Locked { get; set; }
-
-        public bool Hidden { get; set; }
-
-        public override int GetHashCode()
-        {
-            var hashCode = -1357408252;
-            hashCode = hashCode * -1521134295 + Locked.GetHashCode();
-            hashCode = hashCode * -1521134295 + Hidden.GetHashCode();
-            return hashCode;
-        }
-
-        public bool Equals(XLProtectionKey other)
-        {
-            return
-                Locked == other.Locked
-             && Hidden == other.Hidden;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is XLProtectionKey)
-                return Equals((XLProtectionKey)obj);
-            return base.Equals(obj);
-        }
-
-        public override string ToString()
-        {
-            return (Locked ? "Locked" : "") + (Hidden ? "Hidden" : "");
-        }
-
-        public static bool operator ==(XLProtectionKey left, XLProtectionKey right) => left.Equals(right);
-
-        public static bool operator !=(XLProtectionKey left, XLProtectionKey right) => !(left.Equals(right));
+        return (Locked ? "Locked" : "") + (Hidden ? "Hidden" : "");
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2610,57 +2610,9 @@ namespace ClosedXML.Excel
             {
                 var fontId = cellFormat.FontId;
                 var font = (DocumentFormat.OpenXml.Spreadsheet.Font)fonts.ElementAt((Int32)fontId.Value);
-
-                var xlFont = xlStyle.Font;
-                if (font != null)
+                if (font is not null)
                 {
-                    xlFont.Bold = OpenXmlHelper.GetBoolean(font.Bold);
-
-                    if (font.Color != null)
-                        xlFont.FontColor = font.Color.ToClosedXMLColor().Key;
-
-                    if (font.FontFamilyNumbering != null && (font.FontFamilyNumbering).Val != null)
-                    {
-                        xlFont.FontFamilyNumbering =
-                            (XLFontFamilyNumberingValues)Int32.Parse((font.FontFamilyNumbering).Val.ToString());
-                    }
-                    if (font.FontName != null)
-                    {
-                        if ((font.FontName).Val != null)
-                            xlFont.FontName = (font.FontName).Val;
-                    }
-                    if (font.FontSize != null)
-                    {
-                        if ((font.FontSize).Val != null)
-                            xlFont.FontSize = (font.FontSize).Val;
-                    }
-
-                    xlFont.Italic = OpenXmlHelper.GetBoolean(font.Italic);
-                    xlFont.Shadow = OpenXmlHelper.GetBoolean(font.Shadow);
-                    xlFont.Strikethrough = OpenXmlHelper.GetBoolean(font.Strike);
-
-                    if (font.Underline != null)
-                    {
-                        xlFont.Underline = font.Underline.Val != null
-                                            ? (font.Underline).Val.Value.ToClosedXml()
-                                            : XLFontUnderlineValues.Single;
-                    }
-
-                    if (font.VerticalTextAlignment != null)
-                    {
-                        xlFont.VerticalAlignment = font.VerticalTextAlignment.Val != null
-                                                    ? (font.VerticalTextAlignment).Val.Value.ToClosedXml()
-                                                    : XLFontVerticalTextAlignmentValues.Baseline;
-                    }
-
-                    if (font.FontScheme is not null)
-                    {
-                        xlFont.FontScheme = font.FontScheme.Val is not null
-                            ? font.FontScheme.Val.Value.ToClosedXml()
-                            : XLFontScheme.None;
-                    }
-
-                    xlStyle.Font = xlFont;
+                    xlStyle.Font = OpenXmlHelper.FontToClosedXml(font, xlStyle.Font);
                 }
             }
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2600,56 +2600,9 @@ namespace ClosedXML.Excel
             {
                 uint borderId = cellFormat.BorderId.Value;
                 var border = (Border)borders.ElementAt((Int32)borderId);
-                var xlBorder = xlStyle.Border;
-                if (border != null)
+                if (border is not null)
                 {
-                    var bottomBorder = border.BottomBorder;
-                    if (bottomBorder != null)
-                    {
-                        if (bottomBorder.Style != null)
-                            xlBorder.BottomBorder = bottomBorder.Style.Value.ToClosedXml();
-
-                        if (bottomBorder.Color != null)
-                            xlBorder.BottomBorderColor = bottomBorder.Color.ToClosedXMLColor().Key;
-                    }
-                    var topBorder = border.TopBorder;
-                    if (topBorder != null)
-                    {
-                        if (topBorder.Style != null)
-                            xlBorder.TopBorder = topBorder.Style.Value.ToClosedXml();
-                        if (topBorder.Color != null)
-                            xlBorder.TopBorderColor = topBorder.Color.ToClosedXMLColor().Key;
-                    }
-                    var leftBorder = border.LeftBorder;
-                    if (leftBorder != null)
-                    {
-                        if (leftBorder.Style != null)
-                            xlBorder.LeftBorder = leftBorder.Style.Value.ToClosedXml();
-                        if (leftBorder.Color != null)
-                            xlBorder.LeftBorderColor = leftBorder.Color.ToClosedXMLColor().Key;
-                    }
-                    var rightBorder = border.RightBorder;
-                    if (rightBorder != null)
-                    {
-                        if (rightBorder.Style != null)
-                            xlBorder.RightBorder = rightBorder.Style.Value.ToClosedXml();
-                        if (rightBorder.Color != null)
-                            xlBorder.RightBorderColor = rightBorder.Color.ToClosedXMLColor().Key;
-                    }
-                    var diagonalBorder = border.DiagonalBorder;
-                    if (diagonalBorder != null)
-                    {
-                        if (diagonalBorder.Style != null)
-                            xlBorder.DiagonalBorder = diagonalBorder.Style.Value.ToClosedXml();
-                        if (diagonalBorder.Color != null)
-                            xlBorder.DiagonalBorderColor = diagonalBorder.Color.ToClosedXMLColor().Key;
-                        if (border.DiagonalDown != null)
-                            xlBorder.DiagonalDown = border.DiagonalDown;
-                        if (border.DiagonalUp != null)
-                            xlBorder.DiagonalUp = border.DiagonalUp;
-                    }
-
-                    xlStyle.Border = xlBorder;
+                    xlStyle.Border = OpenXmlHelper.BorderToClosedXml(border, xlStyle.Border);
                 }
             }
 

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -245,6 +245,62 @@ namespace ClosedXML.Utils
             };
         }
 
+        public static XLBorderKey BorderToClosedXml(Border b, XLBorderKey defaultBorder)
+        {
+            var nb = defaultBorder;
+
+            var diagonalBorder = b.DiagonalBorder;
+            if (diagonalBorder is not null)
+            {
+                if (diagonalBorder.Style is not null)
+                    nb = nb with { DiagonalBorder = diagonalBorder.Style.Value.ToClosedXml() };
+                if (diagonalBorder.Color is not null)
+                    nb = nb with { DiagonalBorderColor = diagonalBorder.Color.ToClosedXMLColor().Key };
+                if (b.DiagonalUp is not null)
+                    nb = nb with { DiagonalUp = b.DiagonalUp.Value };
+                if (b.DiagonalDown is not null)
+                    nb = nb with { DiagonalDown = b.DiagonalDown.Value };
+            }
+
+            var leftBorder = b.LeftBorder;
+            if (leftBorder is not null)
+            {
+                if (leftBorder.Style is not null)
+                    nb = nb with { LeftBorder = leftBorder.Style.Value.ToClosedXml() };
+                if (leftBorder.Color is not null)
+                    nb = nb with { LeftBorderColor = leftBorder.Color.ToClosedXMLColor().Key };
+            }
+
+            var rightBorder = b.RightBorder;
+            if (rightBorder is not null)
+            {
+                if (rightBorder.Style is not null)
+                    nb = nb with { RightBorder = rightBorder.Style.Value.ToClosedXml() };
+                if (rightBorder.Color is not null)
+                    nb = nb with { RightBorderColor = rightBorder.Color.ToClosedXMLColor().Key };
+            }
+
+            var topBorder = b.TopBorder;
+            if (topBorder is not null)
+            {
+                if (topBorder.Style is not null)
+                    nb = nb with { TopBorder = topBorder.Style.Value.ToClosedXml() };
+                if (topBorder.Color is not null)
+                    nb = nb with { TopBorderColor = topBorder.Color.ToClosedXMLColor().Key };
+            }
+
+            var bottomBorder = b.BottomBorder;
+            if (bottomBorder is not null)
+            {
+                if (bottomBorder.Style is not null)
+                    nb = nb with { BottomBorder = bottomBorder.Style.Value.ToClosedXml() };
+                if (bottomBorder.Color is not null)
+                    nb = nb with { BottomBorderColor = bottomBorder.Color.ToClosedXMLColor().Key };
+            }
+
+            return nb;
+        }
+
         #endregion Public Methods
 
         #region Private Methods

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -301,6 +301,59 @@ namespace ClosedXML.Utils
             return nb;
         }
 
+        public static XLFontKey FontToClosedXml(Font f, XLFontKey nf)
+        {
+            nf = nf with
+            {
+                Bold = GetBoolean(f.Bold),
+                Italic = GetBoolean(f.Italic),
+                Shadow = GetBoolean(f.Shadow),
+                Strikethrough = GetBoolean(f.Strike),
+            };
+
+            var underline = f.Underline;
+            if (underline is not null)
+            {
+                var value = underline.Val?.Value.ToClosedXml() ??
+                            XLFontUnderlineValues.Single;
+                nf = nf with { Underline = value };
+            }
+
+            var verticalTextAlignment = f.VerticalTextAlignment;
+            if (verticalTextAlignment is not null)
+            {
+                var value = verticalTextAlignment.Val?.Value.ToClosedXml() ??
+                            XLFontVerticalTextAlignmentValues.Baseline;
+                nf = nf with { VerticalAlignment = value };
+            }
+
+            var fontSize = f.FontSize?.Val;
+            if (fontSize is not null)
+                nf = nf with { FontSize = fontSize.Value };
+
+            var color = f.Color;
+            if (color is not null)
+                nf = nf with { FontColor = color.ToClosedXMLColor().Key };
+
+            var fontName = f.FontName?.Val?.Value ?? string.Empty;
+            if (!string.IsNullOrEmpty(fontName))
+                nf = nf with { FontName = fontName };
+
+            var fontFamilyNumbering = f.FontFamilyNumbering?.Val?.Value;
+            if (fontFamilyNumbering is not null)
+                nf = nf with { FontFamilyNumbering = (XLFontFamilyNumberingValues)fontFamilyNumbering };
+
+            var fontCharSet = f.FontCharSet?.Val?.Value;
+            if (fontCharSet is not null)
+                nf = nf with { FontCharSet = (XLFontCharSet)fontCharSet };
+
+            var fontScheme = f.FontScheme;
+            if (fontScheme is not null)
+                nf = nf with { FontScheme = fontScheme?.Val?.Value.ToClosedXml() ?? XLFontScheme.None };
+
+            return nf;
+        }
+
         #endregion Public Methods
 
         #region Private Methods


### PR DESCRIPTION
Convert style key structures to immutable structs. Same reasons as in #2364.