### PR TITLE
Reimplement ARABIC function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -152,26 +152,37 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [TestCase("LVII", 57)]
-        [TestCase("mcmxii", 1912)]
+        [TestCase(@"mcmxii", 1912)]
         [TestCase("", 0)]
         [TestCase("-IV", -4)]
-        [TestCase("   XIV", 14)]
-        [TestCase("MCMLXXXIII ", 1983)]
-        public void Arabic_ReturnsCorrectNumber(string roman, int arabic)
+        [TestCase("   XIV   ", 14)]
+        [TestCase(@"MCMLXXXIII ", 1983)]
+        [TestCase(@"IIIIIIIIM", 992)]
+        [TestCase(@"CIVIIX", 102)]
+        [TestCase(@"IIX", 8)]
+        [TestCase(@"VIII", 8)]
+        public void Arabic_returns_correct_number(string roman, int arabic)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr(string.Format($"ARABIC(\"{roman}\")"));
+            var actual = (double)XLWorkbook.EvaluateExpr($"ARABIC(\"{roman}\")");
             Assert.AreEqual(arabic, actual);
         }
 
         [Test]
-        public void Arabic_ThrowsNumberExceptionOnMinus()
+        public void Arabic_solitary_minus_is_not_valid_roman_number()
         {
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("ARABIC(\"-\")"));
         }
 
+        [Test]
+        public void Arabic_can_have_at_most_255_chars()
+        {
+            Assert.AreEqual(255000, XLWorkbook.EvaluateExpr($"ARABIC(\"{new string('M', 255)}\")"));
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"ARABIC(\"{new string('M', 256)}\")"));
+        }
+
         [TestCase("- I")]
         [TestCase("roman")]
-        public void Arabic_ThrowsValueExceptionOnInvalidNumber(string invalidRoman)
+        public void Arabic_returns_conversion_error_on_invalid_numbers(string invalidRoman)
         {
             Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"ARABIC(\"{invalidRoman}\")"));
         }

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -84,6 +84,18 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<string, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToText(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                return f(arg0).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<string, string, ScalarValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -161,39 +161,5 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var isOdd = value % 2 != 0;
             return hasNoFraction && isOdd;
         }
-
-        public static int RomanToArabic(string text)
-        {
-            if (text.Length == 0)
-                return 0;
-            if (text.StartsWith("M", StringComparison.InvariantCultureIgnoreCase))
-                return 1000 + RomanToArabic(text.Substring(1));
-            if (text.StartsWith("CM", StringComparison.InvariantCultureIgnoreCase))
-                return 900 + RomanToArabic(text.Substring(2));
-            if (text.StartsWith("D", StringComparison.InvariantCultureIgnoreCase))
-                return 500 + RomanToArabic(text.Substring(1));
-            if (text.StartsWith("CD", StringComparison.InvariantCultureIgnoreCase))
-                return 400 + RomanToArabic(text.Substring(2));
-            if (text.StartsWith("C", StringComparison.InvariantCultureIgnoreCase))
-                return 100 + RomanToArabic(text.Substring(1));
-            if (text.StartsWith("XC", StringComparison.InvariantCultureIgnoreCase))
-                return 90 + RomanToArabic(text.Substring(2));
-            if (text.StartsWith("L", StringComparison.InvariantCultureIgnoreCase))
-                return 50 + RomanToArabic(text.Substring(1));
-            if (text.StartsWith("XL", StringComparison.InvariantCultureIgnoreCase))
-                return 40 + RomanToArabic(text.Substring(2));
-            if (text.StartsWith("X", StringComparison.InvariantCultureIgnoreCase))
-                return 10 + RomanToArabic(text.Substring(1));
-            if (text.StartsWith("IX", StringComparison.InvariantCultureIgnoreCase))
-                return 9 + RomanToArabic(text.Substring(2));
-            if (text.StartsWith("V", StringComparison.InvariantCultureIgnoreCase))
-                return 5 + RomanToArabic(text.Substring(1));
-            if (text.StartsWith("IV", StringComparison.InvariantCultureIgnoreCase))
-                return 4 + RomanToArabic(text.Substring(2));
-            if (text.StartsWith("I", StringComparison.InvariantCultureIgnoreCase))
-                return 1 + RomanToArabic(text.Substring(1));
-
-            throw new ArgumentOutOfRangeException("text is not a valid roman number");
-        }
     }
 }


### PR DESCRIPTION
More faithful to Excel, accepts invalid roman numbers. Excel accepts all sort of roman numbers, e.g. `ARABIC("IIIIMIXVC")` = (1000 - 4) + (100-16) = 1080