### PR TITLE
Reimplement 10 simple mathtrig funcs

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -717,14 +717,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(45, 0.617369624)]
         [TestCase(-2, 0.457657554)]
         [TestCase(-3, 7.015252551)]
-        public void Cot(double input, double expected)
+        public void Cot(double angle, double expected)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"COT({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"COT({angle})");
             Assert.AreEqual(expected, actual, tolerance * 10.0);
         }
 
         [Test]
-        public void Cot_Input0()
+        public void Cot_returns_division_by_zero_error_on_zero_angle()
         {
             Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COT(0)"));
         }

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1612,6 +1612,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [TestCase("0", ExpectedResult = 0)]
+        [TestCase("10.5", ExpectedResult = 1)]
+        [TestCase("-5.4", ExpectedResult = -1)]
+        [TestCase("-0.00001", ExpectedResult = -1)]
+        [TestCase("-1E+300", ExpectedResult = -1)]
+        [TestCase("\"0 1/2\"", ExpectedResult = 1)]
+        [TestCase("FALSE", ExpectedResult = 0)]
+        [TestCase("TRUE", ExpectedResult = 1)]
+        public double Sign(string arg)
+        {
+            return (double)XLWorkbook.EvaluateExpr($"SIGN({arg})");
+        }
+
+        [TestCase("0", ExpectedResult = 0)]
         [TestCase("1", ExpectedResult = 0.8414709848078965)]
         [TestCase("-1", ExpectedResult = -0.8414709848078965)]
         [TestCase("PI()", ExpectedResult = 0)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -87,9 +87,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(5.7, 2.425828318)]
         [TestCase(6, 2.47788873)]
         [TestCase(1, 0)]
-        public void Acosh_ReturnsCorrectValue(double input, double expectedResult)
+        public void Acosh_returns_correct_number(double angle, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"ACOSH({input})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOSH({angle})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
@@ -114,16 +114,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8, 0.124354995)]
         [TestCase(9, 0.110657221)]
         [TestCase(10, 0.099668652)]
-        public void Acot_ReturnsCorrectValue(double input, double expectedResult)
+        public void Acot_returns_correct_number(double angle, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"ACOT({input})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOT({angle})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
         [Theory]
-        public void Acoth_returns_error_for_absolute_values_smaller_than_one([Range(-0.9, 0.9, 0.1)] double input)
+        public void Acoth_returns_error_for_absolute_angle_smaller_than_one([Range(-0.9, 0.9, 0.1)] double angle)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOTH({input})"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOTH({angle})"));
         }
 
         [TestCase(-10, -0.100335348)]
@@ -145,9 +145,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(9, 0.111571776)]
         [TestCase(10, 0.100335348)]
         [TestCase(1E+100, 1E-100)]
-        public void Acoth_returns_correct_value(double input, double expectedResult)
+        public void Acoth_returns_correct_number(double angle, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"ACOTH({input})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOTH({angle})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 
@@ -721,13 +721,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Cot_returns_division_by_zero_error_on_zero_angle()
+        public void Cot_returns_division_by_zero_error_on_angle_zero()
         {
             Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COT(0)"));
         }
 
         [Test]
-        public void Coth_returns_division_by_zero_error_on_zero_angle()
+        public void Coth_returns_division_by_zero_error_on_angle_zero()
         {
             Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COTH(0)"));
         }
@@ -752,7 +752,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8, 1.000000225)]
         [TestCase(9, 1.00000003)]
         [TestCase(10, 1.000000004)]
-        public void Coth_Examples(double angle, double expected)
+        public void Coth_returns_correct_number(double angle, double expected)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"COTH({angle})");
             Assert.AreEqual(expected, actual, tolerance * 10.0);
@@ -784,9 +784,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8, 1.010756218)]
         [TestCase(9, 2.426486644)]
         [TestCase(10, -1.838163961)]
-        public void Csc_ReturnsCorrectValues(double input, double expected)
+        public void Csc_returns_correct_number(double angle, double expected)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr($"CSC({input})");
+            var actual = (double)XLWorkbook.EvaluateExpr($"CSC({angle})");
             Assert.AreEqual(expected, actual, tolerance * 10);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -804,13 +804,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(9, 0.00024682)]
         [TestCase(10, 0.000090799859712122200000)]
         [TestCase(11, 0.0000334034)]
-        public void CSch_CalculatesCorrectValues(double input, double expectedOutput)
+        public void Csch_calculates_correct_values(double input, double expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, (double)XLWorkbook.EvaluateExpr($@"CSCH({input})"), 0.000000001);
+            Assert.AreEqual(expectedOutput, (double)XLWorkbook.EvaluateExpr($"CSCH({input})"), 0.000000001);
         }
 
         [Test]
-        public void Csch_ReturnsDivisionByZeroErrorOnInput0()
+        public void Csch_returns_division_error_on_angle_zero()
         {
             Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("CSCH(0)"));
         }

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1691,26 +1691,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(11.4, 2.541355049)]
         [TestCase(45, 1.90359)]
         [TestCase(30, 6.48292)]
-        public void Sec_ReturnsCorrectNumber(double input, double expectedOutput)
+        public void Sec_returns_correct_number(double angle, double expectedOutput)
         {
-            double result = (double)XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"SEC({0})",
-                    input.ToString(CultureInfo.InvariantCulture)));
+            var result = (double)XLWorkbook.EvaluateExpr($"SEC({angle})");
             Assert.AreEqual(expectedOutput, result, 0.00001);
 
             // as the secant is symmetric for positive and negative numbers, let's assert twice:
-            double resultForNegative = (double)XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"SEC({0})",
-                    (-input).ToString(CultureInfo.InvariantCulture)));
+            var resultForNegative = (double)XLWorkbook.EvaluateExpr($"SEC({-angle})");
             Assert.AreEqual(expectedOutput, resultForNegative, 0.00001);
-        }
-
-        [Test]
-        public void Sec_ThrowsCellValueExceptionOnNonNumericValue()
-        {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEC(""number"")"));
         }
 
         [TestCase(-9, 0.00024682)]
@@ -1725,13 +1713,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(0, 1)]
         [TestCase(1E+100, 0)]
         [TestCase(1E-100, 1)]
-        public void Sech_ReturnsCorrectNumber(double radians, double expectedOutput)
+        public void Sech_returns_correct_number(double angle, double expectedOutput)
         {
-            var result = (double)XLWorkbook.EvaluateExpr($"SECH({radians})");
+            var result = (double)XLWorkbook.EvaluateExpr($"SECH({angle})");
             Assert.AreEqual(expectedOutput, result, 0.00001);
 
             // as the secant is symmetric for positive and negative numbers, let's assert twice:
-            var resultForNegative = (double)XLWorkbook.EvaluateExpr($"SECH({-radians})");
+            var resultForNegative = (double)XLWorkbook.EvaluateExpr($"SECH({-angle})");
             Assert.AreEqual(expectedOutput, resultForNegative, 0.00001);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -116,7 +116,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(10, 0.099668652)]
         public void Acot_ReturnsCorrectValue(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ACOT({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOT({input})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -600,41 +600,37 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(4, 3, 20)]
         [TestCase(10, 3, 220)]
         [TestCase(0, 0, 1)]
-        public void Combina_CalculatesCorrectValues(int number, int chosen, int expectedResult)
+        [TestCase(1, 0, 1)]
+        [TestCase(10, 15, 1307504)]
+        public void Combina_calculates_correct_values(int number, int chosen, int expectedResult)
         {
             var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})");
-            Assert.AreEqual(expectedResult, (double)actualResult);
+            Assert.AreEqual(expectedResult, actualResult);
         }
 
         [Theory]
-        public void Combina_Returns1WhenChosenIs0([Range(0, 10)] int number)
+        public void Combina_returns_one_when_chosen_is_zero([Range(0, 10)] int number)
         {
-            Combina_CalculatesCorrectValues(number, 0, 1);
+            var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, 0)");
+            Assert.AreEqual(1, actualResult);
         }
 
         [TestCase(-1, 2)]
         [TestCase(-3, -2)]
         [TestCase(2, -2)]
-        public void Combina_ThrowsNumExceptionOnInvalidValues(int number, int chosen)
+        [TestCase(int.MaxValue + 1d, 1)]
+        public void Combina_returns_error_on_invalid_values(double number, int chosen)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"COMBINA({0}, {1})",
-                    number.ToString(CultureInfo.InvariantCulture),
-                    chosen.ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})"));
         }
 
         [TestCase(4.23, 3, 20)]
         [TestCase(10.4, 3.14, 220)]
         [TestCase(0, 0.4, 1)]
-        public void Combina_TruncatesNumbersCorrectly(double number, double chosen, int expectedResult)
+        public void Combina_truncates_numbers_to_zero(double number, double chosen, int expectedResult)
         {
-            var actualResult = XLWorkbook.EvaluateExpr(string.Format(
-                @"COMBINA({0}, {1})",
-                number.ToString(CultureInfo.InvariantCulture),
-                chosen.ToString(CultureInfo.InvariantCulture)));
-
-            Assert.AreEqual(expectedResult, (double)actualResult);
+            var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})");
+            Assert.AreEqual(expectedResult, actualResult);
         }
 
         [TestCase(0, 1)]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -762,9 +762,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Csc_On0_ThrowsDivisionByZeroException()
+        public void Csc_returns_division_by_zero_on_angle_zero()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"CSC(0)"));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("CSC(0)"));
         }
 
         [TestCase(-10, 1.838163961)]
@@ -789,7 +789,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(10, -1.838163961)]
         public void Csc_ReturnsCorrectValues(double input, double expected)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"CSC({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"CSC({input})");
             Assert.AreEqual(expected, actual, tolerance * 10);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1723,19 +1723,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-2, 0.265802229)]
         [TestCase(-1, 0.648054274)]
         [TestCase(0, 1)]
-        public void Sech_ReturnsCorrectNumber(double input, double expectedOutput)
+        [TestCase(1E+100, 0)]
+        [TestCase(1E-100, 1)]
+        public void Sech_ReturnsCorrectNumber(double radians, double expectedOutput)
         {
-            double result = (double)XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"SECH({0})",
-                    input.ToString(CultureInfo.InvariantCulture)));
+            var result = (double)XLWorkbook.EvaluateExpr($"SECH({radians})");
             Assert.AreEqual(expectedOutput, result, 0.00001);
 
             // as the secant is symmetric for positive and negative numbers, let's assert twice:
-            double resultForNegative = (double)XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"SECH({0})",
-                    (-input).ToString(CultureInfo.InvariantCulture)));
+            var resultForNegative = (double)XLWorkbook.EvaluateExpr($"SECH({-radians})");
             Assert.AreEqual(expectedOutput, resultForNegative, 0.00001);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -730,9 +730,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Cot_On0_ThrowsDivisionByZeroException()
+        public void Coth_returns_division_by_zero_error_on_zero_angle()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"COTH(0)"));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COTH(0)"));
         }
 
         [TestCase(-10, -1.000000004)]
@@ -755,9 +755,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8, 1.000000225)]
         [TestCase(9, 1.00000003)]
         [TestCase(10, 1.000000004)]
-        public void Coth_Examples(double input, double expected)
+        public void Coth_Examples(double angle, double expected)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"COTH({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"COTH({angle})");
             Assert.AreEqual(expected, actual, tolerance * 10.0);
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -121,9 +121,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Theory]
-        public void Acoth_ForPlusMinusXSmallerThan1_ThrowsNumberException([Range(-0.9, 0.9, 0.1)] double input)
+        public void Acoth_returns_error_for_absolute_values_smaller_than_one([Range(-0.9, 0.9, 0.1)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(string.Format(@"ACOTH({0})", input.ToString(CultureInfo.InvariantCulture))));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOTH({input})"));
         }
 
         [TestCase(-10, -0.100335348)]
@@ -144,9 +144,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(8, 0.125657214)]
         [TestCase(9, 0.111571776)]
         [TestCase(10, 0.100335348)]
-        public void Acoth_ReturnsCorrectValue(double input, double expectedResult)
+        [TestCase(1E+100, 1E-100)]
+        public void Acoth_returns_correct_value(double input, double expectedResult)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ACOTH({0})", input.ToString(CultureInfo.InvariantCulture)));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ACOTH({input})");
             Assert.AreEqual(expectedResult, actual, tolerance * 10);
         }
 

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -27,6 +27,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coef/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COMBIN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=COTH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTBLANK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTIF/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -28,6 +28,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=codepoints/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coef/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COMBIN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=COMBINA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COTH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTA/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -32,6 +32,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTBLANK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTIFS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CSCH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dereferenced/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DEVSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -60,6 +60,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDBETWEEN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ROUNDDOWN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SECH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SERIESSUM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SINH/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -10,6 +10,7 @@
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=4386F01B791C56499C7EA059B55FFB54/@KeyIndexDefined">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AARRGGBB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOSH/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=argb/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ASINH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ATANH/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -11,6 +11,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AARRGGBB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOT/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOTH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=argb/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ASINH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ATANH/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -77,7 +77,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ROUND", 2, 2, Adapt(Round), FunctionFlags.Scalar);
             ce.RegisterFunction("ROUNDDOWN", 2, 2, Adapt(RoundDown), FunctionFlags.Scalar);
             ce.RegisterFunction("ROUNDUP", 2, 2, Adapt(RoundUp), FunctionFlags.Scalar);
-            ce.RegisterFunction("SEC", 1, Sec);
+            ce.RegisterFunction("SEC", 1, 1, Adapt(Sec), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("SECH", 1, 1, Adapt(Sech), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("SERIESSUM", 4, 4, AdaptSeriesSum(SeriesSum), FunctionFlags.Range, AllowRange.Only, 3);
             ce.RegisterFunction("SIGN", 1, 1, Adapt(Sign), FunctionFlags.Scalar);
@@ -830,17 +830,17 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Floor(value * coef) / coef;
         }
 
-        private static object Sec(List<Expression> p)
+        private static ScalarValue Sec(double angle)
         {
-            if (double.TryParse(p[0], out double number))
-                return 1.0 / Math.Cos(number);
-            else
-                return XLError.IncompatibleValue;
+            // Cos is actually never 0, because PI/2 can't be represented
+            // as a double. It's just a really small number and the result
+            // is thus never infinity.
+            return 1.0 / Math.Cos(angle);
         }
 
-        private static ScalarValue Sech(double radians)
+        private static ScalarValue Sech(double angle)
         {
-            return 1.0 / Math.Cosh(radians);
+            return 1.0 / Math.Cosh(angle);
         }
 
         private static ScalarValue SeriesSum(CalcContext ctx, double input, double initial, double step, Array coefficients)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -26,7 +26,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ABS", 1, 1, Adapt(Abs), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOS", 1, 1, Adapt(Acos), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOSH", 1, 1, Adapt(Acosh), FunctionFlags.Scalar);
-            ce.RegisterFunction("ACOT", 1, Acot);
+            ce.RegisterFunction("ACOT", 1, 1, Adapt(Acot), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("ACOTH", 1, Acoth);
             ce.RegisterFunction("ARABIC", 1, Arabic);
             ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
@@ -157,16 +157,19 @@ namespace ClosedXML.Excel.CalcEngine
             return XLMath.ACosh(number);
         }
 
-        private static object Acot(List<Expression> p)
+        private static ScalarValue Acot(double angle)
         {
-            double x = Math.Atan(1.0 / p[0]);
+            if (angle == 0)
+                return Math.PI / 2;
+
+            var acot = Math.Atan(1.0 / angle);
 
             // Acot in Excel calculates the modulus of the function above.
             // as the % operator is not the modulus, but the remainder, we have to calculate the modulus by hand:
-            while (x < 0)
-                x += Math.PI;
+            while (acot < 0)
+                acot += Math.PI;
 
-            return x;
+            return acot;
         }
 
         private static object Acoth(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("COS", 1, 1, Adapt(Cos), FunctionFlags.Scalar);
             ce.RegisterFunction("COSH", 1, 1, Adapt(Cosh), FunctionFlags.Scalar);
             ce.RegisterFunction("COT", 1, 1, Adapt(Cot), FunctionFlags.Scalar | FunctionFlags.Future);
-            ce.RegisterFunction("COTH", 1, Coth);
+            ce.RegisterFunction("COTH", 1, 1, Adapt(Coth), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("CSC", 1, Csc);
             ce.RegisterFunction("CSCH", 1, Csch);
             ce.RegisterFunction("DECIMAL", 2, MathTrig.Decimal);
@@ -346,13 +346,12 @@ namespace ClosedXML.Excel.CalcEngine
             return 1 / tan;
         }
 
-        private static object Coth(List<Expression> p)
+        private static ScalarValue Coth(double angle)
         {
-            double input = p[0];
-            if (input == 0)
+            if (angle == 0)
                 return XLError.DivisionByZero;
 
-            return 1 / Math.Tanh(input);
+            return 1 / Math.Tanh(angle);
         }
 
         private static object Csc(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -78,7 +78,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ROUNDDOWN", 2, 2, Adapt(RoundDown), FunctionFlags.Scalar);
             ce.RegisterFunction("ROUNDUP", 2, 2, Adapt(RoundUp), FunctionFlags.Scalar);
             ce.RegisterFunction("SEC", 1, Sec);
-            ce.RegisterFunction("SECH", 1, Sech);
+            ce.RegisterFunction("SECH", 1, 1, Adapt(Sech), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("SERIESSUM", 4, 4, AdaptSeriesSum(SeriesSum), FunctionFlags.Range, AllowRange.Only, 3);
             ce.RegisterFunction("SIGN", 1, 1, Adapt(Sign), FunctionFlags.Scalar);
             ce.RegisterFunction("SIN", 1, 1, Adapt(Sin), FunctionFlags.Scalar);
@@ -838,9 +838,9 @@ namespace ClosedXML.Excel.CalcEngine
                 return XLError.IncompatibleValue;
         }
 
-        private static object Sech(List<Expression> p)
+        private static ScalarValue Sech(double radians)
         {
-            return 1.0 / Math.Cosh(p[0]);
+            return 1.0 / Math.Cosh(radians);
         }
 
         private static ScalarValue SeriesSum(CalcContext ctx, double input, double initial, double step, Array coefficients)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -43,7 +43,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("COSH", 1, 1, Adapt(Cosh), FunctionFlags.Scalar);
             ce.RegisterFunction("COT", 1, 1, Adapt(Cot), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("COTH", 1, 1, Adapt(Coth), FunctionFlags.Scalar | FunctionFlags.Future);
-            ce.RegisterFunction("CSC", 1, Csc);
+            ce.RegisterFunction("CSC", 1, 1, Adapt(Csc), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("CSCH", 1, Csch);
             ce.RegisterFunction("DECIMAL", 2, MathTrig.Decimal);
             ce.RegisterFunction("DEGREES", 1, 1, Adapt(Degrees), FunctionFlags.Scalar);
@@ -354,13 +354,12 @@ namespace ClosedXML.Excel.CalcEngine
             return 1 / Math.Tanh(angle);
         }
 
-        private static object Csc(List<Expression> p)
+        private static ScalarValue Csc(double angle)
         {
-            double input = p[0];
-            if (input == 0)
+            if (angle == 0)
                 return XLError.DivisionByZero;
 
-            return 1 / Math.Sin(input);
+            return 1 / Math.Sin(angle);
         }
 
         private static object Csch(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("COMBINA", 2, CombinA);
             ce.RegisterFunction("COS", 1, 1, Adapt(Cos), FunctionFlags.Scalar);
             ce.RegisterFunction("COSH", 1, 1, Adapt(Cosh), FunctionFlags.Scalar);
-            ce.RegisterFunction("COT", 1, Cot);
+            ce.RegisterFunction("COT", 1, 1, Adapt(Cot), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("COTH", 1, Coth);
             ce.RegisterFunction("CSC", 1, Csc);
             ce.RegisterFunction("CSCH", 1, Csch);
@@ -337,10 +337,9 @@ namespace ClosedXML.Excel.CalcEngine
             return cosh;
         }
 
-        private static object Cot(List<Expression> p)
+        private static ScalarValue Cot(double angle)
         {
-            var tan = Math.Tan(p[0]);
-
+            var tan = Math.Tan(angle);
             if (tan == 0)
                 return XLError.DivisionByZero;
 

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -27,7 +27,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("ACOS", 1, 1, Adapt(Acos), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOSH", 1, 1, Adapt(Acosh), FunctionFlags.Scalar);
             ce.RegisterFunction("ACOT", 1, 1, Adapt(Acot), FunctionFlags.Scalar | FunctionFlags.Future);
-            ce.RegisterFunction("ACOTH", 1, Acoth);
+            ce.RegisterFunction("ACOTH", 1, 1, Adapt(Acoth), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("ARABIC", 1, Arabic);
             ce.RegisterFunction("ASIN", 1, 1, Adapt(Asin), FunctionFlags.Scalar);
             ce.RegisterFunction("ASINH", 1, 1, Adapt(Asinh), FunctionFlags.Scalar);
@@ -172,13 +172,12 @@ namespace ClosedXML.Excel.CalcEngine
             return acot;
         }
 
-        private static object Acoth(List<Expression> p)
+        private static ScalarValue Acoth(double angle)
         {
-            double number = p[0];
-            if (Math.Abs(number) < 1)
+            if (Math.Abs(angle) < 1)
                 return XLError.NumberInvalid;
 
-            return 0.5 * Math.Log((number + 1) / (number - 1));
+            return 0.5 * Math.Log((angle + 1) / (angle - 1));
         }
 
         private static object Arabic(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("COT", 1, 1, Adapt(Cot), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("COTH", 1, 1, Adapt(Coth), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("CSC", 1, 1, Adapt(Csc), FunctionFlags.Scalar | FunctionFlags.Future);
-            ce.RegisterFunction("CSCH", 1, Csch);
+            ce.RegisterFunction("CSCH", 1, 1, Adapt(Csch), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("DECIMAL", 2, MathTrig.Decimal);
             ce.RegisterFunction("DEGREES", 1, 1, Adapt(Degrees), FunctionFlags.Scalar);
             ce.RegisterFunction("EVEN", 1, 1, Adapt(Even), FunctionFlags.Scalar);
@@ -362,12 +362,12 @@ namespace ClosedXML.Excel.CalcEngine
             return 1 / Math.Sin(angle);
         }
 
-        private static object Csch(List<Expression> p)
+        private static ScalarValue Csch(double angle)
         {
-            if (Math.Abs((double)p[0].Evaluate()) < Double.Epsilon)
+            if (angle == 0)
                 return XLError.DivisionByZero;
 
-            return 1 / Math.Sinh(p[0]);
+            return 1 / Math.Sinh(angle);
         }
 
         private static object Decimal(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -38,7 +38,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("CEILING", 2, 2, Adapt(Ceiling), FunctionFlags.Scalar);
             ce.RegisterFunction("CEILING.MATH", 1, 3, AdaptLastTwoOptional(CeilingMath, 1, 0), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("COMBIN", 2, 2, Adapt(Combin), FunctionFlags.Scalar);
-            ce.RegisterFunction("COMBINA", 2, CombinA);
+            ce.RegisterFunction("COMBINA", 2, 2, Adapt(CombinA), FunctionFlags.Scalar | FunctionFlags.Future);
             ce.RegisterFunction("COS", 1, 1, Adapt(Cos), FunctionFlags.Scalar);
             ce.RegisterFunction("COSH", 1, 1, Adapt(Cosh), FunctionFlags.Scalar);
             ce.RegisterFunction("COT", 1, 1, Adapt(Cot), FunctionFlags.Scalar | FunctionFlags.Future);
@@ -307,22 +307,25 @@ namespace ClosedXML.Excel.CalcEngine
             return combinations;
         }
 
-        private static object CombinA(List<Expression> p)
+        private static ScalarValue CombinA(double number, double chosen)
         {
-            Int32 number = (int)p[0]; // casting truncates towards 0 as specified
-            Int32 chosen = (int)p[1];
+            number = Math.Truncate(number); // casting truncates towards 0 as specified
+            chosen = Math.Truncate(chosen);
 
-            if (number < 0 || number < chosen)
+            if (number < 0)
                 return XLError.NumberInvalid;
+
             if (chosen < 0)
                 return XLError.NumberInvalid;
 
-            int n = number + chosen - 1;
-            int k = number - 1;
+            var n = number + chosen - 1;
+            if (n > int.MaxValue)
+                return XLError.NumberInvalid;
 
-            return n == k || k == 0
+            var k = number - 1;
+            return chosen == 0 || k == 0
                 ? 1
-                : (long)XLMath.Combin(n, k);
+                : XLMath.Combin(n, k);
         }
 
         private static ScalarValue Cos(double number)

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -80,7 +80,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SEC", 1, Sec);
             ce.RegisterFunction("SECH", 1, Sech);
             ce.RegisterFunction("SERIESSUM", 4, 4, AdaptSeriesSum(SeriesSum), FunctionFlags.Range, AllowRange.Only, 3);
-            ce.RegisterFunction("SIGN", 1, Sign);
+            ce.RegisterFunction("SIGN", 1, 1, Adapt(Sign), FunctionFlags.Scalar);
             ce.RegisterFunction("SIN", 1, 1, Adapt(Sin), FunctionFlags.Scalar);
             ce.RegisterFunction("SINH", 1, 1, Adapt(Sinh), FunctionFlags.Scalar);
             ce.RegisterFunction("SQRT", 1, 1, Adapt(Sqrt), FunctionFlags.Scalar);
@@ -863,9 +863,9 @@ namespace ClosedXML.Excel.CalcEngine
             return total;
         }
 
-        private static object Sign(List<Expression> p)
+        private static ScalarValue Sign(double number)
         {
-            return Math.Sign(p[0]);
+            return Math.Sign(number);
         }
 
         private static ScalarValue Sin(double radians)


### PR DESCRIPTION
Reimplement/convert 11 MathTrig functions (`SIGN`, `SECH`, `SEC`, `COT`, `COTH`, `CSC`, `CSCH`, `ACOT`,  `ACOTH`, `COMBINA`) from legacy `Expression` based signature to standard `AnyValue` one.

Should mostly fix bugs with adapters and coercion. Also, the there was an excessive check on `COMBINA` (`COMBINA(10, 15)` - second is greater than first) that was removed, because Excel accepts such arguments.