### PR TITLE
Update RBUsh 4.0.0

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RBush" Version="3.2.0" />
+    <PackageReference Include="RBush" Version="4.0.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <PackageReference Include="ClosedXML.Parser" Version="[1.2.0,2.0.0)" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.104.1</Version>
+    <Version>0.104.2</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.104.1.{build}
+version: 0.104.2.{build}
 
 image: Visual Studio 2022
 


### PR DESCRIPTION
RBush 3.2.0 depends on netstandard 1.2, which transitively depends classic vulnerabel packages RegEx, HttpClient, ect.

I am pretty sure it's a false positive due to poor implementation of analyzer (Visual Studio reports it for netstandard2.1, but not for netstandard 2.0), but it's just not worth to try to fight the tide.

I don't think these vulnerable packages are not actually used on any maintained runtime. The runtime will just load the implementation shipped with maintained runtime that have this fixed (at least that was a response of netstandard team and I checked it for NetFx and Core).

Just another consequence of not separating implementation and contract as nuget packages for netstandard...