### PR TITLE
Reimplement FIXED function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1827,6 +1827,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-31.565, 2, ExpectedResult = -31.57)]
         [TestCase(1E+100, 2, ExpectedResult = 1E+100)]
         [TestCase(1.25, 0, ExpectedResult = 1)]
+        [TestCase(1, -1E+100, ExpectedResult = 0)]
+        [TestCase(1.123456, 1E+100, ExpectedResult = 1.123456)] // Excel says 0 for anything over 2147483646
         public double Round(double number, double digits)
         {
             return (double)XLWorkbook.EvaluateExpr($"ROUND({number}, {digits})");

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -855,16 +855,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static ScalarValue Round(double value, double digits)
         {
-            var digitCount = (int)Math.Truncate(digits);
-            if (digits < 0)
-            {
-                var coef = Math.Pow(10, Math.Abs(digits));
-                var shifted = value / coef;
-                shifted = Math.Round(shifted, 0, MidpointRounding.AwayFromZero);
-                return shifted * coef;
-            }
-
-            return Math.Round(value, digitCount, MidpointRounding.AwayFromZero);
+            return XLMath.Round(value, digits);
         }
 
         private static ScalarValue RoundDown(double value, double digits)

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -596,6 +596,27 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastTwoOptional(Func<CalcContext, double, double, bool, ScalarValue> f, double defaultValue1, bool defaultValue2)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = args.Length > 1 ? ToNumber(args[1], ctx) : defaultValue1;
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                // AnyValue to bool has different semantic than AnyValue to number, e.g. "0" is not valid for bool coercion
+                var arg2Converted = args.Length > 2 ? args[2] : defaultValue2;
+                if (!CoerceToLogical(arg2Converted, ctx).TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                return f(ctx, arg0, arg1, arg2).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction AdaptLastTwoOptional(Func<double, double, double, double, double, AnyValue> f, double defaultValue0, double defaultValue1)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -161,5 +161,25 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var isOdd = value % 2 != 0;
             return hasNoFraction && isOdd;
         }
+
+        public static double Round(double value, double digits)
+        {
+            digits = Math.Truncate(digits);
+            if (digits < 0)
+            {
+                var coef = Math.Pow(10, Math.Abs(digits));
+                var shifted = value / coef;
+                shifted = Math.Round(shifted, 0, MidpointRounding.AwayFromZero);
+
+                // if coef is infinity
+                if (shifted == 0)
+                    return 0;
+
+                return shifted * coef;
+            }
+
+            // Double can store at most 15 digits and anything below that is float artefact
+            return Math.Round(value, (int)Math.Min(digits, 15), MidpointRounding.AwayFromZero);
+        }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using ClosedXML.Extensions;
 


### PR DESCRIPTION
The original `FIXED` 
* was only replacing `,` as a group separator, but some countries use different group separators (e.g. `.` or ` `).
* didn't work for negative numDecimals (formatting string ended up as `N-2`, should be `N0`)

Also convert from `Expression` based to `AnyValue` base.