### PR TITLE
Reimplement LCM

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1104,20 +1104,54 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(expected, actual);
         }
 
-        [Test]
-        public void Lcm()
+        [TestCase("24, 36", ExpectedResult = 72)]
+        [TestCase("24.9, 36.9", ExpectedResult = 72)]
+        [TestCase("{24, 36}", ExpectedResult = 72)]
+        [TestCase("{1,2,3;4,5,6}", ExpectedResult = 60)]
+        [TestCase("{\"1\",\"2\",\"3\"}", ExpectedResult = 6)]
+        [TestCase("240, 360, 30", ExpectedResult = 720)]
+        [TestCase("5, 0", ExpectedResult = 0)]
+        [TestCase("0, 5", ExpectedResult = 0)]
+        public double Lcm(string args)
         {
-            object actual = XLWorkbook.EvaluateExpr("Lcm(24, 36)");
-            Assert.AreEqual(72, actual);
+            return (double)XLWorkbook.EvaluateExpr($"LCM({args})");
+        }
 
-            object actual1 = XLWorkbook.EvaluateExpr("Lcm(5, 0)");
-            Assert.AreEqual(0, actual1);
+        [Test]
+        public void Lcm_accepts_references()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").InsertData(new object[]
+            {
+                (1, 2, 3),
+                ("4", "5", "6"),
+            });
+            Assert.AreEqual(60, ws.Evaluate("LCM(A1:B2,C1:C2)"));
 
-            object actual2 = XLWorkbook.EvaluateExpr("Lcm(0, 5)");
-            Assert.AreEqual(0, actual2);
+            // Blank is considered 0
+            Assert.AreEqual(0, ws.Evaluate("LCM(A1:A3)"));
 
-            object actual3 = XLWorkbook.EvaluateExpr("Lcm(240, 360, 30)");
-            Assert.AreEqual(720, actual3);
+            // Logical are not converted
+            ws.Cell("A3").Value = true;
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("LCM(A1:A3)"));
+
+            // Unconvertable text causes error
+            ws.Cell("A3").Value = "one";
+            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("LCM(A1:A3)"));
+        }
+
+        [TestCase]
+        public void Lcm_numbers_must_fit_in_double_without_precision_loss()
+        {
+            Assert.AreEqual(9.007E+15, XLWorkbook.EvaluateExpr("LCM(9.007E+15)"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LCM(9.008E+15)"));
+        }
+
+        [TestCase]
+        public void Lcm_numbers_must_be_zero_or_positive()
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LCM(-1)"));
         }
 
         [TestCase(86, 4.4543472962)]

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -11,6 +11,13 @@ namespace ClosedXML.Excel.CalcEngine
 {
     internal static class MathTrig
     {
+        /// <summary>
+        /// Maximum integer number that can be precisely represented in a double.
+        /// Calculated as <c>Math.Pow(2, 53) - 1</c>, but use literal to make it
+        /// constant (=usable in pattern matching).
+        /// </summary>
+        private const double MaxDoubleInt = 9007199254740991;
+
         private static readonly Random _rnd = new Random();
 
         /// <summary>
@@ -55,7 +62,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("FLOOR.MATH", 1, 3, FloorMath);
             ce.RegisterFunction("GCD", 1, 255, Gcd);
             ce.RegisterFunction("INT", 1, 1, Adapt(Int), FunctionFlags.Scalar);
-            ce.RegisterFunction("LCM", 1, 255, Lcm);
+            ce.RegisterFunction("LCM", 1, 255, Adapt(Lcm), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("LN", 1, 1, Adapt(Ln), FunctionFlags.Scalar);
             ce.RegisterFunction("LOG", 1, 2, AdaptLastOptional(Log, 10), FunctionFlags.Scalar);
             ce.RegisterFunction("LOG10", 1, 1, Adapt(Log10), FunctionFlags.Scalar);
@@ -510,6 +517,16 @@ namespace ClosedXML.Excel.CalcEngine
             return a;
         }
 
+        private static double Gcd(double a, double b)
+        {
+            a = Math.Truncate(a);
+            b = Math.Truncate(b);
+            while (b != 0)
+                (a, b) = (b, a % b);
+
+            return a;
+        }
+
         private static double[,] GetArray(Expression expression)
         {
             if (expression is XObjectExpression objectExpression
@@ -541,12 +558,31 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Floor(number);
         }
 
-        private static object Lcm(List<Expression> p)
+        private static ScalarValue Lcm(CalcContext ctx, List<Array> arrays)
         {
-            return p.Select(v => (int)v).Aggregate(Lcm);
+            var result = 1d;
+            foreach (var array in arrays)
+            {
+                foreach (var scalar in array)
+                {
+                    ctx.ThrowIfCancelled();
+                    if (scalar.IsLogical)
+                        return XLError.IncompatibleValue;
+
+                    if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
+                        return error;
+
+                    if (number is < 0 or > MaxDoubleInt)
+                        return XLError.NumberInvalid;
+
+                    result = Lcm(result, Math.Truncate(number));
+                }
+            }
+
+            return result;
         }
 
-        private static int Lcm(int a, int b)
+        private static double Lcm(double a, double b)
         {
             if (a == 0 || b == 0) return 0;
             return a * (b / Gcd(a, b));

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -184,6 +184,23 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, List<Array>, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arrays = new List<Array>();
+                foreach (var arg in args)
+                {
+                    if (arg.TryPickSingleOrMultiValue(out var scalar, out var array, ctx))
+                        array = new ScalarArray(scalar, 1, 1);
+
+                    arrays.Add(array);
+                }
+
+                return f(ctx, arrays).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction AdaptLastOptional(Func<ScalarValue, AnyValue, AnyValue, AnyValue> f, AnyValue lastDefault)
         {
             return (ctx, args) =>


### PR DESCRIPTION
* LCM now accept ranges as arguments
* Added check to only work with whole numbers that can be stored in double without a loss of precision (that's how Excel)
* Switch from `Expression` argument semantic to `AnyValue` based one (better behavior of value coercion).