### PR TITLE
Reimplement VARP function

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -92,10 +92,10 @@ namespace ClosedXML.Excel.CalcEngine
             //TTEST	Returns the probability associated with a Student's t-test
             ce.RegisterFunction("VAR", 1, int.MaxValue, Var, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("VARA", 1, int.MaxValue, VarA, AllowRange.All);
-            ce.RegisterFunction("VARP", 1, int.MaxValue, VarP, AllowRange.All);
+            ce.RegisterFunction("VARP", 1, int.MaxValue, VarP, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("VARPA", 1, int.MaxValue, VarPA, AllowRange.All);
             ce.RegisterFunction("VAR.S", 1, int.MaxValue, Var, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VAR.P", 1, int.MaxValue, VarP);
+            ce.RegisterFunction("VAR.P", 1, int.MaxValue, VarP, FunctionFlags.Range, AllowRange.All);
             //WEIBULL	Returns the Weibull distribution
             //ZTEST	Returns the one-tailed probability-value of a z-test
         }
@@ -452,9 +452,15 @@ namespace ClosedXML.Excel.CalcEngine
             return GetTally(p, false).Var();
         }
 
-        private static object VarP(List<Expression> p)
+        private static AnyValue VarP(CalcContext ctx, Span<AnyValue> args)
         {
-            return GetTally(p, true).VarP();
+            if (!GetSquareDiffSum(ctx, args).TryPickT0(out var tally, out var error))
+                return error;
+
+            if (tally.Count < 1)
+                return XLError.DivisionByZero;
+
+            return tally.SquareDiffSum / tally.Count;
         }
 
         private static object VarPA(List<Expression> p)


### PR DESCRIPTION
Faster, uses less memory, matches Excel behavior.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4169/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method     | RowsCount | Mean         | Error        | StdDev       | Median       | Allocated    |
|----------- |---------- |-------------:|-------------:|-------------:|-------------:|-------------:|
| **VarP**       | **1000**      |     **487.3 μs** |      **9.15 μs** |      **8.98 μs** |     **487.6 μs** |       **4.4 KB** |
| VarPLegacy | 1000      |   3,456.0 μs |     66.07 μs |     76.09 μs |   3,442.7 μs |   4329.29 KB |
| **VarP**       | **10000**     |   **4,876.3 μs** |     **71.98 μs** |    **105.50 μs** |   **4,837.2 μs** |      **4.45 KB** |
| VarPLegacy | 10000     |  80,098.2 μs |  4,692.59 μs | 13,836.22 μs |  74,317.3 μs |  51120.75 KB |
| **VarP**       | **100000**    |  **49,885.9 μs** |    **988.53 μs** |    **924.67 μs** |  **49,459.0 μs** |      **4.64 KB** |
| VarPLegacy | 100000    | 660,956.5 μs | 13,089.09 μs | 22,578.03 μs | 669,426.6 μs | 486422.28 KB |

https://gist.github.com/jahav/2c1a166910170dd87a85545e08bd8d8d