### PR TITLE
Reimplement STDEVP + STDEV.P

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -40,6 +40,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEV/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEVP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMPRODUCT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMSQ/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Faster, less memory intensive, more in line with Excel behavior.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method      | RowsCount | Mean         | Error        | StdDev       | Allocated    |
|------------ |---------- |-------------:|-------------:|-------------:|-------------:|
| **StDev**       | **1000**      |     **486.6 μs** |      **9.24 μs** |     **15.69 μs** |      **4.42 KB** |
| StDevLegacy | 1000      |   3,549.1 μs |     69.40 μs |    117.84 μs |   4329.29 KB |
| **StDev**       | **10000**     |   **4,820.9 μs** |     **32.89 μs** |     **27.47 μs** |      **4.46 KB** |
| StDevLegacy | 10000     |  71,457.2 μs |  1,426.64 μs |  3,161.33 μs |  51120.86 KB |
| **StDev**       | **100000**    |  **50,198.0 μs** |    **417.13 μs** |    **369.77 μs** |      **4.58 KB** |
| StDevLegacy | 100000    | 664,314.1 μs | 13,271.40 μs | 29,408.51 μs | 486413.27 KB |

https://gist.github.com/jahav/ea0e9069ee822a92b0968db74672af68