### PR TITLE
Correctly load quoted and unquoted sheet names in print area definitions

### DIFF
--- a/ClosedXML.Tests/Excel/PageSetup/PrintAreaTests.cs
+++ b/ClosedXML.Tests/Excel/PageSetup/PrintAreaTests.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using System.Linq;
+
+namespace ClosedXML.Tests.Excel
+{
+    [TestFixture]
+    public class PrintAreaTests
+    {
+        [Test]
+        [TestCase("A1:B2")]
+        [TestCase("A1:B2", "D3:D5")]
+        public void CanLoadWorksheetWithMultiplePrintAreas(params string[] printAreaRangeAddresses)
+        {
+            TestHelper.CreateSaveLoadAssert(
+                (_, ws) =>
+                {
+                    foreach (var printAreaRangeAddress in printAreaRangeAddresses)
+                        ws.PageSetup.PrintAreas.Add(printAreaRangeAddress);
+                },
+                (_, ws) =>
+                {
+                    var actualPrintAddresses = ws.PageSetup.PrintAreas.Select(pa => pa.RangeAddress.ToStringRelative());
+                    CollectionAssert.AreEqual(printAreaRangeAddresses, actualPrintAddresses);
+                });
+        }
+    }
+}

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1045,7 +1045,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        private static Regex definedNameRegex = new Regex(@"\A'.*'!.*\z", RegexOptions.Compiled);
+        private static Regex definedNameRegex = new Regex(@"\A('?).*\1!.*\z", RegexOptions.Compiled);
 
         private IEnumerable<String> validateDefinedNames(IEnumerable<String> definedNames)
         {


### PR DESCRIPTION
Fixes #1983 