### PR TITLE
Convert MINVERSE from legacy

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -60,6 +60,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MDETERM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MDeterm/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MINVERSE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MMULT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MROUND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NETWORKDAYS/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -42,6 +42,21 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             set { mat[iRow, iCol] = value; }
         }
 
+        public Boolean IsSingular()
+        {
+            for (var row = 0; row < rows; row++)
+            {
+                for (var col = 0; col < cols; col++)
+                {
+                    var element = mat[row, col];
+                    if (double.IsNaN(element) || double.IsInfinity(element))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
         public Boolean IsSquare()
         {
             return (rows == cols);


### PR DESCRIPTION
Just convert MINVERSE, so it uses type coercion and checks values. The matrix logic is kept unchanged in `XLMatrix`. It mostly adds tests.