### PR TITLE
Mark IF function as a range function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/LogicalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LogicalTests.cs
@@ -1,7 +1,6 @@
 using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
-using ClosedXML.Excel.CalcEngine;
 
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
@@ -133,8 +132,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(true, ws.Evaluate(@"ISREF(IF(TRUE, A1))"));
-            Assert.AreEqual(true, ws.Evaluate(@"ISREF(IF(FALSE,, A1))"));
+            Assert.AreEqual(true, ws.Evaluate("ISREF(IF(TRUE, A1))"));
+            Assert.AreEqual(true, ws.Evaluate("ISREF(IF(FALSE,, A1))"));
+        }
+
+        [Test]
+        public void If_has_scalar_condition_and_range_values()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").InsertData(new[] { 1, 2, 3 });
+            ws.Cell("B1").InsertData(new[] { 4, 5, 6 });
+            ws.Cell("C1").InsertData(new[] { true, false, true });
+            for (var row = 1; row <= 4; ++row)
+                ws.Cell(row, 4).FormulaA1 = "SUM(IF(C1:C3, A1:A3, B1:B3))";
+
+            // Condition is implicitely intersected, because it's a scalar parameter
+            Assert.AreEqual(6, ws.Cell("D1").Value);
+            Assert.AreEqual(15, ws.Cell("D2").Value);
+            Assert.AreEqual(6, ws.Cell("D3").Value);
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("D4").Value);
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             ce.RegisterFunction("AND", 1, int.MaxValue, And, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("FALSE", 0, 0, Adapt(False), FunctionFlags.Scalar);
-            ce.RegisterFunction("IF", 2, 3, AdaptLastOptional(If, false), FunctionFlags.Scalar);
+            ce.RegisterFunction("IF", 2, 3, AdaptLastOptional(If, false), FunctionFlags.Range, AllowRange.Only, 1, 2);
             ce.RegisterFunction("IFERROR", 2, 2, Adapt((Func<ScalarValue, ScalarValue, AnyValue>)IfError), FunctionFlags.Scalar);
             ce.RegisterFunction("NOT", 1, 1, AdaptCoerced(Not), FunctionFlags.Scalar);
             ce.RegisterFunction("OR", 1, int.MaxValue, Or, FunctionFlags.Range, AllowRange.All);


### PR DESCRIPTION
The `IF` function should have a scalar test parameter and then two range parameters. It currently has all parameters marked as scalar and therefore reference values are intersected into single values. That is problem when values from `IF` function are then used as arguments of some range function (e.g. `SUMIFS` or `SUM(IF(TRUE, A1:A5, B1:B5))`).

Mark the function appropriately, so only the condition parameter is implicitly intersected.

The test values in test case use logical values directly, because there is a problem with how implicit intersection is implemented (it should be done earlier and should depend on the context of the function argument, but is global instead). This way, the test actually tests what it should without running afoul of this problem.
Most users use scalar conditions (e.g. `IF(D1 = "Cake", ..)`), so the implicit intersection won't affect most users.

Resolves #1707