### PR TITLE
Update ClosedParser to 2.0 (bang reference)

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -46,7 +46,7 @@
     </PackageReference>
     <PackageReference Include="RBush" Version="4.0.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
-    <PackageReference Include="ClosedXML.Parser" Version="[1.2.0,2.0.0)" />
+    <PackageReference Include="ClosedXML.Parser" Version="2.0.0-preview1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/ClosedXML/Excel/CalcEngine/FormulaParser.cs
+++ b/ClosedXML/Excel/CalcEngine/FormulaParser.cs
@@ -123,6 +123,11 @@ namespace ClosedXML.Excel.CalcEngine
                 return new ReferenceNode(prefixNode, area, _isA1);
             }
 
+            public ValueNode BangReference(List<FormulaFlags> context, SymbolRange range, ReferenceArea reference)
+            {
+                return new NotSupportedNode("Bang reference");
+            }
+
             public ValueNode Reference3D(List<FormulaFlags> context, SymbolRange range, string firstSheet, string lastSheet,
                 ReferenceArea area)
             {
@@ -208,6 +213,11 @@ namespace ClosedXML.Excel.CalcEngine
             {
                 var prefixNode = new PrefixNode(null, sheet, null, null);
                 return new NameNode(prefixNode, name);
+            }
+
+            public ValueNode BangName(List<FormulaFlags> context, SymbolRange range, string name)
+            {
+                return new NotSupportedNode("Bang name");
             }
 
             public ValueNode ExternalName(List<FormulaFlags> context, SymbolRange range, int workbookIndex, string name)

--- a/ClosedXML/Excel/CalcEngine/Visitors/CollectVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/CollectVisitor.cs
@@ -66,6 +66,11 @@ internal abstract class CollectVisitor<TContext> : IAstFactory<object?, object?,
         return default;
     }
 
+    public virtual object? BangReference(TContext context, SymbolRange range, ReferenceArea reference)
+    {
+        return default;
+    }
+
     public virtual object? Reference3D(TContext context, SymbolRange range, string firstSheet, string lastSheet, ReferenceArea reference)
     {
         return default;
@@ -134,6 +139,11 @@ internal abstract class CollectVisitor<TContext> : IAstFactory<object?, object?,
     }
 
     public virtual object? SheetName(TContext context, SymbolRange range, string sheet, string name)
+    {
+        return default;
+    }
+
+    public virtual object? BangName(TContext context, SymbolRange range, string name)
     {
         return default;
     }

--- a/ClosedXML/Excel/Cells/XLCellFormula.cs
+++ b/ClosedXML/Excel/Cells/XLCellFormula.cs
@@ -303,7 +303,7 @@ namespace ClosedXML.Excel
         public void RenameSheet(XLSheetPoint origin, string oldSheetName, string newSheetName)
         {
             var a1 = A1;
-            var res = FormulaConverter.ModifyA1(a1, origin.Row, origin.Column, new RenameRefModVisitor
+            var res = FormulaConverter.ModifyA1(a1, newSheetName, origin.Row, origin.Column, new RenameRefModVisitor
             {
                 Sheets = new Dictionary<string, string?> { { oldSheetName, newSheetName } }
             });

--- a/ClosedXML/Excel/DefinedNames/XLDefinedName.cs
+++ b/ClosedXML/Excel/DefinedNames/XLDefinedName.cs
@@ -115,7 +115,7 @@ internal class XLDefinedName : IXLDefinedName, IWorkbookListener
             }
         }
 
-        var copiedFormula = FormulaConverter.ModifyA1(_formula, 1, 1, new RenameRefModVisitor
+        var copiedFormula = FormulaConverter.ModifyA1(_formula, sheet.Name, 1, 1, new RenameRefModVisitor
         {
             Sheets = new Dictionary<string, string?> { { sheet.Name, targetSheet.Name } },
             Tables = tableRenames,
@@ -172,9 +172,9 @@ internal class XLDefinedName : IXLDefinedName, IWorkbookListener
         if (!_references.ContainsSheet(oldSheetName))
             return;
 
-        var modified = FormulaConverter.ModifyA1(_formula, 1, 1, new RenameRefModVisitor
+        var modified = FormulaConverter.ModifyA1(_formula, newSheetName ?? string.Empty, 1, 1, new RenameRefModVisitor
         {
-            Sheets = new Dictionary<string, string?> { { oldSheetName, newSheetName} }
+            Sheets = new Dictionary<string, string?> { { oldSheetName, newSheetName } }
         });
 
         RefersTo = modified;


### PR DESCRIPTION
Parser version 2.0 has two new methods in the `IAstFactory` interface for bang references (used only in defined names). Adding methods to interface is a breaking change, so major version was increased to 2.

Bang reference (e.g. `!$B$7:$D$8`) are 
* now parseable and formulas with it won't throw during sheet rename and delete or formula conversion from A1 to R1C1 and back.
* calc engine doesn't evaluate them, they are represented as `NotSupportedNode` for now.

There is also a method for bang name (`!Data`), but it's not yet parseable, but will be.

ClosedXML.Parser 2.0.0-preview1 package is unlisted on nuget.org.