### PR TITLE
Refactor RIGHT function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -690,32 +690,46 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual("", actual);
         }
 
-        [Test]
-        public void Right_Bigger_Than_Length()
+        [TestCase(5)]
+        [TestCase(3)]
+        public void Right_returns_whole_text_when_requested_length_is_greater_than_text_length(int length)
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Right(""ABC"", 5)");
+            var actual = XLWorkbook.EvaluateExpr($"""RIGHT("ABC",{length})""");
             Assert.AreEqual("ABC", actual);
         }
 
         [Test]
-        public void Right_Default()
+        public void Right_takes_one_character_by_default()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Right(""ABC"")");
+            var actual = XLWorkbook.EvaluateExpr("""RIGHT("ABC")""");
             Assert.AreEqual("C", actual);
         }
 
         [Test]
-        public void Right_Empty_Input_String()
+        public void Right_returns_error_on_negative_number_of_chars()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Right("""")");
-            Assert.AreEqual("", actual);
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""RIGHT("ABC",-1)"""));
         }
 
         [Test]
-        public void Right_Value()
+        public void Right_returns_empty_string_on_empty_input()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Right(""ABC"", 2)");
-            Assert.AreEqual("BC", actual);
+            var actual = XLWorkbook.EvaluateExpr("""RIGHT("")""");
+            Assert.AreEqual("", actual);
+        }
+
+        [TestCase("ABC", 0, ExpectedResult = "")]
+        [TestCase("ABC", 1, ExpectedResult = "C")]
+        [TestCase("ABC", 2, ExpectedResult = "BC")]
+        [TestCase("ABC", 3, ExpectedResult = "ABC")]
+        [TestCase("ABC", 4, ExpectedResult = "ABC")]
+        [TestCase("ABC", 2.9, ExpectedResult = "BC")]
+        [TestCase("Z\uD83D\uDC69", 1, ExpectedResult = "\uD83D\uDC69")] // Smiley emoji
+        [TestCase("\uD83D\uDC69Z", 2, ExpectedResult = "\uD83D\uDC69Z")]
+        [TestCase("\uD83D\uDC69Z", 3, ExpectedResult = "\uD83D\uDC69Z")]
+        public string Right_takes_specified_number_of_characters(string text, double numChars)
+        {
+            return XLWorkbook.EvaluateExpr($"""RIGHT("{text}",{numChars})""").GetText();
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -58,7 +58,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("PROPER", 1, Proper); // Capitalizes the first letter in each word of a text value
             ce.RegisterFunction("REPLACE", 4, Replace); // Replaces characters within text
             ce.RegisterFunction("REPT", 2, Rept); // Repeats text a given number of times
-            ce.RegisterFunction("RIGHT", 1, 2, Right); // Returns the rightmost characters from a text value
+            ce.RegisterFunction("RIGHT", 1, 2, AdaptLastOptional(Right, 1), FunctionFlags.Scalar); // Returns the rightmost characters from a text value
             ce.RegisterFunction("SEARCH", 2, 3, AdaptLastOptional(Search), FunctionFlags.Scalar); // Finds one text value within another (not case-sensitive)
             ce.RegisterFunction("SUBSTITUTE", 3, 4, Substitute); // Substitutes new text for old text in a text string
             ce.RegisterFunction("T", 1, T); // Converts its arguments to text
@@ -246,10 +246,10 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static ScalarValue Left(CalcContext ctx, string text, double numChars)
         {
-            numChars = Math.Truncate(numChars);
             if (numChars < 0)
                 return XLError.IncompatibleValue;
 
+            numChars = Math.Truncate(numChars);
             if (numChars >= text.Length)
                 return text;
 
@@ -370,18 +370,24 @@ namespace ClosedXML.Excel.CalcEngine
             return sb.ToString();
         }
 
-        private static object Right(List<Expression> p)
+        private static ScalarValue Right(CalcContext ctx, string text, double numChars)
         {
-            var str = (string)p[0];
-            var n = 1;
-            if (p.Count > 1)
+            // Unlike MID, RIGHT uses codepoint semantic
+            if (numChars < 0)
+                return XLError.IncompatibleValue;
+
+            numChars = Math.Truncate(numChars);
+            if (numChars >= text.Length)
+                return text;
+
+            var i = text.Length;
+            while (numChars > 0 && i > 0)
             {
-                n = (int)p[1];
+                i -= i > 1 && char.IsSurrogatePair(text[i - 2], text[i - 1]) ? 2 : 1;
+                numChars--;
             }
 
-            if (n >= str.Length) return str;
-
-            return str.Substring(str.Length - n);
+            return text[i..];
         }
 
         private static AnyValue Search(CalcContext ctx, String findText, String withinText, OneOf<double, Blank> startNum)


### PR DESCRIPTION
Original `RIGHT`

* didn't protect against negative number of characters, 
* didn't take code points, only code units.
 
Converted from `Expression` semantic to `AnyValue` semantic. 30 functions to go.