### PR TITLE
Reimplement DOLLAR

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -35,10 +35,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Dollar()
         {
-            object actual = XLWorkbook.EvaluateExpr("Dollar(12345.123)");
+            using var wb = new XLWorkbook();
+            object actual = wb.Evaluate("DOLLAR(12345.123)");
             Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.12", actual);
 
-            actual = XLWorkbook.EvaluateExpr("Dollar(12345.123, 1)");
+            actual = wb.Evaluate("DOLLAR(12345.123, 1)");
             Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.1", actual);
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -622,7 +622,7 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Log(x);
         }
 
-        private static ScalarValue Log(double x, double @base)
+        private static ScalarValue Log(CalcContext ctx, double x, double @base)
         {
             if (x <= 0 || @base <= 0)
                 return XLError.NumberInvalid;
@@ -825,7 +825,7 @@ namespace ClosedXML.Excel.CalcEngine
             return lowerBound + Math.Round(_rnd.NextDouble() * range, MidpointRounding.AwayFromZero);
         }
 
-        private static ScalarValue Roman(double number, double formValue)
+        private static ScalarValue Roman(CalcContext ctx, double number, double formValue)
         {
             if (number == 0)
                 return string.Empty;
@@ -1131,7 +1131,7 @@ namespace ClosedXML.Excel.CalcEngine
             return Math.Tanh(number);
         }
 
-        private static ScalarValue Trunc(double number, double digits)
+        private static ScalarValue Trunc(CalcContext ctx, double number, double digits)
         {
             var scaling = Math.Pow(10, digits);
             return Math.Truncate(number * scaling) / scaling;

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -261,7 +261,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction AdaptLastOptional(Func<double, double, ScalarValue> f, double lastDefault)
+        public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, double, double, ScalarValue> f, double lastDefault)
         {
             return (ctx, args) =>
             {
@@ -273,7 +273,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg1Converted.TryPickT0(out var arg1, out var err1))
                     return err1;
 
-                return f(arg0, arg1).ToAnyValue();
+                return f(ctx, arg0, arg1).ToAnyValue();
             };
         }
 

--- a/docs/migrations/migrate-to-0.105.rst
+++ b/docs/migrations/migrate-to-0.105.rst
@@ -50,3 +50,7 @@ Functions
 
 `CHAR` now uses win1252 to interpret passed values (values were previously
 interpreted as unicode codepoints).
+
+`DOLLAR` now uses culture of a workbook, not ambient culture from
+`CultureInfo.CurrentCulture`. Reminder: `XLWorkbook.EvaluateExpr` uses
+invariant culture, not ambient culture.


### PR DESCRIPTION
Original implementation didn't work with negative digits (e.g. `DOLLAR(12345.12, -2)` = `$12'300`). Also convert from `Expression` based to `AnyValue` base. 36 functions to go.