### PR TITLE
Reimplement TIME function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -496,8 +496,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Today()
         {
-            var actual = (double)XLWorkbook.EvaluateExpr("Today()");
-            Assert.AreEqual(DateTime.Now.Date.ToSerialDateTime(), actual);
+            var actual = (double)XLWorkbook.EvaluateExpr("TODAY()");
+            Assert.AreEqual(DateTime.Today.ToSerialDateTime(), actual);
         }
 
         [TestCase("\"2/14/2008\"", 1, 5)]

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -448,11 +448,35 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("SECOND(DATE(9999,12,31)+1)"));
         }
 
-        [Test]
-        public void Time()
+        [TestCase(0, 0, 0, ExpectedResult = 0)]
+        [TestCase(0, 0, 1, ExpectedResult = 0.0000115740740741)]
+        [TestCase(0, 0, 2, ExpectedResult = 0.0000231481481481)]
+        [TestCase(0, 0, 20, ExpectedResult = 0.0002314814814815)]
+        [TestCase(2, 3, 20, ExpectedResult = 0.0856481481481481)]
+        [TestCase(12, 0, 0, ExpectedResult = 0.5000000000000000)]
+        [TestCase(23, 59, 59, ExpectedResult = 0.9999884259259260)]
+        [TestCase(26, 120, 240, ExpectedResult = 0.1694444444444450)]
+        [TestCase(1, 2, 3, ExpectedResult = 0.043090277777778)]
+        [TestCase(1.9, 2.9, 3.9, ExpectedResult = 0.043090277777778)]
+        [TestCase(24, 0, 0, ExpectedResult = 0)]
+        [TestCase(0, 42*60, 0, ExpectedResult = 0.75)]
+        [TestCase(0, 0, 60 * 60 * 3, ExpectedResult = 0.125)]
+        [TestCase(120, 240, 347, ExpectedResult = 0.170682870370)]
+        [DefaultFloatingPointTolerance(XLHelper.Epsilon)]
+        public double Time_returns_serial_date_time(double hour, double minute, double second)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr("Time(1,2,3)");
-            Assert.AreEqual(0.043090277777778, actual, XLHelper.Epsilon);
+            return (double)XLWorkbook.EvaluateExpr($"TIME({hour},{minute},{second})");
+        }
+
+        [TestCase(-0.1, 0, 0)]
+        [TestCase(32768, 0, 0)]
+        [TestCase(0, -0.1, 0)]
+        [TestCase(0, 32768, 0)]
+        [TestCase(0, 0, -0.1)]
+        [TestCase(0, 0, 32768)]
+        public void Time_components_must_be_in_zero_to_32767_interval(double hour, double minute, double second)
+        {
+            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"TIME({hour},{minute},{second})"));
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -32,7 +32,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("SECOND", 1, 1, Adapt(Second), FunctionFlags.Scalar); // Converts a serial number to a second
             ce.RegisterFunction("TIME", 3, 3, Adapt(Time), FunctionFlags.Scalar); // Returns the serial number of a particular time
             ce.RegisterFunction("TIMEVALUE", 1, Timevalue); // Converts a time in the form of text to a serial number
-            ce.RegisterFunction("TODAY", 0, Today); // Returns the serial number of today's date
+            ce.RegisterFunction("TODAY", 0, 0, Adapt(Today), FunctionFlags.Scalar | FunctionFlags.Volatile); // Returns the serial number of today's date
             ce.RegisterFunction("WEEKDAY", 1, 2, AdaptLastOptional(Weekday), FunctionFlags.Scalar, AllowRange.None); // Converts a serial number to a day of the week
             ce.RegisterFunction("WEEKNUM", 1, 2, Weeknum); // Converts a serial number to a number representing where the week falls numerically with a year
             ce.RegisterFunction("WORKDAY", 2, 3, AdaptLastOptional(Workday), FunctionFlags.Range, AllowRange.Only, 2); // Returns the serial number of the date before or after a specified number of workdays
@@ -333,9 +333,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return (DateTime.MinValue + date.TimeOfDay).ToOADate();
         }
 
-        private static object Today(List<Expression> p)
+        private static ScalarValue Today()
         {
-            return DateTime.Today;
+            return DateTime.Today.ToSerialDateTime();
         }
 
         private static ScalarValue Weekday(CalcContext ctx, ScalarValue date, ScalarValue flag)

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("MINUTE", 1, 1, Adapt(Minute), FunctionFlags.Scalar); // Converts a serial number to a minute
             ce.RegisterFunction("MONTH", 1, 1, Adapt(Month), FunctionFlags.Scalar); // Converts a serial number to a month
             ce.RegisterFunction("NETWORKDAYS", 2, 3, AdaptLastOptional(NetWorkDays), FunctionFlags.Range, AllowRange.Only, 2); // Returns the number of whole workdays between two dates
-            ce.RegisterFunction("NOW", 0, Now); // Returns the serial number of the current date and time
+            ce.RegisterFunction("NOW", 0, 0, Adapt(Now), FunctionFlags.Scalar | FunctionFlags.Volatile); // Returns the serial number of the current date and time
             ce.RegisterFunction("SECOND", 1, 1, Adapt(Second), FunctionFlags.Scalar); // Converts a serial number to a second
             ce.RegisterFunction("TIME", 3, 3, Adapt(Time), FunctionFlags.Scalar); // Returns the serial number of a particular time
             ce.RegisterFunction("TIMEVALUE", 1, Timevalue); // Converts a time in the form of text to a serial number
@@ -288,9 +288,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return BusinessDaysUntil(startSerialDate, endSerialDate, allHolidays);
         }
 
-        private static object Now(List<Expression> p)
+        private static ScalarValue Now()
         {
-            return DateTime.Now;
+            return DateTime.Now.ToSerialDateTime();
         }
 
         private static ScalarValue Second(CalcContext ctx, double serialDate)


### PR DESCRIPTION
Original didn't work for serial date time above 1 (e.g. `TIME(48,0,0) = 0`, not `2`), plut arguments should in a 0-32767 range.

Also switch from `Expression` to `AnyValue`. 173 functions done, 13 to do.