### PR TITLE
Add formatting storage

### DIFF
--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -101,6 +101,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTSPLIT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TOCOL/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TOROW/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=twips/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=VSTACK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=WRAPCOLS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=WRAPROWS/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/IO/StylesPartReader.cs
+++ b/ClosedXML/Excel/IO/StylesPartReader.cs
@@ -1,0 +1,314 @@
+﻿using DocumentFormat.OpenXml.Spreadsheet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using ClosedXML.Excel.Formatting;
+using ClosedXML.IO;
+using ClosedXML.Utils;
+using DocumentFormat.OpenXml;
+
+namespace ClosedXML.Excel.IO;
+
+internal class StylesPartReader
+{
+    internal static XLWorkbookStyles Load(Stylesheet stylesheet)
+    {
+        // Load fonts
+        var xlFontFormats = new List<XLFontFormat>();
+        if (stylesheet.Fonts is { } fonts)
+        {
+            xlFontFormats = LoadFonts(fonts);
+        }
+
+        // Load master formatting records, generally used by cells, but also by rows or columns
+        var xlCellFormats = new List<XLCellFormat>();
+        if (stylesheet.CellFormats is { } cellFormats)
+        {
+            xlCellFormats = LoadCellFormats(cellFormats, xlFontFormats);
+        }
+
+        return new XLWorkbookStyles(xlCellFormats, xlFontFormats);
+    }
+
+    private static List<XLFontFormat> LoadFonts(Fonts fonts)
+    {
+        var xlFontFormats = new List<XLFontFormat>();
+        foreach (var font in fonts.Elements<Font>())
+        {
+            var xlFontFormat = LoadFont(font);
+            xlFontFormats.Add(xlFontFormat);
+        }
+
+        return xlFontFormats;
+    }
+
+    private static XLFontFormat LoadFont(Font font)
+    {
+        var name = font.FontName?.Val?.Value;
+        var charset = (XLFontCharSet?)LoadOptionalIntElement(font.FontCharSet);
+        var family = LoadIntEnumElement<XLFontFamilyNumberingValues>(font.FontFamilyNumbering);
+        var bold = LoadOptionalBoolElement(font.Bold);
+        var italic = LoadOptionalBoolElement(font.Italic);
+        var strikethrough = LoadOptionalBoolElement(font.Strike);
+        var outline = LoadOptionalBoolElement(font.Outline);
+        var shadow = LoadOptionalBoolElement(font.Shadow);
+        var condense = LoadOptionalBoolElement(font.Condense);
+        var extend = LoadOptionalBoolElement(font.Extend);
+        var color = LoadOptionalColorElement(font.Color);
+        var sizePt = LoadOptionalDoubleElement(font.FontSize);
+        var underline = LoadOptionalEnumElement(font.Underline, XLFontUnderlineValues.Single);
+        var verticalAlignment = LoadOptionalEnumElement<XLFontVerticalTextAlignmentValues>(font.VerticalTextAlignment);
+        var scheme = LoadOptionalEnumElement<XLFontScheme>(font.FontScheme);
+
+        return new XLFontFormat
+        {
+            Name = name,
+            Charset = charset,
+            Family = family,
+            Bold = bold,
+            Italic = italic,
+            Strikethrough = strikethrough,
+            Outline = outline,
+            Shadow = shadow,
+            Condense = condense,
+            Extend = extend,
+            Color = color,
+            Size = XLFontSize.FromPoints(sizePt),
+            Underline = underline,
+            VerticalAlignment = verticalAlignment,
+            Scheme = scheme,
+        };
+    }
+
+    /// <inheritdoc cref="LoadEnumElement{TEnum}(OpenXmlLeafElement,TEnum)"/>
+    /// <remarks>
+    /// Element is referenced as an optional.
+    /// <code><![CDATA[
+    ///   <xsd:element name="elementName" type="ST_SomeEnum" minOccurs="0" maxOccurs="1"/>
+    /// ]]></code>
+    /// </remarks>
+    private static TEnum? LoadOptionalEnumElement<TEnum>(OpenXmlLeafElement? element, TEnum defaultValue)
+        where TEnum : struct, Enum
+    {
+        if (element is null)
+            return null;
+
+        return LoadEnumElement(element, defaultValue);
+    }
+
+    /// <summary>
+    /// Parse enum with a default value.
+    /// <code><![CDATA[
+    /// <xsd:complexType name="CT_SomeEnumType">
+    ///   <xsd:attribute name="val" type="ST_SomeEnum" use="optional" default="foo"/>
+    /// </xsd:complexType>
+    /// 
+    /// <xsd:simpleType name="ST_SomeEnum">
+    ///   <xsd:restriction base="xsd:string">
+    ///     <xsd:enumeration value = "foo"/>
+    ///     <xsd:enumeration value = "bar"/>
+    ///   </xsd:restriction>
+    /// </xsd:simpleType>
+    /// ]]></code>
+    /// </summary>
+    private static TEnum LoadEnumElement<TEnum>(OpenXmlLeafElement element, TEnum defaultValue)
+        where TEnum : struct, Enum
+    {
+        // OpenXML SDK doesn't have a proper way to check for a specific attribute
+        if (!element.HasAttributes || element.GetAttributes().All(e => e.LocalName != "val"))
+            return defaultValue;
+
+        var attributeText = element.GetAttribute("val", string.Empty).Value;
+        if (string.IsNullOrWhiteSpace(attributeText))
+            throw PartStructureException.InvalidAttributeFormat();
+
+        if (!XmlToEnumMapper.Instance.TryGetEnum<TEnum>(attributeText, out var enumValue))
+            throw PartStructureException.InvalidAttributeFormat(attributeText);
+
+        return enumValue;
+    }
+
+    /// <inheritdoc cref="LoadEnumElement{TEnum}(OpenXmlLeafElement)"/>
+    /// <remarks>
+    /// Element is referenced as an optional.
+    /// <code><![CDATA[
+    ///   <xsd:element name="elementName" type="ST_SomeEnum" minOccurs="0" maxOccurs="1"/>
+    /// ]]></code>
+    /// </remarks>
+    private static TEnum? LoadOptionalEnumElement<TEnum>(OpenXmlLeafElement? element)
+        where TEnum : struct, Enum
+    {
+        if (element is null)
+            return null;
+
+        return LoadEnumElement<TEnum>(element);
+    }
+
+    /// <summary>
+    /// Parse enum.
+    /// <code><![CDATA[
+    /// <xsd:complexType name="CT_SomeEnumType">
+    ///   <xsd:attribute name="val" type="ST_SomeEnum" use="required"/>
+    /// </xsd:complexType>
+    /// 
+    /// <xsd:simpleType name="ST_SomeEnum">
+    ///   <xsd:restriction base="xsd:string">
+    ///     <xsd:enumeration value = "foo"/>
+    ///     <xsd:enumeration value = "bar"/>
+    ///   </xsd:restriction>
+    /// </xsd:simpleType>
+    /// ]]></code>
+    /// </summary>
+    private static TEnum LoadEnumElement<TEnum>(OpenXmlLeafElement element)
+        where TEnum : struct, Enum
+    {
+        var attributeText = element.GetAttribute("val", string.Empty).Value;
+        if (string.IsNullOrWhiteSpace(attributeText))
+            throw PartStructureException.InvalidAttributeFormat();
+
+        if (!XmlToEnumMapper.Instance.TryGetEnum<TEnum>(attributeText, out var enumValue))
+            throw PartStructureException.InvalidAttributeFormat(attributeText);
+
+        return enumValue;
+    }
+
+    /// <summary>
+    /// Load an enum stored in an element. The value is stored as an integer. E.g.,
+    /// <c>&lt;someEnumElement val="12" /&gt;</c>. This method assumes that <typeparamref name="TEnum"/>
+    /// values correspond to the int values in the elements attribute.
+    /// <code><![CDATA[
+    /// <xsd:complexType name="CT_SomeEnum">
+    ///   <xsd:attribute name = "val" type="ST_SomeEnumValues" use="required"/>
+    /// </xsd:complexType>
+    /// 
+    /// <xsd:simpleType name = "ST_SomeEnumValues">
+    ///   <xsd:restriction base="xsd:integer">
+    ///     <xsd:minInclusive value="0"/>
+    ///     <xsd:maxInclusive value="14"/>
+    ///   </xsd:restriction>
+    /// </xsd:simpleType>
+    /// ]]></code>
+    /// </summary>
+    /// <param name="element">The element to parse.</param>
+    private static TEnum? LoadIntEnumElement<TEnum>(OpenXmlLeafElement? element)
+        where TEnum : struct, Enum
+    {
+        if (element is null)
+            return null;
+
+        var attributeText = element.GetAttribute("val", string.Empty).Value;
+        if (string.IsNullOrWhiteSpace(attributeText))
+            throw PartStructureException.InvalidAttributeFormat();
+
+        var intValue = XmlConvert.ToInt32(attributeText);
+        if (!Enum.IsDefined(typeof(TEnum), intValue))
+            throw PartStructureException.InvalidAttributeFormat(attributeText);
+
+        return (TEnum)Enum.ToObject(typeof(TEnum), intValue);
+    }
+
+    private static List<XLCellFormat> LoadCellFormats(CellFormats cellFormats, IReadOnlyList<XLFontFormat> xlFontFormats)
+    {
+        var xlCellFormats = new List<XLCellFormat>();
+        foreach (var cellFormat in cellFormats.Elements<CellFormat>())
+        {
+            var xlCellFormat = LoadCellFormat(cellFormat, xlFontFormats);
+            xlCellFormats.Add(xlCellFormat);
+        }
+
+        return xlCellFormats;
+    }
+
+    private static XLCellFormat LoadCellFormat(CellFormat cellFormat, IReadOnlyList<XLFontFormat> xlFontFormats)
+    {
+        var xlCellFormat = new XLCellFormat();
+        if (cellFormat.FontId?.Value is { } fontId && fontId < xlFontFormats.Count)
+        {
+            xlCellFormat = new XLCellFormat { Font = xlFontFormats[(int)fontId] };
+        }
+
+        return xlCellFormat;
+    }
+
+    /// <summary>
+    /// Read optional <c>CT_BooleanProperty</c>.
+    /// </summary>
+    private static bool? LoadOptionalBoolElement(BooleanPropertyType? optionalElement)
+    {
+        return optionalElement is not null ? LoadBoolElement(optionalElement) : null;
+    }
+
+    /// <summary>
+    /// Read <c>CT_BooleanProperty</c>.
+    /// </summary>
+    private static bool LoadBoolElement(BooleanPropertyType element)
+    {
+        return element.Val?.Value ?? true; // Default value is true
+    }
+
+    /// <summary>
+    /// Read optional <c>CT_IntProperty</c>.
+    /// </summary>
+    private static int? LoadOptionalIntElement(OpenXmlLeafElement? optionalElement)
+    {
+        return optionalElement is not null ? LoadIntElement(optionalElement) : null;
+    }
+
+    /// <summary>
+    /// Read <c>CT_IntProperty</c>.
+    /// </summary>
+    private static int LoadIntElement(OpenXmlLeafElement element)
+    {
+        var attributeText = element.GetAttribute("val", string.Empty).Value;
+        if (string.IsNullOrWhiteSpace(attributeText))
+            throw PartStructureException.InvalidAttributeFormat();
+
+        return XmlConvert.ToInt32(attributeText);
+    }
+
+    /// <inheritdoc cref="LoadDoubleElement"/>
+    private static double? LoadOptionalDoubleElement(OpenXmlLeafElement? optionalElement)
+    {
+        return optionalElement is not null ? LoadDoubleElement(optionalElement) : null;
+    }
+
+    /// <summary>
+    /// Load a double stored in an element. E.g., <c>&lt;someEnumElement val="12.4" /&gt;</c>. The
+    /// <c>val</c> is a required attribute. The schema doesn't have directly an element for that,
+    /// but there are several compatible ones like <c>CT_FontSize</c>.
+    /// <code><![CDATA[
+    /// <xsd:complexType name="CT_SomeType">
+    ///   <xsd:attribute name="val" type="xsd:double" use="required"/>
+    /// </xsd:complexType>
+    /// ]]></code>
+    /// </summary>
+    private static double LoadDoubleElement(OpenXmlLeafElement element)
+    {
+        var attributeText = element.GetAttribute("val", string.Empty).Value;
+        if (string.IsNullOrWhiteSpace(attributeText))
+            throw PartStructureException.InvalidAttributeFormat();
+
+        return XmlConvert.ToDouble(attributeText);
+    }
+
+    /// <summary>
+    /// Load an <c>CT_Color</c> from an optional element. It should be declared as <code><![CDATA[
+    /// <xsd:element name="colorElementName" type="CT_Color" minOccurs="0" maxOccurs="1"/>
+    /// ]]></code>
+    /// </summary>
+    private static XLColor? LoadOptionalColorElement(Color? optionalElement)
+    {
+        return optionalElement is not null ? LoadColorElement(optionalElement) : null;
+    }
+
+    /// <summary>
+    /// Load an <c>CT_Color</c> from an required element. It should be declared as <code><![CDATA[
+    /// <xsd:element name="colorElementName" type="CT_Color" />
+    /// ]]></code>
+    /// </summary>
+    private static XLColor LoadColorElement(Color element)
+    {
+        return element.ToClosedXMLColor();
+    }
+}

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -29,9 +29,9 @@ internal class WorksheetPartReader
     private Int32 _lastRow;
     private Int32 _lastColumnNumber;
 
-    internal void LoadWorksheet(XLWorksheet ws, Stylesheet s, Fills fills, Borders borders, Fonts fonts, NumberingFormats numberingFormats, WorksheetPart worksheetPart, SharedStringItem[] sharedStrings, Dictionary<int, DifferentialFormat> differentialFormats, LoadContext context)
+    internal void LoadWorksheet(XLWorksheet ws, Stylesheet s, Fills fills, Borders borders, NumberingFormats numberingFormats, WorksheetPart worksheetPart, SharedStringItem[] sharedStrings, Dictionary<int, DifferentialFormat> differentialFormats, LoadContext context)
     {
-        ApplyStyle(ws, 0, s, fills, borders, fonts, numberingFormats);
+        ApplyStyle(ws, 0, s, fills, borders, numberingFormats, ws.Workbook.Styles);
 
         var styleList = new Dictionary<int, IXLStyle>();// {{0, ws.Style}};
         PageSetupProperties pageSetupProperties = null;
@@ -79,11 +79,11 @@ internal class WorksheetPartReader
                     }
                 }
                 else if (reader.ElementType == typeof(Columns))
-                    LoadColumns(s, numberingFormats, fills, borders, fonts, ws,
+                    LoadColumns(s, numberingFormats, fills, borders, ws,
                         (Columns)reader.LoadCurrentElement());
                 else if (reader.ElementType == typeof(Row))
                 {
-                    LoadRow(s, numberingFormats, fills, borders, fonts, ws, sharedStrings, styleList, reader);
+                    LoadRow(s, numberingFormats, fills, borders, ws, sharedStrings, styleList, reader);
                 }
                 else if (reader.ElementType == typeof(AutoFilter))
                     AutoFilterReader.LoadAutoFilter((AutoFilter)reader.LoadCurrentElement(), ws);
@@ -148,7 +148,7 @@ internal class WorksheetPartReader
     }
 
     private static void LoadColumns(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders,
-                             Fonts fonts, XLWorksheet ws, Columns columns)
+                             XLWorksheet ws, Columns columns)
     {
         if (columns == null) return;
 
@@ -162,7 +162,7 @@ internal class WorksheetPartReader
                                       ? Int32.Parse(wsDefaultColumn.Style.InnerText)
                                       : -1;
         if (styleIndexDefault >= 0)
-            ApplyStyle(ws, styleIndexDefault, s, fills, borders, fonts, numberingFormats);
+            ApplyStyle(ws, styleIndexDefault, s, fills, borders, numberingFormats, ws.Workbook.Styles);
 
         foreach (Column col in columns.Elements<Column>())
         {
@@ -194,7 +194,7 @@ internal class WorksheetPartReader
             Int32 styleIndex = col.Style != null ? Int32.Parse(col.Style.InnerText) : -1;
             if (styleIndex >= 0)
             {
-                ApplyStyle(xlColumns, styleIndex, s, fills, borders, fonts, numberingFormats);
+                ApplyStyle(xlColumns, styleIndex, s, fills, borders, numberingFormats, ws.Workbook.Styles);
             }
             else
             {
@@ -204,7 +204,7 @@ internal class WorksheetPartReader
     }
 
 
-    private void LoadRow(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders, Fonts fonts,
+    private void LoadRow(Stylesheet s, NumberingFormats numberingFormats, Fills fills, Borders borders,
                           XLWorksheet ws, SharedStringItem[] sharedStrings,
                           Dictionary<Int32, IXLStyle> styleList,
                           OpenXmlPartReader reader)
@@ -255,7 +255,7 @@ internal class WorksheetPartReader
             var styleIndex = attributes.GetIntAttribute("s");
             if (styleIndex is not null)
             {
-                ApplyStyle(xlRow, styleIndex.Value, s, fills, borders, fonts, numberingFormats);
+                ApplyStyle(xlRow, styleIndex.Value, s, fills, borders, numberingFormats, ws.Workbook.Styles);
             }
             else
             {
@@ -270,7 +270,7 @@ internal class WorksheetPartReader
 
         while (reader.IsStartElement("c"))
         {
-            LoadCell(sharedStrings, s, numberingFormats, fills, borders, fonts, ws, styleList,
+            LoadCell(sharedStrings, s, numberingFormats, fills, borders, ws, styleList,
                 reader, rowIndex);
 
             // Move from end element of 'cell' either to next cell, extList start or end of row.
@@ -283,7 +283,7 @@ internal class WorksheetPartReader
     }
 
     private void LoadCell(SharedStringItem[] sharedStrings, Stylesheet s, NumberingFormats numberingFormats,
-                          Fills fills, Borders borders, Fonts fonts,
+                          Fills fills, Borders borders,
                           XLWorksheet ws, Dictionary<Int32, IXLStyle> styleList, OpenXmlPartReader reader, Int32 rowIndex)
     {
         Debug.Assert(reader.LocalName == "c" && reader.IsStartElement);
@@ -316,7 +316,7 @@ internal class WorksheetPartReader
         }
         else
         {
-            ApplyStyle(xlCell, styleIndex, s, fills, borders, fonts, numberingFormats);
+            ApplyStyle(xlCell, styleIndex, s, fills, borders, numberingFormats, ws.Workbook.Styles);
         }
 
         var showPhonetic = attributes.GetBoolAttribute("ph", false);
@@ -1239,10 +1239,10 @@ internal class WorksheetPartReader
     }
 
     private static void ApplyStyle(IXLStylized xlStylized, Int32 styleIndex, Stylesheet s, Fills fills, Borders borders,
-        Fonts fonts, NumberingFormats numberingFormats)
+        NumberingFormats numberingFormats, XLWorkbookStyles styles)
     {
         var xlStyleKey = XLStyle.Default.Key;
-        XLWorkbook.LoadStyle(ref xlStyleKey, styleIndex, s, fills, borders, fonts, numberingFormats);
+        XLWorkbook.LoadStyle(ref xlStyleKey, styleIndex, s, fills, borders, numberingFormats, styles);
 
         // When loading columns we must propagate style to each column but not deeper. In other cases we do not propagate at all.
         if (xlStylized is IXLColumns columns)

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -1,0 +1,23 @@
+﻿namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// <para>
+/// A master formatting record that determines a direct formatting of a cell/column/row. The final
+/// formatting used to render a cell is determined by composition of multiple master formatting
+/// records at multiple levels. The least specific is the default one, unrelated to a workbook.
+/// Next level is a workbook formatting record, represented by normal style. Next is column or row
+/// one and the most specific one is in the cell.
+/// </para>
+/// <para>
+/// Master formatting record has optional properties. The unspecified properties are set through
+/// formatting records composition. The <see cref="XLStyleKey"/> (or its reference form
+/// <see cref="XLStyleValue"/>) has everything specified, because it is the final formatting of a
+/// cell.
+/// </para>
+/// </summary>
+internal readonly record struct XLCellFormat
+{
+    public XLFontFormat? Font { get; init; }
+
+    // TODO: Add remaining properties. For now only font
+}

--- a/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
@@ -1,0 +1,37 @@
+﻿namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// A formatting record for <see cref="XLCellFormat"/>. Unlike <see cref="XLFontKey"/>, attributes are optional.
+/// </summary>
+internal readonly record struct XLFontFormat
+{
+    public required XLFontName? Name { get; init; }
+
+    public required XLFontCharSet? Charset { get; init; }
+
+    public required XLFontFamilyNumberingValues? Family { get; init; }
+
+    public required bool? Bold { get; init; }
+
+    public required bool? Italic { get; init; }
+
+    public required bool? Strikethrough { get; init; }
+
+    public required bool? Outline { get; init; }
+
+    public required bool? Shadow { get; init; }
+
+    public required bool? Condense { get; init; }
+
+    public required bool? Extend { get; init; }
+
+    public required XLColor? Color { get; init; }
+
+    public required XLFontSize? Size { get; init; }
+
+    public required XLFontUnderlineValues? Underline { get; init; }
+
+    public required XLFontVerticalTextAlignmentValues? VerticalAlignment { get; init; }
+
+    public required XLFontScheme? Scheme { get; init; }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
@@ -34,4 +34,46 @@ internal readonly record struct XLFontFormat
     public required XLFontVerticalTextAlignmentValues? VerticalAlignment { get; init; }
 
     public required XLFontScheme? Scheme { get; init; }
+
+    public XLFontKey ApplyTo(XLFontKey nf)
+    {
+        // No Outline, Condense or Extend
+        if (Name is not null)
+            nf = nf with { FontName = Name.Value.Text };
+
+        if (Charset is not null)
+            nf = nf with { FontCharSet = Charset.Value };
+
+        if (Family is not null)
+            nf = nf with { FontFamilyNumbering = Family.Value };
+
+        if (Bold is not null)
+            nf = nf with { Bold = Bold.Value };
+
+        if (Italic is not null)
+            nf = nf with { Italic = Italic.Value };
+
+        if (Strikethrough is not null)
+            nf = nf with { Strikethrough = Strikethrough.Value };
+
+        if (Shadow is not null)
+            nf = nf with { Shadow = Shadow.Value };
+
+        if (Color is not null)
+            nf = nf with { FontColor = Color.Key };
+
+        if (Size is not null)
+            nf = nf with { FontSize = Size.Value.Points };
+
+        if (Underline is not null)
+            nf = nf with { Underline = Underline.Value };
+
+        if (VerticalAlignment is not null)
+            nf = nf with { VerticalAlignment = VerticalAlignment.Value };
+
+        if (Scheme is not null)
+            nf = nf with { FontScheme = Scheme.Value };
+
+        return nf;
+    }
 }

--- a/ClosedXML/Excel/Style/XLFontName.cs
+++ b/ClosedXML/Excel/Style/XLFontName.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A font name, two font names are equal when they are case insensitive equal. It is a custom
+/// class because that way <see cref="XLFontFormat"/> and other structures don't have to implement
+/// custom ahs code and equality methods.
+/// </summary>
+internal readonly record struct XLFontName
+{
+    private const StringComparison Comparison = StringComparison.OrdinalIgnoreCase;
+
+    private XLFontName(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException(nameof(text));
+
+        Text = text;
+    }
+
+    public string Text { get; }
+
+    public override int GetHashCode()
+    {
+        return Text.GetHashCode(Comparison);
+    }
+
+    public bool Equal(XLFontName other)
+    {
+        return string.Equals(Text, other.Text, Comparison);
+    }
+
+    [return: NotNullIfNotNull(nameof(text))]
+    public static implicit operator XLFontName?(string? text) => !string.IsNullOrWhiteSpace(text) ? new XLFontName(text) : null;
+}

--- a/ClosedXML/Excel/Style/XLFontSize.cs
+++ b/ClosedXML/Excel/Style/XLFontSize.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Size of a font stored in twips. Storing font size as double causes various problems with
+/// equality of font size. Per MS-OI29500: Office converts the points provided to twips, and
+/// rounding may occur when writing sz@val back to SpreadsheetML files.
+/// </summary>
+internal readonly record struct XLFontSize(short Twips)
+{
+    [return: NotNullIfNotNull(nameof(sizeInPoints))]
+    public static XLFontSize? FromPoints(double? sizeInPoints)
+    {
+        if (sizeInPoints is null)
+            return null;
+
+        var twips = Math.Round(sizeInPoints.Value * 20, MidpointRounding.AwayFromZero);
+        return new XLFontSize(checked((short)twips));
+    }
+}

--- a/ClosedXML/Excel/Style/XLFontSize.cs
+++ b/ClosedXML/Excel/Style/XLFontSize.cs
@@ -19,4 +19,9 @@ internal readonly record struct XLFontSize(short Twips)
         var twips = Math.Round(sizeInPoints.Value * 20, MidpointRounding.AwayFromZero);
         return new XLFontSize(checked((short)twips));
     }
+
+    /// <summary>
+    /// Font size converted to points. Can have rounding issues, so use only when necessary.
+    /// </summary>
+    public double Points => Twips / 20.0;
 }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -1,0 +1,25 @@
+﻿using ClosedXML.Excel.Formatting;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A container for styles and formatting records in a workbook.
+/// </summary>
+internal class XLWorkbookStyles
+{
+    /// <summary>
+    /// The index is XfId, the value is formatting record.
+    /// </summary>
+    private List<XLCellFormat> _masterFormats;
+
+    private readonly List<XLFontFormat> _fontFormats;
+
+    internal XLWorkbookStyles(List<XLCellFormat> masterFormats, List<XLFontFormat> fontFormats)
+    {
+        _masterFormats = masterFormats;
+        _fontFormats = fontFormats;
+    }
+
+    internal IReadOnlyList<XLFontFormat> FontFormats => _fontFormats;
+}

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using ClosedXML.Excel.Formatting;
 using static ClosedXML.Excel.XLProtectionAlgorithm;
 
 namespace ClosedXML.Excel
@@ -129,6 +130,8 @@ namespace ClosedXML.Excel
         internal XLPivotCaches PivotCachesInternal { get; }
 
         internal SharedStringTable SharedStringTable { get; } = new();
+
+        internal XLWorkbookStyles Styles { get; set; } = new(new List<XLCellFormat>(), new List<XLFontFormat>());
 
         #region Nested Type : XLLoadSource
 

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -177,6 +177,11 @@ namespace ClosedXML.Excel
             }
 
             Stylesheet s = workbookPart.WorkbookStylesPart?.Stylesheet;
+            if (s is not null)
+            {
+                Styles = StylesPartReader.Load(s);
+            }
+
             NumberingFormats numberingFormats = s?.NumberingFormats;
             context.LoadNumberFormats(numberingFormats);
             Fills fills = s?.Fills;

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -186,7 +186,6 @@ namespace ClosedXML.Excel
             context.LoadNumberFormats(numberingFormats);
             Fills fills = s?.Fills;
             Borders borders = s?.Borders;
-            Fonts fonts = s?.Fonts;
             Int32 dfCount = 0;
             Dictionary<Int32, DifferentialFormat> differentialFormats;
             if (s != null && s.DifferentialFormats != null)
@@ -199,7 +198,7 @@ namespace ClosedXML.Excel
             if (normalStyle != null)
             {
                 var normalStyleKey = ((XLStyle)Style).Key;
-                LoadStyle(ref normalStyleKey, (Int32)normalStyle.FormatId.Value, s, fills, borders, fonts, numberingFormats);
+                LoadStyle(ref normalStyleKey, (Int32)normalStyle.FormatId.Value, s, fills, borders, numberingFormats, Styles);
                 Style = new XLStyle(null, normalStyleKey);
                 ColumnWidth = XLHelper.CalculateColumnWidth(8, Style.Font, this);
             }
@@ -272,7 +271,7 @@ namespace ClosedXML.Excel
                 }
 
                 var worksheetPartReader = new WorksheetPartReader();
-                worksheetPartReader.LoadWorksheet(ws, s, fills, borders, fonts, numberingFormats, worksheetPart, sharedStrings, differentialFormats, context);
+                worksheetPartReader.LoadWorksheet(ws, s, fills, borders, numberingFormats, worksheetPart, sharedStrings, differentialFormats, context);
 
                 ws.ConditionalFormats.ReorderAccordingToOriginalPriority();
 
@@ -1161,7 +1160,7 @@ namespace ClosedXML.Excel
         }
 
         internal static void LoadStyle(ref XLStyleKey xlStyle, Int32 styleIndex, Stylesheet s, Fills fills, Borders borders,
-                                Fonts fonts, NumberingFormats numberingFormats)
+                                NumberingFormats numberingFormats, XLWorkbookStyles styles)
         {
             if (s == null || s.CellFormats is null) return; //No Stylesheet, no Styles
 
@@ -1209,15 +1208,11 @@ namespace ClosedXML.Excel
                 }
             }
 
-            if (UInt32HasValue(cellFormat.FontId))
+            if (cellFormat.FontId?.Value is { } fontId && fontId < styles.FontFormats.Count)
             {
-                var fontId = cellFormat.FontId;
-                var font = (DocumentFormat.OpenXml.Spreadsheet.Font)fonts.ElementAt((Int32)fontId.Value);
-                if (font is not null)
-                {
-                    var xlFont = OpenXmlHelper.FontToClosedXml(font, xlStyle.Font);
-                    xlStyle = xlStyle with { Font = xlFont };
-                }
+                var xlFontFormat = styles.FontFormats[(int)fontId];
+                var xlFont = xlFontFormat.ApplyTo(xlStyle.Font);
+                xlStyle = xlStyle with { Font = xlFont };
             }
 
             if (UInt32HasValue(cellFormat.NumberFormatId))


### PR DESCRIPTION
This is an initial commit to create centralized repository for formatting records. The `XLStyleKey`/`XLStyleValue` are a final formatting records that specify all properties of format.

That is not how styles are represented or used in workbook. Formatting record contains only some selected attributes, the rest is determined by other formatting records in a hierarchy.

This final-format-representation has many problems when it comes to modifying styles. Named styles are also missing. 

This adds a `StylesPartReader` and starts storing formatting records in a workbook. For now, it only has fonts, will add rest.