### PR TITLE
Fix hyperlink copy between sheets

### DIFF
--- a/ClosedXML.Tests/Excel/Misc/CopyContentsTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/CopyContentsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ClosedXML.Excel;
 using NUnit.Framework;
 using System.Linq;
@@ -126,6 +127,26 @@ namespace ClosedXML.Tests.Excel.Misc
                 Assert.AreEqual("Sheet1", ws1.FirstCell().Address.Worksheet.Name);
                 Assert.AreEqual("Sheet2", ws2.FirstCell().Address.Worksheet.Name);
             }
+        }
+
+        [Test]
+        public void CopyHyperlinksAmongSheets()
+        {
+            using var wb = new XLWorkbook();
+            var source = wb.AddWorksheet();
+            var target = wb.AddWorksheet();
+            source.Cell("A1")
+                .SetValue("link")
+                .CreateHyperlink()
+                .SetValues("https://example.com", "Test tooltip");
+
+            source.Cell("A1").AsRange().CopyTo(target.Cell("B7"));
+
+            var cell = target.Cell("B7");
+            Assert.True(cell.HasHyperlink);
+            Assert.True(cell.GetHyperlink().IsExternal);
+            Assert.AreEqual(new Uri("https://example.com"), cell.GetHyperlink().ExternalAddress);
+            Assert.AreEqual("Test tooltip", cell.GetHyperlink().Tooltip);
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1350,7 +1350,7 @@ namespace ClosedXML.Excel
             FormulaR1C1 = source.FormulaR1C1;
             SliceComment = source.SliceComment == null ? null : new XLComment(this, source.SliceComment, source.Style.Font, source.SliceComment.Style);
 
-            if (Worksheet.Hyperlinks.TryGet(source.SheetPoint, out var sourceHyperlink))
+            if (source.Worksheet.Hyperlinks.TryGet(source.SheetPoint, out var sourceHyperlink))
             {
                 SetCellHyperlink(new XLHyperlink(sourceHyperlink));
             }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.105.0-preview1</Version>
+    <Version>0.105.0-rc</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->


### PR DESCRIPTION
When a range/cell was copied to another sheet, the link in the target sheet wasn't correctly set-up.