### PR TITLE
Remove unused hyperlink prop from misc slice

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -291,7 +291,7 @@ namespace ClosedXML.Excel
         /// <remarks>Shortcut for <c>Value.GetNumber()</c></remarks>
         /// <exception cref="InvalidCastException">If the value of the cell is not a number.</exception>
         Double GetDouble();
-        
+
         /// <summary>
         /// Gets the cell's value as a String.
         /// </summary>
@@ -376,7 +376,7 @@ namespace ClosedXML.Excel
         /// Returns the value of the cell if it formatted as a rich text.
         /// </summary>
         IXLRichText GetRichText();
-        
+
         IXLCells InsertCellsAbove(int numberOfRows);
 
         IXLCells InsertCellsAfter(int numberOfColumns);
@@ -502,7 +502,22 @@ namespace ClosedXML.Excel
 
         IXLCell SetFormulaR1C1(String formula);
 
-        void SetHyperlink(XLHyperlink hyperlink);
+#nullable enable
+        /// <summary>
+        /// Set hyperlink of a cell. When user clicks on a cell with hyperlink,
+        /// the Excel opens the target or moves cursor to the target cells in a
+        /// worksheet. The text of hyperlink is a cell value, the hyperlink
+        /// target and tooltip are defined by the <paramref name="hyperlink"/>
+        /// parameter.
+        /// </summary>
+        /// <remarks>
+        /// If the cell uses worksheet style, the method also sets <see cref="XLThemeColor.Hyperlink">
+        /// hyperlink font color from theme</see> and the underline property.
+        /// </remarks>
+        /// <param name="hyperlink">The new cell hyperlink. Use <c>null</c> to
+        ///   remove the hyperlink.</param>
+        void SetHyperlink(XLHyperlink? hyperlink);
+#nullable disable
 
         /// <inheritdoc cref="Value"/>
         /// <returns>This cell.</returns>

--- a/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
+++ b/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
@@ -10,8 +10,6 @@
 
         internal uint? ValueMetaIndex { get; set; }
 
-        internal bool SettingHyperlink { get; set; }
-
         internal bool HasPhonetic { get; set; }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2294,16 +2294,12 @@ namespace ClosedXML.Excel
                 var xlRange = ws.Range(hl.Reference.Value);
                 foreach (XLCell xlCell in xlRange.Cells())
                 {
-                    xlCell.SettingHyperlink = true;
-
                     if (hl.Id != null)
-                        xlCell.SetHyperlink(new XLHyperlink(hyperlinkDictionary[hl.Id], tooltip));
+                        xlCell.SetCellHyperlink(new XLHyperlink(hyperlinkDictionary[hl.Id], tooltip));
                     else if (hl.Location != null)
-                        xlCell.SetHyperlink(new XLHyperlink(hl.Location.Value, tooltip));
+                        xlCell.SetCellHyperlink(new XLHyperlink(hl.Location.Value, tooltip));
                     else
-                        xlCell.SetHyperlink(new XLHyperlink(hl.Reference.Value, tooltip));
-
-                    xlCell.SettingHyperlink = false;
+                        xlCell.SetCellHyperlink(new XLHyperlink(hl.Reference.Value, tooltip));
                 }
             }
         }


### PR DESCRIPTION
The `MiscSlice.SettingHyperlink` property is only used to modify behavior of a `XLCell.SetHyperlink function`. Essentially, it means don't set style. It therefore isn't a cell state property and shoudln't be in a slice.

The property was originally moved to slice during shift-and-life of cells props to slices without modifications.

Instead of setting property and relying a modified method behavior, jsut extract common behaviort to a separate method.

Related to #2400.