### PR TITLE
Fix potential bug with array formula loading not setting all shared strings

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1321,7 +1321,7 @@ namespace ClosedXML.Excel
                 {
                     for (var row = arrayArea.FirstPoint.Row; row <= arrayArea.LastPoint.Row; ++row)
                     {
-                        valueSlice.SetShareString(cellAddress, false);
+                        valueSlice.SetShareString(new XLSheetPoint(row, col), false);
                     }
                 }
             }


### PR DESCRIPTION
While looking through the ClosedXML source code to understand how array formulas work, I came across this bit of code that looked not quite right. It looks like when loading a workbook, array formula loading iterates through all the cells referenced by the array formula to set the shared strings, but instead of setting it for each cell, it currently appears to just set the master cell over and over again.

It looks like this change happened in commit e49fef9a381da4775a645b3e2f400d4a4bbfe323 when setting formulas was changed to using slices, but maybe a copy-paste mistake missed a required cell address change.

I am definitely not yet familiar with how array formulas work under the hood though, so I might be off base here. Iterating but not changing the call just looked suss to me