### PR TITLE
Reimplement TEXT, DAYS360

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -158,8 +158,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Days360_uses_US_method_by_default()
         {
-            var actual = XLWorkbook.EvaluateExpr("DAYS360(DATE(2002,2,3),DATE(2005,5,31))");
-            Assert.AreEqual(1198, actual);
+            const string formulaFormat = "DAYS360(DATE(2002,2,3),DATE(2005,5,31){0})";
+            var defaultResult = XLWorkbook.EvaluateExpr(string.Format(formulaFormat, string.Empty));
+            var usResult = XLWorkbook.EvaluateExpr(string.Format(formulaFormat, ",FALSE"));
+            var euResult = XLWorkbook.EvaluateExpr(string.Format(formulaFormat, ",TRUE"));
+            Assert.AreEqual(1198, defaultResult);
+            Assert.AreEqual(usResult, defaultResult);
+            Assert.AreNotEqual(euResult, defaultResult);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -156,10 +156,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         }
 
         [Test]
-        public void Days360_Default()
+        public void Days360_uses_US_method_by_default()
         {
-            var actual = XLWorkbook.EvaluateExpr("Days360(\"1/30/2008\", \"2/1/2008\")");
-            Assert.AreEqual(1, actual);
+            var actual = XLWorkbook.EvaluateExpr("DAYS360(DATE(2002,2,3),DATE(2005,5,31))");
+            Assert.AreEqual(1198, actual);
         }
 
         [Test]
@@ -176,18 +176,40 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(-89, actual);
         }
 
-        [Test]
-        public void Days360_US1()
+        [TestCase(2002, 2, 3, 2005, 5, 31, ExpectedResult = 1198)]
+        [TestCase(2005, 5, 31, 2002, 2, 3, ExpectedResult = -1197)]
+        [TestCase(2008, 1, 1, 2008, 3, 31, ExpectedResult = 90)]
+        [TestCase(2008, 3, 31, 2008, 1, 1, ExpectedResult = -89)]
+        [TestCase(2020, 2, 29, 2021, 2, 28, ExpectedResult = 358)]
+        [TestCase(2020, 5, 29, 2020, 4, 1, ExpectedResult = -58)]
+        [TestCase(2020, 5, 29, 2020, 3, 31, ExpectedResult = -58)]
+        [TestCase(2020, 5, 30, 2020, 4, 1, ExpectedResult = -59)]
+        [TestCase(2020, 5, 30, 2020, 3, 31, ExpectedResult = -60)]
+        [TestCase(2020, 5, 30, 2020, 3, 30, ExpectedResult = -60)]
+        public double Days360_US_method(int startYear, int startMonth, int startDay, int endYear, int endMonth, int endDay)
         {
-            var actual = XLWorkbook.EvaluateExpr("DAYS360(\"1/1/2008\", \"3/31/2008\",FALSE)");
-            Assert.AreEqual(90, actual);
+            return (double)XLWorkbook.EvaluateExpr($"DAYS360(DATE({startYear},{startMonth},{startDay}),DATE({endYear},{endMonth},{endDay}),FALSE)");
         }
 
-        [Test]
-        public void Days360_US2()
+        [TestCase(1900, 2, 27, 1900, 2, 27, ExpectedResult = 0)]
+        [TestCase(1900, 2, 27, 1900, 2, 28, ExpectedResult = 1)]
+        [TestCase(1900, 2, 27, 1900, 2, 29, ExpectedResult = 2)]
+        [TestCase(1900, 2, 27, 1900, 3, 1, ExpectedResult = 4)]
+        [TestCase(1900, 2, 28, 1900, 2, 27, ExpectedResult = -1)]
+        [TestCase(1900, 2, 28, 1900, 2, 28, ExpectedResult = 0)]
+        [TestCase(1900, 2, 28, 1900, 2, 29, ExpectedResult = 1)]
+        [TestCase(1900, 2, 28, 1900, 3, 1, ExpectedResult = 3)]
+        [TestCase(1900, 2, 29, 1900, 2, 27, ExpectedResult = -3)]
+        [TestCase(1900, 2, 29, 1900, 2, 28, ExpectedResult = -2)]
+        [TestCase(1900, 2, 29, 1900, 2, 29, ExpectedResult = -1)]
+        [TestCase(1900, 2, 29, 1900, 3, 1, ExpectedResult = 1)]
+        [TestCase(1900, 3, 1, 1900, 2, 27, ExpectedResult = -4)]
+        [TestCase(1900, 3, 1, 1900, 2, 28, ExpectedResult = -3)]
+        [TestCase(1900, 3, 1, 1900, 2, 29, ExpectedResult = -2)]
+        [TestCase(1900, 3, 1, 1900, 3, 1, ExpectedResult = 0)]
+        public double Days360_US_method_for_feb_29_1900(int startYear, int startMonth, int startDay, int endYear, int endMonth, int endDay)
         {
-            var actual = XLWorkbook.EvaluateExpr("DAYS360(\"3/31/2008\", \"1/1/2008\",FALSE)");
-            Assert.AreEqual(-89, actual);
+            return (double)XLWorkbook.EvaluateExpr($"DAYS360(DATE({startYear},{startMonth},{startDay}),DATE({endYear},{endMonth},{endDay}),FALSE)");
         }
 
         [Test]

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -13,8 +13,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         /// </summary>
         private const int Year10K = 2958465;
 
-        private const int Year1900Feb29 = 60;
-
         public static void Register(FunctionRegistry ce)
         {
             ce.RegisterFunction("DATE", 3, 3, Adapt(Date), FunctionFlags.Scalar); // Returns the serial number of a particular date
@@ -154,11 +152,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (!TryGetDate(ctx, serialDateTime, out var serialDate))
                 return XLError.NumberInvalid;
 
-            return Day(ctx, serialDate);
-        }
-
-        private static int Day(CalcContext ctx, int serialDate)
-        {
             return DateParts.From(ctx, serialDate).Day;
         }
 
@@ -307,11 +300,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (!TryGetDate(ctx, serialDateTime, out var serialDate))
                 return XLError.NumberInvalid;
 
-            return Month(ctx, serialDate);
-        }
-
-        private static int Month(CalcContext ctx, int serialDate)
-        {
             return DateParts.From(ctx, serialDate).Month;
         }
 
@@ -570,11 +558,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (!TryGetDate(ctx, serialDateTime, out var serialDate))
                 return XLError.NumberInvalid;
 
-            return Year(ctx, serialDate);
-        }
-
-        private static int Year(CalcContext ctx, int serialDate)
-        {
             return DateParts.From(ctx, serialDate).Year;
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -649,16 +649,13 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (serialDate == 0)
                     return Epoch1900;
 
-                // January and February 1900
-                if (serialDate < 60)
-                {
-                    var offByOneDate = DateTime.FromOADate(serialDate + 1);
-                    return From(offByOneDate);
-                }
-
                 // Everyone loves 29th Feb 1900
                 if (serialDate == 60)
                     return Feb29;
+
+                // January and February 1900. Because of non-existent feb29, adjust by one day
+                if (serialDate < 60)
+                    serialDate++;
 
                 return From(DateTime.FromOADate(serialDate));
             }

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -389,6 +389,26 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, double, double, bool, ScalarValue> f, bool lastDefault)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToNumber(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2Converted = CoerceToLogical(args.Length > 2 ? args[2] : lastDefault, ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                return f(ctx, arg0, arg1, arg2).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction AdaptLastOptional(Func<CalcContext, string, double, ScalarValue> f, double lastDefault)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -276,6 +276,22 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, ScalarValue, string, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToScalarValue(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToText(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                return f(ctx, arg0, arg1).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<ScalarValue, ScalarValue, AnyValue> f)
         {
             return (ctx, args) =>


### PR DESCRIPTION
Mostly add limits on acceptable arguments for DAYS360 and fix the February issue for `DAYS360` (both normal and 1900-02-29).

I am always reminded that "specification" of functions is mostly copied help text from Excel. These two texts have same effects, but one actually say it in a sensible way.

I am also old enough to remember the certification process, that was... pushed through by MS, because EU required "open format" (a lot of changed votes, companies suddenly appearing and pushing... Even [wiki](https://en.wikipedia.org/wiki/Standardization_of_Office_Open_XML) says it was "the most controversial and unusual ISO ballot"). OOXML spec:

> If the start-date is the 31st day of a month, it is changed to the 30th day of that same month. 

That is incorrect, it is when start-date should be last day of a month, not 31st. Last day of month includes February 28/29. That is adjusted in OI-29500, but still... Fix the damn standard.

> If the end-date is the 31st day of a month and the start-date is earlier than the 30th day of a month, the end-date is changed to the 1st day of the following month; otherwise the end-date is changed to the 30th day of the same month.

Note the "; otherwise". What does it mean? Should it be done only if end-date is 31st day of a month or always? Yeah, it's only if the end-date is 31st, but these ambiguities should not be there. 

Let's look at [ODF](https://docs.oasis-open.org/office/OpenDocument/v1.3/os/part4-formula/OpenDocument-v1.3-os-part4-formula.html#DAYS360) specification:
> 4.If EndDate's day-of-month is 31 and StartDate's day-of-month is 30 (after having applied a change for #2 or #3, if necessary), EndDate's day-of-month is changed to 30. 

175 done, 11 functions to go.