### PR TITLE
Small increase to unit test coverage

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
@@ -462,6 +462,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(@"MATCH(22.5, B3:B45, 1)", 22)]
         [TestCase(@"MATCH(""Rep"", B2:I2)", 4)]
         [TestCase(@"MATCH(""Rep"", B2:I2, 1)", 4)]
+        [TestCase(@"MATCH(E2, B2:I2, 0)", 4)]
         [TestCase(@"MATCH(40, G3:G6, -1)", 2)]
         [TestCase(@"MATCH(""Rep"", B2:I5)", XLError.NoValueAvailable)]
         [TestCase(@"MATCH(""Dummy"", B2:I2, 0)", XLError.NoValueAvailable)]

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -53,6 +53,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("E3").Value = false;
             Assert.AreEqual(5, ws.Evaluate("AVERAGEA(10, E3)"));
 
+            // Make sure multiple values not in an array work as intended
+            Assert.AreEqual(15.095, (double)workbook.Evaluate("AVERAGEA(-27.5,93.93,64.51,-70.56)"), tolerance);
+
             // Array logical arguments are ignored
             Assert.AreEqual(2, workbook.Evaluate("AVERAGEA({2,TRUE,TRUE,FALSE,FALSE})"));
 


### PR DESCRIPTION
Many months ago I was working on a local fork of ClosedXML to improve the conformance of some functions, but never got it to a place where I could upstream the changes.

Now that you have done a big port of all the functions and improved their conformance in the process, most of my changes don't need completing and upstreaming, which is awesome!

My local changes did include a small increase to unit test coverage, so I could see if my changes matched Excel's output. I think those are still worth upstreaming so that ClosedXML can have the best test suite possible, so here is a small PR with some more test cases