### PR TITLE
Refactor REPT function

### DIFF
--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -19,6 +19,11 @@ namespace ClosedXML.Excel
         public const String MaxColumnLetter = "XFD";
         public const Double Epsilon = 1e-10;
 
+        /// <summary>
+        /// Maximum number of code units that can be stored in a cell.
+        /// </summary>
+        internal const int CellTextLimit = 32767;
+
         public static Encoding NoBomUTF8 = new UTF8Encoding(false);
 
         public static String LastCell { get { return $"{MaxColumnLetter}{MaxRowNumber}"; } }


### PR DESCRIPTION
Refactor `REPT` function. Add limits to size of created result and return correct `XLError`s instead of exceptions. Of course convert from `Expression` semantic to `AnyValue` semantic.

157 functions done, 29 functions to go.