### PR TITLE
Add SUBTOTAL 101-111 functions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1686,12 +1686,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(2.5, ws.Cell("A3").Value);
             Assert.AreEqual(2.5, ws.Evaluate("SUBTOTAL(1, A1:A4)"));
+
+            ws.Row(2).Hide();
+            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(101, A1:A4)"));
         }
 
         [Test]
-        public void SubtotalCalc()
+        public void Subtotal10Calc()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.DefinedNames.Add("subtotalrange", "$A$37:$A$38");
 
@@ -1757,6 +1760,42 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
+        public void Subtotal100Calc()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Cell("A1").Value = 1;
+            ws.Cell("B1").Value = 2;
+            ws.Cell("C1").Value = Blank.Value;
+            ws.Cell("A2").Value = "A";
+            ws.Cell("B2").Value = 4;
+            ws.Cell("C2").Value = 8;
+            ws.Cell("A3").FormulaA1 = "SUBTOTAL(109, A1:A2)";
+            ws.Cell("B3").FormulaA1 = "SUBTOTAL(109, B1:B2)";
+            ws.Cell("C3").FormulaA1 = "SUBTOTAL(109, C1:C2)";
+            ws.Cell("A4").Value = 16;
+            ws.Cell("B4").Value = 32;
+            ws.Cell("C4").Value = 64;
+            ws.Cell("A5").Value = 128;
+            ws.Cell("B5").Value = 256;
+            ws.Cell("C5").Value = 512;
+            ws.Cell("A6").FormulaA1 = "SUBTOTAL(109, A1:A5)";
+            ws.Cell("B6").FormulaA1 = "SUBTOTAL(109, B1:B5)";
+            ws.Cell("C6").FormulaA1 = "SUBTOTAL(109, C1:C5)";
+
+            ws.Row(2).Hide();
+            ws.Row(5).Hide();
+
+            Assert.AreEqual(1, ws.Cell("A3").Value);
+            Assert.AreEqual(2, ws.Cell("B3").Value);
+            Assert.AreEqual(0, ws.Cell("C3").Value);
+            Assert.AreEqual(17, ws.Cell("A6").Value);
+            Assert.AreEqual(34, ws.Cell("B6").Value);
+            Assert.AreEqual(64, ws.Cell("C6").Value);
+        }
+
+        [Test]
         public void SubtotalCount()
         {
             using var wb = new XLWorkbook();
@@ -1768,6 +1807,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(2, ws.Cell("A4").Value);
             Assert.AreEqual(1, ws.Evaluate("SUBTOTAL(2,A2:A4)"));
+
+            ws.Row(2).Hide();
+            Assert.AreEqual(1, ws.Evaluate("SUBTOTAL(102,A1:A4)"));
         }
 
         [Test]
@@ -1782,6 +1824,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(3, ws.Cell("A4").Value);
             Assert.AreEqual(3, ws.Evaluate("SUBTOTAL(3,A1:A4)"));
+
+            ws.Row(1).Hide();
+            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(103,A1:A4)"));
         }
 
         [Test]
@@ -1796,6 +1841,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(13, ws.Cell("A4").Value);
             Assert.AreEqual(3, ws.Evaluate("SUBTOTAL(4,A1:A4)"));
+
+            ws.Cell("A5").Value = 2.5;
+            ws.Row(2).Hide();
+            Assert.AreEqual(2.5, ws.Evaluate("SUBTOTAL(104,A1:A5)"));
         }
 
         [Test]
@@ -1810,6 +1859,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(-8, ws.Cell("A4").Value);
             Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(5,A1:A4)"));
+
+            ws.Cell("A5").Value = 2.5;
+            ws.Row(1).Hide();
+            Assert.AreEqual(2.5, ws.Evaluate("SUBTOTAL(105,A1:A5)"));
         }
 
         [Test]
@@ -1824,6 +1877,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(6, ws.Cell("A4").Value);
             Assert.AreEqual(6, ws.Evaluate("SUBTOTAL(6,A1:A4)"));
+
+            ws.Row(2).Hide();
+            ws.Cell("A5").Value = 4;
+            Assert.AreEqual(8, ws.Evaluate("SUBTOTAL(106,A1:A5)"));
         }
 
         [Test]
@@ -1835,10 +1892,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = 2;
             ws.Cell("A2").Value = 3;
             ws.Cell("A3").Value = "A";
-            ws.Cell("A4").FormulaA1 = "SUBTOTAL(7,A1,A2,A3)";
+            ws.Cell("A4").FormulaA1 = "SUBTOTAL(7,A1:A3,A5)";
+            ws.Cell("A5").Value = 5;
 
-            Assert.AreEqual(0.7071067811, (double)ws.Cell("A4").Value);
-            Assert.AreEqual(0.7071067811, (double)ws.Evaluate("SUBTOTAL(7,A1:A4)"));
+            Assert.AreEqual(1.5275252316, (double)ws.Cell("A4").Value);
+            Assert.AreEqual(1.5275252316, (double)ws.Evaluate("SUBTOTAL(7,A1:A5)"));
+
+            ws.Row(2).Hide();
+            Assert.AreEqual(2.1213203435, (double)ws.Evaluate("SUBTOTAL(107,A1:A5)"));
         }
 
         [Test]
@@ -1853,6 +1914,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(0.5, ws.Cell("A4").Value);
             Assert.AreEqual(0.5, ws.Evaluate("SUBTOTAL(8,A1:A4)"));
+
+            ws.Row(2).Hide();
+            ws.Cell("A5").Value = 3;
+            Assert.AreEqual(0.5, ws.Evaluate("SUBTOTAL(108,A1:A5)"));
         }
 
         [Test]
@@ -1867,6 +1932,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(5, ws.Cell("A4").Value);
             Assert.AreEqual(5, ws.Evaluate("SUBTOTAL(9,A1:A4)"));
+
+            ws.Row(2).Hide();
+
+            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(109, A1:A4)"));
         }
 
         [Test]
@@ -1883,6 +1952,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(3, ws.Cell("A6").Value);
             Assert.AreEqual(3, ws.Evaluate("SUBTOTAL(10,A1:A6)"));
+
+            ws.Row(1).Hide();
+            ws.Row(5).Hide();
+            Assert.AreEqual(8, ws.Evaluate("SUBTOTAL(110,A1:A6)"));
         }
 
         [Test]
@@ -1897,6 +1970,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.AreEqual(0.25, ws.Cell("A4").Value);
             Assert.AreEqual(0.25, ws.Evaluate("SUBTOTAL(11,A1:A4)"));
+
+            ws.Row(2).Hide();
+            ws.Cell("A5").Value = 4;
+            Assert.AreEqual(1, ws.Evaluate("SUBTOTAL(111,A1:A5)"));
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -3,6 +3,7 @@ using ClosedXML.Excel.CalcEngine.Functions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -845,7 +846,7 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Sqrt(Math.PI * num);
         }
 
-        private static AnyValue Subtotal(CalcContext ctx, double number, AnyValue[] args)
+        private static AnyValue Subtotal(CalcContext ctx, double number, AnyValue[] fnArgs)
         {
             var funcNumber = number switch
             {
@@ -857,20 +858,32 @@ namespace ClosedXML.Excel.CalcEngine
             if (funcNumber < 0)
                 return XLError.IncompatibleValue;
 
+            var args = fnArgs.AsSpan();
             return funcNumber switch
             {
-                1 => Statistical.Average(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                2 => Statistical.Count(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                3 => Statistical.Count(ctx, args.AsSpan(), TallyAll.WithoutSubtotal),
-                4 => Statistical.Max(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                5 => Statistical.Min(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                6 => Product(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                7 => Statistical.StDev(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                8 => Statistical.StDevP(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                9 => Sum(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                10 => Statistical.Var(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                11 => Statistical.VarP(ctx, args.AsSpan(), TallyNumbers.WithoutSubtotal),
-                _ => throw new NotImplementedException(),
+                1 => Statistical.Average(ctx, args, TallyNumbers.Subtotal10),
+                2 => Statistical.Count(ctx, args, TallyNumbers.Subtotal10),
+                3 => Statistical.Count(ctx, args, TallyAll.Subtotal10),
+                4 => Statistical.Max(ctx, args, TallyNumbers.Subtotal10),
+                5 => Statistical.Min(ctx, args, TallyNumbers.Subtotal10),
+                6 => Product(ctx, args, TallyNumbers.Subtotal10),
+                7 => Statistical.StDev(ctx, args, TallyNumbers.Subtotal10),
+                8 => Statistical.StDevP(ctx, args, TallyNumbers.Subtotal10),
+                9 => Sum(ctx, args, TallyNumbers.Subtotal10),
+                10 => Statistical.Var(ctx, args, TallyNumbers.Subtotal10),
+                11 => Statistical.VarP(ctx, args, TallyNumbers.Subtotal10),
+                101 => Statistical.Average(ctx, args, TallyNumbers.Subtotal100),
+                102 => Statistical.Count(ctx, args, TallyNumbers.Subtotal100),
+                103 => Statistical.Count(ctx, args, TallyAll.Subtotal100),
+                104 => Statistical.Max(ctx, args, TallyNumbers.Subtotal100),
+                105 => Statistical.Min(ctx, args, TallyNumbers.Subtotal100),
+                106 => Product(ctx, args, TallyNumbers.Subtotal100),
+                107 => Statistical.StDev(ctx, args, TallyNumbers.Subtotal100),
+                108 => Statistical.StDevP(ctx, args, TallyNumbers.Subtotal100),
+                109 => Sum(ctx, args, TallyNumbers.Subtotal100),
+                110 => Statistical.Var(ctx, args, TallyNumbers.Subtotal100),
+                111 => Statistical.VarP(ctx, args, TallyNumbers.Subtotal100),
+                _ => throw new UnreachableException(),
             };
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyAll.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyAll.cs
@@ -43,7 +43,15 @@ internal class TallyAll : ITally
     /// </summary>
     internal static readonly ITally IncludeErrors = new TallyAll(includeErrors: true);
 
-    internal static readonly ITally WithoutSubtotal = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetNonBlankValuesWithout("SUBTOTAL", reference));
+    /// <summary>
+    /// Tally algorithm for <c>SUBTOTAL</c> functions 1..11.
+    /// </summary>
+    internal static readonly ITally Subtotal10 = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL"));
+
+    /// <summary>
+    /// Tally algorithm for <c>SUBTOTAL</c> functions 101..111.
+    /// </summary>
+    internal static readonly ITally Subtotal100 = new TallyAll(getNonBlankValues: static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL", skipHiddenRows: true));
 
     private TallyAll(bool ignoreArrayText = true, bool includeErrors = false, Func<CalcContext, Reference, IEnumerable<ScalarValue>>? getNonBlankValues = null)
     {

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyNumbers.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyNumbers.cs
@@ -20,14 +20,19 @@ internal class TallyNumbers : ITally
     internal static readonly TallyNumbers WithoutScalarBlank = new(ignoreScalarBlank: true);
 
     /// <summary>
-    /// Tally numbers without values from cells that use <c>SUBTOTAL</c> function.
+    /// Tally algorithm for <c>SUBTOTAL</c> functions 1..11.
     /// </summary>
-    internal static readonly TallyNumbers WithoutSubtotal = new(static (ctx, reference) => ctx.GetNonBlankValuesWithout("SUBTOTAL", reference));
+    internal static readonly TallyNumbers Subtotal10 = new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL"));
+
+    /// <summary>
+    /// Tally algorithm for <c>SUBTOTAL</c> functions 101..111.
+    /// </summary>
+    internal static readonly TallyNumbers Subtotal100 = new(static (ctx, reference) => ctx.GetFilteredNonBlankValues(reference, "SUBTOTAL", skipHiddenRows: true));
 
     /// <summary>
     /// Tally numbers. Any error (including conversion), logical, text is ignored and not tallied.
     /// </summary>
-    internal static readonly TallyNumbers IgnoreErrors  = new(ignoreErrors: true);
+    internal static readonly TallyNumbers IgnoreErrors = new(ignoreErrors: true);
 
     private TallyNumbers(Func<CalcContext, Reference, IEnumerable<ScalarValue>>? getNonBlankValues = null, bool ignoreScalarBlank = false, bool ignoreErrors = false)
     {


### PR DESCRIPTION
`SUBTOTAL` only supported functions 1-11. The additional `SUBTOTAL` functions 101-111 skip values from cells
* that are on hidden rows
* that contain formula that uses a `SUBTOTAL` function

Other than that, they behave same as 1-11.