### PR TITLE
Reimplement SUBSTITUTE

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -888,25 +888,64 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Substitute_Value()
+        public void Substitute_replaces_n_th_occurence()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Substitute(""This is a Tuesday."", ""Tuesday"", ""Monday"")");
+            var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday."", ""Tuesday"", ""Monday"")");
             Assert.AreEqual("This is a Monday.", actual);
 
-            actual = XLWorkbook.EvaluateExpr(@"Substitute(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", ""Monday"", 1)");
+            actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", ""Monday"", 1)");
             Assert.AreEqual("This is a Monday. Next week also has a Tuesday.", actual);
 
-            actual = XLWorkbook.EvaluateExpr(@"Substitute(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", ""Monday"", 2)");
+            actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", ""Monday"", 2)");
             Assert.AreEqual("This is a Tuesday. Next week also has a Monday.", actual);
 
-            actual = XLWorkbook.EvaluateExpr(@"Substitute("""", """", ""Monday"")");
-            Assert.AreEqual("", actual);
-
-            actual = XLWorkbook.EvaluateExpr(@"Substitute(""This is a Tuesday. Next week also has a Tuesday."", """", ""Monday"")");
+            actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", """", ""Monday"")");
             Assert.AreEqual("This is a Tuesday. Next week also has a Tuesday.", actual);
 
-            actual = XLWorkbook.EvaluateExpr(@"Substitute(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", """")");
+            actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", """")");
             Assert.AreEqual("This is a . Next week also has a .", actual);
+        }
+
+        [Test]
+        public void Substitute_on_empty_string_returns_empty_string()
+        {
+            var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE("""","""",""Monday"")");
+            Assert.AreEqual("", actual);
+        }
+
+        [Test]
+        public void Substitute_is_case_sensitive()
+        {
+            var actual = XLWorkbook.EvaluateExpr("""SUBSTITUTE("A","a","Z")""");
+            Assert.AreEqual("A", actual);
+        }
+
+        [Test]
+        public void Substitute_returns_original_string_when_occurrence_is_not_found()
+        {
+            var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABCABC"",""A"",""Z"",3)");
+            Assert.AreEqual(@"ABCABC", actual);
+        }
+
+        [Test]
+        public void Substitute_searches_for_every_occurence()
+        {
+            // AA is matches at every character, it doesn't skip
+            var actual = XLWorkbook.EvaluateExpr("""SUBSTITUTE("AAAAAAAA","AA","ZZ",3)""");
+            Assert.AreEqual(@"AAZZAAAA", actual);
+        }
+
+        [Test]
+        public void Substitute_occurence_must_be_between_one_and_max_int()
+        {
+            var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABC"",""B"",""ZZ"",0.9)");
+            Assert.AreEqual(XLError.IncompatibleValue, actual);
+
+            actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABC"",""B"",""ZZ"", 2147483646.9)");
+            Assert.AreEqual("ABC", actual);
+
+            actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABC"",""B"",""ZZ"", 2147483647)");
+            Assert.AreEqual(XLError.IncompatibleValue, actual);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -1088,17 +1088,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Upper_Empty_Input_String()
+        public void Upper_empty_string_returns_empty_string()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Upper("""")");
-            Assert.AreEqual("", actual);
+            Assert.AreEqual("", XLWorkbook.EvaluateExpr("""UPPER("")"""));
         }
 
         [Test]
-        public void Upper_Value()
+        public void Upper_converts_text_to_upper_case()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Upper(""AbCdEfG"")");
-            Assert.AreEqual("ABCDEFG", actual);
+            var actual = XLWorkbook.EvaluateExpr("""UPPER("AbCdEfG")""");
+            Assert.AreEqual(@"ABCDEFG", actual);
+        }
+
+        [SetCulture("tr-TR")]
+        [Test]
+        public void Upper_uses_workbook_culture()
+        {
+            // Türkiye converts i to İ, not I.
+            using var wb = new XLWorkbook();
+            Assert.AreEqual("İNTELLİGENCE 2.0!", wb.Evaluate("""UPPER("intelligence 2.0!")"""));
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -571,6 +571,37 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptSubstitute(Func<CalcContext, string, string, string, double?, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToText(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToText(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2Converted = ToText(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                double? arg3 = null;
+                if (args.Length > 3)
+                {
+                    // Excel doesn't accept logical, be more permissive.
+                    var arg3Converted = ToNumber(args[3], ctx);
+                    if (!arg3Converted.TryPickT0(out var arg3Number, out var err3))
+                        return err3;
+
+                    arg3 = arg3Number;
+                }
+
+                return f(ctx, arg0, arg1, arg2, arg3).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction AdaptMultinomial(Func<CalcContext, List<IEnumerable<ScalarValue>>, ScalarValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -65,7 +65,7 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("TEXT", 2, _Text); // Formats a number and converts it to text
             ce.RegisterFunction("TEXTJOIN", 3, 255, Adapt(TextJoin), FunctionFlags.Range | FunctionFlags.Future, AllowRange.Except, 0, 1); // Joins text via delimiter
             ce.RegisterFunction("TRIM", 1, 1, Adapt(Trim), FunctionFlags.Scalar); // Removes spaces from text
-            ce.RegisterFunction("UPPER", 1, Upper); // Converts text to uppercase
+            ce.RegisterFunction("UPPER", 1, 1, Adapt(Upper), FunctionFlags.Scalar); // Converts text to uppercase
             ce.RegisterFunction("VALUE", 1, 1, Adapt(Value), FunctionFlags.Scalar); // Converts a text argument to a number
         }
 
@@ -580,9 +580,9 @@ namespace ClosedXML.Excel.CalcEngine
             return sb.ToString();
         }
 
-        private static object Upper(List<Expression> p)
+        private static ScalarValue Upper(CalcContext ctx, string text)
         {
-            return ((string)p[0]).ToUpper();
+            return text.ToUpper(ctx.Culture);
         }
 
         private static AnyValue Value(CalcContext ctx, ScalarValue arg)


### PR DESCRIPTION
Convert `SUBSTITUTE` and `UPPER` from legacy. 22 functions to go.