### PR TITLE
Move IXLRangeBase.Hyperlinks to IXLWorksheet.Hyperlinks

### DIFF
--- a/ClosedXML.Examples/Misc/Hyperlinks.cs
+++ b/ClosedXML.Examples/Misc/Hyperlinks.cs
@@ -105,9 +105,6 @@ namespace ClosedXML.Examples.Misc
             // List all hyperlinks in a worksheet:
             var hyperlinksInWorksheet = ws.Hyperlinks;
 
-            // List all hyperlinks in a range:
-            var hyperlinksInRange = ws.Range("A1:A3").Hyperlinks;
-
             // Clearing a cell with a hyperlink
             ws.Cell(++ro, 1).Value = "ERROR!";
             ws.Cell(ro, 1).GetHyperlink().InternalAddress = "A1";

--- a/ClosedXML/Excel/IXLWorksheet.cs
+++ b/ClosedXML/Excel/IXLWorksheet.cs
@@ -47,6 +47,11 @@ namespace ClosedXML.Excel
         IXLOutline Outline { get; }
 
         /// <summary>
+        /// All hyperlinks in the sheet.
+        /// </summary>
+        IXLHyperlinks Hyperlinks { get; }
+
+        /// <summary>
         /// Gets the first row of the worksheet.
         /// </summary>
         IXLRow FirstRow();

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -53,8 +53,6 @@ namespace ClosedXML.Excel
         /// </value>
         Boolean ShareString { set; }
 
-        IXLHyperlinks Hyperlinks { get; }
-
         /// <summary>
         ///   Returns the collection of cells.
         /// </summary>

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -167,19 +167,6 @@ namespace ClosedXML.Excel
             set { Cells().ForEach(c => c.ShareString = value); }
         }
 
-        public IXLHyperlinks Hyperlinks
-        {
-            get
-            {
-                var hyperlinks = new XLHyperlinks();
-                var hls = from hl in Worksheet.Hyperlinks
-                          where RangeAddress.Contains(hl.Cell.Address)
-                          select hl;
-                hls.ForEach(hyperlinks.Add);
-                return hyperlinks;
-            }
-        }
-
         public XLCellValue Value
         {
             set { Cells().ForEach(c => c.Value = value); }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -647,7 +647,9 @@ namespace ClosedXML.Excel
             return targetSheet;
         }
 
-        public new IXLHyperlinks Hyperlinks { get; private set; }
+        internal XLHyperlinks Hyperlinks { get; }
+
+        IXLHyperlinks IXLWorksheet.Hyperlinks => Hyperlinks;
 
         IXLDataValidations IXLWorksheet.DataValidations
         {

--- a/docs/migrations/migrate-to-0.105.rst
+++ b/docs/migrations/migrate-to-0.105.rst
@@ -1,0 +1,11 @@
+#############################
+Migration from 0.104 to 0.105
+#############################
+
+***********************
+IXLRangeBase.Hyperlinks
+***********************
+
+Property ```IXLRangeBase.Hyperlinks``` has been moved to ```IXLWorksheet.Hyperlinks```.
+The original place could only list hyperlinks and didn't provide correct
+functionality (e.g. removal of hyperlinks).


### PR DESCRIPTION
The implementation in in `XLRangeBase` didn't provide correct functionality (e.g. removal of hyperlinks). It only modified ad-hoc created `IXLHyperlinks` collection with no relationship to worksheet hyperlinks (i.e. that worksheet hyperlinks collection was unmodifed).

Instead of fixing broken property, just move source of truth where it belongs and the only place where it worked, i.e. to `IXLWorksheet`.

Related to #2400.