### PR TITLE
Reimplement AVERAGE function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -119,7 +119,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(0, cell.Value);
             cell = wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=SUM(D1,D2)");
             Assert.AreEqual(0, cell.Value);
-            Assert.That(() => wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=AVERAGE(D1,D2)").Value, Throws.TypeOf<ApplicationException>());
+            Assert.That(() => wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=STDEV(D1,D2)").Value, Throws.TypeOf<ApplicationException>());
         }
 
         [Test]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -39,6 +39,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMPRODUCT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMSQ/@EntryIndexedValue">True</s:Boolean>
@@ -49,6 +50,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unparseable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscaled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscales/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VARP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vlookup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Webp/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>


### PR DESCRIPTION
New implementation requires less memory, is faster and more true to the Excel.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method        | RowsCount | Mean         | Error        | StdDev       | Allocated    |
|-------------- |---------- |-------------:|-------------:|-------------:|-------------:|
| **Average**       | **1000**      |     **207.4 μs** |      **4.12 μs** |      **4.05 μs** |      **3.29 KB** |
| LegacyAverage | 1000      |   3,441.1 μs |     43.59 μs |     40.77 μs |   4329.05 KB |
| **Average**       | **10000**     |   **1,957.3 μs** |     **39.02 μs** |     **60.74 μs** |      **3.31 KB** |
| LegacyAverage | 10000     |  70,813.9 μs |  1,414.03 μs |  2,655.90 μs |  51120.88 KB |
| **Average**       | **100000**    |  **20,497.9 μs** |    **322.75 μs** |    **301.90 μs** |      **3.39 KB** |
| LegacyAverage | 100000    | 691,753.2 μs | 13,626.19 μs | 22,003.76 μs | 486417.38 KB |

https://gist.github.com/jahav/6b6c2e0dd0ae49d2e2980e0280a58a5f