### PR TITLE
Reimplement simple legacy funcs

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1091,7 +1091,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-8.9, -9)]
         public void Int(double input, double expected)
         {
-            var actual = XLWorkbook.EvaluateExpr(string.Format(@"INT({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = XLWorkbook.EvaluateExpr($"INT({input})");
             Assert.AreEqual(expected, actual);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1506,6 +1506,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
+        public void RandBetween()
+        {
+            for (var i = 0; i < 100; ++i)
+            {
+                var randomNumber = (double)XLWorkbook.EvaluateExpr("RANDBETWEEN(10, 20)");
+                Assert.That(randomNumber, Is.GreaterThanOrEqualTo(10).And.LessThanOrEqualTo(20));
+            }
+
+            Assert.AreEqual(101, (double)XLWorkbook.EvaluateExpr("RANDBETWEEN(100.5, 100.9)"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("RANDBETWEEN(100.9, 100.5)"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("RANDBETWEEN(20, 5)"));
+            Assert.That((double)XLWorkbook.EvaluateExpr("RANDBETWEEN(1E+100, 1E+110)"), Is.GreaterThanOrEqualTo(1E+100).And.LessThanOrEqualTo(1E+110));
+        }
+
+        [Test]
         public void Roman()
         {
             object actual = XLWorkbook.EvaluateExpr("Roman(3046, 1)");

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1393,6 +1393,32 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(Math.PI, XLWorkbook.EvaluateExpr("PI()"));
         }
 
+        [TestCase(2, 3, ExpectedResult = 8)]
+        [TestCase(2, 0.5, ExpectedResult = 1.414213562373)]
+        [TestCase(-1.234, 5.0, ExpectedResult = -2.861381721051)]
+        [TestCase(1.234, 5.1, ExpectedResult = 2.9221823578798)]
+        [DefaultFloatingPointTolerance(1e-12)]
+        public double Power(double x, double y)
+        {
+            return (double)XLWorkbook.EvaluateExpr($"POWER({x}, {y})");
+        }
+
+        [Test]
+        public void Power_errors()
+        {
+            // Negative base and fractional exponent
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("POWER(-5, 0.5)"));
+
+            // Spec says this should be #DIV/0!, but Excel says #NUM!
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("POWER(0, 0)"));
+
+            // base is zero and exponent is negative -> #NUM!
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("POWER(0, -5)"));
+
+            // Result is not representable (e.g. out fo range)
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("POWER(1e+100, 1e+100)"));
+        }
+
         [Test]
         public void Product()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1352,17 +1352,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(0.89999, 0.2, ExpectedResult = 0.8)]
         [TestCase(15.5, 3, ExpectedResult = 15.0)]
         [TestCase(1.4, 0.5, ExpectedResult = 1.5)]
+        [TestCase(3, 7, ExpectedResult = 0)]
+        [TestCase(3, 0, ExpectedResult = 0)]
         [DefaultFloatingPointTolerance(1e-12)]
         public double MRound(double number, double multiple)
         {
-            return (double)XLWorkbook.EvaluateExpr(string.Format(CultureInfo.InvariantCulture, "MROUND({0}, {1})", number, multiple));
+            return (double)XLWorkbook.EvaluateExpr($"MROUND({number}, {multiple})");
         }
 
         [TestCase(123456.123, -10)]
         [TestCase(-123456.123, 5)]
         public void MRoundExceptions(double number, double multiple)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(FormattableString.Invariant($"MROUND({number}, {multiple})")));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"MROUND({number}, {multiple})"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1549,26 +1549,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return (double)XLWorkbook.EvaluateExpr($"ROUND({number}, {digits})");
         }
 
-        [Test]
-        public void RoundDown()
+        [TestCase(3.2, 0, ExpectedResult = 3.0)]
+        [TestCase(76.9, 0, ExpectedResult = 76.0)]
+        [TestCase(3.14159, 3, ExpectedResult = 3.141)]
+        [TestCase(-3.14159, 1, ExpectedResult = -3.1)]
+        [TestCase(31415.92654, -2, ExpectedResult = 31400.0)]
+        [TestCase(0, 3, ExpectedResult = 0)]
+        public double RoundDown(double number, double digits)
         {
-            object actual = XLWorkbook.EvaluateExpr("RoundDown(3.2, 0)");
-            Assert.AreEqual(3.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundDown(76.9, 0)");
-            Assert.AreEqual(76.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundDown(3.14159, 3)");
-            Assert.AreEqual(3.141, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundDown(-3.14159, 1)");
-            Assert.AreEqual(-3.1, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundDown(31415.92654, -2)");
-            Assert.AreEqual(31400.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundDown(0, 3)");
-            Assert.AreEqual(0.0, actual);
+            return (double)XLWorkbook.EvaluateExpr($"ROUNDDOWN({number}, {digits})");
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1150,6 +1150,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("LOG(10,1)"));
         }
 
+        [Ignore("LOG10 is interpreted as cell function. Remove when parser is updated.")]
+        [TestCase(86, 1.93449845124)]
+        [TestCase(10, 1)]
+        [TestCase(1E5, 5)]
+        public void Log10_calculates_logarithm(double x, double expectedResult)
+        {
+            Assert.AreEqual(expectedResult, (double)XLWorkbook.EvaluateExpr($"LOG10({x})"), tolerance);
+        }
+
+        [Ignore("LOG10 is interpreted as cell function. Remove when parser is updated.")]
+        [TestCase(0)]
+        [TestCase(-5)]
+        [TestCase(-0.5)]
+        public void Log10_error_conditions(double x)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"LOG10({x})"));
+        }
+
         [Test]
         public void MDeterm()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1533,54 +1533,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual("MMMCMXCIX", actual);
         }
 
-        [Test]
-        public void Round()
+        [TestCase(2.15, 1, ExpectedResult = 2.2)]
+        [TestCase(2.149, 1, ExpectedResult = 2.1)]
+        [TestCase(-1.475, 2, ExpectedResult = -1.48)]
+        [TestCase(21.5, -1, ExpectedResult = 20.0)]
+        [TestCase(626.3, -3, ExpectedResult = 1000.0)]
+        [TestCase(1.98, -1, ExpectedResult = 0.0)]
+        [TestCase(-50.55, -2, ExpectedResult = -100.0)]
+        [TestCase(31.565, 2, ExpectedResult = 31.57)]
+        [TestCase(-31.565, 2, ExpectedResult = -31.57)]
+        [TestCase(1E+100, 2, ExpectedResult = 1E+100)]
+        [TestCase(1.25, 0, ExpectedResult = 1)]
+        public double Round(double number, double digits)
         {
-            object actual = XLWorkbook.EvaluateExpr("Round(2.15, 1)");
-            Assert.AreEqual(2.2, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Round(2.149, 1)");
-            Assert.AreEqual(2.1, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Round(-1.475, 2)");
-            Assert.AreEqual(-1.48, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Round(21.5, -1)");
-            Assert.AreEqual(20.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Round(626.3, -3)");
-            Assert.AreEqual(1000.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Round(1.98, -1)");
-            Assert.AreEqual(0.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Round(-50.55, -2)");
-            Assert.AreEqual(-100.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("ROUND(59 * 0.535, 2)"); // (59 * 0.535) = 31.565
-            Assert.AreEqual(31.57, actual);
-
-            actual = XLWorkbook.EvaluateExpr("ROUND(59 * -0.535, 2)"); // (59 * -0.535) = -31.565
-            Assert.AreEqual(-31.57, actual);
-        }
-
-        [Test]
-        public void Round_References()
-        {
-            IXLWorksheet ws = new XLWorkbook().AddWorksheet("Sheet1");
-            ws.Cell("A1").SetValue(1);
-            ws.Cell("A2").SetValue(2);
-            ws.Cell("A3").SetValue(3);
-            ws.Cell("A4").SetValue(4);
-            ws.Cell("A5").SetValue(5);
-            ws.Cell("A6").SetValue(2);
-
-            // References are treated differently to constant values within calculations by the calc engine,
-            // so let's make sure to include a test to validate that everything keeps working in the future
-            ws.Cell("A8").FormulaA1 = "ROUND((-A1*A$2+A3*A$4)/(A$5+A$6),0)"; // (-1 * 2 + 3 * 4) / (5 + 3) = 1.25
-            var actual = ws.Cell("A8").Value;
-
-            Assert.AreEqual(1.0, actual);
+            return (double)XLWorkbook.EvaluateExpr($"ROUND({number}, {digits})");
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1127,6 +1127,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"LN({x})"));
         }
 
+        [TestCase(10, 10, 1)]
+        [TestCase(8, 2, 3)]
+        [TestCase(86, 2.7182818, 4.4543473428883)]
+        public void Log_calculates_logarithm(double x, double @base, double result)
+        {
+            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"LOG({x}, {@base})"), tolerance);
+        }
+
+        [Test]
+        public void Log_default_base_is_10()
+        {
+            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("LOG(100)"));
+        }
+
+        [Test]
+        public void Log_error_conditions()
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LOG(0)"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LOG(1,0)"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LOG(0,0)"));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("LOG(10,1)"));
+        }
+
         [Test]
         public void MDeterm()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1487,11 +1487,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("QUOTIENT(1, 0)"));
         }
 
-        [Test]
-        public void Radians()
+        [TestCase(270, ExpectedResult = 4.71238898038469)]
+        [TestCase(-180, ExpectedResult = -Math.PI)]
+        [DefaultFloatingPointTolerance(XLHelper.Epsilon)]
+        public double Radians(double angle)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr("Radians(270)");
-            Assert.AreEqual(4.71238898038469, actual, XLHelper.Epsilon);
+            return (double)XLWorkbook.EvaluateExpr($"RADIANS({angle})");
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1111,6 +1111,22 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(720, actual3);
         }
 
+        [TestCase(86, 4.4543472962)]
+        [TestCase(2.7182818, 0.9999999895)]
+        [TestCase(20.085536923, 3)]
+        public void Ln_calculates_logarithm(double x, double ln)
+        {
+            Assert.AreEqual(ln, (double)XLWorkbook.EvaluateExpr($"LN({x})"), tolerance);
+        }
+
+        [TestCase(0)]
+        [TestCase(-0.7)]
+        [TestCase(-10)]
+        public void Ln_non_positive_returns_error(double x)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"LN({x})"));
+        }
+
         [Test]
         public void MDeterm()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1388,6 +1388,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
+        public void Pi()
+        {
+            Assert.AreEqual(Math.PI, XLWorkbook.EvaluateExpr("PI()"));
+        }
+
+        [Test]
         public void Product()
         {
             Assert.AreEqual(24d, XLWorkbook.EvaluateExpr("PRODUCT(2,3,4)"));

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1560,26 +1560,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return (double)XLWorkbook.EvaluateExpr($"ROUNDDOWN({number}, {digits})");
         }
 
-        [Test]
-        public void RoundUp()
+        [TestCase(3.2, 0, ExpectedResult = 4)]
+        [TestCase(76.9, 0, ExpectedResult = 77.0)]
+        [TestCase(3.14159, 3, ExpectedResult = 3.142)]
+        [TestCase(-3.14159, 1, ExpectedResult = -3.2)]
+        [TestCase(31415.92654, -2, ExpectedResult = 31500.0)]
+        [TestCase(0, 3, ExpectedResult = 0)]
+        [TestCase(11, 0, ExpectedResult = 11)]
+        public double RoundUp(double number, double digits)
         {
-            object actual = XLWorkbook.EvaluateExpr("RoundUp(3.2, 0)");
-            Assert.AreEqual(4.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundUp(76.9, 0)");
-            Assert.AreEqual(77.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundUp(3.14159, 3)");
-            Assert.AreEqual(3.142, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundUp(-3.14159, 1)");
-            Assert.AreEqual(-3.2, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundUp(31415.92654, -2)");
-            Assert.AreEqual(31500.0, actual);
-
-            actual = XLWorkbook.EvaluateExpr("RoundUp(0, 3)");
-            Assert.AreEqual(0.0, actual);
+            return (double)XLWorkbook.EvaluateExpr($"ROUNDUP({number}, {digits})");
         }
 
         [TestCase(0, 1)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1471,17 +1471,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("PRODUCT(A1)"));
         }
 
-        [Test]
-        public void Quotient()
+        [TestCase(5, 2, ExpectedResult = 2)]
+        [TestCase(4.5, 3.1, ExpectedResult = 1)]
+        [TestCase(-10, 3, ExpectedResult = -3)]
+        [TestCase(-10, -4, ExpectedResult = 2)]
+        [TestCase(1E+100, 1E+40, ExpectedResult = 1E+60)]
+        public double Quotient(double x, double y)
         {
-            object actual = XLWorkbook.EvaluateExpr("Quotient(5,2)");
-            Assert.AreEqual(2, actual);
+            return (double)XLWorkbook.EvaluateExpr($"QUOTIENT({x}, {y})");
+        }
 
-            actual = XLWorkbook.EvaluateExpr("Quotient(4.5,3.1)");
-            Assert.AreEqual(1, actual);
-
-            actual = XLWorkbook.EvaluateExpr("Quotient(-10,3)");
-            Assert.AreEqual(-3, actual);
+        [Test]
+        public void Quotient_errors()
+        {
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("QUOTIENT(1, 0)"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1311,39 +1311,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A6").Value);
         }
 
-        [Test]
-        public void Mod()
+        [TestCase(1.5, 1, 0.5)]
+        [TestCase(3, 2, 1)]
+        [TestCase(-3, 2, 1)]
+        [TestCase(-3, -2, -1)]
+        [TestCase(-4.3, -0.5, -0.3)]
+        [TestCase(6.9, -0.2, -0.1)]
+        [TestCase(0.7, 0.6, 0.1)]
+        [TestCase(6.2, 1.1, 0.7)]
+        public void Mod(double x, double y, double result)
         {
-            double actual;
+            var actual = (double)XLWorkbook.EvaluateExpr($"MOD({x}, {y})");
+            Assert.AreEqual(result, actual, tolerance);
+        }
 
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(1.5, 1)");
-            Assert.AreEqual(0.5, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(3, 2)");
-            Assert.AreEqual(1, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(-3, 2)");
-            Assert.AreEqual(1, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(3, -2)");
-            Assert.AreEqual(-1, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(-3, -2)");
-            Assert.AreEqual(-1, actual, tolerance);
-
-            //////
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(-4.3, -0.5)");
-            Assert.AreEqual(-0.3, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(6.9, -0.2)");
-            Assert.AreEqual(-0.1, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(0.7, 0.6)");
-            Assert.AreEqual(0.1, actual, tolerance);
-
-            actual = (double)XLWorkbook.EvaluateExpr(@"MOD(6.2, 1.1)");
-            Assert.AreEqual(0.7, actual, tolerance);
+        [Test]
+        public void Mod_divisor_zero_returns_error()
+        {
+            // Spec says that "If y is 0, the return value is unspecified", but Excel says #DIV/0!, so let's go with that.
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("MOD(1, 0)"));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("MOD(0, 0)"));
         }
 
         [TestCase(10, 3, ExpectedResult = 9.0)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1374,26 +1374,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(1260.0, actual);
         }
 
-        [Test]
-        public void Odd()
+        [TestCase(1.5, ExpectedResult = 3)]
+        [TestCase(3, ExpectedResult = 3)]
+        [TestCase(2, ExpectedResult = 3)]
+        [TestCase(-1, ExpectedResult = -1)]
+        [TestCase(-2, ExpectedResult = -3)]
+        [TestCase(0, ExpectedResult = 1)]
+        [TestCase(1E+100, ExpectedResult = 1E+100)]
+        [DefaultFloatingPointTolerance(1e-12)]
+        public double Odd(double number)
         {
-            object actual = XLWorkbook.EvaluateExpr("Odd(1.5)");
-            Assert.AreEqual(3, actual);
-
-            object actual1 = XLWorkbook.EvaluateExpr("Odd(3)");
-            Assert.AreEqual(3, actual1);
-
-            object actual2 = XLWorkbook.EvaluateExpr("Odd(2)");
-            Assert.AreEqual(3, actual2);
-
-            object actual3 = XLWorkbook.EvaluateExpr("Odd(-1)");
-            Assert.AreEqual(-1, actual3);
-
-            object actual4 = XLWorkbook.EvaluateExpr("Odd(-2)");
-            Assert.AreEqual(-3, actual4);
-
-            actual = XLWorkbook.EvaluateExpr("Odd(0)");
-            Assert.AreEqual(1, actual);
+            return (double)XLWorkbook.EvaluateExpr($"ODD({number})");
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1496,6 +1496,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
+        public void Rand()
+        {
+            for (var i = 0; i < 100; ++i)
+            {
+                var randomNumber = (double)XLWorkbook.EvaluateExpr("RAND()");
+                Assert.That(randomNumber, Is.GreaterThanOrEqualTo(0).And.LessThan(1));
+            }
+        }
+
+        [Test]
         public void Roman()
         {
             object actual = XLWorkbook.EvaluateExpr("Roman(3046, 1)");

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -57,6 +57,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MROUND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NETWORKDAYS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OLAP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDBETWEEN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -54,6 +54,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MROUND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NETWORKDAYS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OLAP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -58,6 +58,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NETWORKDAYS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OLAP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDBETWEEN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ROUNDDOWN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/FunctionFlags.cs
+++ b/ClosedXML/Excel/CalcEngine/FunctionFlags.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel.CalcEngine
@@ -33,6 +31,12 @@ namespace ClosedXML.Excel.CalcEngine
         /// Function returns array. Functions without this flag return a scalar value.
         /// CalcEngine treats such functions differently for array formulas.
         /// </summary>
-        ReturnsArray = 4
+        ReturnsArray = 4,
+
+        /// <summary>
+        /// Function is not deterministic.
+        /// </summary>
+        /// <example>RAND(), DATE()</example>
+        Volatile = 8,
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using ClosedXML.Excel.CalcEngine.Functions;
 using static ClosedXML.Excel.CalcEngine.Functions.SignatureAdapter;
 
@@ -14,7 +13,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("AND", 1, int.MaxValue, And, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("FALSE", 0, 0, Adapt(False), FunctionFlags.Scalar);
             ce.RegisterFunction("IF", 2, 3, AdaptLastOptional(If, false), FunctionFlags.Range, AllowRange.Only, 1, 2);
-            ce.RegisterFunction("IFERROR", 2, 2, Adapt((Func<ScalarValue, ScalarValue, AnyValue>)IfError), FunctionFlags.Scalar);
+            ce.RegisterFunction("IFERROR", 2, 2, Adapt(IfError), FunctionFlags.Scalar);
             ce.RegisterFunction("NOT", 1, 1, AdaptCoerced(Not), FunctionFlags.Scalar);
             ce.RegisterFunction("OR", 1, int.MaxValue, Or, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("TRUE", 0, 0, Adapt(True), FunctionFlags.Scalar);
@@ -44,7 +43,7 @@ namespace ClosedXML.Excel.CalcEngine
             return value;
         }
 
-        private static AnyValue False()
+        private static ScalarValue False()
         {
             return false;
         }
@@ -94,7 +93,7 @@ namespace ClosedXML.Excel.CalcEngine
             return value;
         }
 
-        private static AnyValue True()
+        private static ScalarValue True()
         {
             return true;
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -69,7 +69,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("RANDBETWEEN", 2, 2, Adapt(RandBetween), FunctionFlags.Scalar | FunctionFlags.Volatile);
             ce.RegisterFunction("ROMAN", 1, 2, Roman);
             ce.RegisterFunction("ROUND", 2, 2, Adapt(Round), FunctionFlags.Scalar);
-            ce.RegisterFunction("ROUNDDOWN", 2, RoundDown);
+            ce.RegisterFunction("ROUNDDOWN", 2, 2, Adapt(RoundDown), FunctionFlags.Scalar);
             ce.RegisterFunction("ROUNDUP", 1, 2, RoundUp);
             ce.RegisterFunction("SEC", 1, Sec);
             ce.RegisterFunction("SECH", 1, Sech);
@@ -797,15 +797,10 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Round(value, digitCount, MidpointRounding.AwayFromZero);
         }
 
-        private static object RoundDown(List<Expression> p)
+        private static ScalarValue RoundDown(double value, double digits)
         {
-            var value = (Double)p[0];
-            var digits = (Int32)(Double)p[1];
-
-            if (value >= 0)
-                return Math.Floor(value * Math.Pow(10, digits)) / Math.Pow(10, digits);
-
-            return Math.Ceiling(value * Math.Pow(10, digits)) / Math.Pow(10, digits);
+            var coef = Math.Pow(10, Math.Truncate(digits));
+            return Math.Truncate(value * coef) / coef;
         }
 
         private static object RoundUp(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -63,7 +63,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("PI", 0, 0, Adapt(Pi), FunctionFlags.Scalar);
             ce.RegisterFunction("POWER", 2, 2, Adapt(Power), FunctionFlags.Scalar);
             ce.RegisterFunction("PRODUCT", 1, 255, Product, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("QUOTIENT", 2, Quotient);
+            ce.RegisterFunction("QUOTIENT", 2, 2, Adapt(Quotient), FunctionFlags.Scalar);
             ce.RegisterFunction("RADIANS", 1, Radians);
             ce.RegisterFunction("RAND", 0, Rand);
             ce.RegisterFunction("RANDBETWEEN", 2, RandBetween);
@@ -741,12 +741,12 @@ namespace ClosedXML.Excel.CalcEngine
             return state.HasValues ? state.Product : 0;
         }
 
-        private static object Quotient(List<Expression> p)
+        private static ScalarValue Quotient(double dividend, double divisor)
         {
-            Double n = p[0];
-            Double k = p[1];
+            if (divisor == 0)
+                return XLError.DivisionByZero;
 
-            return (int)(n / k);
+            return Math.Truncate(dividend / divisor);
         }
 
         private static object Radians(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -50,7 +50,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("GCD", 1, 255, Gcd);
             ce.RegisterFunction("INT", 1, 1, Adapt(Int), FunctionFlags.Scalar);
             ce.RegisterFunction("LCM", 1, 255, Lcm);
-            ce.RegisterFunction("LN", 1, Ln);
+            ce.RegisterFunction("LN", 1, 1, Adapt(Ln), FunctionFlags.Scalar);
             ce.RegisterFunction("LOG", 1, 2, Log);
             ce.RegisterFunction("LOG10", 1, Log10);
             ce.RegisterFunction("MDETERM", 1, MDeterm, AllowRange.All);
@@ -548,9 +548,12 @@ namespace ClosedXML.Excel.CalcEngine
             return a * (b / Gcd(a, b));
         }
 
-        private static object Ln(List<Expression> p)
+        private static ScalarValue Ln(double x)
         {
-            return Math.Log(p[0]);
+            if (x <= 0)
+                return XLError.NumberInvalid;
+
+            return Math.Log(x);
         }
 
         private static object Log(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -48,7 +48,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("FLOOR", 2, 2, Adapt(Floor), FunctionFlags.Scalar);
             ce.RegisterFunction("FLOOR.MATH", 1, 3, FloorMath);
             ce.RegisterFunction("GCD", 1, 255, Gcd);
-            ce.RegisterFunction("INT", 1, Int);
+            ce.RegisterFunction("INT", 1, 1, Adapt(Int), FunctionFlags.Scalar);
             ce.RegisterFunction("LCM", 1, 255, Lcm);
             ce.RegisterFunction("LN", 1, Ln);
             ce.RegisterFunction("LOG", 1, 2, Log);
@@ -532,9 +532,9 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
-        private static object Int(List<Expression> p)
+        private static ScalarValue Int(double number)
         {
-            return Math.Floor(p[0]);
+            return Math.Floor(number);
         }
 
         private static object Lcm(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -500,7 +500,10 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static int Gcd(int a, int b)
         {
-            return b == 0 ? a : Gcd(b, a % b);
+            while (b != 0)
+                (a, b) = (b, a % b);
+
+            return a;
         }
 
         private static double[,] GetArray(Expression expression)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -60,7 +60,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("MROUND", 2, 2, Adapt(MRound), FunctionFlags.Scalar);
             ce.RegisterFunction("MULTINOMIAL", 1, 255, Multinomial);
             ce.RegisterFunction("ODD", 1, 1, Adapt(Odd), FunctionFlags.Scalar);
-            ce.RegisterFunction("PI", 0, Pi);
+            ce.RegisterFunction("PI", 0, 0, Adapt(Pi), FunctionFlags.Scalar);
             ce.RegisterFunction("POWER", 2, Power);
             ce.RegisterFunction("PRODUCT", 1, 255, Product, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("QUOTIENT", 2, Quotient);
@@ -702,7 +702,7 @@ namespace ClosedXML.Excel.CalcEngine
             return XLMath.IsOdd(num) ? num : num + addValue;
         }
 
-        private static object Pi(List<Expression> p)
+        private static ScalarValue Pi()
         {
             return Math.PI;
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -68,7 +68,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("RAND", 0, 0, Adapt(Rand), FunctionFlags.Scalar | FunctionFlags.Volatile);
             ce.RegisterFunction("RANDBETWEEN", 2, 2, Adapt(RandBetween), FunctionFlags.Scalar | FunctionFlags.Volatile);
             ce.RegisterFunction("ROMAN", 1, 2, Roman);
-            ce.RegisterFunction("ROUND", 2, Round);
+            ce.RegisterFunction("ROUND", 2, 2, Adapt(Round), FunctionFlags.Scalar);
             ce.RegisterFunction("ROUNDDOWN", 2, RoundDown);
             ce.RegisterFunction("ROUNDUP", 1, 2, RoundUp);
             ce.RegisterFunction("SEC", 1, Sec);
@@ -783,21 +783,18 @@ namespace ClosedXML.Excel.CalcEngine
             throw new ArgumentException("Can only support classic roman types.");
         }
 
-        private static object Round(List<Expression> p)
+        private static ScalarValue Round(double value, double digits)
         {
-            var value = (Double)p[0];
-            var digits = (Int32)(Double)p[1];
-            if (digits >= 0)
+            var digitCount = (int)Math.Truncate(digits);
+            if (digits < 0)
             {
-                return Math.Round(value, digits, MidpointRounding.AwayFromZero);
+                var coef = Math.Pow(10, Math.Abs(digits));
+                var shifted = value / coef;
+                shifted = Math.Round(shifted, 0, MidpointRounding.AwayFromZero);
+                return shifted * coef;
             }
-            else
-            {
-                digits = Math.Abs(digits);
-                double temp = value / Math.Pow(10, digits);
-                temp = Math.Round(temp, 0, MidpointRounding.AwayFromZero);
-                return temp * Math.Pow(10, digits);
-            }
+
+            return Math.Round(value, digitCount, MidpointRounding.AwayFromZero);
         }
 
         private static object RoundDown(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -66,7 +66,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("QUOTIENT", 2, 2, Adapt(Quotient), FunctionFlags.Scalar);
             ce.RegisterFunction("RADIANS", 1, 1, Adapt(Radians), FunctionFlags.Scalar);
             ce.RegisterFunction("RAND", 0, 0, Adapt(Rand), FunctionFlags.Scalar | FunctionFlags.Volatile);
-            ce.RegisterFunction("RANDBETWEEN", 2, RandBetween);
+            ce.RegisterFunction("RANDBETWEEN", 2, 2, Adapt(RandBetween), FunctionFlags.Scalar | FunctionFlags.Volatile);
             ce.RegisterFunction("ROMAN", 1, 2, Roman);
             ce.RegisterFunction("ROUND", 2, Round);
             ce.RegisterFunction("ROUNDDOWN", 2, RoundDown);
@@ -759,9 +759,16 @@ namespace ClosedXML.Excel.CalcEngine
             return _rnd.NextDouble();
         }
 
-        private static object RandBetween(List<Expression> p)
+        private static ScalarValue RandBetween(double lowerBound, double upperBound)
         {
-            return _rnd.Next((int)(double)p[0], (int)(double)p[1]);
+            if (lowerBound > upperBound)
+                return XLError.NumberInvalid;
+
+            lowerBound = Math.Ceiling(lowerBound);
+            upperBound = Math.Ceiling(upperBound);
+
+            var range = upperBound - lowerBound;
+            return lowerBound + Math.Round(_rnd.NextDouble() * range, MidpointRounding.AwayFromZero);
         }
 
         private static object Roman(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -57,7 +57,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("MINVERSE", 1, MInverse, AllowRange.All);
             ce.RegisterFunction("MMULT", 2, MMult, AllowRange.All);
             ce.RegisterFunction("MOD", 2, 2, Adapt(Mod), FunctionFlags.Scalar);
-            ce.RegisterFunction("MROUND", 2, MRound);
+            ce.RegisterFunction("MROUND", 2, 2, Adapt(MRound), FunctionFlags.Scalar);
             ce.RegisterFunction("MULTINOMIAL", 1, 255, Multinomial);
             ce.RegisterFunction("ODD", 1, Odd);
             ce.RegisterFunction("PI", 0, Pi);
@@ -631,10 +631,10 @@ namespace ClosedXML.Excel.CalcEngine
             return number - Math.Floor(number / divisor) * divisor;
         }
 
-        private static object MRound(List<Expression> p)
+        private static ScalarValue MRound(double number, double multiple)
         {
-            var number = (Double)p[0];
-            var multiple = (Double)p[1];
+            if (multiple == 0)
+                return 0;
 
             if (Math.Sign(number) != Math.Sign(multiple))
                 return XLError.NumberInvalid;

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -59,7 +59,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("MOD", 2, 2, Adapt(Mod), FunctionFlags.Scalar);
             ce.RegisterFunction("MROUND", 2, 2, Adapt(MRound), FunctionFlags.Scalar);
             ce.RegisterFunction("MULTINOMIAL", 1, 255, Multinomial);
-            ce.RegisterFunction("ODD", 1, Odd);
+            ce.RegisterFunction("ODD", 1, 1, Adapt(Odd), FunctionFlags.Scalar);
             ce.RegisterFunction("PI", 0, Pi);
             ce.RegisterFunction("POWER", 2, Power);
             ce.RegisterFunction("PRODUCT", 1, 255, Product, FunctionFlags.Range, AllowRange.All);
@@ -695,9 +695,9 @@ namespace ClosedXML.Excel.CalcEngine
             return result;
         }
 
-        private static object Odd(List<Expression> p)
+        private static ScalarValue Odd(double number)
         {
-            var num = (int)Math.Ceiling(p[0]);
+            var num = Math.Ceiling(number);
             var addValue = num >= 0 ? 1 : -1;
             return XLMath.IsOdd(num) ? num : num + addValue;
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -52,7 +52,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("LCM", 1, 255, Lcm);
             ce.RegisterFunction("LN", 1, 1, Adapt(Ln), FunctionFlags.Scalar);
             ce.RegisterFunction("LOG", 1, 2, AdaptLastOptional(Log, 10), FunctionFlags.Scalar);
-            ce.RegisterFunction("LOG10", 1, Log10);
+            ce.RegisterFunction("LOG10", 1, 1, Adapt(Log10), FunctionFlags.Scalar);
             ce.RegisterFunction("MDETERM", 1, MDeterm, AllowRange.All);
             ce.RegisterFunction("MINVERSE", 1, MInverse, AllowRange.All);
             ce.RegisterFunction("MMULT", 2, MMult, AllowRange.All);
@@ -567,9 +567,12 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Log(x, @base);
         }
 
-        private static object Log10(List<Expression> p)
+        private static ScalarValue Log10(double x)
         {
-            return Math.Log10(p[0]);
+            if (x <= 0)
+                return XLError.NumberInvalid;
+
+            return Math.Log10(x);
         }
 
         private static object MDeterm(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("PRODUCT", 1, 255, Product, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("QUOTIENT", 2, 2, Adapt(Quotient), FunctionFlags.Scalar);
             ce.RegisterFunction("RADIANS", 1, 1, Adapt(Radians), FunctionFlags.Scalar);
-            ce.RegisterFunction("RAND", 0, Rand);
+            ce.RegisterFunction("RAND", 0, 0, Adapt(Rand), FunctionFlags.Scalar | FunctionFlags.Volatile);
             ce.RegisterFunction("RANDBETWEEN", 2, RandBetween);
             ce.RegisterFunction("ROMAN", 1, 2, Roman);
             ce.RegisterFunction("ROUND", 2, Round);
@@ -754,7 +754,7 @@ namespace ClosedXML.Excel.CalcEngine
             return angle * Math.PI / 180.0;
         }
 
-        private static object Rand(List<Expression> p)
+        private static ScalarValue Rand()
         {
             return _rnd.NextDouble();
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -51,7 +51,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("INT", 1, 1, Adapt(Int), FunctionFlags.Scalar);
             ce.RegisterFunction("LCM", 1, 255, Lcm);
             ce.RegisterFunction("LN", 1, 1, Adapt(Ln), FunctionFlags.Scalar);
-            ce.RegisterFunction("LOG", 1, 2, Log);
+            ce.RegisterFunction("LOG", 1, 2, AdaptLastOptional(Log, 10), FunctionFlags.Scalar);
             ce.RegisterFunction("LOG10", 1, Log10);
             ce.RegisterFunction("MDETERM", 1, MDeterm, AllowRange.All);
             ce.RegisterFunction("MINVERSE", 1, MInverse, AllowRange.All);
@@ -556,10 +556,15 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Log(x);
         }
 
-        private static object Log(List<Expression> p)
+        private static ScalarValue Log(double x, double @base)
         {
-            var lbase = p.Count > 1 ? (double)p[1] : 10;
-            return Math.Log(p[0], lbase);
+            if (x <= 0 || @base <= 0)
+                return XLError.NumberInvalid;
+
+            if (Math.Abs(@base - 1.0) < XLHelper.Epsilon)
+                return XLError.DivisionByZero;
+
+            return Math.Log(x, @base);
         }
 
         private static object Log10(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -70,7 +70,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ROMAN", 1, 2, Roman);
             ce.RegisterFunction("ROUND", 2, 2, Adapt(Round), FunctionFlags.Scalar);
             ce.RegisterFunction("ROUNDDOWN", 2, 2, Adapt(RoundDown), FunctionFlags.Scalar);
-            ce.RegisterFunction("ROUNDUP", 1, 2, RoundUp);
+            ce.RegisterFunction("ROUNDUP", 2, 2, Adapt(RoundUp), FunctionFlags.Scalar);
             ce.RegisterFunction("SEC", 1, Sec);
             ce.RegisterFunction("SECH", 1, Sech);
             ce.RegisterFunction("SERIESSUM", 4, SeriesSum, AllowRange.Only, 3);
@@ -803,15 +803,13 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Truncate(value * coef) / coef;
         }
 
-        private static object RoundUp(List<Expression> p)
+        private static ScalarValue RoundUp(double value, double digits)
         {
-            var value = (Double)p[0];
-            var digits = (Int32)(Double)p[1];
-
+            var coef = Math.Pow(10, Math.Truncate(digits));
             if (value >= 0)
-                return Math.Ceiling(value * Math.Pow(10, digits)) / Math.Pow(10, digits);
+                return Math.Ceiling(value * coef) / coef;
 
-            return Math.Floor(value * Math.Pow(10, digits)) / Math.Pow(10, digits);
+            return Math.Floor(value * coef) / coef;
         }
 
         private static object Sec(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -56,7 +56,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("MDETERM", 1, MDeterm, AllowRange.All);
             ce.RegisterFunction("MINVERSE", 1, MInverse, AllowRange.All);
             ce.RegisterFunction("MMULT", 2, MMult, AllowRange.All);
-            ce.RegisterFunction("MOD", 2, Mod);
+            ce.RegisterFunction("MOD", 2, 2, Adapt(Mod), FunctionFlags.Scalar);
             ce.RegisterFunction("MROUND", 2, MRound);
             ce.RegisterFunction("MULTINOMIAL", 1, 255, Multinomial);
             ce.RegisterFunction("ODD", 1, Odd);
@@ -623,10 +623,10 @@ namespace ClosedXML.Excel.CalcEngine
             return C;
         }
 
-        private static object Mod(List<Expression> p)
+        private static ScalarValue Mod(double number, double divisor)
         {
-            double number = p[0];
-            double divisor = p[1];
+            if (divisor == 0)
+                return XLError.DivisionByZero;
 
             return number - Math.Floor(number / divisor) * divisor;
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -64,7 +64,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("POWER", 2, 2, Adapt(Power), FunctionFlags.Scalar);
             ce.RegisterFunction("PRODUCT", 1, 255, Product, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("QUOTIENT", 2, 2, Adapt(Quotient), FunctionFlags.Scalar);
-            ce.RegisterFunction("RADIANS", 1, Radians);
+            ce.RegisterFunction("RADIANS", 1, 1, Adapt(Radians), FunctionFlags.Scalar);
             ce.RegisterFunction("RAND", 0, Rand);
             ce.RegisterFunction("RANDBETWEEN", 2, RandBetween);
             ce.RegisterFunction("ROMAN", 1, 2, Roman);
@@ -749,9 +749,9 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Truncate(dividend / divisor);
         }
 
-        private static object Radians(List<Expression> p)
+        private static ScalarValue Radians(double angle)
         {
-            return p[0] * Math.PI / 180.0;
+            return angle * Math.PI / 180.0;
         }
 
         private static object Rand(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -15,9 +15,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         // We have many functions with same signature and the adapters should be reusable. Convert parameters
         // through value converters below. We can hopefully generate them at a later date, so try to keep them similar.
 
-        public static CalcEngineFunction Adapt(Func<AnyValue> f)
+        public static CalcEngineFunction Adapt(Func<ScalarValue> f)
         {
-            return (_, _) => f();
+            return (_, _) => f().ToAnyValue();
         }
 
         public static CalcEngineFunction AdaptCoerced(Func<Boolean, AnyValue> f)

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -182,6 +182,22 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastOptional(Func<double, double, ScalarValue> f, double lastDefault)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToNumber(args.Length > 1 ? args[1] : lastDefault, ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                return f(arg0, arg1).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<CalcContext, double, AnyValue[], AnyValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -150,6 +150,13 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return Math.Abs(value % 2) != 0;
         }
 
+        public static Boolean IsOdd(double value)
+        {
+            var hasNoFraction = value % 1 == 0;
+            var isOdd = value % 2 != 0;
+            return hasNoFraction && isOdd;
+        }
+
         public static string ToRoman(int number)
         {
             if ((number < 0) || (number > 3999)) throw new ArgumentOutOfRangeException("insert value betwheen 1 and 3999");


### PR DESCRIPTION
Refactor simple functions with one or two number parameters. There were some small fixes for some functions, mostly about 
* large arguments that were converted to int and thus result wasn't correct (e.g. `QUOTIENT(1E+100, 1E+40)` should be 1E+60,but was -2147483648).
* Returned correct error values (missing or used to throw exceptions)

List of functions:  `GCD`, `INT`, `LN`, `LOG`, `LOG10`, `MOD`, `MROUND`, `ODD`, `PI`, `POWER`, `QUOTIENT`, `RADIANS`, `RAND`, `RANDBETWEEN`, `ROUND`, `ROUNDDOWN`, `ROUNDUP`.

The long term end goal is to eliminate legacy functions, this is just a simple way to decrease the current amount.