### PR TITLE
Update DocumentFormat.OpenXml due to vulnerability in System.IO.Packaging 8.0.0

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="[3.0.1,4.0.0)" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="[3.1.1,4.0.0)" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>
@@ -46,8 +46,6 @@
     </PackageReference>
     <PackageReference Include="RBush" Version="3.2.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
-    <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
-    <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
     <PackageReference Include="ClosedXML.Parser" Version="[1.2.0,2.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
The DocumentFormat.OpenXml depends on System.IO.Packaging. We originally
(when we depended on OpenXML SDK 2.x) used explicit dependency to solve
a problem with race condition.

The OpenXML SDK  3* depends on System.IO.Packaging 8.* anyway, so there is
no need to explicitely depend on it anymore and it can be removed.

The System.IO.Packaging 8.0.0 and earlier have two vulnerabilities:
* https://github.com/advisories/GHSA-qj66-m88j-hmgj
* https://github.com/advisories/GHSA-f32c-w444-8ppv

The 3.1.1 version depends on System.IO.Packaging 8.0.1 and thus we no
longer need explicitly transitive and solve security issue.

I have updated develop branch, but this is for currently released version, so consumers don't have to explicitly depend on 8.0.1 by themselves.

Related to #2494, #2491