### PR TITLE
Ignore `_X00000000_` (capital X followed by 8 hex chars) as XML escaping char for decoding

### DIFF
--- a/ClosedXML.Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XmlEncoderTests.cs
@@ -20,6 +20,9 @@ namespace ClosedXML.Tests.Excel
 
             // https://github.com/ClosedXML/ClosedXML/issues/1154
             Assert.AreEqual("_Xceed_Something", XmlEncoder.DecodeString("_Xceed_Something"));
+
+            // https://github.com/ClosedXML/ClosedXML/issues/2610
+            Assert.AreEqual("DE_XAB500161_seo_title", XmlEncoder.DecodeString("DE_XAB500161_seo_title"));
         }
 
         [Test]

--- a/ClosedXML/Utils/XmlEncoder.cs
+++ b/ClosedXML/Utils/XmlEncoder.cs
@@ -6,8 +6,8 @@ namespace ClosedXML.Utils
 {
     internal static class XmlEncoder
     {
-        private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
-        private static readonly Regex Uppercase_X_HHHHRegex = new Regex("_(X[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
+        private static readonly Regex xHHHHRegex = new Regex("_(x([\\dA-Fa-f]{4}|[\\dA-Fa-f]{8}))_", RegexOptions.Compiled);
+        private static readonly Regex Uppercase_X_HHHHRegex = new Regex("_(X([\\dA-Fa-f]{4}|[\\dA-Fa-f]{8}))_", RegexOptions.Compiled);
 
         public static string EncodeString(string encodeStr)
         {


### PR DESCRIPTION
 
 #### Ignore `_X00000000_` (capital X followed by 8 hex chars) as XML escaping char for decoding. Fixes #2610
 
 ## Investigation
When saving string values, unicode characters that are unsupported by XML are encoded as one of the following formats *(Check [References](#references)  section)*:
1. `_x0000_`
2. `_X0000_`
3. `_x00000000_`
4. `_X00000000_`

**Any hexadecimal characters can be in place of the 0s. And those characters after the `_x` or `_X` represent the unicode hexadecimal code.**

That implies that `_XAB500161_` is a valid escaped unicode character and it's being converted into `š`.

A similar issue was reported before: **Issue #1154**

That issue was fixed in this PR:
https://github.com/ClosedXML/ClosedXML/pull/1155

But this PR only contained a solution that could handle strings with format 1 and format 2 containing 4 hexadecimal characters after `_x` or `_X`.

## Solution
Solution will be to update the regular expressions so that it can handle other two formats of encoded strings containing 8 hexadecimal characters after `_x` or `_X`.


## References
https://github.com/dotnet/corefx/blob/b8b81a66738bb10ef0790023598396861d92b2c4/src/System.Private.Xml/src/System/Xml/XmlConvert.cs#L205

https://github.com/dotnet/corefx/blob/b8b81a66738bb10ef0790023598396861d92b2c4/src/System.Private.Xml/src/System/Xml/XmlConvert.cs#L96
