### PR TITLE
add nuget.config to not rely on settings of development machine

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<packageSources>
+		<clear/>
+		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+	</packageSources>
+</configuration>


### PR DESCRIPTION
When nuget is disabled on development machines then a restore/build will fail.
Settings for packages should be handled by the git repository and not development machine settings.