### PR TITLE
Reimplement YEAR, MONTH, DAY functions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -688,8 +688,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("0", 1900)]
         [TestCase("0.5", 1900)]
         [TestCase("1", 1900)]
+        [TestCase("59", 1900)]
+        [TestCase("60", 1900)]
         [TestCase("366", 1900)]
         [TestCase("367", 1901)]
+        [TestCase("DATE(9999,12,31)+0.9", 9999)]
+        [TestCase("DATE(9999,12,31)+1", XLError.NumberInvalid)]
         [TestCase("-1", XLError.NumberInvalid)]
         [TestCase("\"test\"", XLError.IncompatibleValue)]
         [TestCase("IF(TRUE,)", 1900)] // Blank
@@ -708,7 +712,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = Blank.Value;
-            ws.Cell("A2").FormulaA1 = @"=YEAR(A1)";
+            ws.Cell("A2").FormulaA1 = "YEAR(A1)";
             var valueA2 = ws.Cell("A2").Value;
             Assert.AreEqual(1900, valueA2);
         }

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -116,11 +116,35 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(39682, actual);
         }
 
-        [Test]
-        public void Day()
+        [TestCase(0, ExpectedResult = 0)]
+        [TestCase(1, ExpectedResult = 1)]
+        [TestCase(31, ExpectedResult = 31)]
+        [TestCase(32, ExpectedResult = 1)]
+        [TestCase(59, ExpectedResult = 28)]
+        [TestCase(60, ExpectedResult = 29)]
+        [TestCase(61, ExpectedResult = 1)]
+        [TestCase(30000, ExpectedResult = 18)]
+        [TestCase(45718, ExpectedResult = 2)]
+        public double Day_returns_day_of_a_month_for_serial_culture(double serialDate)
         {
-            var actual = XLWorkbook.EvaluateExpr("Day(\"8/22/2008\")");
-            Assert.AreEqual(22, actual);
+            return XLWorkbook.EvaluateExpr($"DAY({serialDate})").GetNumber();
+        }
+
+        [Test]
+        public void Day_only_accepts_serial_date_from_0_to_upper_limit_of_calendar_system()
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAY(-0.1)"));
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAY(DATE(9999,12,31)+1)"));
+        }
+
+        [SetCulture("eu-ES")]
+        [TestCase("\"2006/1/2 10:45 AM\"", ExpectedResult = 2)]
+        [TestCase("DATE(2006,1,2)", ExpectedResult = 2)]
+        [TestCase("DATE(2006,0,2)", ExpectedResult = 2)]
+        [TestCase("DATE(2013,9,0)", ExpectedResult = 31)]
+        public double Day_examples(string date)
+        {
+            return XLWorkbook.EvaluateExprCurrent($"DAY({date})").GetNumber();
         }
 
         [Test]
@@ -131,16 +155,6 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             actual = XLWorkbook.EvaluateExpr("DAYS(\"2016-10-1\",\"1992-2-29\")");
             Assert.AreEqual(8981, actual);
-        }
-
-        [Test]
-        public void DayWithDifferentCulture()
-        {
-            CultureInfo ci = new CultureInfo(CultureInfo.InvariantCulture.LCID);
-            ci.DateTimeFormat.ShortDatePattern = "dd/MM/yyyy";
-            Thread.CurrentThread.CurrentCulture = ci;
-            var actual = XLWorkbook.EvaluateExpr("Day(\"1/6/2008\")");
-            Assert.AreEqual(1, actual);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -252,7 +252,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(32, ExpectedResult = 2)] // 1900-02-01
         [TestCase(59, ExpectedResult = 2)] // 1900-02-28
         [TestCase(60, ExpectedResult = 2)] // 1900-02-29
-        [TestCase(61, ExpectedResult = 3)] // 1900-02-29
+        [TestCase(61, ExpectedResult = 3)] // 1900-03-01
         [TestCase("DATE(2006,1,2)", ExpectedResult = 1)]
         [TestCase("DATE(2006,0,2)", ExpectedResult = 12)]
         [TestCase("\"2006/1/2 10:45 AM\"", ExpectedResult = 1)]

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -504,18 +504,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             }
         }
 
-        private static ScalarValue Year(double serialDateTime)
+        private static ScalarValue Year(CalcContext ctx, double serialDate)
         {
-            serialDateTime = Math.Truncate(serialDateTime);
-            if (serialDateTime < 0)
-                return XLError.NumberInvalid;
-
-            // Serial date time values from [0, 1) are from 1899-12-31,
-            // but Excel represents them as 1900-01-00.
-            if (serialDateTime < 1)
-                return 1900;
-
-            return serialDateTime.ToSerialDateTime().Year;
+            return GetDateComponent(ctx, serialDate, static d => d.Year, 1900, 1900);
         }
 
         private static object Yearfrac(List<Expression> p)

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -44,6 +44,18 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, double, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                return f(ctx, arg0).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<double, double, ScalarValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -976,6 +976,14 @@ namespace ClosedXML.Excel
             return CalcEngineExpr.EvaluateFormula(expression).ToCellValue();
         }
 
+        /// <summary>
+        /// Evaluate a formula and return a value. Use current culture.
+        /// </summary>
+        internal static XLCellValue EvaluateExprCurrent(String expression)
+        {
+            return new XLCalcEngine(CultureInfo.CurrentCulture).EvaluateFormula(expression).ToCellValue();
+        }
+
         public String Author { get; set; }
 
         public Boolean LockStructure


### PR DESCRIPTION
Reimplement date component functions. Mostly makes things more compliant with limits and edge cases of jan/feb 1900 (e.g `DAY(DATE(1900,1,0)) = 0`).

I am seriously thinking about breaking change. I think I should switch `XLWorkbook.EvaluateExpr` from invariant culture to current culture. There are currently two problems:
* A lot of Excel functions have used CultureInfo.CurrentCulture. That means some places in the call stack use invariant and some current. I need to pick one and in either case something breaks (e.g. `DOLLAR` for invariant doesn't returns `$`, but `¤`). There is also problem with parsing date (depends on culture) and so on.
* Generally speaking, API design in C# for culture-aware functions have following variants(example of `ToUpper`): `ToUpper()` - uses current culture, `ToUpper(CultureInfo)` - explicitely passed culture, `ToUpperInvaraint()` - uses invariant. `XLWorkbook.EvaluateExpr` doesn't follow that.

For now, I have added internal method `XLWorkbook.EvaluateExprCurrent` that uses current culture, but I will think about it before end release of 0.105. I have looked over github and the only usage I found was in forks of ClosedXML.

Long term, I want everything depend on workbook culture specified in `LoadOptions` (default would be current culture). Depending on ambient means it can switch in the middle work with workbook... not good.

167 functions done, 19 functions to go.