### PR TITLE
Reimplement LOWER function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -521,18 +521,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return XLWorkbook.EvaluateExpr($"""LEN("{text}")""").GetNumber();
         }
 
-        [Test]
-        public void Lower_Empty_Input_String()
+        [SetCulture("en-US")]
+        [TestCase("", ExpectedResult = "")]
+        [TestCase("ABC", ExpectedResult = "abc")]
+        [TestCase("Intelligence 2.0!", ExpectedResult = "intelligence 2.0!")]
+        [TestCase("ͶꝎＫǢ", ExpectedResult = "ͷꝏｋǣ")] // Converts even non-latin chars
+        [TestCase("Σ SUM Σ end Σ", ExpectedResult = "σ sum σ end ς")] // Bug for bug behavior of Excel. Σ at the end is turned to ς
+        public string Lower_en(string text)
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Lower("""")");
-            Assert.AreEqual("", actual);
+            using var wb = new XLWorkbook();
+            return wb.Evaluate($"""LOWER("{text}")""").GetText();
         }
 
-        [Test]
-        public void Lower_Value()
+        [SetCulture("tr-TR")]
+        [TestCase("INTELLIGENCE 2.0!", ExpectedResult = "ıntellıgence 2.0!")] // Turkey converts I to i without dot
+        [TestCase("ΣΣΣΣ", ExpectedResult = "σσσς")]
+        public string Lower_tr(string text)
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Lower(""AbCdEfG"")");
-            Assert.AreEqual("abcdefg", actual);
+            using var wb = new XLWorkbook();
+            return wb.Evaluate($"""LOWER("{text}")""").GetText();
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -198,7 +198,7 @@ namespace ClosedXML.Excel.CalcEngine
             return 0.5 * Math.Log((angle + 1) / (angle - 1));
         }
 
-        private static ScalarValue Arabic(string input)
+        private static ScalarValue Arabic(CalcContext ctx, string input)
         {
             if (input.Length > 255)
                 return XLError.IncompatibleValue;

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction Adapt(Func<string, ScalarValue> f)
+        public static CalcEngineFunction Adapt(Func<CalcContext, string, ScalarValue> f)
         {
             return (ctx, args) =>
             {
@@ -92,7 +92,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg0Converted.TryPickT0(out var arg0, out var err0))
                     return err0;
 
-                return f(arg0).ToAnyValue();
+                return f(ctx, arg0).ToAnyValue();
             };
         }
 


### PR DESCRIPTION
Refactor `LOWER`, including bug-for-bug behavior from spec
> when Σ (U+03A3) is found in a word-final position, it is converted to ς (U+03C2) instead of σ (U+03C3).

Obviously, we are relying on standard library for culture-aware casing, while Excel has it's own way to do that, but I checked and it is mostly same. Excel is mostly stuck on Unicode 5.0 codepoints.