### PR TITLE
Split tally into value provider and aggregation

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -596,6 +596,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             value = workbook.Evaluate(@"MAX(-10, { TRUE, FALSE, ""100"" })");
             Assert.AreEqual(-10, value);
 
+            // Reference argument ignores everything but number.
+            ws.Cell("Z1").Value = Blank.Value;
+            ws.Cell("Z2").Value = true;
+            ws.Cell("Z3").Value = "100";
+            ws.Cell("Z4").Value = "hello";
+            ws.Cell("Z5").Value = -4;
+            Assert.AreEqual(-4, ws.Evaluate("MAX(Z1:Z5)"));
+
             AssertScalarToNumberConversion("MAX", 1);
             AssertAnyErrorIsPropagated("MAX");
         }

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CF/@EntryIndexedValue">CF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NA/@EntryIndexedValue">NA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RC/@EntryIndexedValue">RC</s:String>

--- a/ClosedXML/Excel/CalcEngine/Functions/ITally.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/ITally.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace ClosedXML.Excel.CalcEngine.Functions;
+
+internal interface ITally
+{
+    OneOf<T, XLError> Tally<T>(CalcContext ctx, Span<AnyValue> args, T initialState)
+        where T : ITallyState<T>;
+}

--- a/ClosedXML/Excel/CalcEngine/Functions/ITallyState.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/ITallyState.cs
@@ -1,0 +1,6 @@
+﻿namespace ClosedXML.Excel.CalcEngine.Functions;
+
+internal interface ITallyState<out TState>
+{
+    TState Tally(double number);
+}

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -1113,11 +1113,11 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue SumSq(CalcContext ctx, Span<AnyValue> args)
         {
-            var result = Statistical.TallyNumbers(ctx, args, 0.0, static (sumSq, number) => sumSq + number * number);
+            var result = TallyNumbers.Default.Tally(ctx, args, new SumSqState(0.0));
             if (!result.TryPickT0(out var sumSq, out var error))
                 return error;
 
-            return sumSq;
+            return sumSq.Sum;
         }
 
         private static object Tan(List<Expression> p)
@@ -1142,6 +1142,14 @@ namespace ClosedXML.Excel.CalcEngine
 
             var truncated = (int)(number * scaling);
             return (double)truncated / scaling;
+        }
+
+        private readonly record struct SumSqState(double Sum) : ITallyState<SumSqState>
+        {
+            public SumSqState Tally(double number)
+            {
+                return new SumSqState(Sum + number * number);
+            }
         }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -148,7 +148,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
                 var arg1Converted = ToScalarValue(args[1], ctx);
                 if (!arg1Converted.TryPickT0(out var arg1, out var err1))
-                    return err0;
+                    return err1;
 
                 return f(arg0, arg1);
             };

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -360,28 +360,24 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue Max(CalcContext ctx, Span<AnyValue> args)
         {
-            var result = TallyNumbers.Default.Tally(ctx, args, new MaxState());
-            if (!result.TryPickT0(out var tally, out var error))
+            return Max(ctx, args, TallyNumbers.Default);
+        }
+
+        private static AnyValue Max(CalcContext ctx, Span<AnyValue> args, ITally tally)
+        {
+            var result = tally.Tally(ctx, args, new MaxState());
+            if (!result.TryPickT0(out var state, out var error))
                 return error;
 
-            if (!tally.HasValues)
+            if (!state.HasValues)
                 return 0;
 
-            return tally.Max;
+            return state.Max;
         }
 
         private static AnyValue MaxA(CalcContext ctx, Span<AnyValue> args)
         {
-            // Text in array is skipped, in reference counted as 0
-            var result = TallyAll.Default.Tally(ctx, args, new MaxState());
-            if (!result.TryPickT0(out var tally, out var error))
-                return error;
-
-            // Not even one non-ignored value found, return 0.
-            if (!tally.HasValues)
-                return 0;
-
-            return tally.Max;
+            return Max(ctx, args, TallyAll.Default);
         }
 
         private static AnyValue Median(CalcContext ctx, Span<AnyValue> args)
@@ -432,7 +428,12 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue StDev(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyNumbers.Default).TryPickT0(out var squareDiff, out var error))
+            return StDev(ctx, args, TallyNumbers.Default);
+        }
+
+        private static AnyValue StDev(CalcContext ctx, Span<AnyValue> args, ITally tally)
+        {
+            if (!GetSquareDiffSum(ctx, args, tally).TryPickT0(out var squareDiff, out var error))
                 return error;
 
             if (squareDiff.Count <= 1)
@@ -443,18 +444,17 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue StDevA(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyAll.Default).TryPickT0(out var squareDiff, out var error))
-                return error;
-
-            if (squareDiff.Count <= 1)
-                return XLError.DivisionByZero;
-
-            return Math.Sqrt(squareDiff.Sum / (squareDiff.Count - 1));
+            return StDev(ctx, args, TallyAll.Default);
         }
 
         private static AnyValue StDevP(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyNumbers.Default).TryPickT0(out var squareDiff, out var error))
+            return StDevP(ctx, args, TallyNumbers.Default);
+        }
+
+        private static AnyValue StDevP(CalcContext ctx, Span<AnyValue> args, ITally tally)
+        {
+            if (!GetSquareDiffSum(ctx, args, tally).TryPickT0(out var squareDiff, out var error))
                 return error;
 
             if (squareDiff.Count < 1)
@@ -465,18 +465,17 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue StDevPA(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyAll.Default).TryPickT0(out var squareDiff, out var error))
-                return error;
-
-            if (squareDiff.Count < 1)
-                return XLError.DivisionByZero;
-
-            return Math.Sqrt(squareDiff.Sum / squareDiff.Count);
+            return StDevP(ctx, args, TallyAll.Default);
         }
 
         private static AnyValue Var(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyNumbers.Default).TryPickT0(out var squareDiff, out var error))
+            return Var(ctx, args, TallyNumbers.Default);
+        }
+
+        private static AnyValue Var(CalcContext ctx, Span<AnyValue> args, ITally tally)
+        {
+            if (!GetSquareDiffSum(ctx, args, tally).TryPickT0(out var squareDiff, out var error))
                 return error;
 
             if (squareDiff.Count <= 1)
@@ -487,18 +486,17 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue VarA(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyAll.Default).TryPickT0(out var squareDiff, out var error))
-                return error;
-
-            if (squareDiff.Count <= 1)
-                return XLError.DivisionByZero;
-
-            return squareDiff.Sum / (squareDiff.Count - 1);
+            return Var(ctx, args,TallyAll.Default);
         }
 
         private static AnyValue VarP(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyNumbers.Default).TryPickT0(out var squareDiff, out var error))
+            return VarP(ctx, args, TallyNumbers.Default);
+        }
+
+        private static AnyValue VarP(CalcContext ctx, Span<AnyValue> args, ITally tally)
+        {
+            if (!GetSquareDiffSum(ctx, args, tally).TryPickT0(out var squareDiff, out var error))
                 return error;
 
             if (squareDiff.Count < 1)
@@ -509,13 +507,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static AnyValue VarPA(CalcContext ctx, Span<AnyValue> args)
         {
-            if (!GetSquareDiffSum(ctx, args, TallyAll.Default).TryPickT0(out var squareDiff, out var error))
-                return error;
-
-            if (squareDiff.Count < 1)
-                return XLError.DivisionByZero;
-
-            return squareDiff.Sum / squareDiff.Count;
+            return VarP(ctx, args, TallyAll.Default);
         }
 
         private static AnyValue Large(CalcContext ctx, AnyValue arrayParam, double kParam)

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyAll.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyAll.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.CalcEngine.Functions;
+
+/// <summary>
+/// A tally function for *A functions (e.g. AverageA, MinA, MaxA). The behavior is buggy in Excel,
+/// because they doesn't count logical values in array, but do count them in reference ¯\_(ツ)_/¯.
+///
+/// <list type="bullet">
+///   <item>Scalar values are converted to number, conversion might lead to errors.</item>
+///   <item>Array values ignore logical and text (unless <c>ignoreArrayText</c> is <c>false</c>).</item>
+///   <item>Reference values include logical, text is evaluated as zero.</item>
+/// </list>
+/// Any error is propagated.
+/// </summary>
+internal class TallyAll : ITally
+{
+    private readonly bool _ignoreArrayText;
+
+    /// <inheritdoc cref="TallyAll"/>
+    /// <remarks>This tally ignores text in arrays.</remarks>
+    internal static readonly ITally Default = new TallyAll(ignoreArrayText: true);
+
+    /// <inheritdoc cref="TallyAll"/>
+    /// <remarks>This tally counts text in arrays as <c>0</c>.</remarks>
+    internal static readonly ITally WithArrayText = new TallyAll(ignoreArrayText: false);
+
+    private TallyAll(bool ignoreArrayText)
+    {
+        _ignoreArrayText = ignoreArrayText;
+    }
+
+    public OneOf<T, XLError> Tally<T>(CalcContext ctx, Span<AnyValue> args, T initialState)
+        where T : ITallyState<T>
+    {
+        var state = initialState;
+        foreach (var arg in args)
+        {
+            if (arg.TryPickScalar(out var scalar, out var collection))
+            {
+                // Scalars are converted to number.
+                if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
+                    return error;
+
+                // All scalars are counted
+                state = state.Tally(number);
+            }
+            else
+            {
+                bool isArray;
+                IEnumerable<ScalarValue> valuesIterator;
+                if (collection.TryPickT0(out var array, out var reference))
+                {
+                    valuesIterator = array;
+                    isArray = true;
+                }
+                else
+                {
+                    valuesIterator = ctx.GetNonBlankValues(reference);
+                    isArray = false;
+                }
+                foreach (var value in valuesIterator)
+                {
+                    // Blank lines are ignored. Logical are counted in reference, but not in array.
+                    if (!isArray && value.TryPickLogical(out var logical))
+                    {
+                        state = state.Tally(logical ? 1 : 0);
+                    }
+                    else if (value.TryPickNumber(out var number))
+                    {
+                        state = state.Tally(number);
+                    }
+                    else if (value.IsText && (!isArray || !_ignoreArrayText))
+                    {
+                        // Some *A functions consider text in an array (e.g. {"3", "Hello"}) as a zero and others don't.
+                        // The text values from cells behave differently. Unlike array, the *A functions consider cell text as 0.
+                        state = state.Tally(0);
+                    }
+                    else if (value.TryPickError(out var error))
+                    {
+                        return error;
+                    }
+                }
+            }
+        }
+
+        return state;
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyNumbers.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyNumbers.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace ClosedXML.Excel.CalcEngine.Functions;
+
+internal class TallyNumbers : ITally
+{
+    internal static readonly ITally Default = new TallyNumbers();
+
+    /// <summary>
+    /// The method tries to convert scalar arguments to numbers, but ignores non-numbers in
+    /// reference/array. Any error found is propagated to the result.
+    /// </summary>
+    public OneOf<T, XLError> Tally<T>(CalcContext ctx, Span<AnyValue> args, T initialState)
+        where T : ITallyState<T>
+    {
+        var tally = initialState;
+        foreach (var arg in args)
+        {
+            if (arg.TryPickScalar(out var scalar, out var collection))
+            {
+                // Scalars are converted to number.
+                if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
+                    return error;
+
+                tally = tally.Tally(number);
+            }
+            else
+            {
+                var valuesIterator = !collection.TryPickT0(out var array, out var reference)
+                    ? ctx.GetNonBlankValues(reference)
+                    : array;
+                foreach (var value in valuesIterator)
+                {
+                    if (value.TryPickError(out var error))
+                        return error;
+
+                    // For arrays and references, only the number type is used. Other types are ignored.
+                    if (value.TryPickNumber(out var number))
+                        tally = tally.Tally(number);
+                }
+            }
+        }
+
+        return tally;
+    }
+}


### PR DESCRIPTION
The `Tally` is dead, long live the `ITally`.

Tally calculation was done in one function and it was rather hard to read, requiring a delegate with many parameters and functions overload.

This splits tally calculation into two parts:
* function converting arguments into scalar values
* actual algorithm that aggregates values into a single value (e.g. sum or average).

The `ITally` implementations (`TallyNumbers` and `TallyAll`) will be reusable across many functions (though Excel is inconsistent, there is only limited number of ways it counts or doesn't count some values).

Because `ITally` is an interface, I will also be able to provide custom substotal `ITally` that filters out cells with `SUBTOTAL` function or that are in hidden rows. Thus I will be able to reuse functions in subtotal (e.g. AVERAGE) and only supply different `ITally` implementation.