### PR TITLE
Reimplement REPLACE function

### DIFF
--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -128,6 +128,30 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, string, double, double, string, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToText(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToNumber(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2Converted = ToNumber(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                var arg3Converted = ToText(args[3], ctx);
+                if (!arg3Converted.TryPickT0(out var arg3, out var err3))
+                    return err3;
+
+                return f(ctx, arg0, arg1, arg2, arg3).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<CalcContext, string, double, double, ScalarValue> f)
         {
             return (ctx, args) =>


### PR DESCRIPTION
Original `REPLACE` didn't guard against out of bounds parameters and didn't check limits of `startPos` and `numChar`. Also switch from `Expression` to `AnyValue` semantic.