### PR TITLE
Reimplement SUMPRODUCT function

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -40,6 +40,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMIF/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMPRODUCT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -85,7 +85,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SUM", 1, int.MaxValue, Sum, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("SUMIF", 2, 3, SumIf, AllowRange.Only, 0, 2);
             ce.RegisterFunction("SUMIFS", 3, 255, SumIfs, AllowRange.Only, new[] { 0 }.Concat(Enumerable.Range(0, 128).Select(x => x * 2 + 1)).ToArray());
-            ce.RegisterFunction("SUMPRODUCT", 1, 30, SumProduct, AllowRange.All);
+            ce.RegisterFunction("SUMPRODUCT", 1, 30, SumProduct, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("SUMSQ", 1, 255, SumSq);
             //ce.RegisterFunction("SUMX2MY2", SumX2MY2, 1);
             //ce.RegisterFunction("SUMX2PY2", SumX2PY2, 1);
@@ -1027,48 +1027,69 @@ namespace ClosedXML.Excel.CalcEngine
             return tally.Sum();
         }
 
-        private static object SumProduct(List<Expression> p)
+        private static AnyValue SumProduct(CalcContext ctx, Span<AnyValue> args)
         {
-            // all parameters should be IEnumerable
-            if (p.Any(param => !(param is IEnumerable)))
-                return XLError.NoValueAvailable;
+            if (args.Length < 1)
+                return XLError.IncompatibleValue;
 
-            var counts = p.Cast<IEnumerable>().Select(param =>
+            var width = 0;
+            var height = 0;
+
+            // Check that all arguments have same width and height.
+            foreach (var arg in args)
             {
-                int i = 0;
-                foreach (var item in param)
-                    i++;
-                return i;
-            })
-            .Distinct()
-            .ToArray();
-
-            // All parameters should have the same length
-            if (counts.Length > 1)
-                return XLError.NoValueAvailable;
-
-            var values = p
-                .Cast<IEnumerable>()
-                .Select(range =>
+                int argWidth;
+                int argHeight;
+                if (arg.TryPickSingleOrMultiValue(out var scalar, out var array, ctx))
                 {
-                    var results = new List<double>();
-                    foreach (var c in range)
-                    {
-                        if (c.IsNumber())
-                            results.Add(c.CastTo<double>());
-                        else
-                            results.Add(0.0);
-                    }
-                    return results;
-                })
-                .ToArray();
+                    // We don't need to do this check for every value later, because scalar
+                    // blank value can only happen for 1x1.
+                    if (scalar.IsBlank)
+                        return XLError.IncompatibleValue;
 
-            return Enumerable.Range(0, counts.Single())
-                .Aggregate(0d, (t, i) =>
-                    t + values.Aggregate(1d,
-                        (product, list) => product * list[i]
-                    )
-                );
+                    argWidth = 1;
+                    argHeight = 1;
+                }
+                else
+                {
+                    argWidth = array.Width;
+                    argHeight = array.Height;
+                }
+
+                // If this is the first argument, use it as a baseline width and height
+                if (width == 0) width = argWidth;
+                if (height == 0) height = argHeight;
+
+                if (width != argWidth || height != argHeight)
+                    return XLError.IncompatibleValue;
+            }
+
+            // Calculate SumProduct
+            var sum = 0.0;
+            for (var rowIdx = 0; rowIdx < height; ++rowIdx)
+            {
+                for (var colIdx = 0; colIdx < width; ++colIdx)
+                {
+                    var product = 1.0;
+                    foreach (var arg in args)
+                    {
+                        if (!arg.TryPickSingleOrMultiValue(out var scalar, out var array, ctx))
+                            scalar = array[rowIdx, colIdx];
+
+                        if (scalar.TryPickError(out var error))
+                            return error;
+
+                        if (!scalar.TryPickNumber(out var number))
+                            number = 0;
+
+                        product *= number;
+                    }
+
+                    sum += product;
+                }
+            }
+
+            return sum;
         }
 
         private static object SumSq(List<Expression> p)


### PR DESCRIPTION
New one is much faster and has behavior more in line with Excel behavior.

Benchmark: https://gist.github.com/jahav/6882efc19aae8f54f2f82333c95509d6
```

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method           | RowsCount | Mean           | Error        | StdDev       | Median         |
|----------------- |---------- |---------------:|-------------:|-------------:|---------------:|
| **SumProduct**       | **1000**      |       **343.4 μs** |      **6.10 μs** |      **8.15 μs** |       **344.4 μs** |
| LegacySumProduct | 1000      |     5,835.0 μs |    116.60 μs |    326.95 μs |     5,698.1 μs |
| **SumProduct**       | **10000**     |     **3,230.8 μs** |     **29.36 μs** |     **26.02 μs** |     **3,222.8 μs** |
| LegacySumProduct | 10000     |   126,489.6 μs |  2,529.34 μs |  2,484.15 μs |   127,267.1 μs |
| **SumProduct**       | **100000**    |    **31,846.1 μs** |    **244.95 μs** |    **204.55 μs** |    **31,802.1 μs** |
| LegacySumProduct | 100000    | 1,070,912.3 μs | 20,589.77 μs | 21,144.18 μs | 1,077,512.9 μs |


Fixes #1202