### PR TITLE
Refactor EDATE

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -40,6 +40,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dereferenced/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DEVSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=EDATE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enumerables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FACTDOUBLE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=FILTERXML/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
`EDATE` worked fine, only added limits and unified tests to a theory. One of functions that use correct 1900-02-28 (`EDATE("1900-01-31", 1)` = `1900-02-28`, not `1900-02-29`).

181 functions done, 5 function to go.