### PR TITLE
Reimplement COUNT function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -81,17 +81,40 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheets.First();
             XLCellValue value;
-            value = ws.Evaluate(@"=COUNT(D3:D45)");
+            value = ws.Evaluate("COUNT(D3:D45)");
             Assert.AreEqual(0, value);
 
-            value = ws.Evaluate(@"=COUNT(G3:G45)");
+            value = ws.Evaluate("COUNT(G3:G45)");
             Assert.AreEqual(43, value);
 
-            value = ws.Evaluate(@"=COUNT(G:G)");
+            value = ws.Evaluate("COUNT(G:G)");
             Assert.AreEqual(43, value);
 
-            value = workbook.Evaluate(@"=COUNT(Data!G:G)");
+            value = workbook.Evaluate("COUNT(Data!G:G)");
             Assert.AreEqual(43, value);
+
+            // Scalar blank, logical and text is counted as numbers
+            Assert.AreEqual(4, ws.Evaluate("COUNT(IF(TRUE,,),TRUE, FALSE, \"1\")"));
+
+            // Non-number values in arrays are not counted as numbers.
+            Assert.AreEqual(0, ws.Evaluate("COUNT({TRUE,FALSE,\"1\"})"));
+
+            // Text is not counted as number.
+            Assert.AreEqual(0, ws.Evaluate("COUNT(\"Hello\")"));
+
+            // Blank cells are not counted as numbers
+            ws.Cell("Z1").Value = Blank.Value;
+            Assert.AreEqual(0, ws.Evaluate("COUNT(Z1)"));
+
+            // Scalar errors are not propagated
+            Assert.AreEqual(1, ws.Evaluate("COUNT(1, #NULL!)"));
+
+            // Array errors are not propagated
+            Assert.AreEqual(1, ws.Evaluate("COUNT({1, #NULL!})"));
+
+            // Reference errors are not propagated
+            ws.Cell("Z1").Value = XLError.NullValue;
+            Assert.AreEqual(0, ws.Evaluate("COUNT(Z1)"));
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -23,7 +23,7 @@ namespace ClosedXML.Excel.CalcEngine
             //CHITEST	Returns the test for independence
             //CONFIDENCE	Returns the confidence interval for a population mean
             //CORREL	Returns the correlation coefficient between two data sets
-            ce.RegisterFunction("COUNT", 1, int.MaxValue, Count, AllowRange.All);
+            ce.RegisterFunction("COUNT", 1, int.MaxValue, Count, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("COUNTA", 1, 255, CountA, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("COUNTBLANK", 1, CountBlank, AllowRange.All);
             ce.RegisterFunction("COUNTIF", 2, CountIf, AllowRange.Only, 0);
@@ -156,9 +156,35 @@ namespace ClosedXML.Excel.CalcEngine
             return binomDist;
         }
 
-        private static object Count(List<Expression> p)
+        private static AnyValue Count(CalcContext ctx, Span<AnyValue> args)
         {
-            return GetTally(p, true).Count();
+            if (args.Length < 1)
+                return XLError.IncompatibleValue;
+
+            var count = 0;
+            foreach (var arg in args)
+            {
+                if (arg.TryPickScalar(out var scalar, out var collection))
+                {
+                    // Scalars are converted to number.
+                    if (scalar.ToNumber(ctx.Culture).TryPickT0(out _, out _))
+                        count++;
+                }
+                else
+                {
+                    var valuesIterator = collection.TryPickT0(out var array, out var reference)
+                        ? array
+                        : ctx.GetNonBlankValues(reference);
+                    foreach (var value in valuesIterator)
+                    {
+                        // For arrays and references, only the number type is used. Other types are ignored.
+                        if (value.TryPickNumber(out var number))
+                            count++;
+                    }
+                }
+            }
+
+            return count;
         }
 
         private static AnyValue CountA(CalcContext ctx, Span<AnyValue> values)


### PR DESCRIPTION
It is faster and uses less memory than original.

It's kind of annoying to write basically same loop for many functions, but each one is slightly of different (e.g. `AVERAGE(1, "Hello")` is `#VALUE!` while `COUNT(1, "Hello")` is `1`). I have tried with `Aggregate` extension function and it had so many knobs it's just not worth it.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method      | RowsCount | Mean         | Error        | StdDev       | Allocated    |
|------------ |---------- |-------------:|-------------:|-------------:|-------------:|
| **Count**       | **1000**      |     **286.6 μs** |      **1.52 μs** |      **1.18 μs** |       **3.9 KB** |
| CountLegacy | 1000      |   3,369.6 μs |     41.89 μs |     39.18 μs |   4329.21 KB |
| **Count**       | **10000**     |   **2,726.2 μs** |     **32.29 μs** |     **28.62 μs** |      **3.93 KB** |
| CountLegacy | 10000     |  68,899.5 μs |  1,371.67 μs |  3,067.94 μs |  51122.06 KB |
| **Count**       | **100000**    |  **28,434.3 μs** |    **367.39 μs** |    **343.65 μs** |      **3.98 KB** |
| CountLegacy | 100000    | 650,625.3 μs | 12,987.03 μs | 25,330.20 μs | 486413.91 KB |
