### PR TITLE
Reimplement VARA function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
     [TestFixture]
     public class StatisticalTests
     {
-        private double tolerance = 1e-6;
+        private const double tolerance = 1e-6;
         private XLWorkbook workbook;
 
         [Test]
@@ -1149,6 +1149,55 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Reference error is propagated
             ws.Cell("Z1").Value = XLError.NoValueAvailable;
             Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("VAR(Z1)"));
+        }
+
+        [Test]
+        [DefaultFloatingPointTolerance(tolerance)]
+        public void VarA()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Example from specification
+            Assert.AreEqual(2683.2, ws.Evaluate("VARA(1202, 1220, 1323, 1254, 1302)"));
+
+            // Scalar blank is converted to 0
+            Assert.AreEqual(0.5, workbook.Evaluate("VARA(IF(TRUE,), 1)"));
+
+            // Scalar logical is converted to number
+            Assert.AreEqual(0.5, workbook.Evaluate("VARA(FALSE, TRUE)"));
+
+            // Scalar text is converted to number
+            Assert.AreEqual(2, workbook.Evaluate("VARA(\"5\", \"7\")"));
+
+            // Scalar text that is not convertible return error
+            Assert.AreEqual(XLError.IncompatibleValue, workbook.Evaluate("VARA(5, \"Hello\")"));
+
+            // Array non-number arguments are ignored
+            Assert.AreEqual(2, workbook.Evaluate("VARA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"));
+
+            // Reference argument ignores blanks, uses numbers, logical and text as zero
+            ws.Cell("A1").Value = Blank.Value; // Ignore
+            ws.Cell("A2").Value = true; // Include
+            ws.Cell("A3").Value = ""; // Consider 0
+            ws.Cell("A4").Value = "100"; // Consider 0
+            ws.Cell("A5").Value = "hello"; // Consider 0
+            ws.Cell("A6").Value = 5;
+            ws.Cell("A7").Value = 7;
+            Assert.AreEqual(9.366666667, (double)ws.Evaluate("VARA(A1:A7)"));
+
+            // Need at least one sample, otherwise returns error (text in array is ignored)
+            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("VARA({\"hello\"})"));
+
+            // Scalar error is propagated
+            Assert.AreEqual(XLError.NullValue, workbook.Evaluate("VARA(1, #NULL!)"));
+
+            // Array error is propagated
+            Assert.AreEqual(XLError.NullValue, workbook.Evaluate("VARA({1, #NULL!})"));
+
+            // Reference error is propagated
+            ws.Cell("B1").Value = XLError.NoValueAvailable;
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("VAR(B1)"));
         }
 
         [Test]


### PR DESCRIPTION
Another `Tally` function replaced. Faster than previous, doesn't allocate memory, more in line with specification/Excel.

```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4317/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method | RowsCount | Mean        | Error     | StdDev    | Allocated |
|------- |---------- |------------:|----------:|----------:|----------:|
| **VarP**   | **1000**      |    **585.5 μs** |   **0.80 μs** |   **0.63 μs** |   **5.04 KB** |
| **VarP**   | **10000**     |  **5,657.4 μs** |  **38.77 μs** |  **36.27 μs** |   **5.07 KB** |
| **VarP**   | **100000**    | **58,644.2 μs** | **332.41 μs** | **294.67 μs** |    **5.2 KB** |
