### PR TITLE
Blanks should not be ignored in not-equls criteria funcs (SUMIF/S, COUTNIF/S)

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -2303,6 +2303,22 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula));
         }
 
+        [TestCase("SUMIFS(A1:A3, B1:B3,\"<>B\")", 11)]
+        [TestCase("SUMIFS(A1:A3, B1:B3,\"<>\")", 110)]
+        public void SumIfs_matches_blank_cells_when_criteria_is_not_equal(string formula, double expectedSum)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 10;
+            ws.Cell("A3").Value = 100;
+            ws.Cell("B1").Value = Blank.Value;
+            ws.Cell("B2").Value = string.Empty;
+            ws.Cell("B3").Value = "B";
+
+            Assert.AreEqual(expectedSum, ws.Evaluate(formula));
+        }
+
         [Test]
         public void SumProduct()
         {

--- a/ClosedXML/Excel/CalcEngine/Functions/Criteria.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Criteria.cs
@@ -36,7 +36,23 @@ internal class Criteria
     /// <summary>
     /// Can a blank value match the criteria?
     /// </summary>
-    internal bool CanBlankValueMatch => _value.IsBlank && _comparison is Comparison.Equal or Comparison.None;
+    internal bool CanBlankValueMatch
+    {
+        get
+        {
+            // Criteria accepts only values equal to blank (it's either blank or empty text).
+            // Therefore blank values must be included, because blank is equal to blank.
+            if (_comparison is Comparison.Equal or Comparison.None && _value.IsBlank)
+                return true;
+
+            // Criteria accepts only values that are not a concrete value. Blank values
+            // are not concrete values and therefore must be included.
+            if (_comparison == Comparison.NotEqual && !_value.IsBlank)
+                return true;
+
+            return false;
+        }
+    }
 
     internal static Criteria Create(ScalarValue criteria, CultureInfo culture)
     {


### PR DESCRIPTION
When `TallyCriteria` applies criteria to criteria areas, it uses optimized used-only cells iterator. That makes evaluation much faster for criteria functions with large references (e.g. full column).

To determine whether `TallyCriteria` should use optimized iterator or go-over-everything iterator, is checks whether whether it's even possible for blank value to be included (e.g. `>2` will bever match blank).

This check didn't properly include values for not equal operator and therefore criteria functions (`SUMIF`, `SUMIFS`,`COUNTIF`, `COUNTIFS`...) just skipped blank cells without including them in the result.

Resolves #1567