### PR TITLE
Reimplement GEOMEAN function

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -22,6 +22,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FILTERXML/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formulae/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=furigana/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=GEOMEAN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hiragana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HLOOKUP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IFERROR/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -518,7 +518,7 @@ namespace ClosedXML.Excel.CalcEngine
         // utility for tallying statistics
         private static Tally GetTally(List<Expression> p, bool numbersOnly)
         {
-            return new Tally(p, numbersOnly);
+            return new Tally(p);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -103,16 +103,6 @@ namespace ClosedXML.Excel.CalcEngine
             return nums.Sum(x => Math.Pow(x - Average(), 2));
         }
 
-        public object GeoMean()
-        {
-            var nums = NumericValuesInternal();
-
-            if (nums.Length == 0) return XLError.NumberInvalid;
-            if (HasNonPositiveNumbers()) return XLError.NumberInvalid;
-
-            return Math.Pow(Product(), 1.0 / nums.Length);
-        }
-
         public IEnumerator<object> GetEnumerator()
         {
             return _list.GetEnumerator();

--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -10,23 +10,13 @@ namespace ClosedXML.Excel.CalcEngine
     internal class Tally : IEnumerable<Object>
     {
         private readonly List<object> _list = new List<object>();
-        private readonly bool NumbersOnly;
 
         private double[]? _numericValues;
 
         public Tally()
-            : this(false)
         { }
 
-        public Tally(bool numbersOnly)
-            : this(null, numbersOnly)
-        { }
-
-        public Tally(IEnumerable<Expression> p)
-            : this(p, false)
-        { }
-
-        public Tally(IEnumerable<Expression>? p, bool numbersOnly)
+        public Tally(IEnumerable<Expression>? p)
         {
             if (p != null)
             {
@@ -35,8 +25,6 @@ namespace ClosedXML.Excel.CalcEngine
                     Add(e);
                 }
             }
-
-            NumbersOnly = numbersOnly;
         }
 
         public void Add(Expression e)
@@ -97,11 +85,6 @@ namespace ClosedXML.Excel.CalcEngine
             int medianIndex = (int)Math.Floor(nums.Length / 2d);
 
             return nums[medianIndex];
-        }
-
-        public double Count()
-        {
-            return Count(NumbersOnly);
         }
 
         public double Count(bool numbersOnly)


### PR DESCRIPTION
Faster, uses less memory is more in line with Excel. 

I am kind of worried that Excel gives me exact `5` for `GEOMEAN(5,5,5,5)` and I get a slight error due to calculation. On the other hand, MathNet also gives an error, so I guess I am fine (`Statistics.GeometricMean(new double[] {5,5,5,5}).ToString("G17")` gives me `4.9999999999999991`).