### PR TITLE
Update System.IO.Packaging

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="RBush" Version="3.2.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
-    <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
+    <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
     <PackageReference Include="ClosedXML.Parser" Version="[1.2.0,2.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
There are two security advisories ([CVE-2024-43484](https://github.com/ClosedXML/ClosedXML/security/dependabot/4) [CVE-2024-43483](https://github.com/ClosedXML/ClosedXML/security/dependabot/3)) that we should update `System.IO.Packages`.

The advisory contained a wrong a fixed version. The advisory claims 8.0.10, but that is inaccurate (no such package on NuGet plus confirmed at [MS discussion thread](https://github.com/dotnet/runtime/issues/108676#issuecomment-2400901885)).