### PR TITLE
Don't throw on unknown/malformed VML color

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/XLColorTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/XLColorTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel;
+
+public class XLColorTests
+{
+    public static IEnumerable<object[]> VmlColors
+    {
+        get
+        {
+            // Hexadecimal color
+            yield return new object[] { "#F0E0D0", Color.FromArgb(0xF0, 0xE0, 0xD0) };
+
+            // Named color
+            yield return new object[] { "red", Color.Red };
+
+            // Palette color
+            yield return new object[] { "Menu [30]", Color.FromArgb(0xF0, 0xF0, 0xF0) };
+            yield return new object[] { "Menu", Color.FromArgb(0xF0, 0xF0, 0xF0) };
+
+            // Unknown/malformed color
+            yield return new object[] { "#NFOBACKGROUND", Color.FromName("#NFOBACKGROUND") };
+        }
+    }
+
+    [TestCaseSource(nameof(VmlColors))]
+    public void FromVmlColor_converts_hexadecimal_colors(string colorText, Color expectedColor)
+    {
+        var color = XLColor.FromVmlColor(colorText);
+
+        Assert.That(color, Is.EqualTo(XLColor.FromColor(expectedColor)));
+    }
+}

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -101,7 +101,7 @@ namespace ClosedXML.Excel
         /// <returns>Parsed color with full opacity.</returns>
         internal static XLColor FromHexRgb(String hexColorRgb)
         {
-            return FromColor(ColorStringParser.ParseFromRgb(hexColorRgb));
+            return FromColor(ColorStringParser.ParseFromRgb6(hexColorRgb));
         }
 
         public static XLColor FromName(String name)

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Excel
         /// entry, but we have no way to get them. Win10 doesn't even have a tool, use Classic Color Panel. We will use the default
         /// values that are default on Windows.
         /// </summary>
-        private static readonly Lazy<Dictionary<String, XLColor>> _paletteEntries = new(() => new Dictionary<String, XLColor>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Lazy<Dictionary<String, XLColor>> VmlPaletteColors = new(() => new Dictionary<String, XLColor>(StringComparer.OrdinalIgnoreCase)
         {
             { "ButtonFace", FromRgb(0xF0F0F0) },
             { "WindowText", FromRgb(0x000000) },
@@ -45,6 +45,29 @@ namespace ClosedXML.Excel
             { "ThreeDFace", FromRgb(0xF0F0F0) },
             { "ThreeDShadow", FromRgb(0xA0A0A0) },
             { "ThreeDHighlight", FromRgb(0xFFFFFF) }
+        });
+
+        /// <summary>
+        /// Named colors for VML ST_ColorType from ISO-29500:4.
+        /// </summary>
+        private static readonly Lazy<Dictionary<string, XLColor>> VmlNamedColors = new(() => new Dictionary<string, XLColor>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Black", Black },
+            { "Silver", Silver },
+            { "Gray", Gray },
+            { "White", White },
+            { "Maroon", Maroon },
+            { "Red", Red },
+            { "Purple", Purple },
+            { "Fuchsia", Fuchsia },
+            { "Green", Green  },
+            { "Lime", Lime },
+            { "Olive", Olive },
+            { "Yellow", Yellow },
+            { "Navy", Navy },
+            { "Blue", Blue },
+            { "Teal", Teal },
+            { "Aqua", Aqua },
         });
 
         internal static XLColor FromKey(ref XLColorKey key)
@@ -148,21 +171,38 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Parse VML ST_ColorType type from ECMA-376, Part 4 §20.1.2.3.
         /// </summary>
-        internal static XLColor FromVmlColor(String colorType)
+        internal static XLColor FromVmlColor(String vmlColor)
         {
-            // ST_ColorType can have an *optional* index to a palette (*system* palette, not indexed colors),
-            // but it only brings trouble because VML is used pretty much only for unusual features like notes,
-            // form controls ect. Ignore the palette entry completely, it is a legacy feature from times of 256 colors.
-            var paletteIndexStart = colorType.IndexOf("[", StringComparison.Ordinal);
-            var hasPaletteEntry = paletteIndexStart >= 0;
-            colorType = hasPaletteEntry ? colorType.Substring(0, paletteIndexStart).Trim() : colorType;
-            if (colorType.StartsWith("#", StringComparison.Ordinal))
-                return FromHtml(colorType);
+            // Check if VML color is a hexadecimal RGB color.
+            var rgbColorText = vmlColor.AsSpan().Trim();
+            if (rgbColorText.StartsWith("#".AsSpan()) && ColorStringParser.TryParseRgb6(rgbColorText[1..], out var rgbColor))
+            {
+                return FromColor(rgbColor);
+            }
 
-            if (_paletteEntries.Value.TryGetValue(colorType, out var xlColor))
-                return xlColor;
+            // Check if VML color is a VML named color.
+            var namedColorText = vmlColor.Trim();
+            if (VmlNamedColors.Value.TryGetValue(namedColorText, out var namedColor))
+            {
+                return namedColor;
+            }
 
-            return FromName(colorType);
+            // Check if VML color is a palette color. ST_ColorType palette entry can have an *optional* index to
+            // a palette (that is a *system* palette, not indexed colors). The palette index only brings trouble
+            // because VML is used pretty much only for unusual features like notes, form controls ect. Strip the
+            // palette index if found, it is a legacy feature from times of 256 colors.
+            var paletteIndexStart = vmlColor.IndexOf('[');
+            var hasPaletteIndex = paletteIndexStart >= 0;
+            var paletteColorName = hasPaletteIndex ? vmlColor[..paletteIndexStart] : vmlColor;
+            paletteColorName = paletteColorName.Trim();
+            if (VmlPaletteColors.Value.TryGetValue(paletteColorName, out var paletteColor))
+            {
+                return paletteColor;
+            }
+
+            // Don't crash on unparsable colors, e.g. None or malformed #RED should still be represented, even
+            // though we don't actually know how to map them.
+            return FromName(vmlColor);
         }
 
         private static Dictionary<Int32, XLColor>? _indexedColors;

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -612,15 +612,17 @@ namespace ClosedXML.Excel
 
         private void LoadColorsAndLines<T>(IXLDrawing<T> drawing, XElement shape)
         {
-            var strokeColor = shape.Attribute("strokecolor");
-            if (strokeColor != null) drawing.Style.ColorsAndLines.LineColor = XLColor.FromVmlColor(strokeColor.Value);
+            var strokeColor = shape.Attribute(@"strokecolor");
+            if (strokeColor is not null)
+                drawing.Style.ColorsAndLines.LineColor = XLColor.FromVmlColor(strokeColor.Value);
 
-            var strokeWeight = shape.Attribute("strokeweight");
+            var strokeWeight = shape.Attribute(@"strokeweight");
             if (strokeWeight != null && TryGetPtValue(strokeWeight.Value, out var lineWeight))
                 drawing.Style.ColorsAndLines.LineWeight = lineWeight;
 
-            var fillColor = shape.Attribute("fillcolor");
-            if (fillColor != null) drawing.Style.ColorsAndLines.FillColor = XLColor.FromVmlColor(fillColor.Value);
+            var fillColor = shape.Attribute(@"fillcolor");
+            if (fillColor is not null)
+                drawing.Style.ColorsAndLines.FillColor = XLColor.FromVmlColor(fillColor.Value);
 
             var fill = shape.Elements().FirstOrDefault(e => e.Name.LocalName == "fill");
             if (fill != null)

--- a/ClosedXML/Utils/ColorStringParser.cs
+++ b/ClosedXML/Utils/ColorStringParser.cs
@@ -77,31 +77,58 @@ namespace ClosedXML.Utils
         /// <summary>
         /// Parse RRGGBB color.
         /// </summary>
-        internal static Color ParseFromRgb(string rgbColor)
+        internal static Color ParseFromRgb6(string rgbColor)
+        {
+            if (!TryParseRgb6(rgbColor.AsSpan(), out var color))
+                throw new FormatException($"Unable to parse {rgbColor}.");
+
+            return color;
+        }
+
+        internal static bool TryParseRgb6(ReadOnlySpan<char> rgbColor, out Color color)
         {
             if (rgbColor.Length != 6)
-                throw new FormatException("Color should have 6 chars.");
+            {
+                color = default;
+                return false;
+            }
 
-            ReadOnlySpan<char> rgbSpan = rgbColor.AsSpan();
+            if (!TryReadHex(rgbColor, 0, 2, out var red) ||
+                !TryReadHex(rgbColor, 2, 2, out var green) ||
+                !TryReadHex(rgbColor, 4, 2, out var blue))
+            {
+                color = default;
+                return false;
+            }
 
-            return Color.FromArgb(
-                ReadHex(rgbSpan, 0, 2),
-                ReadHex(rgbSpan, 2, 2),
-                ReadHex(rgbSpan, 4, 2));
+            color = Color.FromArgb(red, green, blue);
+            return true;
         }
 
         private static int ReadHex(ReadOnlySpan<char> text, int start, int length)
+        {
+            if (!TryReadHex(text, start, length, out var hexValue))
+                throw new FormatException($"Unable to parse {text.ToString()}.");
+
+            return hexValue;
+        }
+
+        private static bool TryReadHex(ReadOnlySpan<char> text, int start, int length, out int result)
         {
             var value = 0;
             for (var i = start; i < start + length; ++i)
             {
                 if (!TryGetHex(text[i], out var hexDigit))
-                    throw new FormatException($"Unable to parse {text.ToString()}.");
+                {
+                    result = 0;
+                    return false;
+                }
 
                 value = value * 16 + (int)hexDigit;
             }
 
-            return value;
+            result = value;
+            return true;
         }
 
         private static bool TryGetHex(char c, out uint hexDigit)


### PR DESCRIPTION
VML parsing used to throw on strings that started with # and weren't RGB colors, e.g. `#NFOBACKGROUND`. The VML color parsing shouldn't throw on any string. VML is a terrible, barely documented, format and many producers produce a malformed content. Deal with it.

The parsing should now satisfy the `ST_ColorType` structure described in the spec. When it encounters unknown format, use `Color.FromName` that accepts any string (for some it detects correct color, for unknown it just stores name and uses defautl color). If the value is ever written back, we will know the malformed color name to write.

The VmlNamedColors use symbolic names, because that way we can preserve name for roundtrip saving.

Fixes #2627.