### PR TITLE
Reimplement VARPA function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -1162,19 +1162,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(2683.2, ws.Evaluate("VARA(1202, 1220, 1323, 1254, 1302)"));
 
             // Scalar blank is converted to 0
-            Assert.AreEqual(0.5, workbook.Evaluate("VARA(IF(TRUE,), 1)"));
+            Assert.AreEqual(0.5, ws.Evaluate("VARA(IF(TRUE,), 1)"));
 
             // Scalar logical is converted to number
-            Assert.AreEqual(0.5, workbook.Evaluate("VARA(FALSE, TRUE)"));
+            Assert.AreEqual(0.5, ws.Evaluate("VARA(FALSE, TRUE)"));
 
             // Scalar text is converted to number
-            Assert.AreEqual(2, workbook.Evaluate("VARA(\"5\", \"7\")"));
+            Assert.AreEqual(2, ws.Evaluate("VARA(\"5\", \"7\")"));
 
             // Scalar text that is not convertible return error
-            Assert.AreEqual(XLError.IncompatibleValue, workbook.Evaluate("VARA(5, \"Hello\")"));
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("VARA(5, \"Hello\")"));
 
             // Array non-number arguments are ignored
-            Assert.AreEqual(2, workbook.Evaluate("VARA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"));
+            Assert.AreEqual(2, ws.Evaluate("VARA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"));
 
             // Reference argument ignores blanks, uses numbers, logical and text as zero
             ws.Cell("A1").Value = Blank.Value; // Ignore
@@ -1187,17 +1187,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(9.366666667, (double)ws.Evaluate("VARA(A1:A7)"));
 
             // Need at least one sample, otherwise returns error (text in array is ignored)
-            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("VARA({\"hello\"})"));
+            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("VARA({\"hello\"})"));
 
             // Scalar error is propagated
-            Assert.AreEqual(XLError.NullValue, workbook.Evaluate("VARA(1, #NULL!)"));
+            Assert.AreEqual(XLError.NullValue, ws.Evaluate("VARA(1, #NULL!)"));
 
             // Array error is propagated
-            Assert.AreEqual(XLError.NullValue, workbook.Evaluate("VARA({1, #NULL!})"));
+            Assert.AreEqual(XLError.NullValue, ws.Evaluate("VARA({1, #NULL!})"));
 
             // Reference error is propagated
             ws.Cell("B1").Value = XLError.NoValueAvailable;
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("VAR(B1)"));
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("VARA(B1)"));
         }
 
         [Test]
@@ -1256,6 +1256,55 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Reference error is propagated
             ws.Cell("Z1").Value = XLError.NoValueAvailable;
             Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("VARP(Z1)"));
+        }
+
+        [Test]
+        [DefaultFloatingPointTolerance(tolerance)]
+        public void VarPA()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Example from specification
+            Assert.AreEqual(2146.56, ws.Evaluate("VARPA(1202, 1220, 1323, 1254, 1302)"));
+
+            // Scalar blank is converted to 0
+            Assert.AreEqual(0.25, ws.Evaluate("VARPA(IF(TRUE,), 1)"));
+
+            // Scalar logical is converted to a number
+            Assert.AreEqual(0.25, ws.Evaluate("VARPA(FALSE, TRUE)"));
+
+            // Scalar text is converted to a number
+            Assert.AreEqual(1, ws.Evaluate("VARPA(\"5\", \"7\")"));
+
+            // Scalar text that is not convertible returns error
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("VARPA(5, \"Hello\")"));
+
+            // Array non-number arguments are ignored
+            Assert.AreEqual(1, ws.Evaluate("VARPA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"));
+
+            // Reference argument ignores blanks, uses numbers, logical and text as zero
+            ws.Cell("A1").Value = Blank.Value; // Ignore
+            ws.Cell("A2").Value = true; // Include
+            ws.Cell("A3").Value = ""; // Consider 0
+            ws.Cell("A4").Value = "100"; // Consider 0
+            ws.Cell("A5").Value = "hello"; // Consider 0
+            ws.Cell("A6").Value = 5;
+            ws.Cell("A7").Value = 7;
+            Assert.AreEqual(7.805555556, (double)ws.Evaluate("VARPA(A1:A7)"));
+
+            // Need at least one sample, otherwise returns error (text in array is ignored)
+            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("VARPA({\"hello\"})"));
+
+            // Scalar error is propagated
+            Assert.AreEqual(XLError.NullValue, ws.Evaluate("VARPA(1, #NULL!)"));
+
+            // Array error is propagated
+            Assert.AreEqual(XLError.NullValue, ws.Evaluate("VARPA({1, #NULL!})"));
+
+            // Reference error is propagated
+            ws.Cell("B1").Value = XLError.NoValueAvailable;
+            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("VARPA(B1)"));
         }
 
         [Test]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -56,6 +56,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscaled/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Upscales/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=VARP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=VARPA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vlookup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Webp/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -96,7 +96,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("VAR", 1, int.MaxValue, Var, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("VARA", 1, int.MaxValue, VarA, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("VARP", 1, int.MaxValue, VarP, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VARPA", 1, int.MaxValue, VarPA, AllowRange.All);
+            ce.RegisterFunction("VARPA", 1, int.MaxValue, VarPA, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("VAR.S", 1, int.MaxValue, Var, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("VAR.P", 1, int.MaxValue, VarP, FunctionFlags.Range, AllowRange.All);
             //WEIBULL	Returns the Weibull distribution
@@ -526,9 +526,15 @@ namespace ClosedXML.Excel.CalcEngine
             return squareDiff.Sum / squareDiff.Count;
         }
 
-        private static object VarPA(List<Expression> p)
+        private static AnyValue VarPA(CalcContext ctx, Span<AnyValue> args)
         {
-            return GetTally(p).VarP();
+            if (!GetSquareDiffSumA(ctx, args).TryPickT0(out var squareDiff, out var error))
+                return error;
+
+            if (squareDiff.Count < 1)
+                return XLError.DivisionByZero;
+
+            return squareDiff.Sum / squareDiff.Count;
         }
 
         private static AnyValue Large(CalcContext ctx, AnyValue arrayParam, double kParam)


### PR DESCRIPTION
New one is faster, uses less memory and is in line with Excel behavior.
```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.4317/23H2/2023Update/SunValley3)
AMD Ryzen 5 5500U with Radeon Graphics, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.100-preview.7.24407.12
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```
| Method      | RowsCount | Mean         | Error        | StdDev       | Median       | Allocated    |
|------------ |---------- |-------------:|-------------:|-------------:|-------------:|-------------:|
| **VarPA**       | **1000**      |     **572.7 μs** |      **9.77 μs** |     **14.32 μs** |     **564.2 μs** |      **5.04 KB** |
| VarPALegacy | 1000      |   3,318.8 μs |     14.22 μs |     12.61 μs |   3,322.3 μs |   4329.23 KB |
| **VarPA**       | **10000**     |   **5,637.3 μs** |     **46.71 μs** |     **43.69 μs** |   **5,608.2 μs** |      **5.07 KB** |
| VarPALegacy | 10000     |  69,486.4 μs |  1,388.46 μs |  3,893.38 μs |  69,414.0 μs |  51121.08 KB |
| **VarPA**       | **100000**    |  **59,913.8 μs** |     **57.77 μs** |     **48.24 μs** |  **59,924.0 μs** |       **5.2 KB** |
| VarPALegacy | 100000    | 640,984.9 μs | 12,579.48 μs | 24,236.38 μs | 643,780.6 μs | 486415.98 KB |

https://gist.github.com/jahav/690e7a7106270b0629f6d82b6ac0408f