### PR TITLE
Refactor simple number functions from legacy

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -856,7 +856,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-1, -57.2957795130823)]
         public void Degrees_ReturnsCorrectResult(double input, double expected)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"DEGREES({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"DEGREES({input})");
             Assert.AreEqual(expected, actual, tolerance);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -197,15 +197,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1, 1.570796327)]
         public void Asin_ReturnsCorrectResult(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ASIN({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ASIN({input})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
         [Theory]
         public void Asin_ThrowsNumberExceptionWhenAbsOfInputGreaterThan1([Range(-3, -1.1, 0.1)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ASIN({0})", input.ToString(CultureInfo.InvariantCulture))));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ASIN({0})", (-input).ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ASIN({input})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ASIN({-input})"));
         }
 
         [TestCase(0, 0)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -959,15 +959,6 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FACT(""x"")"));
         }
 
-        [Test]
-        public void FactDouble()
-        {
-            object actual1 = XLWorkbook.EvaluateExpr("FactDouble(6)");
-            Assert.AreEqual(48.0, actual1);
-            object actual2 = XLWorkbook.EvaluateExpr("FactDouble(7)");
-            Assert.AreEqual(105.0, actual2);
-        }
-
         [TestCase(0, 1L)]
         [TestCase(1, 1L)]
         [TestCase(2, 2L)]
@@ -993,20 +984,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(2.8, 2L)]
         public void FactDouble_ReturnsCorrectResult(double input, long expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"FACTDOUBLE({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"FACTDOUBLE({input})");
             Assert.AreEqual(expectedResult, actual);
+        }
+
+        [TestCase(301)]
+        [TestCase(1e+100)]
+        public void FactDouble_returns_error_on_too_large_value(double n)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FACTDOUBLE({n})"));
         }
 
         [Theory]
         public void FactDouble_ThrowsNumberExceptionForInputSmallerThanMinus1([Range(-10, -2)] int input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"FACTDOUBLE({0})", input.ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FACTDOUBLE({input})"));
         }
 
         [Test]
         public void FactDouble_ThrowsValueExceptionForNonNumericInput()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(string.Format(@"FACTDOUBLE(""x"")")));
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FACTDOUBLE(""x"")"));
         }
 
         [TestCase(24.3, 5, 20)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -65,7 +65,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Theory]
         public void Acosh_NumbersBelow1ThrowNumberException([Range(-1, 0.9, 0.1)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ACOSH({0})", input.ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOSH({input})"));
         }
 
         [TestCase(1.2, 0.622362504)]
@@ -88,7 +88,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1, 0)]
         public void Acosh_ReturnsCorrectValue(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ACOSH({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOSH({input})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1007,6 +1007,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FACTDOUBLE(""x"")"));
         }
 
+        [TestCase(0, 0, 0)]
+        [TestCase(0, 1, 0)]
         [TestCase(24.3, 5, 20)]
         [TestCase(6.7, 1, 6)]
         [TestCase(-8.1, 2, -10)]
@@ -1015,7 +1017,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-5.5, -2.1, -4.2)]
         public void Floor(double input, double significance, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"FLOOR({input.ToInvariantString()}, {significance.ToInvariantString()})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})");
             Assert.AreEqual(expectedResult, actual, tolerance);
         }
 
@@ -1023,13 +1025,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-6.7, 0)]
         public void Floor_ThrowsDivisionByZeroOnZeroSignificance(double input, double significance)
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr($"FLOOR({input.ToInvariantString()}, {significance.ToInvariantString()})"));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
         }
 
         [TestCase(6.7, -1)]
         public void Floor_ThrowsNumberExceptionOnInvalidInput(double input, double significance)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FLOOR({input.ToInvariantString()}, {significance.ToInvariantString()})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -225,9 +225,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(5, 2.31243834127275)]
         public void Asinh_ReturnsCorrectResult(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ASINH({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ASINH({input})");
             Assert.AreEqual(expectedResult, actual, tolerance);
-            var minusActual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ASINH({0})", (-input).ToString(CultureInfo.InvariantCulture)));
+            var minusActual = (double)XLWorkbook.EvaluateExpr($"ASINH({-input})");
             Assert.AreEqual(-expectedResult, minusActual, tolerance);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -676,10 +676,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8.4, 2223.53348628359)]
         public void Cosh_ReturnsCorrectResult(double input, double expectedResult)
         {
-            var actualResult = (double)XLWorkbook.EvaluateExpr(string.Format("COSH({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actualResult = (double)XLWorkbook.EvaluateExpr($"COSH({input})");
             Assert.AreEqual(expectedResult, actualResult, tolerance);
-            var actualResult2 = (double)XLWorkbook.EvaluateExpr(string.Format("COSH({0})", (-input).ToString(CultureInfo.InvariantCulture)));
+            var actualResult2 = (double)XLWorkbook.EvaluateExpr($"COSH({-input})");
             Assert.AreEqual(expectedResult, actualResult2, tolerance);
+        }
+
+        [TestCase(711)]
+        [TestCase(-711)]
+        [TestCase(100000)]
+        public void Cosh_too_large_returns_error(double input)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"COSH({input})"));
         }
 
         [TestCase(1, 0.642092616)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -349,19 +349,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-0.999, -3.8002011672502)]
         public void Atanh_ReturnsCorrectResults(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"ATANH({0})",
-                    input.ToString(CultureInfo.InvariantCulture)));
-
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATANH({input})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
         [Theory]
         public void Atanh_ThrowsNumberExceptionWhenAbsOfInput1OrGreater([Range(1, 5, 0.2)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ATANH({0})", input.ToString(CultureInfo.InvariantCulture))));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ATANH({0})", (-input).ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ATANH({input})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ATANH({-input})"));
         }
 
         [TestCase(0, 36, "0")]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -248,9 +248,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(5, 1.37340076694502)]
         public void Atan_ReturnsCorrectResult(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN({input})");
             Assert.AreEqual(expectedResult, actual, tolerance);
-            var minusActual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN({0})", (-input).ToString(CultureInfo.InvariantCulture)));
+            var minusActual = (double)XLWorkbook.EvaluateExpr($"ATAN({-input})");
             Assert.AreEqual(-expectedResult, minusActual, tolerance);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -648,7 +648,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8.4, -0.519288654116686)]
         public void Cos_ReturnsCorrectResult(double input, double expectedResult)
         {
-            var actualResult = (double)XLWorkbook.EvaluateExpr(string.Format("COS({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actualResult = (double)XLWorkbook.EvaluateExpr($"COS({input})");
             Assert.AreEqual(expectedResult, actualResult, tolerance);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -860,40 +860,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(expected, actual, tolerance);
         }
 
-        [Test]
-        public void Even()
-        {
-            object actual = XLWorkbook.EvaluateExpr("Even(3)");
-            Assert.AreEqual(4, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Even(2)");
-            Assert.AreEqual(2, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Even(-1)");
-            Assert.AreEqual(-2, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Even(-2)");
-            Assert.AreEqual(-2, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Even(0)");
-            Assert.AreEqual(0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Even(1.5)");
-            Assert.AreEqual(2, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Even(2.01)");
-            Assert.AreEqual(4, actual);
-        }
-
-        [TestCase(1.5, 2)]
         [TestCase(3, 4)]
         [TestCase(2, 2)]
         [TestCase(-1, -2)]
+        [TestCase(-2, -2)]
         [TestCase(0, 0)]
+        [TestCase(1.5, 2)]
+        [TestCase(2.01, 4)]
+        [TestCase(1e+100, 1e+100)]
         [TestCase(Math.PI, 4)]
-        public void Even_ReturnsCorrectResults(double input, double expectedResult)
+        public void Even(double number, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"EVEN({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = XLWorkbook.EvaluateExpr($"EVEN({number})");
             Assert.AreEqual(expectedResult, actual);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -49,16 +49,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1, 0)]
         public void Acos_ReturnsCorrectValue(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ACOS({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOS({input.ToInvariantString()})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
         [Theory]
-        public void Acos_ThrowsNumberExceptionOutsideRange([Range(1.1, 3, 0.1)] double input)
+        public void Acos_returns_error_when_number_outside_range([Range(1.1, 3, 0.1)] double input)
         {
             // checking input and it's additive inverse as both are outside range.
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ACOS({0})", input.ToString(CultureInfo.InvariantCulture))));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ACOS({0})", (-input).ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({input.ToInvariantString()})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({(-input).ToInvariantString()})"));
         }
 
         [Theory]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -888,10 +888,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(10, 22026.4657948067)]
         [TestCase(11, 59874.1417151978)]
         [TestCase(12, 162754.791419004)]
-        public void Exp_ReturnsCorrectResults(double input, double expectedResult)
+        [TestCase(-1E+100, 0)]
+        public void Exp_returns_correct_results(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"EXP({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"EXP({input})");
             Assert.AreEqual(expectedResult, actual, tolerance);
+        }
+
+        [TestCase(710)]
+        public void Exp_with_too_large_result_return_error(double input)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"EXP({input})"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
     [TestFixture]
+    [SetCulture("en-US")]
     public class MathTrigTests
     {
         private readonly double tolerance = 1e-10;
@@ -49,7 +50,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1, 0)]
         public void Acos_ReturnsCorrectValue(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"ACOS({input.ToInvariantString()})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOS({input})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
@@ -57,8 +58,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Acos_returns_error_when_number_outside_range([Range(1.1, 3, 0.1)] double input)
         {
             // checking input and it's additive inverse as both are outside range.
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({input.ToInvariantString()})"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({(-input).ToInvariantString()})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({input})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({-input})"));
         }
 
         [Theory]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -257,7 +257,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Atan2_Returns0OnSecond0AndFirstGreater0([Range(0.1, 5, 0.4)] double input)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN2({0}, 0)", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, 0)");
             Assert.AreEqual(0, actual, tolerance);
         }
 
@@ -282,12 +282,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             for (int i = 1; i < 5; i++)
             {
-                var actual = (double)XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"ATAN2({0}, {1})",
-                    (x * i).ToString(CultureInfo.InvariantCulture),
-                    (y * i).ToString(CultureInfo.InvariantCulture)));
-
+                var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({x * i}, {y * i})");
                 Assert.AreEqual(expectedResult, actual, tolerance);
             }
         }
@@ -295,42 +290,42 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Atan2_ReturnsHalfPiOn0AsFirstInputWhenSecondGreater0([Range(0.1, 5, 0.4)] double input)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN2(0, {0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2(0, {input})");
             Assert.AreEqual(0.5 * Math.PI, actual, tolerance);
         }
 
         [Test]
         public void Atan2_ReturnsMinus3QuartersOfPiWhenFirstSmaller0AndSecondItsNegative([Range(-5, -0.1, 0.3)] double input)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN2({0}, {0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, {input})");
             Assert.AreEqual(-0.75 * Math.PI, actual, tolerance);
         }
 
         [Test]
         public void Atan2_ReturnsMinusHalfPiOn0AsFirstInputWhenSecondSmaller0([Range(-5, -0.1, 0.4)] double input)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN2(0, {0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2(0, {input})");
             Assert.AreEqual(-0.5 * Math.PI, actual, tolerance);
         }
 
         [Test]
         public void Atan2_ReturnsPiOn0AsSecondInputWhenFirstSmaller0([Range(-5, -0.1, 0.4)] double input)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN2({0}, 0)", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, 0)");
             Assert.AreEqual(Math.PI, actual, tolerance);
         }
 
         [Test]
         public void Atan2_ReturnsQuarterOfPiWhenInputsAreEqualAndGreater0([Range(0.1, 5, 0.3)] double input)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ATAN2({0}, {0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, {input})");
             Assert.AreEqual(0.25 * Math.PI, actual, tolerance);
         }
 
         [Test]
         public void Atan2_ThrowsDiv0ExceptionOn0And0()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"ATAN2(0, 0)"));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("ATAN2(0, 0)"));
         }
 
         [TestCase(-0.99, -2.64665241236225)]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -35,6 +35,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DEVSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enumerables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=FACTDOUBLE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FILTERXML/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formulae/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=furigana/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -11,6 +11,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AARRGGBB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=argb/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ASINH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofilter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AVERAGEA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AVERAGEIF/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -12,6 +12,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=argb/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ASINH/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ATANH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofilter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AVERAGEA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AVERAGEIF/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -9,6 +9,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=4386F01B791C56499C7EA059B55FFB54/@KeyIndexDefined">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AARRGGBB/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=argb/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofilter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AVERAGEA/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -495,7 +495,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             }
         }
 
-        private static AnyValue Year(double serialDateTime)
+        private static ScalarValue Year(double serialDateTime)
         {
             serialDateTime = Math.Truncate(serialDateTime);
             if (serialDateTime < 0)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -34,7 +34,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("COMBIN", 2, 2, Adapt(Combin), FunctionFlags.Scalar);
             ce.RegisterFunction("COMBINA", 2, CombinA);
             ce.RegisterFunction("COS", 1, 1, Adapt(Cos), FunctionFlags.Scalar);
-            ce.RegisterFunction("COSH", 1, Cosh);
+            ce.RegisterFunction("COSH", 1, 1, Adapt(Cosh), FunctionFlags.Scalar);
             ce.RegisterFunction("COT", 1, Cot);
             ce.RegisterFunction("COTH", 1, Coth);
             ce.RegisterFunction("CSC", 1, Csc);
@@ -326,9 +326,13 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Cos(number);
         }
 
-        private static object Cosh(List<Expression> p)
+        private static ScalarValue Cosh(double number)
         {
-            return Math.Cosh(p[0]);
+            var cosh = Math.Cosh(number);
+            if (double.IsInfinity(cosh))
+                return XLError.NumberInvalid;
+
+            return cosh;
         }
 
         private static object Cot(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -23,7 +23,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ACOT", 1, Acot);
             ce.RegisterFunction("ACOTH", 1, Acoth);
             ce.RegisterFunction("ARABIC", 1, Arabic);
-            ce.RegisterFunction("ASIN", 1, Asin);
+            ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
             ce.RegisterFunction("ASINH", 1, Asinh);
             ce.RegisterFunction("ATAN", 1, Atan);
             ce.RegisterFunction("ATAN2", 2, Atan2);
@@ -193,13 +193,12 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
-        private static object Asin(List<Expression> p)
+        private static ScalarValue Asin(double number)
         {
-            double input = p[0];
-            if (Math.Abs(input) > 1)
+            if (Math.Abs(number) > 1)
                 return XLError.NumberInvalid;
 
-            return Math.Asin(input);
+            return Math.Asin(number);
         }
 
         private static object Asinh(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -19,7 +19,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             ce.RegisterFunction("ABS", 1, 1, Adapt(Abs), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOS", 1, 1, Adapt(Acos), FunctionFlags.Scalar);
-            ce.RegisterFunction("ACOSH", 1, Acosh);
+            ce.RegisterFunction("ACOSH", 1, 1, Adapt(Acosh), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOT", 1, Acot);
             ce.RegisterFunction("ACOTH", 1, Acoth);
             ce.RegisterFunction("ARABIC", 1, Arabic);
@@ -143,13 +143,12 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Acos(number);
         }
 
-        private static object Acosh(List<Expression> p)
+        private static ScalarValue Acosh(double number)
         {
-            double number = p[0];
             if (number < 1)
                 return XLError.NumberInvalid;
 
-            return XLMath.ACosh(p[0]);
+            return XLMath.ACosh(number);
         }
 
         private static object Acot(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -40,7 +40,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("CSC", 1, Csc);
             ce.RegisterFunction("CSCH", 1, Csch);
             ce.RegisterFunction("DECIMAL", 2, MathTrig.Decimal);
-            ce.RegisterFunction("DEGREES", 1, Degrees);
+            ce.RegisterFunction("DEGREES", 1, 1, Adapt(Degrees), FunctionFlags.Scalar);
             ce.RegisterFunction("EVEN", 1, Even);
             ce.RegisterFunction("EXP", 1, Exp);
             ce.RegisterFunction("FACT", 1, 1, Adapt(Fact), FunctionFlags.Scalar);
@@ -405,9 +405,9 @@ namespace ClosedXML.Excel.CalcEngine
             return result;
         }
 
-        private static object Degrees(List<Expression> p)
+        private static ScalarValue Degrees(double number)
         {
-            return p[0] * (180.0 / Math.PI);
+            return number * (180.0 / Math.PI);
         }
 
         private static object Even(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -26,7 +26,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
             ce.RegisterFunction("ASINH", 1, 1, Adapt(Asinh), FunctionFlags.Scalar);
             ce.RegisterFunction("ATAN", 1, 1, Adapt(Atan), FunctionFlags.Scalar);
-            ce.RegisterFunction("ATAN2", 2, Atan2);
+            ce.RegisterFunction("ATAN2", 2, 2, Adapt(Atan2), FunctionFlags.Scalar);
             ce.RegisterFunction("ATANH", 1, 1, Adapt(Atanh), FunctionFlags.Scalar);
             ce.RegisterFunction("BASE", 2, 3, Base);
             ce.RegisterFunction("CEILING", 2, Ceiling);
@@ -211,10 +211,8 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Atan(number);
         }
 
-        private static object Atan2(List<Expression> p)
+        private static ScalarValue Atan2(double x, double y)
         {
-            double x = p[0];
-            double y = p[1];
             if (x == 0 && y == 0)
                 return XLError.DivisionByZero;
 
@@ -296,7 +294,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return -Math.Ceiling(-number / Math.Abs(significance)) * Math.Abs(significance);
         }
 
-        private static AnyValue Combin(double number, double numberChosen)
+        private static ScalarValue Combin(double number, double numberChosen)
         {
             var combinationsResult = XLMath.CombinChecked(number, numberChosen);
             if (!combinationsResult.TryPickT0(out var combinations, out var error))
@@ -919,7 +917,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             if (!sumRange.TryPickArea(out var sumArea, out var sumAreaError))
                 return sumAreaError;
-            
+
             var tally = new TallyCriteria();
             foreach (var (selectionRange, selectionCriteria) in criteriaRanges)
             {

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ARABIC", 1, Arabic);
             ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
             ce.RegisterFunction("ASINH", 1, 1, Adapt(Asinh), FunctionFlags.Scalar);
-            ce.RegisterFunction("ATAN", 1, Atan);
+            ce.RegisterFunction("ATAN", 1, 1, Adapt(Atan), FunctionFlags.Scalar);
             ce.RegisterFunction("ATAN2", 2, Atan2);
             ce.RegisterFunction("ATANH", 1, Atanh);
             ce.RegisterFunction("BASE", 2, 3, Base);
@@ -206,9 +206,9 @@ namespace ClosedXML.Excel.CalcEngine
             return XLMath.Asinh(number);
         }
 
-        private static object Atan(List<Expression> p)
+        private static ScalarValue Atan(double number)
         {
-            return Math.Atan(p[0]);
+            return Math.Atan(number);
         }
 
         private static object Atan2(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -33,7 +33,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("CEILING.MATH", 1, 3, CeilingMath);
             ce.RegisterFunction("COMBIN", 2, 2, Adapt(Combin), FunctionFlags.Scalar);
             ce.RegisterFunction("COMBINA", 2, CombinA);
-            ce.RegisterFunction("COS", 1, Cos);
+            ce.RegisterFunction("COS", 1, 1, Adapt(Cos), FunctionFlags.Scalar);
             ce.RegisterFunction("COSH", 1, Cosh);
             ce.RegisterFunction("COT", 1, Cot);
             ce.RegisterFunction("COTH", 1, Coth);
@@ -321,9 +321,9 @@ namespace ClosedXML.Excel.CalcEngine
                 : (long)XLMath.Combin(n, k);
         }
 
-        private static object Cos(List<Expression> p)
+        private static ScalarValue Cos(double number)
         {
-            return Math.Cos(p[0]);
+            return Math.Cos(number);
         }
 
         private static object Cosh(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("DECIMAL", 2, MathTrig.Decimal);
             ce.RegisterFunction("DEGREES", 1, 1, Adapt(Degrees), FunctionFlags.Scalar);
             ce.RegisterFunction("EVEN", 1, 1, Adapt(Even), FunctionFlags.Scalar);
-            ce.RegisterFunction("EXP", 1, Exp);
+            ce.RegisterFunction("EXP", 1, 1, Adapt(Exp), FunctionFlags.Scalar);
             ce.RegisterFunction("FACT", 1, 1, Adapt(Fact), FunctionFlags.Scalar);
             ce.RegisterFunction("FACTDOUBLE", 1, FactDouble);
             ce.RegisterFunction("FLOOR", 2, Floor);
@@ -417,9 +417,13 @@ namespace ClosedXML.Excel.CalcEngine
             return XLMath.IsEven(num) ? num : num + addValue;
         }
 
-        private static object Exp(List<Expression> p)
+        private static ScalarValue Exp(double number)
         {
-            return Math.Exp(p[0]);
+            var exp = Math.Exp(number);
+            if (double.IsInfinity(exp))
+                return XLError.NumberInvalid;
+
+            return exp;
         }
 
         private static ScalarValue Fact(double n)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -45,7 +45,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("EXP", 1, 1, Adapt(Exp), FunctionFlags.Scalar);
             ce.RegisterFunction("FACT", 1, 1, Adapt(Fact), FunctionFlags.Scalar);
             ce.RegisterFunction("FACTDOUBLE", 1, 1, Adapt(FactDouble), FunctionFlags.Scalar);
-            ce.RegisterFunction("FLOOR", 2, Floor);
+            ce.RegisterFunction("FLOOR", 2, 2, Adapt(Floor), FunctionFlags.Scalar);
             ce.RegisterFunction("FLOOR.MATH", 1, 3, FloorMath);
             ce.RegisterFunction("GCD", 1, 255, Gcd);
             ce.RegisterFunction("INT", 1, Int);
@@ -456,19 +456,22 @@ namespace ClosedXML.Excel.CalcEngine
             return fact;
         }
 
-        private static object Floor(List<Expression> p)
+        private static ScalarValue Floor(double number, double significance)
         {
-            double number = p[0];
-            double significance = p[1];
+            // Rounding down, to zero. If we are at the zero, there is nowhere to go.
+            if (number == 0)
+                return 0;
+
+            if (number > 0 && significance < 0)
+                return XLError.NumberInvalid;
 
             if (significance == 0)
                 return XLError.DivisionByZero;
-            else if (significance < 0 && number > 0)
-                return XLError.NumberInvalid;
-            else if (significance < 0)
+
+            if (significance < 0)
                 return -Math.Floor(-number / -significance) * -significance;
-            else
-                return Math.Floor(number / significance) * significance;
+
+            return Math.Floor(number / significance) * significance;
         }
 
         private static object FloorMath(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -1,10 +1,8 @@
 // Keep this file CodeMaid organised and cleaned
 using ClosedXML.Excel.CalcEngine.Functions;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using static ClosedXML.Excel.CalcEngine.Functions.SignatureAdapter;
@@ -20,7 +18,7 @@ namespace ClosedXML.Excel.CalcEngine
         public static void Register(FunctionRegistry ce)
         {
             ce.RegisterFunction("ABS", 1, 1, Adapt(Abs), FunctionFlags.Scalar);
-            ce.RegisterFunction("ACOS", 1, Acos);
+            ce.RegisterFunction("ACOS", 1, 1, Adapt(Acos), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOSH", 1, Acosh);
             ce.RegisterFunction("ACOT", 1, Acot);
             ce.RegisterFunction("ACOTH", 1, Acoth);
@@ -137,13 +135,12 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Abs(number);
         }
 
-        private static object Acos(List<Expression> p)
+        private static ScalarValue Acos(double number)
         {
-            double input = p[0];
-            if (Math.Abs(input) > 1)
+            if (Math.Abs(number) > 1)
                 return XLError.NumberInvalid;
 
-            return Math.Acos(p[0]);
+            return Math.Acos(number);
         }
 
         private static object Acosh(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("EVEN", 1, 1, Adapt(Even), FunctionFlags.Scalar);
             ce.RegisterFunction("EXP", 1, 1, Adapt(Exp), FunctionFlags.Scalar);
             ce.RegisterFunction("FACT", 1, 1, Adapt(Fact), FunctionFlags.Scalar);
-            ce.RegisterFunction("FACTDOUBLE", 1, FactDouble);
+            ce.RegisterFunction("FACTDOUBLE", 1, 1, Adapt(FactDouble), FunctionFlags.Scalar);
             ce.RegisterFunction("FLOOR", 2, Floor);
             ce.RegisterFunction("FLOOR.MATH", 1, 3, FloorMath);
             ce.RegisterFunction("GCD", 1, 255, Gcd);
@@ -434,25 +434,25 @@ namespace ClosedXML.Excel.CalcEngine
             return XLMath.Factorial((int)Math.Floor(n));
         }
 
-        private static object FactDouble(List<Expression> p)
+        private static ScalarValue FactDouble(double n)
         {
-            var input = p[0].Evaluate();
-
-            if (!(input is long || input is int || input is byte || input is double || input is float))
-                return XLError.IncompatibleValue;
-
-            var num = Math.Floor(p[0]);
-            double fact = 1.0;
-
+            var num = Math.Floor(n);
             if (num < -1)
                 return XLError.NumberInvalid;
 
+            var fact = 1.0;
+
             if (num > 1)
             {
-                var start = Math.Abs(num % 2) < XLHelper.Epsilon ? 2 : 1;
-                for (int i = start; i <= num; i += 2)
+                var start = XLMath.IsEven(num) ? 2 : 1;
+                for (var i = start; i <= num; i += 2)
+                {
                     fact *= i;
+                    if (double.IsInfinity(fact))
+                        return XLError.NumberInvalid;
+                }
             }
+
             return fact;
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -132,7 +132,7 @@ namespace ClosedXML.Excel.CalcEngine
             return radians / Math.PI * 200.0;
         }
 
-        private static AnyValue Abs(double number)
+        private static ScalarValue Abs(double number)
         {
             return Math.Abs(number);
         }
@@ -426,7 +426,7 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Exp(p[0]);
         }
 
-        private static AnyValue Fact(double n)
+        private static ScalarValue Fact(double n)
         {
             if (n is < 0 or >= 171)
                 return XLError.NumberInvalid;

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ACOTH", 1, Acoth);
             ce.RegisterFunction("ARABIC", 1, Arabic);
             ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
-            ce.RegisterFunction("ASINH", 1, Asinh);
+            ce.RegisterFunction("ASINH", 1, 1, Adapt(Asinh), FunctionFlags.Scalar);
             ce.RegisterFunction("ATAN", 1, Atan);
             ce.RegisterFunction("ATAN2", 2, Atan2);
             ce.RegisterFunction("ATANH", 1, Atanh);
@@ -201,9 +201,9 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Asin(number);
         }
 
-        private static object Asinh(List<Expression> p)
+        private static ScalarValue Asinh(double number)
         {
-            return XLMath.ASinh(p[0]);
+            return XLMath.Asinh(number);
         }
 
         private static object Atan(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -27,7 +27,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ASINH", 1, 1, Adapt(Asinh), FunctionFlags.Scalar);
             ce.RegisterFunction("ATAN", 1, 1, Adapt(Atan), FunctionFlags.Scalar);
             ce.RegisterFunction("ATAN2", 2, Atan2);
-            ce.RegisterFunction("ATANH", 1, Atanh);
+            ce.RegisterFunction("ATANH", 1, 1, Adapt(Atanh), FunctionFlags.Scalar);
             ce.RegisterFunction("BASE", 2, 3, Base);
             ce.RegisterFunction("CEILING", 2, Ceiling);
             ce.RegisterFunction("CEILING.MATH", 1, 3, CeilingMath);
@@ -221,13 +221,12 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Atan2(y, x);
         }
 
-        private static object Atanh(List<Expression> p)
+        private static ScalarValue Atanh(double number)
         {
-            double input = p[0];
-            if (Math.Abs(input) >= 1)
+            if (Math.Abs(number) >= 1)
                 return XLError.NumberInvalid;
 
-            return XLMath.ATanh(p[0]);
+            return XLMath.ATanh(number);
         }
 
         private static object Base(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("CSCH", 1, Csch);
             ce.RegisterFunction("DECIMAL", 2, MathTrig.Decimal);
             ce.RegisterFunction("DEGREES", 1, 1, Adapt(Degrees), FunctionFlags.Scalar);
-            ce.RegisterFunction("EVEN", 1, Even);
+            ce.RegisterFunction("EVEN", 1, 1, Adapt(Even), FunctionFlags.Scalar);
             ce.RegisterFunction("EXP", 1, Exp);
             ce.RegisterFunction("FACT", 1, 1, Adapt(Fact), FunctionFlags.Scalar);
             ce.RegisterFunction("FACTDOUBLE", 1, FactDouble);
@@ -410,9 +410,9 @@ namespace ClosedXML.Excel.CalcEngine
             return number * (180.0 / Math.PI);
         }
 
-        private static object Even(List<Expression> p)
+        private static ScalarValue Even(double number)
         {
-            var num = (int)Math.Ceiling(p[0]);
+            var num = Math.Ceiling(number);
             var addValue = num >= 0 ? 1 : -1;
             return XLMath.IsEven(num) ? num : num + addValue;
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -32,7 +32,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction Adapt(Func<double, AnyValue> f)
+        public static CalcEngineFunction Adapt(Func<double, ScalarValue> f)
         {
             return (ctx, args) =>
             {
@@ -40,7 +40,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg0Converted.TryPickT0(out var arg0, out var err0))
                     return err0;
 
-                return f(arg0);
+                return f(arg0).ToAnyValue();
             };
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction Adapt(Func<double, double, AnyValue> f)
+        public static CalcEngineFunction Adapt(Func<double, double, ScalarValue> f)
         {
             return (ctx, args) =>
             {
@@ -56,7 +56,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg1Converted.TryPickT0(out var arg1, out var err1))
                     return err1;
 
-                return f(arg0, arg1);
+                return f(arg0, arg1).ToAnyValue();
             };
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -135,6 +135,16 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return Math.Abs(value % 2) == 0;
         }
 
+        public static Boolean IsEven(double value)
+        {
+            // Check the number doesn't have any fractions and that it is even.
+            // Due to rounding after division, only checking for % 2 could fail
+            // for numbers really close to whole number.
+            var hasNoFraction = value % 1 == 0;
+            var isEven = value % 2 == 0;
+            return hasNoFraction && isEven;
+        }
+
         public static Boolean IsOdd(Int32 value)
         {
             return Math.Abs(value % 2) != 0;

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -37,7 +37,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return (grads / 10.0) * 9.0;
         }
 
-        public static double ASinh(double x)
+        public static double Asinh(double x)
         {
             return (Math.Log(x + Math.Sqrt(x * x + 1.0)));
         }
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         public static double ACsch(double x)
         {
-            return (ASinh(1.0 / x));
+            return (Asinh(1.0 / x));
         }
 
         public static double Sech(double x)


### PR DESCRIPTION
Refactor simple number functions (`SIN`, `COS`, `DOUBLEFACT`) so they use new signature (through adapt pattern).

The goal is to decrease number of functions that use legacy infrastructure and adapters for `Expression`. Adapters don't work properly (and never will) and cause bugs.

93 functions still use legacy infrastructure.