### PR TITLE
Reimplement WORKDAY function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -587,39 +587,36 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [TestCase(2, 1, 3)]
         [TestCase(0, 5, 6)]
         [TestCase(2, 8, 12)]
+        [TestCase(10, -1, 9)]
+        [TestCase(10, -2, 6)]
+        [TestCase(10, -3, 5)]
+        [TestCase(9, -1, 6)]
+        [TestCase(9, -2, 5)]
+        [TestCase(8, -1, 6)]
+        [TestCase(7, -1, 6)]
+        [TestCase(6, -1, 5)]
         public void Workdays(int startDate, int dayOffset, int expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"WORKDAY({startDate}, {dayOffset})");
             Assert.AreEqual(expected, actual);
         }
 
-        [Test]
-        [Ignore("Only for test")]
-        public void Workdays_against_excel()
+        [TestCase(0, 1, new[] { 1 }, 2)]
+        [TestCase(0, 1, new[] { 2 }, 3)]
+        [TestCase(0, 5, new[] { 2, 4 }, 10)]
+        [TestCase(0, 4, new[] { 2, 4, 6 }, 10)]
+        [TestCase(0, 3, new[] { 2, 3, 4, 6 }, 10)]
+        [TestCase(0, 2, new[] { 2, 3, 4, 5, 6 }, 10)]
+        [TestCase(0, 1, new[] { 2, 3, 5 }, 4)]
+        [TestCase(0, 2, new[] { 2, 3, 5 }, 6)]
+        [TestCase(2, 1, new[] { 2 }, 3)]
+        [TestCase(15, -1, new[] { 13 }, 12)] // 15 = Sunday
+        [TestCase(100, -5, new[] { 82, 93, 94, 95, 94, 100 }, 88)]
+        [TestCase(98, -2, new[] { 97 }, 95)]
+        public void Workdays_with_holiday(int startDate, int dayOffset, int[] holidays, int expected)
         {
-            using var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet();
-            ws.Cell("A1").Value = "StartDate";
-            ws.Cell("B1").Value = "EndDate";
-            ws.Cell("C1").Value = "CML";
-            ws.Cell("D1").Value = "Excel";
-            ws.Cell("E1").Value = "Diff";
-            var row = 2;
-            for (var start = 0; start < 100; start++)
-            {
-                for (var end = start; end < 100; end++)
-                {
-                    ws.Cell(row, 1).Value = start;
-                    ws.Cell(row, 2).Value = end;
-                    ws.Cell(row, 3).Value = XLWorkbook.EvaluateExpr($"WORKDAY({start}, {end})");
-                    ws.Cell(row, 4).FormulaA1 = $"WORKDAY({start}, {end})";
-                    ws.Cell(row, 5).FormulaA1 = $"IF(C{row} <> D{row},\"DIFFERENT\", \"SAME\")";
-
-                    row++;
-                }
-            }
-
-            wb.SaveAs(@"C:\Temp\issues\workday.xlsx");
+            var actual = XLWorkbook.EvaluateExpr($"WORKDAY({startDate}, {dayOffset}, {{{string.Join(",", holidays)}}})");
+            Assert.AreEqual(expected, actual);
         }
 
         [TestCase("\"8/22/2008\"", 2008)]

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -581,6 +581,47 @@ namespace ClosedXML.Tests.Excel.DataValidations
             Assert.AreEqual(new DateTime(2009, 5, 4).ToSerialDateTime(), actual);
         }
 
+        [TestCase(0, 0, 0)]
+        [TestCase(0, 1, 2)]
+        [TestCase(1, 1, 2)]
+        [TestCase(2, 1, 3)]
+        [TestCase(0, 5, 6)]
+        [TestCase(2, 8, 12)]
+        public void Workdays(int startDate, int dayOffset, int expected)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"WORKDAY({startDate}, {dayOffset})");
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [Ignore("Only for test")]
+        public void Workdays_against_excel()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = "StartDate";
+            ws.Cell("B1").Value = "EndDate";
+            ws.Cell("C1").Value = "CML";
+            ws.Cell("D1").Value = "Excel";
+            ws.Cell("E1").Value = "Diff";
+            var row = 2;
+            for (var start = 0; start < 100; start++)
+            {
+                for (var end = start; end < 100; end++)
+                {
+                    ws.Cell(row, 1).Value = start;
+                    ws.Cell(row, 2).Value = end;
+                    ws.Cell(row, 3).Value = XLWorkbook.EvaluateExpr($"WORKDAY({start}, {end})");
+                    ws.Cell(row, 4).FormulaA1 = $"WORKDAY({start}, {end})";
+                    ws.Cell(row, 5).FormulaA1 = $"IF(C{row} <> D{row},\"DIFFERENT\", \"SAME\")";
+
+                    row++;
+                }
+            }
+
+            wb.SaveAs(@"C:\Temp\issues\workday.xlsx");
+        }
+
         [TestCase("\"8/22/2008\"", 2008)]
         [TestCase("\"1/2/2006 10:45 AM\"", 2006)]
         [TestCase("0", 1900)]

--- a/ClosedXML/Extensions/DateTimeExtensions.cs
+++ b/ClosedXML/Extensions/DateTimeExtensions.cs
@@ -1,54 +1,16 @@
-#nullable disable
-
 // Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal static class DateTimeExtensions
 {
-    internal static class DateTimeExtensions
+    public static double ToSerialDateTime(this DateTime dateTime)
     {
-        public static Double MaxOADate
-        {
-            get
-            {
-                return 2958465.99999999;
-            }
-        }
-
-        public static bool IsWorkDay(this DateTime date, IEnumerable<DateTime> bankHolidays)
-        {
-            return date.DayOfWeek != DayOfWeek.Saturday
-                   && date.DayOfWeek != DayOfWeek.Sunday
-                   && !bankHolidays.Contains(date);
-        }
-
-        public static DateTime NextWorkday(this DateTime date, IReadOnlyList<DateTime> bankHolidays)
-        {
-            var nextDate = date.AddDays(1);
-            while (!nextDate.IsWorkDay(bankHolidays))
-                nextDate = nextDate.AddDays(1);
-
-            return nextDate;
-        }
-
-        public static DateTime PreviousWorkDay(this DateTime date, IReadOnlyCollection<DateTime> bankHolidays)
-        {
-            var previousDate = date.AddDays(-1);
-            while (!previousDate.IsWorkDay(bankHolidays))
-                previousDate = previousDate.AddDays(-1);
-
-            return previousDate;
-        }
-
-        public static double ToSerialDateTime(this DateTime dateTime)
-        {
-            // Excel says 1900 was a leap year  :( Replicate an incorrect behavior thanks
-            // to Lotus 1-2-3 decision from 1983...
-            var oDate = dateTime.ToOADate();
-            const int nonExistent1900Feb29SerialDate = 60;
-            return oDate <= nonExistent1900Feb29SerialDate ? oDate - 1 : oDate;
-        }
+        // Excel says 1900 was a leap year  :( Replicate an incorrect behavior thanks
+        // to Lotus 1-2-3 decision from 1983...
+        var oDate = dateTime.ToOADate();
+        const int nonExistent1900Feb29SerialDate = 60;
+        return oDate <= nonExistent1900Feb29SerialDate ? oDate - 1 : oDate;
     }
 }


### PR DESCRIPTION
Reimplement `WORKDAY` function.

I am not sure if it isn't overengineered, instead of just going over days and checking each one, it goes over segments between holidays. It should scale with number of holidays, not number of days.

On the other hand, it's kind of pointless, on the other hand... I am faster than Excel ( ˶ˆᗜˆ˵ ) How often can I say that? This function is not well designed optimal in Excel, try to make a range of hundreds cells that calculate the `WORKDAY(1, 2100000, some holidays in range)` and it takes Excel a second or two to calculate it.
 
This also removes one of the last usages of `Tally` class. After this, only three `Tally` usages remain: `SUBTOTAL`, `SUMIF` and `SUMIFS`. Of course they are most complex, on the other hand they have several issues.

I have also tested the results against Excel to make sure I didn't make a mistake. https://gist.github.com/jahav/24ae75c08b8c471e7510d77c14a1018e