### PR TITLE
Reimplement MIN

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -591,18 +591,38 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Min()
         {
             var ws = workbook.Worksheets.First();
-            XLCellValue value;
-            value = ws.Evaluate(@"=MIN(D3:D45)");
-            Assert.AreEqual(0, value);
+            Assert.AreEqual(0, ws.Evaluate("MIN(D3:D45)"));
+            Assert.AreEqual(2, ws.Evaluate("MIN(G3:G45)"));
+            Assert.AreEqual(2, ws.Evaluate("MIN(G:G)"));
+            Assert.AreEqual(2, workbook.Evaluate("MIN(Data!G:G)"));
 
-            value = ws.Evaluate(@"=MIN(G3:G45)");
-            Assert.AreEqual(2, value);
+            // Scalar blank argument is converted
+            Assert.AreEqual(0, workbook.Evaluate("MIN(IF(TRUE,,), 1)"));
 
-            value = ws.Evaluate(@"=MIN(G:G)");
-            Assert.AreEqual(2, value);
+            // Scalar logical arguments is converted
+            Assert.AreEqual(0, workbook.Evaluate("MIN(FALSE, 1)"));
+            Assert.AreEqual(1, workbook.Evaluate("MIN(TRUE, 2)"));
 
-            value = workbook.Evaluate(@"=MIN(Data!G:G)");
-            Assert.AreEqual(2, value);
+            // Scalar text argument is converted is possible
+            Assert.AreEqual(2, workbook.Evaluate("MIN(\"2\", 3)"));
+
+            // Scalar text argument is not a number returns error
+            Assert.AreEqual(XLError.IncompatibleValue, workbook.Evaluate("MIN(\"hello\", 3)"));
+
+            // Array non-number arguments are ignored
+            Assert.AreEqual(5, workbook.Evaluate("MIN({5, TRUE, FALSE, \"1\", \"hello\"})"));
+
+            // Reference non-number arguments are ignored
+            ws.Cell("Z1").Value = Blank.Value;
+            ws.Cell("Z2").Value = "1";
+            ws.Cell("Z3").Value = "hello";
+            ws.Cell("Z4").Value = false;
+            ws.Cell("Z5").Value = true;
+            ws.Cell("Z6").Value = 5;
+            Assert.AreEqual(5, ws.Evaluate("MIN(Z1:Z6)"));
+
+            // If there is no value, return 0
+            Assert.AreEqual(0, ws.Evaluate("MIN({\"hello\"})"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -599,14 +599,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Scalar blank argument is converted
             Assert.AreEqual(0, workbook.Evaluate("MIN(IF(TRUE,,), 1)"));
 
-            // Scalar logical arguments is converted
+            // Scalar logical argument is converted
             Assert.AreEqual(0, workbook.Evaluate("MIN(FALSE, 1)"));
             Assert.AreEqual(1, workbook.Evaluate("MIN(TRUE, 2)"));
 
-            // Scalar text argument is converted is possible
+            // Scalar text argument is converted if possible
             Assert.AreEqual(2, workbook.Evaluate("MIN(\"2\", 3)"));
 
-            // Scalar text argument is not a number returns error
+            // Scalar text argument that is not convertible returns error
             Assert.AreEqual(XLError.IncompatibleValue, workbook.Evaluate("MIN(\"hello\", 3)"));
 
             // Array non-number arguments are ignored


### PR DESCRIPTION
Reimplement MIN function, faster, less memory, more accurate to Excel for edge conditions.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method    | RowsCount | Mean         | Error        | StdDev       | Allocated    |
|---------- |---------- |-------------:|-------------:|-------------:|-------------:|
| **Min**    | **1000**      |   **302.0 us** |   **3.77 us** |   **3.34 us** |    **3.9 KB** |
| MinLegacy | 1000      |   3,674.7 μs |    115.47 μs |    325.67 μs |   4329.26 KB |
| **Min**    | **10000**     |  **2,841.8 us** |  **22.44 us** |  **19.89 us** |   **3.92 KB** |
| MinLegacy | 10000     |  72,550.6 μs |  1,821.89 μs |  5,227.35 μs |51121.92 KB |
| **Min**    | **100000**    | **29,899.5 us** | **583.84 us** | **648.94 us** |   **4.04 KB** |
| MinLegacy | 100000    | 668,690.2 μs | 13,171.85 μs | 26,305.62 μs | 486414.45 KB |


https://gist.github.com/jahav/676c42871ce3b7cf0158a1c7a1190504