### PR TITLE
Remove allocations in SUMPRODUCT

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -41,6 +41,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMPRODUCT/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
The SUMPRODUCT is using TryGetSingleOrMultiple in an inner loop. That allocates a `ReferenceArray` for a reference argument. That means an allocation for each item.

This method preallocates `ReferenceArray` in adapt layer before passing it to the function, thus reducing useless allocations.

This change increases performance of `SUMPRODUCT` by 50%.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method     | RowsCount | Mean        | Error     | StdDev    | Median      | Allocated |
|----------- |---------- |------------:|----------:|----------:|------------:|----------:|
| **SumProduct** | **1000**      |    **159.0 μs** |   **0.96 μs** |   **0.85 μs** |    **158.5 μs** |   **3.03 KB** |
| **SumProduct** | **10000**     |  **1,590.2 μs** |  **31.58 μs** |  **39.94 μs** |  **1,614.9 μs** |   **3.05 KB** |
| **SumProduct** | **100000**    | **16,343.8 μs** | **316.94 μs** | **412.12 μs** | **16,672.5 μs** |   **3.12 KB** |


Original performance (#2433):

| Method           | RowsCount | Mean           | Error        | StdDev       | Median         |
|----------------- |---------- |---------------:|-------------:|-------------:|---------------:|
| **SumProduct**       | **1000**      |       **343.4 μs** |      **6.10 μs** |      **8.15 μs** |       **344.4 μs** |
| **SumProduct**       | **10000**     |     **3,230.8 μs** |     **29.36 μs** |     **26.02 μs** |     **3,222.8 μs** |
| **SumProduct**       | **100000**    |    **31,846.1 μs** |    **244.95 μs** |    **204.55 μs** |    **31,802.1 μs** |
