### PR TITLE
Improve error message when adding a pivot value field

### DIFF
--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.PivotTables
+{
+    /// <summary>
+    /// Test methods of interface <see cref="IXLPivotValues"/> implemented through <see cref="XLPivotDataFields"/> class.
+    /// </summary>
+    internal class XLPivotDataFieldsTests
+    {
+        #region IXLPivotValues methods
+
+        #region Add
+
+        [Test]
+        public void Add_source_name_must_be_from_pivot_cache_field_names()
+        {
+            using var wb = new XLWorkbook();
+            var data = wb.AddWorksheet();
+            var range = data.Cell("A1").InsertData(new object[]
+            {
+                ("Name", "Price"),
+                ("Cake", 10),
+            });
+            var ptSheet = wb.AddWorksheet();
+            var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => pt.Values.Add("Wrong field name"));
+
+            Assert.NotNull(ex);
+            StringAssert.StartsWith("Field 'Wrong field name' is not in the fields of a pivot cache. Should be one of 'Name','Price'.", ex.Message);
+        }
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
@@ -4,6 +4,9 @@ using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.PivotTables
 {
+    /// <summary>
+    /// Tests methods of interface <see cref="IXLPivotField"/> implemented through <see cref="XLPivotTableAxisField"/>.
+    /// </summary>
     [TestFixture]
     internal class XLPivotTableAxisFieldTests
     {

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -6,6 +6,9 @@ using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.PivotTables
 {
+    /// <summary>
+    /// Test methods of interface <see cref="IXLPivotFields"/> implemented through <see cref="XLPivotTableAxis"/>.
+    /// </summary>
     [TestFixture]
     internal class XLPivotTableAxisTests
     {

--- a/ClosedXML/Excel/PivotTables/Areas/XLPivotDataFields.cs
+++ b/ClosedXML/Excel/PivotTables/Areas/XLPivotDataFields.cs
@@ -105,7 +105,10 @@ internal class XLPivotDataFields : IXLPivotValues, IReadOnlyCollection<XLPivotDa
     internal XLPivotDataField AddField(string sourceName, string? customName)
     {
         if (!_pivotTable.TryGetSourceNameFieldIndex(sourceName, out var fieldIndex))
-            throw new ArgumentOutOfRangeException($"Field '{sourceName}' is not in the pivot cache.");
+        {
+            var validNames = string.Join("','", _pivotTable.PivotCache.FieldNames);
+            throw new ArgumentOutOfRangeException(nameof(sourceName), $"Field '{sourceName}' is not in the fields of a pivot cache. Should be one of '{validNames}'.");
+        }
 
         if (fieldIndex.IsDataField)
             throw new ArgumentException("'Values' field can be used only on row or column axis.");

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotValueStyleFormat.cs
@@ -7,8 +7,8 @@ namespace ClosedXML.Excel;
 internal class XLPivotValueStyleFormat : XLPivotStyleFormatBase, IXLPivotValueStyleFormat
 {
     /// <summary>
-    /// A list of references that specify which data cells will be styles.
-    /// A data cell will be styles, if it lies on all referenced fields.
+    /// A list of references that specify which data cells will be styled.
+    /// A data cell will be styled, if it lies on all referenced fields.
     /// The term "lie on" means that either column or a row of data cell
     /// intersects a label cell of referenced field.
     /// </summary>


### PR DESCRIPTION
Improve error message of exception thrown by `IXLPivotValues.Add` method. When pivot cache doesn't contain field with passed name, it returns a message that includes a list of pivot cache field names.