### PR TITLE
CodeGen - read simple type union

### DIFF
--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/IValueRestriction.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/IValueRestriction.cs
@@ -1,0 +1,3 @@
+﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
+public interface IValueRestriction;

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictEnumeration.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictEnumeration.cs
@@ -1,0 +1,15 @@
+﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
+/// <summary>
+/// Value of <see cref="ISimpleType"/> can be the <paramref name="Value"/>.
+/// <example>
+/// <code><![CDATA[
+///   <xsd:restriction base="xsd:string">
+///     <xsd:enumeration value="none"/>
+///     <xsd:enumeration value="thin"/>
+///   </xsd:restriction>
+/// ]]></code>
+/// </example>
+/// </summary>
+/// <param name="Value">Allowed value of simple type.</param>
+public record RestrictEnumeration(string Value) : IValueRestriction;

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictLength.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictLength.cs
@@ -1,0 +1,13 @@
+﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
+/// <summary>
+/// Length of a <see cref="ISimpleType"/> must have a specified length.
+/// <example>
+/// <code><![CDATA[
+///   <xsd:restriction base="xsd:hexBinary">
+///     <xsd:length value="4"/>
+///   </xsd:restriction>
+/// ]]></code>
+/// </example>
+/// </summary>
+public record RestrictLength(int Value) : IValueRestriction;

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictMaxInclusive.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictMaxInclusive.cs
@@ -1,0 +1,13 @@
+﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
+/// <summary>
+/// Numerical value must be at most the specified value.
+/// <example>
+/// <code><![CDATA[
+///   <xsd:restriction base="xsd:nonNegativeInteger">
+///     <xsd:maxInclusive value="180"/>
+///   </ xsd:restriction>
+/// ]]></code>
+/// </example>
+/// </summary>
+public record RestrictMaxInclusive(int Value) : IValueRestriction;

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictMinInclusive.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/RestrictMinInclusive.cs
@@ -1,0 +1,14 @@
+﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
+/// <summary>
+/// Numerical value must be at least the specified value.
+/// <example>
+/// <code><![CDATA[
+///   <xsd:restriction base="xsd:integer">
+///     <xsd:minInclusive value="0"/>
+///     <xsd:maxInclusive value="14"/>
+///   </xsd:restriction>
+/// ]]></code>
+/// </example>
+/// </summary>
+public record RestrictMinInclusive(int Value) : IValueRestriction;

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/Restriction.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/Restriction.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
+/// <summary>
+/// A definition of a restriction of a <see cref="ISimpleType"/> through a base type and additional
+/// restrictions of possible values.
+/// </summary>
+public class Restriction
+{
+    /// <summary>
+    /// Name of a base type, e.g., <c>xsd:string</c>.
+    /// </summary>
+    public required string BaseTypeName {get; init; }
+
+    /// <summary>
+    /// Additional restrictions on possible values.
+    /// </summary>
+    public required List<IValueRestriction> ValueRestrictions { get; init; }
+}

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleType.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleType.cs
@@ -3,7 +3,8 @@
 namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
 
 /// <summary>
-/// <c><![CDATA[<xsd:simpleType>]]></c> inside <c><![CDATA[<xsd:schema>]]></c>.
+/// <c><![CDATA[<xsd:simpleType>]]></c> inside <c><![CDATA[<xsd:schema>]]></c>. The allowed values
+/// are restricted by <see cref="Restrictions"/>.
 /// <example>
 /// <code><![CDATA[
 /// <xsd:simpleType name="ST_Something">
@@ -15,20 +16,14 @@ namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
 /// ]]></code>
 /// </example>
 /// </summary>
-public class SimpleTypeEnum : ISimpleType
+public class SimpleType : ISimpleType
 {
     public required string Name { get; init; }
 
     public required string BaseTypeName { get; init; }
 
     /// <summary>
-    /// List of enum values.
+    /// Conditions the value must satisfy.
     /// </summary>
-    public required List<string> Values { get; init; }
-
-    public required int? Length { get; init; }
-
-    public required int? MinInclusive { get; init; }
-
-    public required int? MaxInclusive { get; init; }
+    public required List<IValueRestriction> Restrictions { get; init; }
 }

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeUnion.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeUnion.cs
@@ -1,7 +1,10 @@
-﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+﻿using System.Collections.Generic;
 
-// TODO: Implement
+namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+
 public class SimpleTypeUnion : ISimpleType
 {
     public required string Name { get; init; }
+
+    public required List<Restriction> RestrictionsUnion { get; init; } = [];
 }

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Xml.Linq;
 using ClosedXML.IO.CodeGen.Model;
 using ClosedXML.IO.CodeGen.Model.Elements;
 using ClosedXML.IO.CodeGen.Model.SimpleTypes;
@@ -157,52 +155,14 @@ public class XsdSchemaParser
         var simpleTypeName = reader.GetString("name");
         if (reader.TryOpen("restriction", XsdNs))
         {
-            var baseType = reader.GetString("base");
-
-            int? length = null;
-            int? minInclusive = null;
-            int? maxInclusive = null;
-            var values = new List<string>();
-
-            while (!reader.TryClose("restriction", XsdNs))
-            {
-                if (reader.TryOpen("enumeration", XsdNs))
-                {
-                    var value = reader.GetString("value");
-                    values.Add(value);
-                    reader.Close("enumeration", XsdNs);
-                }
-                else if (reader.TryOpen("length", XsdNs))
-                {
-                    length = reader.GetInt("value");
-                    reader.Close("length", XsdNs);
-                }
-                else if (reader.TryOpen("minInclusive", XsdNs))
-                {
-                    minInclusive = reader.GetInt("value");
-                    reader.Close("minInclusive", XsdNs);
-                }
-                else if (reader.TryOpen("maxInclusive", XsdNs))
-                {
-                    maxInclusive = reader.GetInt("value");
-                    reader.Close("maxInclusive", XsdNs);
-                }
-                else
-                {
-                    throw PartStructureException.ExpectedChoiceElementNotFound(reader);
-                }
-            }
-
+            var restriction = ParseRestriction(reader);
             reader.Close("simpleType", XsdNs);
 
-            return new SimpleTypeEnum
+            return new SimpleType
             {
                 Name = simpleTypeName,
-                BaseTypeName = baseType,
-                Values = values,
-                Length = length,
-                MinInclusive = minInclusive,
-                MaxInclusive = maxInclusive
+                BaseTypeName = restriction.BaseTypeName,
+                Restrictions = restriction.ValueRestrictions,
             };
         }
 
@@ -221,17 +181,71 @@ public class XsdSchemaParser
 
         if (reader.TryOpen("union", XsdNs))
         {
-            // TODO: Implement, but it's a minor use
-            reader.Skip();
+            var unionRestrictions = new List<Restriction>();
+            while (reader.TryOpen("simpleType", XsdNs))
+            {
+                reader.Open("restriction", XsdNs);
+                var restriction = ParseRestriction(reader);
+                reader.Close("simpleType", XsdNs);
+
+                unionRestrictions.Add(restriction);
+            }
+
+            reader.Close("union", XsdNs);
             reader.Close("simpleType", XsdNs);
 
             return new SimpleTypeUnion
             {
-                Name = simpleTypeName
+                Name = simpleTypeName,
+                RestrictionsUnion = unionRestrictions
             };
         }
 
         throw PartStructureException.ExpectedChoiceElementNotFound(reader);
+    }
+
+    private static Restriction ParseRestriction(XmlTreeReader reader)
+    {
+        var baseType = reader.GetString("base");
+        var valueRestrictions = new List<IValueRestriction>();
+
+        while (!reader.TryClose("restriction", XsdNs))
+        {
+            if (reader.TryOpen("enumeration", XsdNs))
+            {
+                var value = reader.GetString("value");
+                valueRestrictions.Add(new RestrictEnumeration(value));
+                reader.Close("enumeration", XsdNs);
+            }
+            else if (reader.TryOpen("length", XsdNs))
+            {
+                var length = reader.GetInt("value");
+                valueRestrictions.Add(new RestrictLength(length));
+                reader.Close("length", XsdNs);
+            }
+            else if (reader.TryOpen("minInclusive", XsdNs))
+            {
+                var minInclusive = reader.GetInt("value");
+                valueRestrictions.Add(new RestrictMinInclusive(minInclusive));
+                reader.Close("minInclusive", XsdNs);
+            }
+            else if (reader.TryOpen("maxInclusive", XsdNs))
+            {
+                var maxInclusive = reader.GetInt("value");
+                valueRestrictions.Add(new RestrictMaxInclusive(maxInclusive));
+                reader.Close("maxInclusive", XsdNs);
+            }
+            else
+            {
+                throw PartStructureException.ExpectedChoiceElementNotFound(reader);
+            }
+        }
+
+        return new Restriction
+        {
+            BaseTypeName = baseType,
+            ValueRestrictions = valueRestrictions
+        };
     }
 
     private static AttributeGroupDefinition ParseAttributeGroupDefinition(XmlTreeReader reader)


### PR DESCRIPTION
This changes enables `XsdSchemaParser` to read union simple types. Currently only the one in xml.xsd, i.e.
```xml
  <xsd:simpleType name="ST_TextRotation">
    <xsd:union>
      <xsd:simpleType>
        <xsd:restriction base="xsd:nonNegativeInteger">
          <xsd:maxInclusive value="180"/>
        </xsd:restriction>
      </xsd:simpleType>
      <xsd:simpleType>
        <xsd:restriction base="xsd:nonNegativeInteger">
          <xsd:enumeration value="255"/>
        </xsd:restriction>
      </xsd:simpleType>
    </xsd:union>
  </xsd:simpleType>
```