### PR TITLE
Reimplement ROMAN function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1520,17 +1520,44 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.That((double)XLWorkbook.EvaluateExpr("RANDBETWEEN(1E+100, 1E+110)"), Is.GreaterThanOrEqualTo(1E+100).And.LessThanOrEqualTo(1E+110));
         }
 
-        [Test]
-        public void Roman()
+        [TestCase(1, 0, ExpectedResult = "I")]
+        [TestCase(3046, 1, ExpectedResult = @"MMMVLI")]
+        [TestCase(3999, 1, ExpectedResult = @"MMMLMVLIV")]
+        [TestCase(999, 0, ExpectedResult = @"CMXCIX")]
+        [TestCase(999.99, 0.9, ExpectedResult = @"CMXCIX")]
+        [TestCase(999, 1, ExpectedResult = @"LMVLIV")]
+        [TestCase(999, 2, ExpectedResult = @"XMIX")]
+        [TestCase(999, 3, ExpectedResult = @"VMIV")]
+        [TestCase(999, 4, ExpectedResult = @"IM")]
+        public string Roman(double value, double form)
         {
-            object actual = XLWorkbook.EvaluateExpr("Roman(3046, 1)");
-            Assert.AreEqual("MMMXLVI", actual);
+            return (string)XLWorkbook.EvaluateExpr($"ROMAN({value}, {form})");
+        }
 
-            actual = XLWorkbook.EvaluateExpr("Roman(270)");
-            Assert.AreEqual("CCLXX", actual);
+        [Test]
+        public void Roman_value_0_is_empty_string()
+        {
+            Assert.AreEqual(string.Empty, XLWorkbook.EvaluateExpr("ROMAN(0, 0)"));
+        }
 
-            actual = XLWorkbook.EvaluateExpr("Roman(3999, true)");
-            Assert.AreEqual("MMMCMXCIX", actual);
+        [Test]
+        public void Roman_has_optional_second_argument_with_default_value_0()
+        {
+            Assert.AreEqual(@"CMXCIX", XLWorkbook.EvaluateExpr("ROMAN(999)"));
+        }
+
+        [Test]
+        public void Roman_form_must_be_between_0_and_4()
+        {
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(1, -1)"));
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(1, 5)"));
+        }
+
+        [Test]
+        public void Roman_value_must_be_between_0_and_3999()
+        {
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(-1, 0)"));
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(4000, 0)"));
         }
 
         [TestCase(2.15, 1, ExpectedResult = 2.2)]

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -157,26 +157,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return hasNoFraction && isOdd;
         }
 
-        public static string ToRoman(int number)
-        {
-            if ((number < 0) || (number > 3999)) throw new ArgumentOutOfRangeException("insert value betwheen 1 and 3999");
-            if (number < 1) return string.Empty;
-            if (number >= 1000) return "M" + ToRoman(number - 1000);
-            if (number >= 900) return "CM" + ToRoman(number - 900);
-            if (number >= 500) return "D" + ToRoman(number - 500);
-            if (number >= 400) return "CD" + ToRoman(number - 400);
-            if (number >= 100) return "C" + ToRoman(number - 100);
-            if (number >= 90) return "XC" + ToRoman(number - 90);
-            if (number >= 50) return "L" + ToRoman(number - 50);
-            if (number >= 40) return "XL" + ToRoman(number - 40);
-            if (number >= 10) return "X" + ToRoman(number - 10);
-            if (number >= 9) return "IX" + ToRoman(number - 9);
-            if (number >= 5) return "V" + ToRoman(number - 5);
-            if (number >= 4) return "IV" + ToRoman(number - 4);
-            if (number >= 1) return "I" + ToRoman(number - 1);
-            throw new ArgumentOutOfRangeException("something bad happened");
-        }
-
         public static int RomanToArabic(string text)
         {
             if (text.Length == 0)


### PR DESCRIPTION
The ROMAN function wasn't implemented correctly and didn't work with all forms 0-4. E.g. test asserted that `ROMAN(3046, 1)` is `MMMXLVI`, but that is classic form (form 0). For form 1, it should be Excel gives `MMMVLI`. 

This PR reimplements function ROMAN, so it works correctly and works with all forms. The code was also exhaustively tested  with all possible values (only values 1-3999 are allowed as a number) compared matched with Excel.

The description of the function in spec is kind of confusing, so am using subtract algorithm. I started with minimal set of subtract symbols and kept adding them for each form until it all matched Excel.

The code used to check correct result against Excel
```csharp

using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();
ws.Cell(1, 1).Value = "Value";
ws.Cell(1, 2).Value = "Form";
ws.Cell(1, 3).Value = "ClosedXML";
ws.Cell(1, 4).Value = "Excel";
ws.Cell(1, 5).Value = "Check";
var row = 2;
for (var form = 0; form <= 4; ++form)
{
	for (var i = 1; i < 4000; ++i)
	{
		ws.Cell(row, 1).Value = i;
		ws.Cell(row, 2).Value = form;
		ws.Cell(row, 3).Value = XLWorkbook.EvaluateExpr($"ROMAN({i}, {form})");
		ws.Cell(row, 4).FormulaA1 = $"ROMAN(A{row}, B{row})";
		ws.Cell(row, 5).FormulaA1 = $"IF(C{row} = D{row}, \"SAME\", \"DIFFERENT\")";
		row++;
	}
}

wb.SaveAs($@"c:\Temp\Issues\0913\roman_all.xlsx");
```