### PR TITLE
Reimplement NETWORKDAYS function

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -39,6 +39,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NETWORKDAYS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OLAP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/CalcContext.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcContext.cs
@@ -124,6 +124,26 @@ namespace ClosedXML.Excel.CalcEngine
         }
 
         /// <summary>
+        /// This method should be used mostly for range arguments. If a value is scalar,
+        /// return a single value enumerable.
+        /// </summary>
+        internal IEnumerable<ScalarValue> GetNonBlankValues(AnyValue value)
+        {
+            if (value.TryPickScalar(out var scalar, out var collection))
+            {
+                if (scalar.IsBlank)
+                    return System.Array.Empty<ScalarValue>();
+
+                return new ScalarArray(scalar, 1, 1);
+            }
+
+            if (collection.TryPickT0(out var array, out var reference))
+                return array.Where(x => !x.IsBlank);
+            
+            return GetNonBlankValues(reference);
+        }
+
+        /// <summary>
         /// Get cells with a value for a reference.
         /// </summary>
         /// <param name="reference">Reference for which to return cells.</param>

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -231,6 +231,24 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, ScalarValue, ScalarValue, AnyValue, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToScalarValue(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToScalarValue(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2 = args.Length > 2 ? args[2] : AnyValue.Blank;
+
+                return f(ctx, arg0, arg1, arg2).ToAnyValue();
+            };
+        }
+
         /// <summary>
         /// Adapt a function that accepts areas as arguments (e.g. SUMPRODUCT). The key benefit is
         /// that all <c>ReferenceArray</c> allocation is done once for a function. The method


### PR DESCRIPTION
NetWorkDays uses a `Tally` for holidays, so it gets reimplemented.

The original also had few bugs with holidays (e.g. double counting same holiday date, counting holidays on Saturday or Sunday...).