### PR TITLE
Changed int to uint since Excel files can have pagebreaks with a uint id

### DIFF
--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -1228,7 +1228,7 @@ namespace ClosedXML.Excel.IO
                 var existingBreaks = rowBreaks.ChildElements.OfType<Break>().ToArray();
                 var rowBreaksToDelete = existingBreaks
                     .Where(rb => !rb.Id.HasValue ||
-                                 !xlWorksheet.PageSetup.RowBreaks.Contains((int)rb.Id.Value))
+                                 !xlWorksheet.PageSetup.RowBreaks.Contains(rb.Id.Value))
                     .ToList();
 
                 foreach (var rb in rowBreaksToDelete)

--- a/ClosedXML/Excel/PageSetup/IXLPageSetup.cs
+++ b/ClosedXML/Excel/PageSetup/IXLPageSetup.cs
@@ -263,7 +263,7 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets a list with the row breaks (for printing).
         /// </summary>
-        List<Int32> RowBreaks { get; }
+        List<UInt32> RowBreaks { get; }
         /// <summary>
         /// Gets a list with the column breaks (for printing).
         /// </summary>
@@ -272,7 +272,7 @@ namespace ClosedXML.Excel
         /// Adds a horizontal page break after the given row.
         /// </summary>
         /// <param name="row">The row to insert the break.</param>
-        void AddHorizontalPageBreak(Int32 row);
+        void AddHorizontalPageBreak(UInt32 row);
 
         /// <summary>
         /// Adds a vertical page break after the given column.

--- a/ClosedXML/Excel/PageSetup/XLPageSetup.cs
+++ b/ClosedXML/Excel/PageSetup/XLPageSetup.cs
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel
                 Header = new XLHeaderFooter(worksheet);
                 Footer = new XLHeaderFooter(worksheet);
                 ColumnBreaks = new List<Int32>();
-                RowBreaks = new List<Int32>();
+                RowBreaks = new List<UInt32>();
             }
         }
         public IXLPrintAreas PrintAreas { get; private set; }
@@ -193,9 +193,9 @@ namespace ClosedXML.Excel
         public XLPageOrderValues PageOrder { get; set; }
         public XLShowCommentsValues ShowComments { get; set; }
 
-        public List<Int32> RowBreaks { get; private set; }
+        public List<UInt32> RowBreaks { get; private set; }
         public List<Int32> ColumnBreaks { get; private set; }
-        public void AddHorizontalPageBreak(Int32 row)
+        public void AddHorizontalPageBreak(UInt32 row)
         {
             if (!RowBreaks.Contains(row))
                 RowBreaks.Add(row);

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -521,7 +521,7 @@ namespace ClosedXML.Excel
 
         public IXLRow AddHorizontalPageBreak()
         {
-            Worksheet.PageSetup.AddHorizontalPageBreak(RowNumber());
+            Worksheet.PageSetup.AddHorizontalPageBreak((UInt32)RowNumber());
             return this;
         }
 

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -195,7 +195,7 @@ namespace ClosedXML.Excel
         public IXLRows AddHorizontalPageBreaks()
         {
             foreach (XLRow row in Rows)
-                row.Worksheet.PageSetup.AddHorizontalPageBreak(row.RowNumber());
+                row.Worksheet.PageSetup.AddHorizontalPageBreak((UInt32)row.RowNumber());
             return this;
         }
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -2321,7 +2321,7 @@ namespace ClosedXML.Excel
             if (rowBreaks == null) return;
 
             foreach (Break rowBreak in rowBreaks.Elements<Break>())
-                ws.PageSetup.RowBreaks.Add(Int32.Parse(rowBreak.Id.InnerText));
+                ws.PageSetup.RowBreaks.Add(UInt32.Parse(rowBreak.Id.InnerText));
         }
 
         private void LoadSheetProperties(SheetProperties sheetProperty, XLWorksheet ws, out PageSetupProperties pageSetupProperties)

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1367,10 +1367,10 @@ namespace ClosedXML.Excel
         {
             for (var i = 0; i < PageSetup.RowBreaks.Count; i++)
             {
-                int br = PageSetup.RowBreaks[i];
+                uint br = PageSetup.RowBreaks[i];
                 if (range.RangeAddress.FirstAddress.RowNumber <= br)
                 {
-                    PageSetup.RowBreaks[i] = br + rowsShifted;
+                    PageSetup.RowBreaks[i] = (uint)(br + rowsShifted);
                 }
             }
         }


### PR DESCRIPTION
fixes https://github.com/ClosedXML/ClosedXML/issues/1732 
This change affects the API of IXLPageSetup and XLPageSetup since currently int is used where uint should be.