### PR TITLE
Reimplement DATEDIF

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -576,8 +576,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             return (double)XLWorkbook.EvaluateExpr($"FISHER({sourceValue})");
         }
 
-        // TODO : the string case will be treated correctly when Coercion is implemented better
-        //[TestCase("asdf", ExpectedResult = XLError.IncompatibleValue)]
+        [TestCase("\"asdf\"", ExpectedResult = XLError.IncompatibleValue)]
         [TestCase("5", ExpectedResult = XLError.NumberInvalid)]
         [TestCase("-1", ExpectedResult = XLError.NumberInvalid)]
         [TestCase("1", ExpectedResult = XLError.NumberInvalid)]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -36,6 +36,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COUNTIFS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CSCH/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=DATEDIF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dereferenced/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DEVSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -92,6 +92,26 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
+        public static CalcEngineFunction Adapt(Func<CalcContext, double, double, string, ScalarValue> f)
+        {
+            return (ctx, args) =>
+            {
+                var arg0Converted = ToNumber(args[0], ctx);
+                if (!arg0Converted.TryPickT0(out var arg0, out var err0))
+                    return err0;
+
+                var arg1Converted = ToNumber(args[1], ctx);
+                if (!arg1Converted.TryPickT0(out var arg1, out var err1))
+                    return err1;
+
+                var arg2Converted = ToText(args[2], ctx);
+                if (!arg2Converted.TryPickT0(out var arg2, out var err2))
+                    return err2;
+
+                return f(ctx, arg0, arg1, arg2).ToAnyValue();
+            };
+        }
+
         public static CalcEngineFunction Adapt(Func<double, double, double, bool, AnyValue> f)
         {
             return (ctx, args) =>

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -34,7 +34,7 @@ namespace ClosedXML.Excel.CalcEngine
             //EXPONDIST	Returns the exponential distribution
             //FDIST	Returns the F probability distribution
             //FINV	Returns the inverse of the F probability distribution
-            ce.RegisterFunction("FISHER", 1, Fisher); // Returns the Fisher transformation
+            ce.RegisterFunction("FISHER", 1, 1, Adapt(Fisher), FunctionFlags.Scalar); // Returns the Fisher transformation
             //FISHERINV	Returns the inverse of the Fisher transformation
             //FORECAST	Returns a value along a linear trend
             //FREQUENCY	Returns a frequency distribution as a vertical array
@@ -265,10 +265,10 @@ namespace ClosedXML.Excel.CalcEngine
             return squareDiff.Sum;
         }
 
-        private static object Fisher(List<Expression> p)
+        private static ScalarValue Fisher(CalcContext ctx, double x)
         {
-            var x = (double)p[0];
-            if (x <= -1 || x >= 1) return XLError.NumberInvalid;
+            if (x is <= -1 or >= 1)
+                return XLError.NumberInvalid;
 
             return 0.5 * Math.Log((1 + x) / (1 - x));
         }


### PR DESCRIPTION
Reimplement `DATEDIF`, including Excel quirks. It's longer, but more faithful. Values were tested against Excel by using [this gist](https://gist.github.com/jahav/4b5ef411b4c66db008788b1f52f08923). Also convert `FISHER`.

179 functions done, 7 function to go.