### PR TITLE
Add methods to XLSheetRange to determine an area after area deletion

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -101,5 +101,40 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             Assert.AreEqual(expected, left.Overlaps(right));
         }
+
+        [TestCase("B5:B8", "A1:C3", "B2:B5")] // Deleted area fully above (with a row space) with overlapping width
+        [TestCase("B5:B8", "A2:C4", "B2:B5")] // The deleted are ends exactly at the row above the area
+        [TestCase("B5:B8", "A6:C7", "B5:B6")] // The deleted is fully within the area, bot not at top/bottom row
+        [TestCase("B5:B8", "A5:C8", null)] // Delete are exactly covers the area
+        [TestCase("B5:B8", "A4:C9", null)] // Delete fully covers the area
+        [TestCase("B5:B8", "A9:C10", "B5:B8")] // The deleted is fully below the area.
+        [TestCase("B5:B8", "A6:C10", "B5:B5")] // The deleted partially intersects the area and is below.
+        [TestCase("B5:B8", "A1:A10", "B5:B8")] // Deleted area is fully on the left
+        [TestCase("B5:B8", "C1:C10", "B5:B8")] // Deleted area is fully on the right
+        [TestCase("B5:D8", "B9:C10", "B5:D8")] // Partial deletion is below -> not affected
+        public void TryDeleteAreaAndShiftUp_without_partial_cover(string leftOperand, string deleted, string expected)
+        {
+            var originalArea = XLSheetRange.Parse(leftOperand);
+            var deletedArea = XLSheetRange.Parse(deleted);
+            var expectedResult = expected is not null ? XLSheetRange.Parse(expected) : (XLSheetRange?)null;
+
+            var success = originalArea.TryDeleteAreaAndShiftUp(deletedArea, out var result);
+
+            Assert.True(success);
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestCase("B5:D8", "A1:B3")] // Partial above
+        [TestCase("B5:D8", "C6:D8")] // Partial inside
+        [TestCase("B5:D8", "B1:B6")] // Partial above and inside
+        public void TryDeleteAreaAndShiftUp_with_partial_cover(string leftOperand, string deleted)
+        {
+            var originalArea = XLSheetRange.Parse(leftOperand);
+            var deletedArea = XLSheetRange.Parse(deleted);
+            var success = originalArea.TryDeleteAreaAndShiftUp(deletedArea, out var result);
+
+            Assert.False(success);
+            Assert.Null(result);
+        }
     }
 }


### PR DESCRIPTION
Implement methods that calculate position and size of an area, if another area in a sheet is deleted. These methods will be used in `ISheetListener` to react on area deletion (e.g. row is deleted -> shift up). There are two variants:

* delete area and shift area to the left
* delete area and shift area up

![image](https://github.com/user-attachments/assets/4939871b-caf4-4e2c-9edf-13c161d3f49e)

The methods use `Try*` pattern, because if an area is not covered (e.g. when deleting area `D1:F1` and shifting up, area `C3:E5` is not covered, because column `C` is not deleted). In such situations, a part of cells should be kept in place, while rest should be shifted. That is not possible, because area must remain square. If that happens, the `Try*` method return `false` and it's up to the caller to resolve.

![image](https://github.com/user-attachments/assets/50835b42-a9c7-4bf8-8d7b-9806ab29489a)


Related to #2400