### PR TITLE
Reimplement SERIESSUM function

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -60,6 +60,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDBETWEEN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ROUNDDOWN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=SERIESSUM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sheetless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SINH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sparklines/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/CalcContext.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcContext.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using ClosedXML.Excel.CalcEngine.Visitors;
 using ClosedXML.Parser;
 using System;
+using System.Threading;
 using ClosedXML.Excel.CalcEngine.Functions;
 
 namespace ClosedXML.Excel.CalcEngine
@@ -73,6 +74,16 @@ namespace ClosedXML.Excel.CalcEngine
         public uint? RecalculateSheetId { get; set; }
 
         internal XLSheetPoint FormulaSheetPoint => new(FormulaAddress.RowNumber, FormulaAddress.ColumnNumber);
+
+        internal CancellationToken CancellationToken { get; init; } = CancellationToken.None;
+
+        /// <summary>
+        /// A helper method to check is user cancelled the calculation in function loops.
+        /// </summary>
+        internal void ThrowIfCancelled()
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+        }
 
         internal ScalarValue GetCellValue(XLWorksheet? sheet, int rowNumber, int columnNumber)
         {

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -849,6 +849,7 @@ namespace ClosedXML.Excel.CalcEngine
             var i = 0;
             foreach (var coefScalar in coefficients)
             {
+                ctx.ThrowIfCancelled();
                 if (!coefScalar.TryPickNumberOrBlank(out var coef, out var error))
                     return error;
 

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -403,7 +403,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
                     arg3 = new ScalarArray(number, 1, 1);
                 }
-;
+
                 return f(ctx, arg0, arg1, arg2, arg3).ToAnyValue();
             };
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -367,6 +367,47 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptSeriesSum(Func<CalcContext, double, double, double, Array, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                // SERIESSUM doesn't convert logical values to number...
+                if (args[0].IsLogical)
+                    return XLError.IncompatibleValue;
+
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                if (args[1].IsLogical)
+                    return XLError.IncompatibleValue;
+
+                var arg1Converted = ToNumber(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                if (args[2].IsLogical)
+                    return XLError.IncompatibleValue;
+
+                var arg2Converted = ToNumber(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                if (args[3].TryPickSingleOrMultiValue(out var scalar, out var arg3, ctx))
+                {
+                    if (scalar.IsLogical)
+                        return XLError.IncompatibleValue;
+
+                    if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
+                        return error;
+
+                    arg3 = new ScalarArray(number, 1, 1);
+                }
+;
+                return f(ctx, arg0, arg1, arg2, arg3).ToAnyValue();
+            };
+        }
+
         /// <summary>
         /// Adapt a function that accepts areas as arguments (e.g. SUMPRODUCT). The key benefit is
         /// that all <c>ReferenceArray</c> allocation is done once for a function. The method

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -352,6 +352,32 @@ namespace ClosedXML.Excel.CalcEngine
             return false;
         }
 
+        /// <summary>
+        /// Try to pick a number (interpret blank as number 0).
+        /// </summary>
+        public bool TryPickNumberOrBlank(out double number, out XLError error)
+        {
+            if (_index == NumberValue)
+            {
+                number = _number;
+                error = default;
+                return true;
+            }
+
+            // This is mostly useful for unified approach area + array. Literal array
+            // can't contain blanks, but area can. In most cases, blank is interpreted as 0.
+            if (_index == BlankValue)
+            {
+                number = 0;
+                error = default;
+                return true;
+            }
+
+            number = default;
+            error = IsError ? _error : XLError.IncompatibleValue;
+            return false;
+        }
+
         public bool TryPickText(out string text, out XLError error)
         {
             if (_index == TextValue)


### PR DESCRIPTION
Reimplement SERIESSUM function to be more faithful to Excel (conversion behavior of arguments) and remove use of `XObjectExpression` adapter (related to #2482). It is now also short circuited, so when number is infinity, it stops evaluating.