### PR TITLE
Move hyperlink from MiscSlice to XLHyperlinks collection

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -74,5 +74,32 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             Assert.AreEqual(expected, left.Intersect(right));
         }
+
+        [TestCase("A1", "A1", true)]
+        [TestCase("A1", "A2", false)]
+        [TestCase("B1:B3", "A2:C2", true)]
+        [TestCase("A1:A3", "B2:C2", false)]
+        [TestCase("A1:D6", "B2:C3", true)]
+        [TestCase("A1:C6", "B4:E10", true)]
+        public void Intersects_checks_whether_the_range_has_intersection_with_another(string leftOperand, string rightOperand, bool expected)
+        {
+            var left = XLSheetRange.Parse(leftOperand);
+            var right = XLSheetRange.Parse(rightOperand);
+
+            Assert.AreEqual(expected, left.Intersects(right));
+        }
+
+        [TestCase("A1", "A1", true)]
+        [TestCase("B1:C3", "B1:C3", true)]
+        [TestCase("A1:D4", "B2:C3", true)]
+        [TestCase("B3:C3", "B2:C3", false)]
+        [TestCase("A2:C2", "B2:C3", false)]
+        public void Overlaps_checks_whether_left_fully_overlaps_right(string leftOperand, string rightOperand, bool expected)
+        {
+            var left = XLSheetRange.Parse(leftOperand);
+            var right = XLSheetRange.Parse(rightOperand);
+
+            Assert.AreEqual(expected, left.Overlaps(right));
+        }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/CalcContext.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcContext.cs
@@ -92,7 +92,7 @@ namespace ClosedXML.Excel.CalcEngine
             // for them doesn't make sense.
             if (_recursive)
             {
-                var cell = sheet.GetCell(rowNumber, columnNumber);
+                var cell = sheet.GetCell(point);
                 return cell?.Value ?? Blank.Value;
             }
 

--- a/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
+++ b/ClosedXML/Excel/CalcEngine/CellRangeReference.cs
@@ -71,22 +71,22 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 for (int co = range.RangeAddress.FirstAddress.ColumnNumber; co <= range.RangeAddress.LastAddress.ColumnNumber; co++)
                 {
-                    var value = GetCellValue(sheet, ro, co);
+                    var value = GetCellValue(sheet, new XLSheetPoint(ro, co));
                     yield return value;
                 }
             }
         }
 
-        private static XLCellValue GetCellValue(XLWorksheet sheet, int ro, int co)
+        private static XLCellValue GetCellValue(XLWorksheet sheet, XLSheetPoint point)
         {
-            var cell = sheet.GetCell(ro, co);
+            var cell = sheet.GetCell(point);
             if (cell is null)
                 return Blank.Value;
 
             if (cell.Formula is null || !cell.Formula.IsDirty)
                 return cell.CachedValue;
 
-            throw new GettingDataException(new XLBookPoint(sheet.SheetId, new XLSheetPoint(ro, co)));
+            throw new GettingDataException(new XLBookPoint(sheet.SheetId, point));
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
+++ b/ClosedXML/Excel/Cells/XLMiscSliceContent.cs
@@ -4,8 +4,6 @@
     {
         internal XLComment? Comment { get; set; }
 
-        internal XLHyperlink? Hyperlink { get; set; }
-
         internal uint? CellMetaIndex { get; set; }
 
         internal uint? ValueMetaIndex { get; set; }

--- a/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetPoint.cs
@@ -26,6 +26,11 @@ namespace ClosedXML.Excel
         /// </summary>
         public readonly Int32 Column;
 
+        public static implicit operator XLSheetRange(XLSheetPoint point)
+        {
+            return new XLSheetRange(point);
+        }
+
         public override bool Equals(object obj)
         {
             return obj is XLSheetPoint point && Equals(point);

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace ClosedXML.Excel
@@ -67,7 +68,7 @@ namespace ClosedXML.Excel
         /// </summary>
         public int BottomRow => LastPoint.Row;
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is XLSheetRange range && Equals(range);
         }
@@ -266,11 +267,20 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
+        /// Does this range intersects with <paramref name="other"/>.
+        /// </summary>
+        /// <returns><c>true</c> if intersects, <c>false</c> otherwise.</returns>
+        internal bool Intersects(XLSheetRange other)
+        {
+            return Intersect(other) is not null;
+        }
+
+        /// <summary>
         /// Do an intersection between this range and other range.
         /// </summary>
         /// <param name="other">Other range.</param>
         /// <returns>The intersection range if it exists and is non-empty or null, if intersection doesn't exist.</returns>
-        public XLSheetRange? Intersect(XLSheetRange other)
+        internal XLSheetRange? Intersect(XLSheetRange other)
         {
             var leftColumn = Math.Max(LeftColumn, other.LeftColumn);
             var rightColumn = Math.Min(RightColumn, other.RightColumn);
@@ -281,6 +291,17 @@ namespace ClosedXML.Excel
                 return null;
 
             return new XLSheetRange(topRow, leftColumn, bottomRow, rightColumn);
+        }
+
+        /// <summary>
+        /// Does this range overlaps the <paramref name="otherRange"/>?
+        /// </summary>
+        internal bool Overlaps(XLSheetRange otherRange)
+        {
+            return TopRow <= otherRange.TopRow &&
+                RightColumn >= otherRange.RightColumn &&
+                BottomRow >= otherRange.BottomRow &&
+                LeftColumn <= otherRange.LeftColumn;
         }
 
         /// <summary>
@@ -320,6 +341,17 @@ namespace ClosedXML.Excel
             var topLeftCorner = FirstPoint.ShiftRow(rowShift);
             var bottomRightCorner = LastPoint.ShiftRow(rowShift);
             return new XLSheetRange(topLeftCorner, bottomRightCorner);
+        }
+
+        public IEnumerator<XLSheetPoint> GetEnumerator()
+        {
+            for (var row = TopRow; row <= BottomRow; ++row)
+            {
+                for (var col = LeftColumn; col <= RightColumn; ++col)
+                {
+                    yield return new XLSheetPoint(row, col);
+                }
+            }
         }
     }
 }

--- a/ClosedXML/Excel/Hyperlinks/IXLHyperlinks.cs
+++ b/ClosedXML/Excel/Hyperlinks/IXLHyperlinks.cs
@@ -1,16 +1,51 @@
-#nullable disable
-
 using System.Collections.Generic;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+public interface IXLHyperlinks: IEnumerable<XLHyperlink>
 {
-    public interface IXLHyperlinks: IEnumerable<XLHyperlink>
-    {
-        void Add(XLHyperlink hyperlink);
-        void Delete(XLHyperlink hyperlink);
-        void Delete(IXLAddress address);
-        bool TryDelete(IXLAddress address);
-        XLHyperlink Get(IXLAddress address);
-        bool TryGet(IXLAddress address, out XLHyperlink hyperlink);
-    }
+    /// <summary>
+    /// Remove the hyperlink from a worksheet. Doesn't throw if hyperlinks is
+    /// not attached to a worksheet.
+    /// </summary>
+    /// <remarks>
+    /// If hyperlink range uses a <see cref="XLThemeColor.Hyperlink">hyperlink
+    /// theme color</see>, the style is reset to the sheet style font color.
+    /// The <see cref="IXLFontBase.Underline"/> is also set to sheet style
+    /// underline.
+    /// </remarks>
+    /// <param name="hyperlink">Hyperlink to remove.</param>
+    /// <returns><c>true</c> if hyperlink was part of the worksheet and was
+    ///   removed. <c>false</c> otherwise.</returns>
+    bool Delete(XLHyperlink hyperlink);
+
+    /// <summary>
+    /// Delete a hyperlink defined for a single cell. It doesn't delete
+    /// hyperlinks that cover the cell.
+    /// </summary>
+    /// <remarks>
+    /// If hyperlink range uses a <see cref="XLThemeColor.Hyperlink">hyperlink
+    /// theme color</see>, the style is reset to the sheet style font color.
+    /// The <see cref="IXLFontBase.Underline"/> is also set to sheet style
+    /// underline.
+    /// </remarks>
+    /// <param name="address">Address of the cell.</param>
+    /// <returns><c>true</c> if there was such hyperlink and was deleted.
+    ///   <c>false</c> otherwise.</returns>
+    bool Delete(IXLAddress address);
+
+    /// <summary>
+    /// Get a hyperlink for a single cell.
+    /// </summary>
+    /// <param name="address">Address of the cell.</param>
+    /// <exception cref="KeyNotFoundException">Cell doesn't have a hyperlink.</exception>
+    XLHyperlink Get(IXLAddress address);
+
+    /// <summary>
+    /// Get a hyperlink for a single cell.
+    /// </summary>
+    /// <param name="address">Address of the cell.</param>
+    /// <param name="hyperlink">Found hyperlink.</param>
+    /// <returns><c>true</c> if there was a hyperlink for <paramref name="address"/>, <c>false</c> otherwise.</returns>
+    bool TryGet(IXLAddress address, out XLHyperlink hyperlink);
 }

--- a/ClosedXML/Excel/Hyperlinks/XLHyperlink_Internal.cs
+++ b/ClosedXML/Excel/Hyperlinks/XLHyperlink_Internal.cs
@@ -63,6 +63,6 @@ namespace ClosedXML.Excel
             IsExternal = false;
         }
 
-        internal XLWorksheet Worksheet { get; set; }
+        internal XLHyperlinks Container { get; set; }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -63,7 +63,7 @@ namespace ClosedXML.Excel
             DefinedNames = new XLDefinedNames(this);
             SheetView = new XLSheetView(this);
             Tables = new XLTables();
-            Hyperlinks = new XLHyperlinks();
+            Hyperlinks = new XLHyperlinks(this);
             DataValidations = new XLDataValidations(this);
             PivotTables = new XLPivotTables(this);
             _protection = new XLSheetProtection(DefaultProtectionAlgorithm);
@@ -1929,9 +1929,9 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Get cell or null, if cell doesn't exist.
         /// </summary>
-        internal XLCell? GetCell(int ro, int co)
+        internal XLCell? GetCell(XLSheetPoint point)
         {
-            return Worksheet.Internals.CellsCollection.GetUsedCell(new XLSheetPoint(ro, co));
+            return Worksheet.Internals.CellsCollection.GetUsedCell(point);
         }
 
         public XLRange GetOrCreateRange(XLRangeParameters xlRangeParameters)

--- a/docs/migrations/migrate-to-0.105.rst
+++ b/docs/migrations/migrate-to-0.105.rst
@@ -9,3 +9,27 @@ IXLRangeBase.Hyperlinks
 Property ```IXLRangeBase.Hyperlinks``` has been moved to ```IXLWorksheet.Hyperlinks```.
 The original place could only list hyperlinks and didn't provide correct
 functionality (e.g. removal of hyperlinks).
+
+*************
+IXLHyperlinks
+*************
+
+IXLHyperlinks.Add was removed
+-----------------------------
+
+The method was removed, because there is no way to actually use it. It has a
+parameter ```XLHyperlink```, but doesn't have an range where should hyperlink
+be created. ```XLHyperlink``` can't have a ```XLHyperlink.Cell``` property set
+to a valid value, because that would mean hyperlink is already attached to
+a worksheet.
+
+IXLHyperlinks.TryDelete was removed
+-----------------------------------
+
+It worked same way as ```IXLHyperlinks.Delete```.
+
+IXLHyperlinks.Delete returns bool
+---------------------------------
+
+Originally, it returned ```void```. The ```bool``` value indicates if a
+hyperlink was present and thus removed.


### PR DESCRIPTION
The key benefit of this move is that the source of the truth moves to one place: XLHyperlinks. Originally, there were three places with a location of a hyperlink:

* XLHyperlink.Cell
* XLHyperlinks dictionary of ranges
* MiscSlice

The hyperlink is not in really a part of slices. Slices are for things inherently attached to cells. Hyperlink is not inherently part of the cell. It is a property of an area, just like merged ranges, table or pivot table. It is an additional property of a range, not part of a cell.

Related to #2400