### PR TITLE
Update rich text when text of a run changes

### DIFF
--- a/ClosedXML.Tests/Excel/RichText/XLRichStringTests.cs
+++ b/ClosedXML.Tests/Excel/RichText/XLRichStringTests.cs
@@ -701,7 +701,7 @@ namespace ClosedXML.Tests
         [Test]
         public void CanChangeInlinedRichText()
         {
-            void testRichText(IXLRichText richText)
+            static void AssertRichText(IXLRichText richText)
             {
                 Assert.IsNotNull(richText);
                 Assert.IsTrue(richText.Any());
@@ -715,7 +715,7 @@ namespace ClosedXML.Tests
                 using (var workbook = new XLWorkbook(inputStream))
                 {
                     var richText = workbook.Worksheets.First().Cell("A1").GetRichText();
-                    testRichText(richText);
+                    AssertRichText(richText);
                     richText.AddText(" - changed");
                     workbook.SaveAs(outputStream);
                 }
@@ -727,7 +727,7 @@ namespace ClosedXML.Tests
                     Assert.IsTrue(cell.HasRichText);
                     var rt = cell.GetRichText();
                     Assert.AreEqual("Year (range: 3 yrs) - changed", rt.ToString());
-                    testRichText(rt);
+                    AssertRichText(rt);
                 }
             }
         }
@@ -781,8 +781,12 @@ namespace ClosedXML.Tests
             richText.AddText("Hello");
             Assert.AreEqual(cell.Value, "Hello");
 
-            richText.AddText(" World");
+            var world = richText.AddText(" World");
             Assert.AreEqual(cell.Value, "Hello World");
+
+            world.Text = " World!";
+            Assert.AreEqual(cell.Value, "Hello World!");
+            Assert.AreEqual(cell.GetRichText().Text, "Hello World!");
 
             richText.ClearText();
             Assert.AreEqual(cell.Value, string.Empty);

--- a/ClosedXML/Excel/RichText/XLFormattedText.cs
+++ b/ClosedXML/Excel/RichText/XLFormattedText.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Excel
         private XLPhonetics _phonetics;
         protected T Container;
 
-        public XLFormattedText(IXLFormattedText<T> defaultRichText, IXLFontBase defaultFont)
+        protected XLFormattedText(IXLFormattedText<T> defaultRichText, IXLFontBase defaultFont)
             : this(defaultFont)
         {
             foreach (var rt in defaultRichText)
@@ -28,13 +28,13 @@ namespace ClosedXML.Excel
             }
         }
 
-        public XLFormattedText(String text, IXLFontBase defaultFont)
+        protected XLFormattedText(String text, IXLFontBase defaultFont)
             : this(defaultFont)
         {
             AddText(text);
         }
 
-        public XLFormattedText(IXLFontBase defaultFont)
+        protected XLFormattedText(IXLFontBase defaultFont)
         {
             Length = 0;
             _defaultFont = defaultFont;

--- a/ClosedXML/Excel/RichText/XLRichString.cs
+++ b/ClosedXML/Excel/RichText/XLRichString.cs
@@ -9,16 +9,25 @@ namespace ClosedXML.Excel
         private readonly IXLWithRichString _withRichString;
         private readonly XLFont _font;
         private readonly Action _onChange;
+        private string _text;
 
         public XLRichString(String text, IXLFontBase font, IXLWithRichString withRichString, Action? onChange)
         {
-            Text = text;
+            _text = text;
             _font = new XLFont(font);
             _withRichString = withRichString;
             _onChange = onChange ?? (() => { });
         }
 
-        public String Text { get; set; }
+        public String Text
+        {
+            get => _text;
+            set
+            {
+                _text = value;
+                _onChange();
+            }
+        }
 
         public IXLRichString AddText(String text)
         {
@@ -235,7 +244,7 @@ namespace ClosedXML.Excel
             FontScheme = value; return this;
         }
 
-        public override bool Equals(object obj) => Equals(obj as XLRichString);
+        public override bool Equals(object? obj) => Equals(obj as XLRichString);
 
         public Boolean Equals(IXLRichString? other) => Equals(other as XLRichString);
 


### PR DESCRIPTION
When a property setter `IXLRichString.Text` (basically a representation of a rich text run) was called, the enveloping rich text `IXLRichText` didn't change.

We have mutable API for rich texts, but the implementation must be immutable. Immutability is required by shared string table that stores whole rich text as one entry in a dictionary. Key in a dictionary must be immutable (keep same hash keys and so on).

To solve this problem, `IXLRichText` is mostly a facade that changes immutable text when user calls a mutating method.

Property setter IXLRichText.Text didn't call "update-immutable-rich-text" method and thus text wasn't changed.

My confidence in `RichText` and `XLComment` (aka.  *mutable-API-changing-immutable-`XLImmutableRichText`* adapters) is low and they should be rethought and rewritten and `XLFormattedText` probably deleted. Let's add it to the never-ending pile "should be done".

Fixes #2430