### PR TITLE
Reimplement COUNTIF

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
@@ -103,7 +103,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("a*", @"zaba", false)]
         public void Matches(string pattern, string text, bool matches)
         {
-            Assert.AreEqual(matches, Wildcard.Matches(pattern.AsSpan(), text.AsSpan()));
+            Assert.AreEqual(matches, new Wildcard(pattern).Matches(text.AsSpan()));
         }
 
         private static int SearchWildcard(string text, string pattern)

--- a/ClosedXML/Excel/CalcEngine/Functions/Criteria.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Criteria.cs
@@ -141,8 +141,8 @@ internal class Criteria
 
         return _comparison switch
         {
-            Comparison.Equal or Comparison.None => Wildcard.Matches(actual.AsSpan(), value.GetText().AsSpan()),
-            Comparison.NotEqual => !Wildcard.Matches(actual.AsSpan(), value.GetText().AsSpan()),
+            Comparison.Equal or Comparison.None => new Wildcard(actual).Matches(value.GetText().AsSpan()),
+            Comparison.NotEqual => !new Wildcard(actual).Matches(value.GetText().AsSpan()),
             Comparison.LessThan => _culture.CompareInfo.Compare(value.GetText(), actual) < 0,
             Comparison.LessOrEqualTo => _culture.CompareInfo.Compare(value.GetText(), actual) <= 0,
             Comparison.GreaterThan => _culture.CompareInfo.Compare(value.GetText(), actual) > 0,

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -154,6 +154,20 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, AnyValue, ScalarValue, AnyValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0 = args[0];
+
+                var arg1Converted = ToScalarValue(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                return f(ctx, arg0, arg1);
+            };
+        }
+
         public static CalcEngineFunction AdaptLastOptional(Func<ScalarValue, AnyValue, AnyValue, AnyValue> f, AnyValue lastDefault)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Wildcard.cs
+++ b/ClosedXML/Excel/CalcEngine/Wildcard.cs
@@ -1,202 +1,125 @@
-#nullable disable
-
 using System;
 
-namespace ClosedXML.Excel.CalcEngine
+namespace ClosedXML.Excel.CalcEngine;
+
+/// <summary>
+/// A wildcard is at most 255 chars long text. It can contain <c>*</c> which indicates any number characters (including zero)
+/// and <c>?</c> which indicates any single character. If you need to find <c>*</c> or <c>?</c> in a text, prefix them with
+/// an escape character <c>~</c>.
+/// </summary>
+internal readonly struct Wildcard
 {
-    /// <summary>
-    /// A wildcard is at most 255 chars long text. It can contain <c>*</c> which indicates any number characters (including zero)
-    /// and <c>?</c> which indicates any single character. If you need to find <c>*</c> or <c>?</c> in a text, prefix them with
-    /// an escape character <c>~</c>.
-    /// </summary>
-    internal readonly struct Wildcard
+    private readonly string _pattern;
+    private readonly bool _unpairedTilda;
+
+    public Wildcard(string pattern)
     {
-        private readonly String _pattern;
+        _pattern = pattern;
+        var tildes = 0;
+        while (tildes < _pattern.Length && _pattern[_pattern.Length - tildes - 1] == '~')
+            tildes++;
 
-        public Wildcard(String pattern)
+        _unpairedTilda = tildes % 2 == 1;
+    }
+
+    /// <summary>
+    /// Search for the wildcard anywhere in the text.
+    /// </summary>
+    /// <param name="input">Text used to search for a pattern.</param>
+    /// <returns>zero-based index of a first character in a text that matches to a pattern or -1, if match wasn't found.</returns>
+    public int Search(ReadOnlySpan<char> input)
+    {
+        var pattern = _pattern.AsSpan();
+        if (_pattern.Length > 255)
+            return -1;
+
+        if (_unpairedTilda)
+            pattern = pattern[..^1];
+
+        for (var i = 0; i <= input.Length; i++)
         {
-            _pattern = pattern;
+            var (isMatch, _) = MatchFromStart(pattern, input[i..]);
+            if (isMatch)
+                return i;
         }
 
-        /// <summary>
-        /// Search for the wildcard anywhere in the text.
-        /// </summary>
-        /// <param name="text">Text used to search for a pattern.</param>
-        /// <returns>zero-based index of a first character in a text that matches to a pattern or -1, if match wasn't found.</returns>
-        public int Search(ReadOnlySpan<char> text)
+        return -1;
+    }
+
+    /// <summary>
+    /// Match the pattern against input.
+    /// </summary>
+    /// <returns>Pattern matches whole input.</returns>
+    public bool Matches(ReadOnlySpan<char> input)
+    {
+        var pattern = _pattern.AsSpan();
+        if (_pattern.Length > 255)
+            return false;
+
+        if (_unpairedTilda)
+            pattern = pattern[..^1];
+
+        var (isMatch, inputEndIndex) = MatchFromStart(pattern, input);
+        return isMatch && inputEndIndex == input.Length;
+    }
+
+    /// <summary>
+    /// Does the start of an input match the pattern?
+    /// </summary>
+    private static (bool IsMatch, int InputEndIndex) MatchFromStart(ReadOnlySpan<char> pattern, ReadOnlySpan<char> input)
+    {
+        var inputIndex = 0;
+        var patternIndex = 0;
+        var starIndex = -1; // Index of a last processed '*' in the pattern
+        var matchIndex = 0; // Input index for last processed '*'. Basically a bookmark for backtracking.
+
+        while (inputIndex < input.Length)
         {
-            return Search(_pattern.AsSpan(), text).StartIndex;
-        }
-
-        /// <summary>
-        /// Does pattern matches whole text?
-        /// </summary>
-        public static bool Matches(ReadOnlySpan<char> pattern, ReadOnlySpan<char> text)
-        {
-            var (startIndex, endIndex) = Search(pattern, text);
-            if (startIndex != 0)
-                return false;
-
-            if (endIndex != text.Length)
-                return false;
-
-            return true;
-        }
-
-        private static (int StartIndex, int EndIndex) Search(ReadOnlySpan<char> pattern, ReadOnlySpan<char> text)
-        {
-            // Excel limits pattern size to 255, likely to avoid performance problems due to backtracking.
-            if (pattern.Length > 255)
-                return (-1, 0);
-
-            // Check to remove trailing escape ~
-            if (pattern.Length >= 2 && pattern[pattern.Length - 1] == '~' && pattern[pattern.Length - 2] != '~')
-                pattern = pattern.Slice(0, pattern.Length - 1);
-
-            // pattern index should be an index of first character of a segment. Segments start and ends with a star.
-            var patternIdx = 0;
-
-            // Index of a first segment that was recognized in the text. -1 indicates not found.
-            var firstSegmentStartIdx = -1;
-
-            // Skip the first stars in the pattern. The Search method searches within the text and it doesn't have
-            // to start at the beginning, thus stars are irrelevant for Search method.
-            while (patternIdx < pattern.Length && pattern[patternIdx] == '*')
+            if (patternIndex < pattern.Length)
             {
-                patternIdx++;
-
-                // If the pattern starts with a star, it must start at the beginning of a text
-                firstSegmentStartIdx = 0;
-            }
-
-            if (patternIdx >= pattern.Length)
-            {
-                // Whole pattern consists of * wildcards, any text satisfies the pattern.
-                return (0, text.Length);
-            }
-
-            // Text index points to the first char of yet unprocessed text. As pattern segments are matched in a text, text index increases,
-            // so the same substring of a text can't be used to match two segments.
-            var textIdx = 0;
-
-            // Because of escapes, we can't just check end character for star, we have to track it. Updated for every segment is processed.
-            var endsWithStar = false;
-
-            while (patternIdx < pattern.Length)
-            {
-                if (textIdx >= text.Length)
+                if (pattern[patternIndex] == '?')
                 {
-                    // There is still a non-star pattern, but text has ended - there is no way we can find the last segment in the text.
-                    return (-1, 0);
-                }
-
-                endsWithStar = false;
-
-                // Each loop is searching only for a specific a segment in a text that hasn't yet been processed.
-                // Segment pattern starts after previous star wildcard and ends before next star wildcard/end of pattern.
-                var segmentEnd = patternIdx;
-                for (; segmentEnd < pattern.Length; ++segmentEnd)
-                {
-                    var segmentChar = pattern[segmentEnd];
-                    if (segmentChar == '*')
-                    {
-                        endsWithStar = true;
-                        break;
-                    }
-
-                    if (segmentChar == '~' && segmentEnd + 1 < pattern.Length)
-                        segmentEnd++;
-                }
-
-                var segmentLength = segmentEnd - patternIdx;
-                var segmentPattern = pattern.Slice(patternIdx, segmentLength);
-
-                // Search only in a text that hasn't yet been used to match some previous segment pattern.
-                var textAfterPrevSegment = text.Slice(textIdx);
-                var patternPosInSegment = SearchSegment(segmentPattern, textAfterPrevSegment);
-                if (patternPosInSegment.TextStartIdx < 0)
-                {
-                    // Segment pattern is not present in the text -> whole pattern isn't in the text
-                    return (-1, 0);
-                }
-
-                if (firstSegmentStartIdx < 0)
-                    firstSegmentStartIdx = patternPosInSegment.TextStartIdx;
-
-                patternIdx += segmentLength;
-                textIdx += patternPosInSegment.TextAfterLastIdx;
-
-                // Skip stars between segments. Due to backtracking, they are rather irrelevant.
-                while (patternIdx < pattern.Length && pattern[patternIdx] == '*')
-                {
-                    endsWithStar = true;
-                    patternIdx++;
-                }
-            }
-
-            if (endsWithStar)
-                textIdx = text.Length;
-
-            return (firstSegmentStartIdx, textIdx);
-        }
-
-        /// <summary>
-        /// Check if a segment can be found in a text.
-        /// </summary>
-        /// <param name="segmentPattern">Non-empty pattern without <c>*</c> wildcard, though it can contain ? and escaped *.</param>
-        /// <param name="text">Non-empty text.</param>
-        /// <returns>First index of the pattern in the <paramref name="text"/> or -1 if not found.</returns>
-        private static (int TextStartIdx, int TextAfterLastIdx) SearchSegment(ReadOnlySpan<char> segmentPattern, ReadOnlySpan<char> text)
-        {
-            var textBacktrackStart = 0;
-            var patternIdx = 0;
-            var textIdx = 0;
-
-            while (patternIdx < segmentPattern.Length)
-            {
-                if (textIdx >= text.Length)
-                {
-                    // There is unmatched star-less pattern, but text is already over -> impossible to match the rest of a segment pattern
-                    return (-1, 0);
-                }
-
-                var patternChar = segmentPattern[patternIdx++];
-                if (patternChar == '?')
-                {
-                    textIdx++;
+                    inputIndex++;
+                    patternIndex++;
                     continue;
                 }
 
-                if (patternChar == '~')
+                if (pattern[patternIndex] == '*')
                 {
-                    if (patternIdx < segmentPattern.Length)
-                    {
-                        patternChar = segmentPattern[patternIdx++];
-                    }
-                    else
-                    {
-                        // There is only escape char, but the pattern has ended. Thus we matched.
-                        return (textBacktrackStart, textIdx);
-                    }
+                    starIndex = patternIndex;
+                    matchIndex = inputIndex;
+                    patternIndex++;
+                    continue;
                 }
 
-                var textChar = text[textIdx++];
-                var sameChar = textChar == patternChar ||
-                               char.ToUpperInvariant(textChar) == char.ToUpperInvariant(patternChar);
-                if (!sameChar)
-                {
-                    // Text and pattern don't match - we need to backtrack.
-                    if (++textBacktrackStart >= text.Length)
-                    {
-                        return (-1, 0);
-                    }
+                if (pattern[patternIndex] == '~' && patternIndex + 1 < pattern.Length)
+                    patternIndex++;
 
-                    textIdx = textBacktrackStart;
-                    patternIdx = 0;
+                if (char.ToUpperInvariant(pattern[patternIndex]) == char.ToUpperInvariant(input[inputIndex]))
+                {
+                    inputIndex++;
+                    patternIndex++;
+                    continue;
                 }
             }
 
-            return (textBacktrackStart, textIdx);
+            // Pattern didn't match the input. If there was a previous '*', backtrack and try next position in input.
+            if (starIndex != -1)
+            {
+                matchIndex++;
+                inputIndex = matchIndex;
+                patternIndex = starIndex + 1;
+                continue;
+            }
+
+            // No match for pattern char or pattern is complete while input has characters left
+            return (patternIndex == pattern.Length, inputIndex);
         }
+
+        // The input has been fully matched. Check for remaining '*' in the pattern
+        while (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+            patternIndex++;
+
+        return (patternIndex == pattern.Length, inputIndex);
     }
 }


### PR DESCRIPTION
Reimplement COUNTIF function. The implementation basically reuses `TallyCriteria`, is simpler and more faithful to Excel semantic.  It also decreases dependency on `CalcEngineHelpers` that is a legacy way to deal with criteria.