### PR TITLE
Skip calculated fields in pivot table cache

### DIFF
--- a/ClosedXML/Excel/IO/PivotTableCacheDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableCacheDefinitionPartReader.cs
@@ -105,6 +105,13 @@ namespace ClosedXML.Excel.IO
                     continue;
                 }
 
+                if (cacheField.Formula is not null)
+                {
+                    // PivotCacheRecords will be missing any fields with formulas, though they will be in the cache fields.
+                    // Skip adding these to the cache
+                    continue;
+                }
+
                 var fieldStats = ReadCacheFieldStats(cacheField);
                 var fieldSharedItems = cacheField.SharedItems is not null
                     ? ReadSharedItems(cacheField)


### PR DESCRIPTION
Partial solution to #821. Can open workbooks now but calculated fields are still not supported. Previously would throw an exception saying:

> The column 'X' does not appear in the source range.
