### PR TITLE
Reimplement INDEX function

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Array.cs
+++ b/ClosedXML/Excel/CalcEngine/Array.cs
@@ -358,4 +358,42 @@ namespace ClosedXML.Excel.CalcEngine
 
         public override int Height => _original.Width;
     }
+
+    /// <summary>
+    /// An array that is a rectangular slice of the original array.
+    /// </summary>
+    internal class SlicedArray : Array
+    {
+        private readonly Array _original;
+        private readonly int _rowOfs;
+        private readonly int _colOfs;
+
+        /// <summary>
+        /// Create a sliced array from the original array.
+        /// </summary>
+        /// <param name="original">Original array.</param>
+        /// <param name="rowOfs">The row offset indicating the starting row of the slice in the original array.</param>
+        /// <param name="rows">The number of rows in the sliced array.</param>
+        /// <param name="colOfs">The column offset indicating the starting column of the slice in the original array.</param>
+        /// <param name="cols">The number of columns in the sliced array.</param>
+        public SlicedArray(Array original, int rowOfs, int rows, int colOfs, int cols)
+        {
+            if (rowOfs < 0 || rows < 1 || colOfs < 0 || cols < 1 ||
+                rowOfs + rows > original.Height ||
+                colOfs + cols > original.Width)
+                throw new ArgumentOutOfRangeException();
+
+            _original = original;
+            _rowOfs = rowOfs;
+            Height = rows;
+            _colOfs = colOfs;
+            Width = cols;
+        }
+
+        public override ScalarValue this[int y, int x] => _original[y + _rowOfs, x + _colOfs];
+
+        public override int Width { get; }
+
+        public override int Height { get; }
+    }
 }

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -316,6 +316,24 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptIndex(Func<CalcContext, AnyValue, List<int>, AnyValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0 = args[0];
+                var numbers = new List<int>(args.Length - 1);
+                for (var i = 1; i < args.Length; ++i)
+                {
+                    if (!ToNumber(args[i], ctx).TryPickT0(out var number, out var error))
+                        return error;
+
+                    numbers.Add((int)number);
+                }
+
+                return f(ctx, arg0, numbers);
+            };
+        }
+
         /// <summary>
         /// Adapt a function that accepts areas as arguments (e.g. SUMPRODUCT). The key benefit is
         /// that all <c>ReferenceArray</c> allocation is done once for a function. The method


### PR DESCRIPTION
Reimplement the INDEX function. It should now be able to deal with all situations. In addition to original implementation, it can now return a non-single value (e.g. row or column) and can select areas form multi-area references.

It is also related to #2482, where the `IXLCell.Value` in the original implementation may cause stack overflow. 

In 0.103 the recalculation process was switched from recursive one to calculation chain, but the remaining adapters cause problems. I can't ask recursively for a value of a cell while I am being asked for a value of a cell. That might cause SO in some situations. I need to get rid of the adapters to `Expression`.

It is also related to #1788 and #2493.