### PR TITLE
Reimplement MATCH function

### DIFF
--- a/ClosedXML/Excel/CalcEngine/AnyValue.cs
+++ b/ClosedXML/Excel/CalcEngine/AnyValue.cs
@@ -192,6 +192,24 @@ namespace ClosedXML.Excel.CalcEngine
         }
 
         /// <summary>
+        /// Return array from a single area reference or array. If value is scalar, return false.
+        /// </summary>
+        public bool TryPickCollectionArray(out Array array, CalcContext ctx)
+        {
+            if (TryPickArea(out var areaAddress, out _))
+            {
+                array = new ReferenceArray(areaAddress, ctx);
+                return true;
+            }
+
+            if (TryPickArray(out array))
+                return true;
+
+            array = null;
+            return false;
+        }
+
+        /// <summary>
         /// <para>
         /// Try to get a value more in line with an array formula semantic. The output is always
         /// either single value or an array.

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -334,6 +334,23 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptMatch(Func<CalcContext, ScalarValue, AnyValue, int, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToScalarValue(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1 = args[1];
+                var arg2Converted = args.Length > 2 ? ToNumber(args[2], ctx) : 1;
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                return f(ctx, arg0, arg1, (int)arg2).ToAnyValue();
+            };
+        }
+
         /// <summary>
         /// Adapt a function that accepts areas as arguments (e.g. SUMPRODUCT). The key benefit is
         /// that all <c>ReferenceArray</c> allocation is done once for a function. The method


### PR DESCRIPTION
The original `MATCH` implementation had several problems, e.g.
* match type 0: criteria was only half-working (plus regex)
* match type 1: didn't use bisection for 
* didn't correctly omit values with different type

The key problem was that it accessed `IXLCell.Value` which is a big no-no that might cause stack overflow (#2482).

The new implementation should match Excel behavior, including how does bisection work on unsorted arrays/references ([gist that was used to assert results are same](https://gist.github.com/jahav/2840c106b571e28ea3298d4855310dd9)).

It is also related to https://github.com/ClosedXML/ClosedXML/issues/1788 and https://github.com/ClosedXML/ClosedXML/issues/2493.

BTW: I know understand what Microsoft means by *`XMATCH` is more efficient than `MATCH`*. `MATCH` doesn't use bisection for descending data (match type -1), it uses find first. log N vs N complexity.