### PR TITLE
Reimplement MAXA function

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -36,6 +36,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kanji/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Katakana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OLAP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -151,7 +151,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue AverageA(CalcContext ctx, Span<AnyValue> args)
         {
-            var state = (Sum:0.0, Count: 0);
+            var state = (Sum: 0.0, Count: 0);
             var result = TallyAll(ctx, args, state, static (state, value) => (state.Sum + value, state.Count + 1));
 
             if (!result.TryPickT0(out var tally, out var error))
@@ -402,10 +402,16 @@ namespace ClosedXML.Excel.CalcEngine
             if (args.Length < 1)
                 return XLError.IncompatibleValue;
 
-            double? max = null;
-            var result = TallyNumbers(ctx, args, max, static (max, itemValue) => max.HasValue ? Math.Max(max.Value, itemValue) : itemValue);
+            var state = (Max: double.MinValue, HasValues: false);
+            var result = TallyNumbers(ctx, args, state, static (state, value) => (Math.Max(state.Max, value), true));
 
-            return result.Match<AnyValue>(m => m ?? 0, e => e);
+            if (!result.TryPickT0(out var tally, out var error))
+                return error;
+
+            if (!tally.HasValues)
+                return 0;
+
+            return tally.Max;
         }
 
         private static object MaxA(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -136,8 +136,6 @@ namespace ClosedXML.Excel.CalcEngine
                 : nums.Aggregate(1d, (a, b) => a * b);
         }
 
-        public double Range() => Max() - Min();
-
         public double Std()
         {
             var values = NumericValuesInternal();
@@ -191,12 +189,6 @@ namespace ClosedXML.Excel.CalcEngine
         private static double Sum2(IEnumerable<double> nums)
         {
             return nums.Sum(d => d * d);
-        }
-
-        private bool HasNonPositiveNumbers()
-        {
-            var nums = NumericValuesInternal();
-            return nums.Any(x => x <= 0);
         }
 
         private IEnumerable<double> NumericValuesEnumerable()


### PR DESCRIPTION
Remove another use of `Tally`. New one is faster, uses less memory and is more in line with Excel.... through Excel behavior is pretty screwed up in this case. `MAXA({TRUE, TRUE, 0}) = 0` vs `E1 = TRUE, E2 = TRUE, E3 = 0, MAXA(E1:E3) = 1`? WTF?