### PR TITLE
Fix O(n^2) issue in pivot cache creation

### DIFF
--- a/ClosedXML/Excel/PivotTables/XLPivotCache.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotCache.cs
@@ -59,14 +59,8 @@ namespace ClosedXML.Excel
             for (var column = area.LeftColumn; column <= area.RightColumn; ++column)
             {
                 var header = sheet.Cell(area.TopRow, column).GetFormattedString();
-                var sharedItems = new XLPivotCacheSharedItems();
 
-                var fieldRecords = new XLPivotCacheValues(sharedItems, new List<XLPivotCacheValue>());
-                for (var row = area.TopRow + 1; row <= area.BottomRow; ++row)
-                {
-                    var value = valueSlice.GetCellValue(new XLSheetPoint(row, column));
-                    fieldRecords.Add(value);
-                }
+                var fieldRecords = new XLPivotCacheValues(valueSlice, column, area);
 
                 AddField(AdjustedFieldName(header), fieldRecords);
             }

--- a/ClosedXML/Excel/PivotTables/XLPivotCacheSharedItems.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotCacheSharedItems.cs
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel
         private readonly List<string> _stringStorage = new();
 
         /// <summary>
-        /// Strings in a pivot table are case insensitive.
+        /// Strings in a pivot table are case-insensitive.
         /// </summary>
         private readonly Dictionary<string, int> _stringMap = new(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Fixes #2402.

Creation should use index values instead of strings in pivot cache records (=the Excel way), but that is not something I want in 0.104.