### PR TITLE
Update RBush and OpenXML SDK dependencies (security)

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -44,7 +44,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="RBush" Version="3.2.0" />
+    <PackageReference Include="RBush" Version="4.0.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <PackageReference Include="ClosedXML.Parser" Version="[1.2.0,2.0.0)" />
   </ItemGroup>

--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="[3.0.1,4.0.0)" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="[3.1.1,4.0.0)" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Fody" Version="6.3.0">
       <PrivateAssets>all</PrivateAssets>
@@ -46,8 +46,6 @@
     </PackageReference>
     <PackageReference Include="RBush" Version="3.2.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
-    <!-- Pre-6.0.0 System.IO.Packaging has a race condition https://github.com/dotnet/runtime/issues/43012 -->
-    <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
     <PackageReference Include="ClosedXML.Parser" Version="[1.2.0,2.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
Cherry pick changes from [0.104.2](https://github.com/ClosedXML/ClosedXML/releases/tag/0.104.2) (#2504, #2503) to develop branch.

Because OpenXML SDK released 3.1.1 (that contains reference to System.IO.Packaging 8.0.1), I can just remove out explicit dependency on System.IO.Packaging 8.0.1.