### PR TITLE
Add selection criteria logic for functions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/CriteriaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CriteriaTests.cs
@@ -1,0 +1,214 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine.Functions;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine;
+
+[TestFixture]
+internal class CriteriaTests
+{
+    [Test]
+    [SetCulture("cs-CZ")] // cs-CZ has ',' as a decimal separator (e.g. '1,2' is one point two).
+    [TestCaseSource(nameof(CriteriaTestCases))]
+    public void Selection_criteria_uses_type_and_comparator_to_match_values(string selectionCriteria, XLCellValue value, bool expectedResult)
+    {
+        var criteria = Criteria.Create(selectionCriteria, CultureInfo.CurrentCulture);
+        Assert.AreEqual(expectedResult, criteria.Match(value));
+    }
+
+    public static IEnumerable<object> CriteriaTestCases
+    {
+        get
+        {
+            // Blank without compare is interpreted as number 0
+            yield return S("", 0);
+            yield return S("", "0 0/2");
+            yield return F("", Blank.Value);
+            yield return F("", "");
+            yield return F(" ", 0);
+            yield return S(" ", " ");
+
+            // Blank with equal op is interpreted as blank and type checked
+            yield return S("=", Blank.Value);
+            yield return F("=", 0);
+            yield return F("=", "0 0/2");
+            yield return F("=", "");
+
+            // Blank with not equal is interpreted as anything but blank value
+            yield return F("<>", Blank.Value);
+            yield return S("<>", 0);
+            yield return S("<>", "0 0/2");
+            yield return S("<>", "");
+
+            // Any comparison with blank always return false, like NaN.
+            foreach (var cmp in new[] { "<", "<=", ">=", ">" })
+            {
+                yield return F(cmp, Blank.Value);
+                yield return F(cmp, 0);
+                yield return F(cmp, "0 0/2");
+                yield return F(cmp, "");
+            }
+
+            // Logical are compared by type and value
+            foreach (var eq in new[] { "", "=" })
+            {
+                yield return S(eq + "TRUE", true);
+                yield return S(eq + "true", true);
+                yield return F(eq + "TRUE", "TRUE");
+                yield return F(eq + "TRUE", 1);
+                yield return S(eq + "FALSE", false);
+                yield return S(eq + "false", false);
+                yield return F(eq + "FALSE", "FALSE");
+                yield return F(eq + "FALSE", 0);
+                yield return F(eq + "FALSE", Blank.Value);
+            }
+
+            yield return S("<>TRUE", false);
+            yield return S("<>TRUE", 1);
+            yield return S("<>TRUE", "Text");
+            yield return S("<>TRUE", XLError.DivisionByZero);
+            yield return F("<>TRUE", true);
+
+            yield return S(">FALSE", true);
+            yield return F(">FALSE", false);
+            yield return F(">TRUE", true);
+
+            yield return S(">=FALSE", true);
+            yield return S(">=FALSE", false);
+
+            yield return S("<=FALSE", false);
+            yield return F("<=FALSE", true);
+
+            yield return S("<TRUE", false);
+            yield return F("<TRUE", true);
+
+            // Number converts text, if possible
+            foreach (var eq in new[] { "", "=" })
+            {
+                yield return S(eq + "1", 1);
+                yield return S(eq + ",5", 0.5);
+                yield return S(eq + "36:00", "1 1/2");
+                yield return F(eq + "1,5", "text");
+                yield return F(eq + "1", true);
+                yield return F(eq + "1", Blank.Value);
+                yield return F(eq + "1", XLError.NullValue);
+            }
+
+            yield return S("<>1", 0.9);
+            yield return F("<>1", 1);
+            yield return F("<>,5", "0 1/2");
+            yield return S("<>1", Blank.Value);
+            yield return S("<>1", true);
+            yield return S("<>1", false);
+            yield return S("<>1", "text");
+            yield return S("<>1", XLError.NullValue);
+
+            yield return F("<1", 1);
+            yield return S("<=1", 1);
+            foreach (var lt in new[] { "<", "<=" })
+            {
+                yield return S(lt + "1", 0);
+                yield return S(lt + "1", 0.9);
+                yield return S(lt + "0,5", "0,4");
+                yield return S(lt + "24:00", "0 1/2");
+                yield return F(lt + "24:00", "0 3/2");
+                yield return F(lt + "1", "text");
+                yield return F(lt + "1", "");
+                yield return F(lt + "1", false);
+            }
+
+            yield return F(">1", 1);
+            yield return S(">=1", 1);
+            foreach (var gt in new[] { ">", ">=" })
+            {
+                yield return S(gt + "1", 2);
+                yield return S(gt + "1", 1.1);
+                yield return S(gt + "0,5", "0,6");
+                yield return S(gt + "24:00", "1 1/2");
+                yield return F(gt + "24:00", "0 1/2");
+                yield return F(gt + "1", "text");
+                yield return F(gt + "1", "");
+                yield return F(gt + "0", true);
+            }
+
+            // Text for equals is a wildcard
+            foreach (var eq in new[] { "", "=" })
+            {
+                yield return S(eq + "abc", "abc");
+                yield return F(eq + "ab", "abc");
+                yield return S(eq + "AbC", "aBc");
+                yield return S(eq + "?", "a");
+                yield return S(eq + "?", "1");
+                yield return F(eq + "?", "ab");
+                yield return S(eq + "a?", "ab");
+
+                // Fail for other types
+                yield return F(eq + "?", 1);
+            }
+
+            // Not equal matches with the text and then inverts the result.
+            yield return F("<>?", "a");
+            yield return F("<>?", "b");
+            yield return S("<>?", "ab");
+            yield return S("<>?", 1);
+            yield return S("<>?", true);
+
+            // Text comparison are culture dependent and don't use wildcards
+            // In Czech, order of letters is 'h', 'ch', 'i' (yes, there is a two grapheme letter).
+            yield return F("<a", "a");
+            yield return S("<=a", "a");
+            foreach (var lt in new[] { "<", "<=" })
+            {
+                yield return S(lt + "z", "a");
+                yield return F(lt + "b", "c");
+                yield return S(lt + "?", "!");
+                yield return F(lt + "?", "a");
+                yield return S(lt + "ch", "h"); // 'h' <= 'ch' = true
+                yield return F(lt + "ch", "i"); // 'i' <= 'ch' = false.
+            }
+
+            yield return F(">a", "a");
+            yield return S(">=a", "a");
+            foreach (var gt in new[] { ">", ">=" })
+            {
+                yield return S(gt + "a", "b");
+                yield return F(gt + "?", "!");
+                yield return S(gt + "?", "a");
+                yield return S(gt + "ch", "i"); // 'i' > 'ch' = true.
+                yield return F(gt + "ch", "h"); // 'h' > 'ch' = false
+            }
+
+            // Errors
+            foreach (var eq in new[] { "", "=" })
+            {
+                yield return S(eq + "#DIV/0!", XLError.DivisionByZero);
+                yield return F(eq + "#DIV/0!", "#DIV/0!");
+                yield return F(eq + "#NULL!", 1);
+            }
+
+            yield return S(">#NULL!", XLError.DivisionByZero);
+            yield return F(">#DIV/0!", XLError.NullValue);
+
+            yield return S(">=#NULL!", XLError.DivisionByZero);
+            yield return S(">=#NULL!", XLError.NullValue);
+            yield return F(">=#DIV/0!", XLError.NullValue);
+
+            yield return S("<=#DIV/0!", XLError.NullValue);
+            yield return S("<=#NULL!", XLError.NullValue);
+            yield return F("<=#NULL!", XLError.DivisionByZero);
+
+            yield return S("<#DIV/0!", XLError.NullValue);
+            yield return F("<#NULL!", XLError.DivisionByZero);
+
+            yield break;
+
+            static object[] S(string s, XLCellValue v)
+                => new object[] { s, v, true };
+
+            static object[] F(string s, XLCellValue v)
+                => new object[] { s, v, false };
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
@@ -88,6 +88,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(-1, SearchWildcard(new string('a', 1000), new string('a', 256)));
         }
 
+        [TestCase("?", "a", true)]
+        [TestCase("?", "ab", false)]
+        [TestCase("a?", "ab", true)]
+        [TestCase("a?", "abc", false)]
+        [TestCase("?b", "ab", true)]
+        [TestCase("?b", "aab", false)]
+        [TestCase("a*", "abc", true)]
+        [TestCase("*a*", "abc", true)]
+        [TestCase("*c", "abc", true)]
+        [TestCase("*a*a", "abc", false)]
+        [TestCase("*a*a", "aba", true)]
+        [TestCase("*a*a", @"zaba", true)]
+        [TestCase("a*", @"zaba", false)]
+        public void Matches(string pattern, string text, bool matches)
+        {
+            Assert.AreEqual(matches, Wildcard.Matches(pattern.AsSpan(), text.AsSpan()));
+        }
+
         private static int SearchWildcard(string text, string pattern)
         {
             return new Wildcard(pattern).Search(text.AsSpan());

--- a/ClosedXML/Excel/CalcEngine/Functions/Criteria.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Criteria.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace ClosedXML.Excel.CalcEngine.Functions;
+
+/// <summary>
+/// A representation of selection criteria used in IFs functions <c>{SUM,AVERAGE,COUNT}{IF,IFS}</c>
+/// and database functions (<c>D{AVERAGE,COUNT,COUNTA,...}</c>).
+/// </summary>
+internal class Criteria
+{
+    private static readonly List<(string Prefix, Comparison Comparison)> AllComparisons = new()
+    {
+        ("<>", Comparison.NotEqual),
+        (">=", Comparison.GreaterOrEqualTo),
+        ("<=", Comparison.LessOrEqualTo),
+        ("=", Comparison.Equal),
+        (">", Comparison.GreaterThan),
+        ("<", Comparison.LessThan),
+    };
+
+    private readonly Comparison _comparison;
+    private readonly ScalarValue _value;
+    private readonly CultureInfo _culture;
+
+    private Criteria(Comparison comparison, ScalarValue value, CultureInfo culture)
+    {
+        _comparison = comparison;
+        _value = value;
+        _culture = culture;
+    }
+
+    internal static Criteria Create(string text, CultureInfo culture)
+    {
+        // There can't be space at the start, comparison must start at first char
+        var comparison = Comparison.Equal;
+        var prefixLength = 0;
+        foreach (var (prefix, prefixComparison) in AllComparisons)
+        {
+            if (text.StartsWith(prefix))
+            {
+                comparison = prefixComparison;
+                prefixLength = prefix.Length;
+                break;
+            }
+        }
+
+        var value = XLCellValue.FromText(text[prefixLength..], culture);
+
+        if (value.IsBlank)
+        {
+            // Empty string is matched as number 0
+            return text.Length > 0
+                ? new Criteria(comparison, ScalarValue.Blank, culture)
+                : new Criteria(comparison, 0, culture);
+        }
+
+        if (value.IsBoolean)
+            return new Criteria(comparison, value.GetBoolean(), culture);
+
+        if (value.IsUnifiedNumber)
+            return new Criteria(comparison, value.GetUnifiedNumber(), culture);
+
+        if (value.IsText)
+            return new Criteria(comparison, value.GetText(), culture);
+
+        return new Criteria(comparison, value.GetError(), culture);
+    }
+
+    internal bool Match(XLCellValue value)
+    {
+        return _value switch
+        {
+            { IsBlank: true } => CompareBlank(value),
+            { IsLogical: true } => CompareLogical(value, _value.GetLogical()),
+            { IsNumber: true } => CompareNumber(value, _value.GetNumber()),
+            { IsText: true } => CompareText(value, _value.GetText()),
+            { IsError: true } => CompareError(value, _value.GetError()),
+            _ => throw new UnreachableException(),
+        };
+    }
+
+    private bool CompareBlank(XLCellValue value)
+    {
+        if (!value.IsBlank)
+            return _comparison == Comparison.NotEqual;
+
+        // Any comparison with a blank doesn't make sense and always returns false.
+        // Both values are blank, so only equal matches.
+        return _comparison == Comparison.Equal;
+    }
+
+    private bool CompareLogical(XLCellValue value, bool actual)
+    {
+        if (!value.IsBoolean)
+            return _comparison == Comparison.NotEqual;
+
+        return Compare(value.GetBoolean().CompareTo(actual));
+    }
+
+    private bool CompareNumber(XLCellValue value, double actual)
+    {
+        double number;
+        if (value.IsUnifiedNumber)
+        {
+            number = value.GetUnifiedNumber();
+        }
+        else if (value.TryGetText(out var text) &&
+                 ScalarValue.TextToNumber(text, _culture).TryPickT0(out var parsedNumber, out _))
+        {
+            number = parsedNumber;
+        }
+        else
+        {
+            return _comparison == Comparison.NotEqual;
+        }
+
+        return Compare(number.CompareTo(actual));
+    }
+
+    private bool CompareText(XLCellValue value, string actual)
+    {
+        if (!value.IsText)
+            return _comparison == Comparison.NotEqual;
+
+        return _comparison switch
+        {
+            Comparison.Equal => Wildcard.Matches(actual.AsSpan(), value.GetText().AsSpan()),
+            Comparison.NotEqual => !Wildcard.Matches(actual.AsSpan(), value.GetText().AsSpan()),
+            Comparison.LessThan => _culture.CompareInfo.Compare(value.GetText(), actual) < 0,
+            Comparison.LessOrEqualTo => _culture.CompareInfo.Compare(value.GetText(), actual) <= 0,
+            Comparison.GreaterThan => _culture.CompareInfo.Compare(value.GetText(), actual) > 0,
+            Comparison.GreaterOrEqualTo => _culture.CompareInfo.Compare(value.GetText(), actual) >= 0,
+            _ => throw new UnreachableException()
+        };
+    }
+
+    private bool CompareError(XLCellValue value, XLError actual)
+    {
+        if (!value.IsError)
+            return _comparison == Comparison.NotEqual;
+
+        return Compare(value.GetError().CompareTo(actual));
+    }
+
+    private bool Compare(int cmp)
+    {
+        return _comparison switch
+        {
+            Comparison.Equal => cmp == 0,
+            Comparison.NotEqual => cmp != 0,
+            Comparison.LessThan => cmp < 0,
+            Comparison.LessOrEqualTo => cmp <= 0,
+            Comparison.GreaterThan => cmp > 0,
+            Comparison.GreaterOrEqualTo => cmp >= 0,
+            _ => throw new UnreachableException()
+        };
+    }
+
+    private enum Comparison
+    {
+        Equal,
+        NotEqual,
+        LessThan,
+        LessOrEqualTo,
+        GreaterThan,
+        GreaterOrEqualTo,
+    }
+}
+


### PR DESCRIPTION
Implement selection criteria that are used in several other functions: `SUMIF`, `SUMIFS`, `COUNTIF`, `COUNTIFS`, `AVERAGEIF`, `AVERAGEIFS` and db functions (`DAVERAGE`, `DCOUNT`...).

This is for final removal of `Tally` that are only used in `SUMIF/S` (though COUNTIF/S and AVERAGEIF/S will likely be also fixed in same batch).

The basic logic is to try to parse the criteria text and get comparison and a typed value. After that, just match values of same type using comparisons. There are few curveballs:

* when value is number, it also tries to convert text to a number (e.g. ">0 1/2" as criteria and value is text "24:00", the criteria is converted to `>0.5` and value text is converted to `1`)
* equal and not-equal for text use wildcards (e.g. `=?b` matches `ab`, 'bb', '?b', ...)
* empty text is sometimes compared as blank, sometimes as 0 and sometimes as empty string.