### PR TITLE
Convert MDETERM from legacy

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -58,6 +58,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Katakana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MDETERM/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MDeterm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MROUND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NETWORKDAYS/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -342,13 +342,20 @@ namespace ClosedXML.Excel.CalcEngine
 
         public bool TryPickNumber(out double number)
         {
+            return TryPickNumber(out number, out _);
+        }
+
+        public bool TryPickNumber(out double number, out XLError error)
+        {
             if (_index == NumberValue)
             {
                 number = _number;
+                error = default;
                 return true;
             }
 
             number = default;
+            error = IsError ? _error : XLError.IncompatibleValue;
             return false;
         }
 


### PR DESCRIPTION
Just convert `MDETERM`, so it uses coercion and checks values. The matrix logic is kept unchanged in `XLMatrix`.