### PR TITLE
Hyperlinks move on structual changes

### DIFF
--- a/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
+++ b/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Hyperlinks;
+
+[TestFixture]
+public class XLHyperlinksTests
+{
+    [TestCaseSource(nameof(StructuralChangeCases))]
+    public void Hyperlink_is_moved_on_sheet_structure_change(string hyperlinkPosition, Action<IXLWorksheet> structuralChange, string expectedPosition)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var hyperlink = new XLHyperlink("https://example.com");
+        ws.Cell(hyperlinkPosition).SetHyperlink(hyperlink);
+
+        structuralChange(ws);
+
+        Assert.False(ws.Cell(hyperlinkPosition).HasHyperlink);
+        Assert.AreSame(ws.Cell(expectedPosition).GetHyperlink(), hyperlink);
+    }
+
+    public static IEnumerable<object[]> StructuralChangeCases
+    {
+        get
+        {
+            return new List<(string, Action<IXLWorksheet>, string)>
+            {
+                ("D5", ws => ws.Range("A5:B5").Delete(XLShiftDeletedCells.ShiftCellsLeft), "B5"),
+                ("D5", ws => ws.Range("B2:D4").Delete(XLShiftDeletedCells.ShiftCellsUp), "D2"),
+                ("D5", ws => ws.Column("D").InsertColumnsBefore(2), "F5"), // Insert column leftward
+                ("D5", ws => ws.Row(2).InsertRowsAbove(4), "D9"), // Insert row above
+            }.Select(x => new object[] { x.Item1, x.Item2, x.Item3 });
+        }
+    }
+}

--- a/ClosedXML/ClosedXML.csproj.DotSettings
+++ b/ClosedXML/ClosedXML.csproj.DotSettings
@@ -4,6 +4,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccolumns/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Ccoordinates/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cdefinednames/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Chyperlinks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cpivottables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cpivottables_005Careas/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cranges/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -785,12 +785,9 @@ namespace ClosedXML.Excel
                 Style.Font.Underline = XLFontUnderlineValues.Single;
         }
 
-        internal void SetCellHyperlink(XLHyperlink? hyperlink)
+        internal void SetCellHyperlink(XLHyperlink hyperlink)
         {
             Worksheet.Hyperlinks.Clear(SheetPoint);
-            if (hyperlink is null)
-                return;
-
             Worksheet.Hyperlinks.Add(SheetPoint, hyperlink);
         }
 #nullable disable

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1407,9 +1407,6 @@ namespace ClosedXML.Excel
             var mergesToRemove = Worksheet.Internals.MergedRanges.Where(Contains).ToList();
             mergesToRemove.ForEach(r => Worksheet.Internals.MergedRanges.Remove(r));
 
-            var hyperlinksToRemove = Worksheet.Hyperlinks.Where(hl => Contains(hl.Cell.AsRange())).ToList();
-            hyperlinksToRemove.ForEach(hl => Worksheet.Hyperlinks.Delete(hl));
-
             var shiftedRange = AsRange();
             if (shiftDeleteCells == XLShiftDeletedCells.ShiftCellsUp)
                 Worksheet.NotifyRangeShiftedRows(shiftedRange, rowModifier * -1);

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1199,17 +1199,21 @@ namespace ClosedXML.Excel
             ShiftDataValidationColumns(range, columnsShifted);
             ShiftPageBreaksColumns(range, columnsShifted);
             RemoveInvalidSparklines();
+
+            ISheetListener hyperlinks = Hyperlinks;
             if (columnsShifted > 0)
             {
                 var area = XLSheetRange
                     .FromRangeAddress(range.RangeAddress)
                     .ExtendRight(columnsShifted - 1);
                 Workbook.CalcEngine.OnInsertAreaAndShiftRight(range.Worksheet, area);
+                hyperlinks.OnInsertAreaAndShiftRight(range.Worksheet, area);
             }
             else if (columnsShifted < 0)
             {
                 var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
                 Workbook.CalcEngine.OnDeleteAreaAndShiftLeft(range.Worksheet, area);
+                hyperlinks.OnDeleteAreaAndShiftLeft(range.Worksheet, area);
             }
         }
 
@@ -1341,17 +1345,21 @@ namespace ClosedXML.Excel
             ShiftDataValidationRows(range, rowsShifted);
             RemoveInvalidSparklines();
             ShiftPageBreaksRows(range, rowsShifted);
+
+            ISheetListener hyperlinks = Hyperlinks;
             if (rowsShifted > 0)
             {
                 var area = XLSheetRange
                     .FromRangeAddress(range.RangeAddress)
                     .ExtendBelow(rowsShifted - 1);
                 Workbook.CalcEngine.OnInsertAreaAndShiftDown(range.Worksheet, area);
+                hyperlinks.OnInsertAreaAndShiftDown(range.Worksheet, area);
             }
             else if (rowsShifted < 0)
             {
                 var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
                 Workbook.CalcEngine.OnDeleteAreaAndShiftUp(range.Worksheet, area);
+                hyperlinks.OnDeleteAreaAndShiftUp(range.Worksheet, area);
             }
         }
 


### PR DESCRIPTION
Fixes #2400. The hyperlink shift broke when `XLCell` was lift-and-shifted to slices. In that moment, the `XLCell` stopped updating it's coordinates automatically.

This is the first implementation of `ISheetListener` I hope to use as a foundation of structural changes. Currently, we rely on a `IXLRange` repository that moves ranges around on structural changes.

It has several drawbacks:

* `XLWorksheet` is a god class that handles all shifting stuff.
* `XLRangeRepository` keeps track of all ranges. Any time a range is created, it is added to repository and when any structural change happens, every tracked range is updated. That can get really expensive and isn't transparent to the developer.
* The whole thing is not modular and rather of complicated.
* Doesn't support insertion of areas, only insertion of rows and columns.

Instead, I want each component to deal with it on it's own (e.g. hyperlink, merged range, tables, sparklines...). That will make it more modular and hopefully simpler to reason about.

In most cases, it will be simple shift, like in the hyperlink case, but in many other cases there could be a more complex logic (e.g. shifted merged range, shift headers/footers of a table...). The complex logic should be encapsulated in the component itself, not `XLWorksheet`.

In the long run, I hope to remove need to track and update size/position of `XLRange`, just like I did for `XLCell` (for several other reasons, e.g. `XLRange` is bounded to a worksheet - that can be missed when copying between workbooks/sheets and so on).