### PR TITLE
Reimplement MULTINOMIAL function

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Text;
 
@@ -121,11 +119,18 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return result;
         }
 
-        internal static double Factorial(int n)
+        internal static double Factorial(double n)
         {
+            n = Math.Truncate(n);
             var factorial = 1d;
             while (n > 1)
+            {
                 factorial *= n--;
+
+                // n can be very large, stop when we reach infinity.
+                if (double.IsInfinity(factorial))
+                    return factorial;
+            }
 
             return factorial;
         }


### PR DESCRIPTION
The original `MULTINOMIAL` had few problems:
* didn't accept ranges as arguments
* was using an array of maximum passed number
* argument coercion didn't match Excel
* `Expression` based

It also had some mechanism to store already calculated factories... That was removed, because:
* It allocated memory based on the supplied arguments (`new double[(uint)numbers.Max() + 1]`).. that is rather easy to misuse by supplying finely crafted arguments.
* Multiplying doubles take ~3 cycles, so it's not worth worrying about it. Excel fails if argument is > 171 (factorial is out of double range), so it's just few thousand cycles. New implementation short-circuits when value is infinity.
* It didn't even save time. There was is a cycle in a cycle, which is basically how much it takes to calculate actual denominator (there is not much difference between addition and multiplication for doubles):
```csharp
foreach (var number in numbers)
{
    for (int i = 2; i <= number; i++)
    {
        denomFactorPowers[i]++;
    }
}
```