### PR TITLE
#2425: A fix for ParsingException: Unexpected token EofSymbolId

### DIFF
--- a/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -77,27 +77,6 @@ namespace ClosedXML.Tests.Excel.Tables
             return wb;
         }
 
-        private XLWorkbook PrepareWorkbookWithDefinedNames()
-        {
-            var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet("ListOfPeople");
-
-            var data = new[]
-            {
-                new Person{FirstName = "Francois", LastName = "Botha", Age = 39, DateOfBirth = new DateTime(1980,1,1), IsActive = true},
-                new Person{FirstName = "Leon", LastName = "Oosthuizen", Age = 40, DateOfBirth = new DateTime(1979,1,1), IsActive = false},
-                new Person{FirstName = "Rian", LastName = "Prinsloo", Age = 41, DateOfBirth = new DateTime(1978,1,1), IsActive = false}
-            };
-
-            ws.FirstCell().CellRight().CellBelow().InsertTable(data);
-
-            ws.Columns().AdjustToContents();
-
-            ws.DefinedNames.Add("ListOfPeople_Age", "ListOfPeople[Age]");
-
-            return wb;
-        }
-
         private Person[] NewData
         {
             get
@@ -590,13 +569,47 @@ namespace ClosedXML.Tests.Excel.Tables
         }
 
         [Test]
-        public void CanReplaceWhenWorksheetHasDefinedNames()
+        public void CanReplaceWhenWorksheetHasDefinedNamesWithoutSheetReferences()
         {
             using (var ms = new MemoryStream())
             {
-                using (var wb = PrepareWorkbookWithDefinedNames())
+                using (var wb = PrepareWorkbook())
                 {
                     var ws = wb.Worksheets.First();
+
+                    ws.DefinedNames.Add("ListOfPeople_Age", "ListOfPeople[Age]");
+
+                    var table = ws.Tables.First();
+
+                    IEnumerable<Person> personEnumerable = NewData;
+                    var replacedRange = table.ReplaceData(personEnumerable);
+
+                    Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
+                    ws.Columns().AdjustToContents();
+
+                    wb.SaveAs(ms);
+                }
+
+                using (var wb = new XLWorkbook(ms))
+                {
+                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                    Assert.AreEqual(2, table.DataRange.RowCount());
+                    Assert.AreEqual(6, table.DataRange.ColumnCount());
+                }
+            }
+        }
+
+        [Test]
+        public void CanReplaceWhenWorksheetHasDefinedNamesWithSheetReferences()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var wb = PrepareWorkbook())
+                {
+                    var ws = wb.Worksheets.First();
+
+                    ws.DefinedNames.Add("ListOfPeople_Age", "ListOfPeople!A1");
 
                     var table = ws.Tables.First();
 

--- a/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -568,16 +568,21 @@ namespace ClosedXML.Tests.Excel.Tables
             }
         }
 
-        [Test]
-        public void CanReplaceWhenWorksheetHasDefinedNamesWithoutSheetReferences()
+        [TestCase("ListOfPeople[Age]")] // Defined name formula without a A1 reference
+        [TestCase("ListOfPeople!A1")] // Defined name formula with an A1 reference
+        public void CanReplaceTableDataWhenWorksheetHasDefinedNames(string nameFormula)
         {
+            // When table data are replaced, the size of a table is modified. That
+            // means rows below it are shifted up/down and defined names should be
+            // adjusted.
+            // TODO: add assert for name shift when formulas are properly shifted. Originally, it threw even on defined name with A1 reference
             using (var ms = new MemoryStream())
             {
                 using (var wb = PrepareWorkbook())
                 {
                     var ws = wb.Worksheets.First();
 
-                    ws.DefinedNames.Add("ListOfPeople_Age", "ListOfPeople[Age]");
+                    ws.DefinedNames.Add("ListOfPeople_Age", nameFormula);
 
                     var table = ws.Tables.First();
 
@@ -585,39 +590,6 @@ namespace ClosedXML.Tests.Excel.Tables
                     var replacedRange = table.ReplaceData(personEnumerable);
 
                     Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(2, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
-            }
-        }
-
-        [Test]
-        public void CanReplaceWhenWorksheetHasDefinedNamesWithSheetReferences()
-        {
-            using (var ms = new MemoryStream())
-            {
-                using (var wb = PrepareWorkbook())
-                {
-                    var ws = wb.Worksheets.First();
-
-                    ws.DefinedNames.Add("ListOfPeople_Age", "ListOfPeople!A1");
-
-                    var table = ws.Tables.First();
-
-                    IEnumerable<Person> personEnumerable = NewData;
-                    var replacedRange = table.ReplaceData(personEnumerable);
-
-                    Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
 
                     wb.SaveAs(ms);
                 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1481,11 +1481,14 @@ namespace ClosedXML.Excel
         {
             foreach (var definedName in definedNames)
             {
-                var newRangeList =
-                    definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaRows(r, this, range, rowsShifted)).Where(
-                        newReference => newReference.Length > 0).ToList();
-                var unionFormula = string.Join(",", newRangeList);
-                definedName.SetRefersTo(unionFormula);
+//                if (definedName.SheetReferencesList.Count() > 0)
+                {
+                    var newRangeList =
+                        definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaRows(r, this, range, rowsShifted)).Where(
+                            newReference => newReference.Length > 0).ToList();
+                    var unionFormula = string.Join(",", newRangeList);
+                    definedName.SetRefersTo(unionFormula);
+                }
             }
         }
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1481,7 +1481,7 @@ namespace ClosedXML.Excel
         {
             foreach (var definedName in definedNames)
             {
-//                if (definedName.SheetReferencesList.Count() > 0)
+                if (definedName.SheetReferencesList.Count() > 0)
                 {
                     var newRangeList =
                         definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaRows(r, this, range, rowsShifted)).Where(


### PR DESCRIPTION
`ReplaceData` method used to raise following exception when the worksheet had defined names:
>ClosedXML.Parser.ParsingException: 'Error at char 0 of '': Unexpected token EofSymbolId.'