### PR TITLE
Reimplement TIMEVALUE function

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -592,18 +592,34 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"TIME({hour},{minute},{second})"));
         }
 
-        [Test]
-        public void TimeValue1()
+        [TestCase("2:24 AM", ExpectedResult = 0.1)]
+        [TestCase("August 22, 2008 6:35 AM", ExpectedResult = 0.27430555555555558)]
+        [DefaultFloatingPointTolerance(XLHelper.Epsilon)]
+        public double TimeValue_returns_time_component_of_serial_date_extracted_from_text(string time)
         {
-            var actual = (double)XLWorkbook.EvaluateExpr("TimeValue(\"2:24 AM\")");
-            Assert.IsTrue(XLHelper.AreEqual(0.1, actual));
+            return (double)XLWorkbook.EvaluateExprCurrent($"TIMEVALUE(\"{time}\")");
+        }
+
+        [TestCase("\"10.5\"")]
+        [TestCase("\"0\"")]
+        public void TimeValue_doesnt_coerce_number_in_a_text_to_a_time(string numberText)
+        {
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExprCurrent($"TIMEVALUE({numberText})"));
+        }
+
+        [TestCase("TRUE")]
+        [TestCase("FALSE")]
+        [TestCase("0.25")]
+        [TestCase("TIME(18,25,48)")]
+        public void TimeValue_returns_coercion_error_on_non_text(string nonText)
+        {
+            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExprCurrent($"TIMEVALUE({nonText})"));
         }
 
         [Test]
-        public void TimeValue2()
+        public void TimeValue_propagates_error()
         {
-            var actual = (double)XLWorkbook.EvaluateExpr("TimeValue(\"22-Aug-2008 6:35 AM\")");
-            Assert.IsTrue(XLHelper.AreEqual(0.27430555555555558, actual));
+            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExprCurrent("TIMEVALUE(#DIV/0!)"));
         }
 
         [Test]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -91,6 +91,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tahoma/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TANH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTJOIN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=TIMEVALUE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TRUNC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unconvertable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=underlaying/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -16,6 +16,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         public static void Register(FunctionRegistry ce)
         {
             var dateValue = DateValue;
+            var timeValue = TimeValue;
             ce.RegisterFunction("DATE", 3, 3, Adapt(Date), FunctionFlags.Scalar); // Returns the serial number of a particular date
             ce.RegisterFunction("DATEDIF", 3, 3, Adapt(DateDif), FunctionFlags.Scalar); // Calculates the number of days, months, or years between two dates
             ce.RegisterFunction("DATEVALUE", 1, 1, Adapt(dateValue), FunctionFlags.Scalar); // Converts a date in the form of text to a serial number
@@ -32,7 +33,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("NOW", 0, 0, Adapt(Now), FunctionFlags.Scalar | FunctionFlags.Volatile); // Returns the serial number of the current date and time
             ce.RegisterFunction("SECOND", 1, 1, Adapt(Second), FunctionFlags.Scalar); // Converts a serial number to a second
             ce.RegisterFunction("TIME", 3, 3, Adapt(Time), FunctionFlags.Scalar); // Returns the serial number of a particular time
-            ce.RegisterFunction("TIMEVALUE", 1, Timevalue); // Converts a time in the form of text to a serial number
+            ce.RegisterFunction("TIMEVALUE", 1, 1, Adapt(timeValue), FunctionFlags.Scalar); // Converts a time in the form of text to a serial number
             ce.RegisterFunction("TODAY", 0, 0, Adapt(Today), FunctionFlags.Scalar | FunctionFlags.Volatile); // Returns the serial number of today's date
             ce.RegisterFunction("WEEKDAY", 1, 2, AdaptLastOptional(Weekday), FunctionFlags.Scalar, AllowRange.None); // Converts a serial number to a day of the week
             ce.RegisterFunction("WEEKNUM", 1, 2, AdaptLastOptional(WeekNum, 1), FunctionFlags.Scalar); // Converts a serial number to a number representing where the week falls numerically with a year
@@ -390,11 +391,15 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             }
         }
 
-        private static object Timevalue(List<Expression> p)
+        private static ScalarValue TimeValue(CalcContext ctx, ScalarValue value)
         {
-            var date = (DateTime)p[0];
+            if (!value.TryPickText(out var text, out var error))
+                return error;
 
-            return (DateTime.MinValue + date.TimeOfDay).ToOADate();
+            if (!ScalarValue.ToSerialDateTime(text, ctx.Culture, out var serialDateTime))
+                return XLError.IncompatibleValue;
+
+            return serialDateTime % 1.0;
         }
 
         private static ScalarValue Today()


### PR DESCRIPTION
Convert from `Expression` based semantic to `AnyValue` based one, add few tests, enforce coercion logic.

184 functions done, 2 to go.