### PR TITLE
Reimplement DEVSQ function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -539,7 +539,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-10)]
         public double DevSq(string sourceValue)
         {
-            return (double)workbook.Worksheets.First().Evaluate($"=DEVSQ({sourceValue})");
+            return (double)workbook.Worksheets.First().Evaluate($"DEVSQ({sourceValue})");
         }
 
         [TestCase("D3:D45", ExpectedResult = XLError.IncompatibleValue)]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -19,6 +19,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTA/@EntryIndexedValue">True</s:Boolean>	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dereferenced/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=DEVSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FILTERXML/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formulae/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Tally.cs
@@ -72,14 +72,6 @@ namespace ClosedXML.Excel.CalcEngine
                 return _list.Count(o => !CalcEngineHelpers.ValueIsBlank(o));
         }
 
-        public object DevSq()
-        {
-            var nums = NumericValuesInternal();
-            if (nums.Length == 0) return XLError.IncompatibleValue;
-
-            return nums.Sum(x => Math.Pow(x - Average(), 2));
-        }
-
         public IEnumerator<object> GetEnumerator()
         {
             return _list.GetEnumerator();


### PR DESCRIPTION
Faster, less memory intensive, more in line with Excel type semantic and spec.
The original test used to have `#VALUE!` error, but Excel shows `#NUM!` error, so I changed it. Spec has no info on errors.
Only 10 usages of `Tally` left...