### PR TITLE
Reimplement 10 simple MathTrig funcs

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1624,6 +1624,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return (double)XLWorkbook.EvaluateExpr($"SIN({arg})");
         }
 
+        [TestCase("0", 0)]
+        [TestCase("1", 1.1752011936438014)]
+        [TestCase("10", 11013.232874703393)]
+        [TestCase("100", 1.3440585709080678E+43)]
+        [TestCase("100", 1.3440585709080678E+43)]
+        [TestCase("711", XLError.NumberInvalid)]
+        [TestCase("-711", XLError.NumberInvalid)]
+        public void Sinh(string arg, object result)
+        {
+            var actual = XLWorkbook.EvaluateExpr($"SINH({arg})");
+            Assert.AreEqual(result, actual);
+        }
+
         [TestCase(0, 1)]
         [TestCase(0.3, 1.0467516)]
         [TestCase(0.6, 1.21162831)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1717,6 +1717,22 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.IsTrue(Math.Abs(0.70710321482284566 - (double)actual) < XLHelper.Epsilon);
         }
 
+        [TestCase(0, 0)]
+        [TestCase(1, 1)]
+        [TestCase(2, 1.4142135624)]
+        [TestCase(1E+300, 1E+150)]
+        public void Sqrt(double x, double result)
+        {
+            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"SQRT({x})"), tolerance);
+        }
+
+        [TestCase(-1)]
+        [TestCase(-0.0001)]
+        public void Sqrt_returns_invalid_number_for_negative_numbers(double x)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"SQRT({x})"));
+        }
+
         [Test]
         public void SqrtPi()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1611,6 +1611,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return (double)XLWorkbook.EvaluateExpr($"ROUNDUP({number}, {digits})");
         }
 
+        [TestCase("0", ExpectedResult = 0)]
+        [TestCase("1", ExpectedResult = 0.8414709848078965)]
+        [TestCase("-1", ExpectedResult = -0.8414709848078965)]
+        [TestCase("PI()", ExpectedResult = 0)]
+        [TestCase("PI()/2", ExpectedResult = 1)]
+        [TestCase("30*PI()/180", ExpectedResult = 0.5)]
+        [TestCase("RADIANS(30)", ExpectedResult = 0.5)]
+        [DefaultFloatingPointTolerance(tolerance)]
+        public double Sin(string arg)
+        {
+            return (double)XLWorkbook.EvaluateExpr($"SIN({arg})");
+        }
+
         [TestCase(0, 1)]
         [TestCase(0.3, 1.0467516)]
         [TestCase(0.6, 1.21162831)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -445,16 +445,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-5.5, 2.1, -4.2)]
         [TestCase(-5.5, -2.1, -6.3)]
         [TestCase(-5.5, 0, 0)]
+        [TestCase(0, 0, 0)]
+        [TestCase(0, 0.1, 0)]
+        [TestCase(0, -0.1, 0)]
+        [TestCase(0.1, 0, 0)]
+        [TestCase(-0.1, 0, 0)]
         public void Ceiling(double input, double significance, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"CEILING({input.ToInvariantString()}, {significance.ToInvariantString()})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})");
             Assert.AreEqual(expectedResult, actual, tolerance);
         }
 
         [TestCase(6.7, -1)]
-        public void Ceiling_ThrowsNumberExceptionOnInvalidInput(double input, double significance)
+        [TestCase(0.1, -0.2)]
+        public void Ceiling_returns_error_on_different_number_and_significance(double input, double significance)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"CEILING({input.ToInvariantString()}, {significance.ToInvariantString()})"));
+            // Spec says "if x and significance have different signs, #NUM! is returned.",
+            // but in reality it only happens when number is positive and step negative.
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})"));
         }
 
         [TestCase(24.3, 5, null, 25)]
@@ -480,13 +488,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-5.5, 2.1, 10, -6.3)]
         [TestCase(-5.5, -2.1, 10, -6.3)]
         [TestCase(-5.5, 0, 10, 0)]
-        public void CeilingMath(double input, double? step, double? mode, double expectedResult)
+        public void CeilingMath(double input, double? significance, double? mode, double expectedResult)
         {
             var parameters = new StringBuilder();
             parameters.Append(input);
-            if (step != null)
+            if (significance != null)
             {
-                parameters.Append(", ").Append(step);
+                parameters.Append(", ").Append(significance);
                 if (mode != null)
                     parameters.Append(", ").Append(mode);
             }

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -2483,13 +2483,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("SUMSQ(A1)"));
         }
 
-        [Test]
-        public void Trunc()
+        [TestCase(27.64799257, null, 27)]
+        [TestCase(0, null, 0)]
+        [TestCase(0, 0, 0)]
+        [TestCase(3.1415926, 0, 3)]
+        [TestCase(3.1415926, 1, 3.1)]
+        [TestCase(3.1415926, 3, 3.141)]
+        [TestCase(3.1415926, 5, 3.14159)]
+        [TestCase(-4.3, 0, -4)]
+        [TestCase(8.9, null, 8)]
+        [TestCase(-8.9, null, -8)]
+        [TestCase(0.45, null, 0)]
+        public void Trunc(double number, double? digits, object expectedResult)
         {
-            var input = 27.64799257;
-            var expectedResult = 27;
-            var actual = (double)XLWorkbook.EvaluateExpr($"TRUNC({input.ToString(CultureInfo.InvariantCulture)})");
-            Assert.AreEqual(expectedResult, actual);
+            var formula = digits is null ? $"TRUNC({number})" : $"TRUNC({number}, {digits})";
+            Assert.AreEqual(expectedResult, (double)XLWorkbook.EvaluateExpr(formula));
         }
 
         [TestCase(27.64799257, -1, 20)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -2502,6 +2502,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"TAN({radians})"));
         }
 
+        [TestCase(-1, -0.761594156)]
+        [TestCase(0, 0)]
+        [TestCase(1, 0.761594156)]
+        [TestCase(1E+300, 1)]
+        [TestCase(-1E+300, -1)]
+        [DefaultFloatingPointTolerance(tolerance)]
+        public void Tanh(double number, double result)
+        {
+            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"TANH({number})"));
+        }
+
         [TestCase(27.64799257, null, 27)]
         [TestCase(0, null, 0)]
         [TestCase(0, 0, 0)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
@@ -459,6 +460,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(24.3, 5, null, 25)]
         [TestCase(6.7, null, null, 7)]
         [TestCase(-8.1, 2, null, -8)]
+        [TestCase(-5.5, 2, -1, -6)]
+        [TestCase(-5.5, 2, -0.1, -6)]
         [TestCase(5.5, 2.1, 0, 6.3)]
         [TestCase(5.5, -2.1, 0, 6.3)]
         [TestCase(5.5, 0, 0, 0)]
@@ -477,14 +480,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-5.5, 2.1, 10, -6.3)]
         [TestCase(-5.5, -2.1, 10, -6.3)]
         [TestCase(-5.5, 0, 10, 0)]
-        public void CeilingMath(double input, double? step, int? mode, double expectedResult)
+        public void CeilingMath(double input, double? step, double? mode, double expectedResult)
         {
-            string parameters = input.ToString(CultureInfo.InvariantCulture);
+            var parameters = new StringBuilder();
+            parameters.Append(input);
             if (step != null)
             {
-                parameters = parameters + ", " + step?.ToString(CultureInfo.InvariantCulture);
+                parameters.Append(", ").Append(step);
                 if (mode != null)
-                    parameters = parameters + ", " + mode?.ToString(CultureInfo.InvariantCulture);
+                    parameters.Append(", ").Append(mode);
             }
 
             var actual = (double)XLWorkbook.EvaluateExpr($"CEILING.MATH({parameters})");

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1736,11 +1736,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void SqrtPi()
         {
-            var actual = (double)XLWorkbook.EvaluateExpr("SqrtPi(1)");
-            Assert.AreEqual(1.7724538509055159, actual, XLHelper.Epsilon);
+            var actual = (double)XLWorkbook.EvaluateExpr("SQRTPI(1)");
+            Assert.AreEqual(1.7724538509055159, actual, tolerance);
 
-            actual = (double)XLWorkbook.EvaluateExpr("SqrtPi(2)");
-            Assert.AreEqual(2.5066282746310002, actual, XLHelper.Epsilon);
+            actual = (double)XLWorkbook.EvaluateExpr("SQRTPI(2)");
+            Assert.AreEqual(2.5066282746310002, actual, tolerance);
+
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("SQRTPI(-1)"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
     [SetCulture("en-US")]
     public class MathTrigTests
     {
-        private readonly double tolerance = 1e-10;
+        private const double tolerance = 1e-10;
 
         [Theory]
         public void Abs_ReturnsItselfOnPositiveNumbers([Range(0, 10, 0.1)] double input)
@@ -2481,6 +2481,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Reference error is propagated
             ws.Cell("A1").Value = XLError.NoValueAvailable;
             Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("SUMSQ(A1)"));
+        }
+
+        [TestCase(-1, ExpectedResult = -1.5574077247)]
+        [TestCase(0, ExpectedResult = 0)]
+        [TestCase(1, ExpectedResult = 1.5574077247)]
+        [TestCase(134217727, ExpectedResult = 3.2584564256)]
+        [TestCase(-134217727, ExpectedResult = -3.2584564256)]
+        [DefaultFloatingPointTolerance(tolerance)]
+        public double Tan(double radians)
+        {
+            return (double)XLWorkbook.EvaluateExpr($"TAN({radians})");
+        }
+
+        [TestCase(134217728)]
+        [TestCase(-134217728)]
+        [TestCase(1E+100)]
+        public void Tan_returns_invalid_number_for_radians_outside_limit(double radians)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"TAN({radians})"));
         }
 
         [TestCase(27.64799257, null, 27)]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -62,6 +62,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SQRTPI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEVA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEVP/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -71,6 +71,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMPRODUCT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=TANH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TRUNC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -71,6 +71,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMPRODUCT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SUMSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=TRUNC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unhide/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -61,6 +61,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ROUNDDOWN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SINH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SQRTPI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=STDEV/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/FunctionFlags.cs
+++ b/ClosedXML/Excel/CalcEngine/FunctionFlags.cs
@@ -38,5 +38,14 @@ namespace ClosedXML.Excel.CalcEngine
         /// </summary>
         /// <example>RAND(), DATE()</example>
         Volatile = 8,
+
+        /// <summary>
+        /// The function is a future function (i.e. functions not present in Excel 2007). Future
+        /// functions are displayed to the user with a name (e.g <c>SEC</c>), but are actually
+        /// stored in the workbook with a prefix <c>_xlfn</c> (e.g. <c>_xlfn.SEC</c>).
+        /// The prefix is there for backwards compatibility, to not clash with user defined
+        /// functions and other such reasons. See [MS-XLSX] 2.3.3 for complete list.
+        /// </summary>
+        Future = 16
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -83,7 +83,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SIGN", 1, Sign);
             ce.RegisterFunction("SIN", 1, Sin);
             ce.RegisterFunction("SINH", 1, Sinh);
-            ce.RegisterFunction("SQRT", 1, Sqrt);
+            ce.RegisterFunction("SQRT", 1, 1, Adapt(Sqrt), FunctionFlags.Scalar);
             ce.RegisterFunction("SQRTPI", 1, SqrtPi);
             ce.RegisterFunction("SUBTOTAL", 2, 255, Adapt(Subtotal), FunctionFlags.Range, AllowRange.Except, 0);
             ce.RegisterFunction("SUM", 1, int.MaxValue, Sum, FunctionFlags.Range, AllowRange.All);
@@ -881,9 +881,12 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Sinh(p[0]);
         }
 
-        private static object Sqrt(List<Expression> p)
+        private static ScalarValue Sqrt(double x)
         {
-            return Math.Sqrt(p[0]);
+            if (x < 0)
+                return XLError.NumberInvalid;
+
+            return Math.Sqrt(x);
         }
 
         private static object SqrtPi(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -95,7 +95,7 @@ namespace ClosedXML.Excel.CalcEngine
             //ce.RegisterFunction("SUMX2PY2", SumX2PY2, 1);
             //ce.RegisterFunction("SUMXMY2", SumXMY2, 1);
             ce.RegisterFunction("TAN", 1, 1, Adapt(Tan), FunctionFlags.Scalar);
-            ce.RegisterFunction("TANH", 1, Tanh);
+            ce.RegisterFunction("TANH", 1, 1, Adapt(Tanh), FunctionFlags.Scalar);
             ce.RegisterFunction("TRUNC", 1, 2, AdaptLastOptional(Trunc, 0), FunctionFlags.Scalar);
         }
 
@@ -1068,9 +1068,9 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Tan(radians);
         }
 
-        private static object Tanh(List<Expression> p)
+        private static ScalarValue Tanh(double number)
         {
-            return Math.Tanh(p[0]);
+            return Math.Tanh(number);
         }
 
         private static ScalarValue Trunc(double number, double digits)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -82,7 +82,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SERIESSUM", 4, SeriesSum, AllowRange.Only, 3);
             ce.RegisterFunction("SIGN", 1, Sign);
             ce.RegisterFunction("SIN", 1, 1, Adapt(Sin), FunctionFlags.Scalar);
-            ce.RegisterFunction("SINH", 1, Sinh);
+            ce.RegisterFunction("SINH", 1, 1, Adapt(Sinh), FunctionFlags.Scalar);
             ce.RegisterFunction("SQRT", 1, 1, Adapt(Sqrt), FunctionFlags.Scalar);
             ce.RegisterFunction("SQRTPI", 1, 1, Adapt(SqrtPi), FunctionFlags.Scalar);
             ce.RegisterFunction("SUBTOTAL", 2, 255, Adapt(Subtotal), FunctionFlags.Range, AllowRange.Except, 0);
@@ -876,9 +876,13 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Sin(radians);
         }
 
-        private static object Sinh(List<Expression> p)
+        private static ScalarValue Sinh(double number)
         {
-            return Math.Sinh(p[0]);
+            var sinh = Math.Sinh(number);
+            if (double.IsInfinity(sinh))
+                return XLError.NumberInvalid;
+
+            return sinh;
         }
 
         private static ScalarValue Sqrt(double number)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -81,7 +81,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SECH", 1, Sech);
             ce.RegisterFunction("SERIESSUM", 4, SeriesSum, AllowRange.Only, 3);
             ce.RegisterFunction("SIGN", 1, Sign);
-            ce.RegisterFunction("SIN", 1, Sin);
+            ce.RegisterFunction("SIN", 1, 1, Adapt(Sin), FunctionFlags.Scalar);
             ce.RegisterFunction("SINH", 1, Sinh);
             ce.RegisterFunction("SQRT", 1, 1, Adapt(Sqrt), FunctionFlags.Scalar);
             ce.RegisterFunction("SQRTPI", 1, 1, Adapt(SqrtPi), FunctionFlags.Scalar);
@@ -871,9 +871,9 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Sign(p[0]);
         }
 
-        private static object Sin(List<Expression> p)
+        private static ScalarValue Sin(double radians)
         {
-            return Math.Sin(p[0]);
+            return Math.Sin(radians);
         }
 
         private static object Sinh(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -94,7 +94,7 @@ namespace ClosedXML.Excel.CalcEngine
             //ce.RegisterFunction("SUMX2MY2", SumX2MY2, 1);
             //ce.RegisterFunction("SUMX2PY2", SumX2PY2, 1);
             //ce.RegisterFunction("SUMXMY2", SumXMY2, 1);
-            ce.RegisterFunction("TAN", 1, Tan);
+            ce.RegisterFunction("TAN", 1, 1, Adapt(Tan), FunctionFlags.Scalar);
             ce.RegisterFunction("TANH", 1, Tanh);
             ce.RegisterFunction("TRUNC", 1, 2, AdaptLastOptional(Trunc, 0), FunctionFlags.Scalar);
         }
@@ -1057,9 +1057,15 @@ namespace ClosedXML.Excel.CalcEngine
             return sumSq.Sum;
         }
 
-        private static object Tan(List<Expression> p)
+        private static ScalarValue Tan(double radians)
         {
-            return Math.Tan(p[0]);
+            // Cutoff point for Excel. .NET Core allows all values and .NET Fx ~< 1e+19.
+            // To ensure consistent behavior for all platforms, respect Excel limit. It's
+            // lower than both the .NET Core and the .NET Fx one.
+            if (Math.Abs(radians) >= 134217728)
+                return XLError.NumberInvalid;
+
+            return Math.Tan(radians);
         }
 
         private static object Tanh(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -96,7 +96,7 @@ namespace ClosedXML.Excel.CalcEngine
             //ce.RegisterFunction("SUMXMY2", SumXMY2, 1);
             ce.RegisterFunction("TAN", 1, Tan);
             ce.RegisterFunction("TANH", 1, Tanh);
-            ce.RegisterFunction("TRUNC", 1, 2, Trunc);
+            ce.RegisterFunction("TRUNC", 1, 2, AdaptLastOptional(Trunc, 0), FunctionFlags.Scalar);
         }
 
         #endregion Register
@@ -1067,18 +1067,10 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Tanh(p[0]);
         }
 
-        private static object Trunc(List<Expression> p)
+        private static ScalarValue Trunc(double number, double digits)
         {
-            var number = (double)p[0];
-
-            var num_digits = 0d;
-            if (p.Count > 1)
-                num_digits = (double)p[1];
-
-            var scaling = Math.Pow(10, num_digits);
-
-            var truncated = (int)(number * scaling);
-            return (double)truncated / scaling;
+            var scaling = Math.Pow(10, digits);
+            return Math.Truncate(number * scaling) / scaling;
         }
 
         private static Dictionary<int, IReadOnlyList<(string Symbol, int Value)>> BuildRomanForms()

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SIN", 1, Sin);
             ce.RegisterFunction("SINH", 1, Sinh);
             ce.RegisterFunction("SQRT", 1, 1, Adapt(Sqrt), FunctionFlags.Scalar);
-            ce.RegisterFunction("SQRTPI", 1, SqrtPi);
+            ce.RegisterFunction("SQRTPI", 1, 1, Adapt(SqrtPi), FunctionFlags.Scalar);
             ce.RegisterFunction("SUBTOTAL", 2, 255, Adapt(Subtotal), FunctionFlags.Range, AllowRange.Except, 0);
             ce.RegisterFunction("SUM", 1, int.MaxValue, Sum, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("SUMIF", 2, 3, AdaptLastOptional(SumIf), FunctionFlags.Range, AllowRange.Only, 0, 2);
@@ -881,18 +881,20 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Sinh(p[0]);
         }
 
-        private static ScalarValue Sqrt(double x)
+        private static ScalarValue Sqrt(double number)
         {
-            if (x < 0)
+            if (number < 0)
                 return XLError.NumberInvalid;
 
-            return Math.Sqrt(x);
+            return Math.Sqrt(number);
         }
 
-        private static object SqrtPi(List<Expression> p)
+        private static ScalarValue SqrtPi(double number)
         {
-            var num = (Double)p[0];
-            return Math.Sqrt(Math.PI * num);
+            if (number < 0)
+                return XLError.NumberInvalid;
+
+            return Math.Sqrt(Math.PI * number);
         }
 
         private static AnyValue Subtotal(CalcContext ctx, double number, AnyValue[] fnArgs)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -36,7 +36,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ATANH", 1, 1, Adapt(Atanh), FunctionFlags.Scalar);
             ce.RegisterFunction("BASE", 2, 3, Base);
             ce.RegisterFunction("CEILING", 2, Ceiling);
-            ce.RegisterFunction("CEILING.MATH", 1, 3, CeilingMath);
+            ce.RegisterFunction("CEILING.MATH", 1, 3, AdaptLastTwoOptional(CeilingMath, 1, 0), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("COMBIN", 2, 2, Adapt(Combin), FunctionFlags.Scalar);
             ce.RegisterFunction("COMBINA", 2, CombinA);
             ce.RegisterFunction("COS", 1, 1, Adapt(Cos), FunctionFlags.Scalar);
@@ -281,23 +281,19 @@ namespace ClosedXML.Excel.CalcEngine
                 return Math.Ceiling(number / significance) * significance;
         }
 
-        private static object CeilingMath(List<Expression> p)
+        private static ScalarValue CeilingMath(double number, double step, double mode)
         {
-            double number = p[0];
-            double significance = 1;
-            if (p.Count > 1) significance = p[1];
+            if (step == 0)
+                return 0;
 
-            double mode = 0;
-            if (p.Count > 2) mode = p[2];
+            step = Math.Abs(step);
 
-            if (significance == 0)
-                return 0d;
-            else if (number >= 0)
-                return Math.Ceiling(number / Math.Abs(significance)) * Math.Abs(significance);
-            else if (mode == 0)
-                return Math.Ceiling(number / Math.Abs(significance)) * Math.Abs(significance);
-            else
-                return -Math.Ceiling(-number / Math.Abs(significance)) * Math.Abs(significance);
+            // Mode 1 basically mimics behavior of CEILING function,
+            // i.e. ceil away from zero even for negative numbers.
+            if (number < 0 && mode != 0)
+                return Math.Floor(number / step) * step;
+
+            return Math.Ceiling(number / step) * step;
         }
 
         private static ScalarValue Combin(double number, double numberChosen)

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -413,6 +413,26 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, ScalarValue> f, double defaultValue1, double defaultValue2)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = args.Length > 1 ? ToNumber(args[1], ctx) : defaultValue1;
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                     return err1;
+
+                var arg2Converted = args.Length > 2 ? ToNumber(args[2], ctx) : defaultValue2;
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                return f(arg0, arg1, arg2).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, double, AnyValue> f, double defaultValue0, double defaultValue1)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -84,6 +84,22 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<string, string, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToText(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToText(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                return f(arg0, arg1).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<CalcContext, AnyValue, double, AnyValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel.CalcEngine
             // LEGACY: Remove after switch to new engine. CONCATENATE function doesn't actually accept ranges, but it's legacy implementation has a check and there is a test.
             ce.RegisterFunction("CONCATENATE", 1, int.MaxValue, Concatenate, AllowRange.All); //	Joins several text items into one text item
             ce.RegisterFunction("DOLLAR", 1, 2, Dollar); // Converts a number to text, using the $ (dollar) currency format
-            ce.RegisterFunction("EXACT", 2, Exact); // Checks to see if two text values are identical
+            ce.RegisterFunction("EXACT", 2, 2, Adapt(Exact), FunctionFlags.Scalar); // Checks to see if two text values are identical
             ce.RegisterFunction("FIND", 2, 3, AdaptLastOptional(Find), FunctionFlags.Scalar); //Finds one text value within another (case-sensitive)
             ce.RegisterFunction("FIXED", 1, 3, Fixed); // Formats a number as text with a fixed number of decimals
             //ce.RegisterFunction("JIS	Changes half-width (single-byte) English letters or katakana within a character string to full-width (double-byte) characters
@@ -475,12 +475,9 @@ namespace ClosedXML.Excel.CalcEngine
             return value.ToString("C" + dec);
         }
 
-        private static object Exact(List<Expression> p)
+        private static ScalarValue Exact(string lhs, string rhs)
         {
-            var t1 = (string)p[0];
-            var t2 = (string)p[1];
-
-            return t1 == t2;
+            return lhs == rhs;
         }
 
         private static object Fixed(List<Expression> p)


### PR DESCRIPTION
Convert another 10 simple functions (`EXACT`, `CEILING.MATH`, `CEILING`, `TRUNC`, `TAN`, `TANH`, `SQRT`, `SQRTPI`, `SIN`, `SINH`) from legacy `Expression` based signature with adapter to `AnyValue` based evaluation.

122 functions down, 64 to go. Most of them should be simple, the hard ones were reimplemented first.

Related to #2482