### PR TITLE
Reimplement CHAR function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -21,22 +21,33 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Char_Empty_Input_String()
+        public void Char_returns_error_on_empty_string()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"Char("""")"));
+            // Calc engine tries to coerce it to number and fails. It never even reaches the functions.
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"CHAR("""")"));
         }
 
-        [Test]
-        public void Char_Input_Too_Large()
+        [TestCase(0)]
+        [TestCase(256)]
+        [TestCase(9797)]
+        public void Char_number_must_be_between_1_and_255(int number)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"Char(9797)"));
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"CHAR({number})"));
         }
 
-        [Test]
-        public void Char_Value()
+        [TestCase(48, '0')]
+        [TestCase(97, 'a')]
+        [TestCase(128, '€')]
+        [TestCase(138, 'Š')]
+        [TestCase(169, '©')]
+        [TestCase(182, '¶')]
+        [TestCase(230, 'æ')]
+        [TestCase(255, 'ÿ')]
+        [TestCase(255.9, 'ÿ')]
+        public void Char_interprets_number_as_win1252(double number, char expected)
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Char(97)");
-            Assert.AreEqual("a", actual);
+            var actual = XLWorkbook.EvaluateExpr($"CHAR({number})");
+            Assert.AreEqual(expected.ToString(), actual);
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -12,11 +12,25 @@ namespace ClosedXML.Excel.CalcEngine
 {
     internal static class Text
     {
+        /// <summary>
+        /// Characters 0x80 to 0xFF of win-1252 encoding. Core doesn't include win-1252 encoding,
+        /// so keep conversion table in this string.
+        /// </summary>
+        private const string Windows1252 =
+            "\u20AC\u0081\u201A\u0192\u201E\u2026\u2020\u2021\u02C6\u2030\u0160\u2039\u0152\u008D\u017D\u008F" +
+            "\u0090\u2018\u2019\u201C\u201D\u2022\u2013\u2014\u02DC\u2122\u0161\u203A\u0153\u009D\u017E\u0178" +
+            "\u00A0\u00A1\u00A2\u00A3\u00A4\u00A5\u00A6\u00A7\u00A8\u00A9\u00AA\u00AB\u00AC\u00AD\u00AE\u00AF" +
+            "\u00B0\u00B1\u00B2\u00B3\u00B4\u00B5\u00B6\u00B7\u00B8\u00B9\u00BA\u00BB\u00BC\u00BD\u00BE\u00BF" +
+            "\u00C0\u00C1\u00C2\u00C3\u00C4\u00C5\u00C6\u00C7\u00C8\u00C9\u00CA\u00CB\u00CC\u00CD\u00CE\u00CF" +
+            "\u00D0\u00D1\u00D2\u00D3\u00D4\u00D5\u00D6\u00D7\u00D8\u00D9\u00DA\u00DB\u00DC\u00DD\u00DE\u00DF" +
+            "\u00E0\u00E1\u00E2\u00E3\u00E4\u00E5\u00E6\u00E7\u00E8\u00E9\u00EA\u00EB\u00EC\u00ED\u00EE\u00EF" +
+            "\u00F0\u00F1\u00F2\u00F3\u00F4\u00F5\u00F6\u00F7\u00F8\u00F9\u00FA\u00FB\u00FC\u00FD\u00FE\u00FF";
+
         public static void Register(FunctionRegistry ce)
         {
             ce.RegisterFunction("ASC", 1, 1, Adapt(Asc), FunctionFlags.Scalar); // Changes full-width (double-byte) English letters or katakana within a character string to half-width (single-byte) characters
             //ce.RegisterFunction("BAHTTEXT	Converts a number to text, using the ß (baht) currency format
-            ce.RegisterFunction("CHAR", 1, _Char); // Returns the character specified by the code number
+            ce.RegisterFunction("CHAR", 1, 1, Adapt(Char), FunctionFlags.Scalar); // Returns the character specified by the code number
             ce.RegisterFunction("CLEAN", 1, Clean); //	Removes all nonprintable characters from text
             ce.RegisterFunction("CODE", 1, Code); // Returns a numeric code for the first character in a text string
             ce.RegisterFunction("CONCAT", 1, int.MaxValue, Concat, AllowRange.All); //	Joins several text items into one text item
@@ -104,14 +118,25 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
-        private static object _Char(List<Expression> p)
+        private static ScalarValue Char(double number)
         {
-            var i = (int)p[0];
-            if (i < 1 || i > 255)
+            number = Math.Truncate(number);
+            if (number is < 1 or > 255)
                 return XLError.IncompatibleValue;
 
-            var c = (char)i;
-            return c.ToString();
+            // Spec says to interpret numbers as values encoded in iso-8859-1. The actual
+            // encoding depends on authoring language, e.g. JP uses JIS X 0201. Fun fact,
+            // JP has values 253-255 from iso-8859-1, not JIS. EN/CZ/RU uses win-1252.
+            // Anyway, there is no way to get a map of all encodings, so let's use one.
+            // Win-1252 is probably the best default choice, because this function is
+            // pre-unicode and Excel was mostly sold in US/EU.
+            var value = checked((int)number);
+
+            // Values 1-127 in win-1252 are ASCII. The values directly map to codepoints.
+            if (value < 0x80)
+                return char.ToString((char)value);
+
+            return Windows1252[value - 0x80].ToString();
         }
 
         private static object Code(List<Expression> p)

--- a/docs/migrations/migrate-to-0.105.rst
+++ b/docs/migrations/migrate-to-0.105.rst
@@ -43,3 +43,10 @@ The setters ```IXLCell.FormulaA1```, ```IXLCell.FormulaR1C1``` and
 ```=``` sign (i.e. ``` = A1+B4 ``` will turn into ```A1+B4```). A formula
 starting with an equals sign is not a valid formula per formula grammar and
 causes problems with parsing.
+
+*********
+Functions
+*********
+
+`CHAR` now uses win1252 to interpret passed values (values were previously
+interpreted as unicode codepoints).


### PR DESCRIPTION
The actual conversion from value to char should depend on locale (authoring language in Excel), but the problem is 
* I have no idea which languages map to which encoding in Excel (e.g. Russian language also uses win1252 [=not anything with Cyrillic script] and Korean doesn't even has anything over 128 [=no hangul])
* .NET Core contains a very limited amount of encodings. Basically only iso-8859-1 and utf

I hope to solve both by adding a property to `LoadOptions` in the future, but I think Win1252 is a good default choice, unless user supplies other choice. `CHAR` is a pre-unicode function. Excel was mostly sold in US/EU that do use that encoding.