### PR TITLE
Reimplement STDEV + STDEV.S

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -119,7 +119,6 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(0, cell.Value);
             cell = wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=SUM(D1,D2)");
             Assert.AreEqual(0, cell.Value);
-            Assert.That(() => wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=STDEV(D1,D2)").Value, Throws.TypeOf<ApplicationException>());
         }
 
         [Test]


### PR DESCRIPTION
Faster, use less memory and is more in line with Excel behavior.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method      | RowsCount | Mean         | Error        | StdDev       | Allocated    |
|------------ |---------- |-------------:|-------------:|-------------:|-------------:|
| **StDev**       | **1000**      |     **494.2 μs** |      **8.54 μs** |      **7.57 μs** |       **4.4 KB** |
| StDevLegacy | 1000      |   3,535.8 μs |     57.38 μs |     50.87 μs |   4329.38 KB |
| **StDev**       | **10000**     |   **4,798.9 μs** |     **56.95 μs** |     **47.56 μs** |      **4.45 KB** |
| StDevLegacy | 10000     |  71,428.2 μs |  1,424.47 μs |  2,640.34 μs |  51121.82 KB |
| **StDev**       | **100000**    |  **49,952.7 μs** |    **473.84 μs** |    **395.68 μs** |       **4.6 KB** |
| StDevLegacy | 100000    | 713,217.0 μs | 13,764.51 μs | 38,597.15 μs | 486423.05 KB |

https://gist.github.com/jahav/c3eef7b896515cfb39d0965800566742