### PR TITLE
Codegen - Add a xsd copy visitor

### DIFF
--- a/ClosedXML.IO.CodeGen/ClosedXML.IO.CodeGen.csproj
+++ b/ClosedXML.IO.CodeGen/ClosedXML.IO.CodeGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ClosedXML.IO.CodeGen/INode.cs
+++ b/ClosedXML.IO.CodeGen/INode.cs
@@ -1,7 +1,7 @@
 ﻿namespace ClosedXML.IO.CodeGen;
 
 /// <summary>
-/// A visitor pattern node, used by a <see cref="IXsdVisitor{T}"/>.
+/// A node visited by a <see cref="IXsdVisitor{TResult}"/>.
 /// </summary>
 public interface INode
 {

--- a/ClosedXML.IO.CodeGen/INode.cs
+++ b/ClosedXML.IO.CodeGen/INode.cs
@@ -1,0 +1,9 @@
+﻿namespace ClosedXML.IO.CodeGen;
+
+/// <summary>
+/// A visitor pattern node, used by a <see cref="IXsdVisitor{T}"/>.
+/// </summary>
+public interface INode
+{
+    T Accept<T>(IXsdVisitor<T> visitor);
+}

--- a/ClosedXML.IO.CodeGen/IXsdVisitor.cs
+++ b/ClosedXML.IO.CodeGen/IXsdVisitor.cs
@@ -6,12 +6,24 @@ using ClosedXML.IO.CodeGen.Model.TopLevel;
 namespace ClosedXML.IO.CodeGen;
 
 /// <summary>
-/// A visitor for visitor pattern.
+/// A visitor for visiting <see cref="INode">nodes</see> and running a code for each type of a node.
 /// </summary>
 /// <typeparam name="TResult">Type of returned value.</typeparam>
 public interface IXsdVisitor<out TResult>
 {
     TResult Visit(Schema schema);
+
+    TResult Visit(SimpleType simpleType);
+
+    TResult Visit(SimpleTypeList simpleType);
+
+    TResult Visit(SimpleTypeUnion simpleType);
+
+    TResult Visit(ElementDefinition elementDefinition);
+
+    TResult Visit(GroupDefinition groupDefinition);
+
+    TResult Visit(AttributeGroupDefinition attributeGroupDefinition);
 
     TResult Visit(ComplexTypeSequence complexType);
 
@@ -21,31 +33,19 @@ public interface IXsdVisitor<out TResult>
 
     TResult Visit(ComplexTypeElement complexType);
 
-    TResult Visit(ElementDefinition elementDefinition);
-
-    TResult Visit(GroupDefinition groupDefinition);
-
-    TResult Visit(AttributeGroupDefinition attributeGroupDefinition);
-
     TResult Visit(AttributeElement attributeElement);
 
     TResult Visit(AttributeGroupReference attributeGroupReference);
 
-    TResult Visit(SimpleType simpleType);
-
-    TResult Visit(SimpleTypeList simpleTypeList);
-
-    TResult Visit(SimpleTypeUnion simpleTypeUnion);
-
-    TResult Visit(GroupReference groupReference);
-
-    TResult Visit(Any any);
+    TResult Visit(Sequence sequence);
 
     TResult Visit(Choice choice);
 
     TResult Visit(ElementType elementType);
 
-    TResult Visit(Sequence sequence);
-
     TResult Visit(ElementReference elementReference);
+
+    TResult Visit(GroupReference groupReference);
+
+    TResult Visit(Any any);
 }

--- a/ClosedXML.IO.CodeGen/IXsdVisitor.cs
+++ b/ClosedXML.IO.CodeGen/IXsdVisitor.cs
@@ -1,0 +1,51 @@
+﻿using ClosedXML.IO.CodeGen.Model;
+using ClosedXML.IO.CodeGen.Model.Elements;
+using ClosedXML.IO.CodeGen.Model.SimpleTypes;
+using ClosedXML.IO.CodeGen.Model.TopLevel;
+
+namespace ClosedXML.IO.CodeGen;
+
+/// <summary>
+/// A visitor for visitor pattern.
+/// </summary>
+/// <typeparam name="TResult">Type of returned value.</typeparam>
+public interface IXsdVisitor<out TResult>
+{
+    TResult Visit(Schema schema);
+
+    TResult Visit(ComplexTypeSequence complexType);
+
+    TResult Visit(ComplexTypeChoice complexType);
+
+    TResult Visit(ComplexTypeSimpleContent complexType);
+
+    TResult Visit(ComplexTypeElement complexType);
+
+    TResult Visit(ElementDefinition elementDefinition);
+
+    TResult Visit(GroupDefinition groupDefinition);
+
+    TResult Visit(AttributeGroupDefinition attributeGroupDefinition);
+
+    TResult Visit(AttributeElement attributeElement);
+
+    TResult Visit(AttributeGroupReference attributeGroupReference);
+
+    TResult Visit(SimpleType simpleType);
+
+    TResult Visit(SimpleTypeList simpleTypeList);
+
+    TResult Visit(SimpleTypeUnion simpleTypeUnion);
+
+    TResult Visit(GroupReference groupReference);
+
+    TResult Visit(Any any);
+
+    TResult Visit(Choice choice);
+
+    TResult Visit(ElementType elementType);
+
+    TResult Visit(Sequence sequence);
+
+    TResult Visit(ElementReference elementReference);
+}

--- a/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
@@ -8,7 +8,7 @@
 /// ]]></code>
 /// </example>
 /// </summary>
-public class AttributeElement
+public class AttributeElement : INode
 {
     /// <summary>
     /// Name is technically optional in ref attribute:
@@ -25,4 +25,9 @@ public class AttributeElement
     public AttributeUseType Use { get; set; } = AttributeUseType.Optional;
 
     public string? DefaultValue { get; set; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
@@ -22,7 +22,7 @@ public class AttributeElement : INode
 
     public required string? Type { get; set; }
 
-    public AttributeUseType Use { get; set; } = AttributeUseType.Optional;
+    public AttributeUseType Use { get; set; }
 
     public string? DefaultValue { get; set; }
 

--- a/ClosedXML.IO.CodeGen/Model/AttributeUseType.cs
+++ b/ClosedXML.IO.CodeGen/Model/AttributeUseType.cs
@@ -5,6 +5,10 @@
 /// </summary>
 public enum AttributeUseType
 {
+    /// <summary>
+    /// Default is <see cref="Optional"/>.
+    /// </summary>
+    Default,
     Optional,
     Required
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/Any.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/Any.cs
@@ -14,4 +14,9 @@ public class Any : IElementGroup
     public List<IElementGroup> Children { get; } = [];
 
     public required ProcessContents ProcessContent { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/AttributeGroupReference.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/AttributeGroupReference.cs
@@ -22,4 +22,9 @@ public class AttributeGroupReference : ILeafElement
     /// Name of referenced attribute group (<see cref="AttributeGroupDefinition.Name"/>).
     /// </summary>
     public required string RefName { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/AttributeGroupReference.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/AttributeGroupReference.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using ClosedXML.IO.CodeGen.Model.TopLevel;
+
+namespace ClosedXML.IO.CodeGen.Model.Elements;
+
+/// <summary>
+/// An <c><![CDATA[<xsd:attributeGroup>]]></c> inside a <c><![CDATA[<xsd:complexType>]]></c>.
+/// <example>
+/// <code><![CDATA[
+/// <xsd:complexType name="CT_pivotTableDefinition">
+///   <xsd:attribute name="dataPosition" type="xsd:unsignedInt" use="optional"/>
+///   <xsd:attributeGroup ref="AG_AutoFormat"/>
+/// </xsd:complexType>
+/// ]]></code>
+/// </example>
+/// </summary>
+public class AttributeGroupReference : ILeafElement
+{
+    public List<IElementGroup> Children { get; } = [];
+
+    /// <summary>
+    /// Name of referenced attribute group (<see cref="AttributeGroupDefinition.Name"/>).
+    /// </summary>
+    public required string RefName { get; init; }
+}

--- a/ClosedXML.IO.CodeGen/Model/Elements/Choice.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/Choice.cs
@@ -10,4 +10,9 @@ public class Choice : IElementGroup
     public required List<IElementGroup> Children { get; init; } = [];
 
     public required Occurrences Occurrences { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/ElementReference.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/ElementReference.cs
@@ -21,4 +21,9 @@ public class ElementReference : ILeafElement
     public required string RefName { get; init; }
 
     public required Occurrences Occurrences { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/ElementType.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/ElementType.cs
@@ -27,4 +27,9 @@ public class ElementType : IElementGroup
     public required string TypeName { get; init; }
 
     public required Occurrences Occurrences { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/GroupReference.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/GroupReference.cs
@@ -16,4 +16,9 @@ public class GroupReference : ILeafElement
     public required string RefName { get; init; }
 
     public required Occurrences Occurrences { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/IElementGroup.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/IElementGroup.cs
@@ -5,7 +5,7 @@ namespace ClosedXML.IO.CodeGen.Model.Elements;
 /// <summary>
 /// A node in a complex type element tree.
 /// </summary>
-public interface IElementGroup
+public interface IElementGroup: INode
 {
     /// <summary>
     /// Children elements.

--- a/ClosedXML.IO.CodeGen/Model/Elements/Sequence.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/Sequence.cs
@@ -10,4 +10,9 @@ public class Sequence : IElementGroup
     public required List<IElementGroup> Children { get; init; } = [];
 
     public required Occurrences Occurrences { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/Occurrences.cs
+++ b/ClosedXML.IO.CodeGen/Model/Occurrences.cs
@@ -1,3 +1,3 @@
 ﻿namespace ClosedXML.IO.CodeGen.Model;
 
-public readonly record struct Occurrences(int Min, int Max);
+public readonly record struct Occurrences(int? Min, int? Max);

--- a/ClosedXML.IO.CodeGen/Model/ProcessContents.cs
+++ b/ClosedXML.IO.CodeGen/Model/ProcessContents.cs
@@ -6,6 +6,11 @@
 public enum ProcessContents
 {
     /// <summary>
+    /// Default value, has same meaning as <see cref="Strict"/>.
+    /// </summary>
+    Default,
+
+    /// <summary>
     /// All elements should be validated against schema. This should be used when content
     /// should only contain known schema.
     /// </summary>

--- a/ClosedXML.IO.CodeGen/Model/Schema.cs
+++ b/ClosedXML.IO.CodeGen/Model/Schema.cs
@@ -5,7 +5,7 @@ namespace ClosedXML.IO.CodeGen.Model;
 /// <summary>
 /// A representation of a one XSD file.
 /// </summary>
-public class Schema
+public class Schema : INode
 {
     /// <summary>
     /// Imports in the file.
@@ -16,4 +16,9 @@ public class Schema
     /// One of <c>xsd:attributeGroup</c>, <c>xsd:complexType</c>, <c>xsd:element</c> or <c>xsd:simpleType</c>.
     /// </summary>
     public List<object> Entries { get; } = [];
+
+    T INode.Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/ISimpleType.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/ISimpleType.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A marker interface for types inside <c><![CDATA[<xsd:simpleType>]]></c>.
 /// </summary>
-public interface ISimpleType
+public interface ISimpleType : INode
 {
     string Name { get; }
 }

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleType.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleType.cs
@@ -26,4 +26,9 @@ public class SimpleType : ISimpleType
     /// Conditions the value must satisfy.
     /// </summary>
     public required List<IValueRestriction> Restrictions { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeList.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeList.cs
@@ -16,4 +16,9 @@ public class SimpleTypeList : ISimpleType
     public required string Name { get; init; }
 
     public required string ItemType { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeUnion.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeUnion.cs
@@ -7,4 +7,9 @@ public class SimpleTypeUnion : ISimpleType
     public required string Name { get; init; }
 
     public required List<Restriction> RestrictionsUnion { get; init; } = [];
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/AttributeGroupDefinition.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/AttributeGroupDefinition.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// ]]></code>
 /// </example>
 /// </summary>
-public class AttributeGroupDefinition : IReferencable
+public class AttributeGroupDefinition : IReferencable, INode
 {
     /// <summary>
     /// Name of the the attribute group type.
@@ -22,4 +22,9 @@ public class AttributeGroupDefinition : IReferencable
     public required string Name { get; init; }
 
     public required List<AttributeElement> Attributes { get; init; } = [];
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
@@ -3,11 +3,7 @@ using ClosedXML.IO.CodeGen.Model.Elements;
 
 namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
-/// <summary>
-/// <c><![CDATA[<xsd:complexType/>]]></c> inside <c><![CDATA[<xsd:schema/>]]></c>. It doesn't have
-/// any elements, only attributes.
-/// </summary>
-public class ComplexType : IReferencable
+public abstract class ComplexType : IReferencable
 {
     /// <summary>
     /// Name of the complex type.

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
@@ -3,6 +3,9 @@ using ClosedXML.IO.CodeGen.Model.Elements;
 
 namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
+/// <summary>
+/// Base class for nodes representing a <c><![CDATA[<xsd:compleType>]]></c>.
+/// </summary>
 public abstract class ComplexType : IReferencable
 {
     /// <summary>

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
@@ -11,4 +11,10 @@ public abstract class ComplexType : IReferencable
     public required string Name { get; set; }
 
     public List<OneOf<AttributeElement, AttributeGroupReference>> Attributes { get; set; } = [];
+
+    /// <summary>
+    /// Can text be freely interspersed with elements? Only used when <c>complexType</c> contains
+    /// <c>any</c>.
+    /// </summary>
+    public required bool? Mixed { get; init; }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using ClosedXML.IO.CodeGen.Model.Elements;
 
 namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
@@ -13,5 +14,5 @@ public class ComplexType : IReferencable
     /// </summary>
     public required string Name { get; set; }
 
-    public List<AttributeElement> Attributes { get; set; } = [];
+    public List<OneOf<AttributeElement, AttributeGroupReference>> Attributes { get; set; } = [];
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeChoice.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeChoice.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// </summary>
 public class ComplexTypeChoice : ComplexType, INode
 {
-    public required List<IElementGroup> Choices { get; init; } = [];
+    public required Choice Choice { get; init; }
 
     public T Accept<T>(IXsdVisitor<T> visitor)
     {

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeChoice.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeChoice.cs
@@ -18,7 +18,12 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// ]]></code>
 /// </example>
 /// </summary>
-public class ComplexTypeChoice : ComplexType
+public class ComplexTypeChoice : ComplexType, INode
 {
     public required List<IElementGroup> Choices { get; init; } = [];
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeElement.cs
@@ -1,0 +1,13 @@
+﻿namespace ClosedXML.IO.CodeGen.Model.TopLevel;
+
+/// <summary>
+/// <c><![CDATA[<xsd:complexType/>]]></c> inside <c><![CDATA[<xsd:schema/>]]></c>. It doesn't have
+/// any elements, only attributes.
+/// </summary>
+public class ComplexTypeElement : ComplexType, INode
+{
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
+}

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSequence.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSequence.cs
@@ -18,7 +18,12 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// ]]></code>
 /// </example>
 /// </summary>
-public class ComplexTypeSequence : ComplexType
+public class ComplexTypeSequence : ComplexType, INode
 {
     public required List<IElementGroup> Elements { get; init; } = [];
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSequence.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSequence.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// </summary>
 public class ComplexTypeSequence : ComplexType, INode
 {
-    public required List<IElementGroup> Elements { get; init; } = [];
+    public required Sequence Sequence { get; init; }
 
     public T Accept<T>(IXsdVisitor<T> visitor)
     {

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSimpleContent.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSimpleContent.cs
@@ -19,8 +19,6 @@ public class ComplexTypeSimpleContent : ComplexType, INode
 {
     public required string BaseTypeName { get; init; }
 
-    public required List<AttributeElement> ExtensionAttributes { get; init; }
-
     public T Accept<T>(IXsdVisitor<T> visitor)
     {
         return visitor.Visit(this);

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSimpleContent.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSimpleContent.cs
@@ -15,9 +15,14 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 ///   <xsd:simpleContent>
 /// ]]>
 /// </summary>
-public class ComplexTypeSimpleContent : ComplexType
+public class ComplexTypeSimpleContent : ComplexType, INode
 {
     public required string BaseTypeName { get; init; }
 
     public required List<AttributeElement> ExtensionAttributes { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ElementDefinition.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ElementDefinition.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// ]]></code>
 /// </example>
 /// </summary>
-public class ElementDefinition : IReferencable
+public class ElementDefinition : IReferencable, INode
 {
     /// <summary>
     /// Name of the element. Referenced by <see cref="ElementReference.RefName"/>.
@@ -21,4 +21,9 @@ public class ElementDefinition : IReferencable
     /// The type name of the element.
     /// </summary>
     public required string TypeName { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/GroupDefinition.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/GroupDefinition.cs
@@ -14,9 +14,14 @@ namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 /// ]]></code>
 /// </example>
 /// </summary>
-public class GroupDefinition : IReferencable
+public class GroupDefinition : IReferencable, INode
 {
     public required string Name { get; init; }
 
     public required IElementGroup Content { get; init; }
+
+    public T Accept<T>(IXsdVisitor<T> visitor)
+    {
+        return visitor.Visit(this);
+    }
 }

--- a/ClosedXML.IO.CodeGen/OneOf.cs
+++ b/ClosedXML.IO.CodeGen/OneOf.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace ClosedXML.IO.CodeGen;
+
+public readonly record struct OneOf<T1, T2>
+{
+    private readonly T1? _t1;
+    private readonly T2? _t2;
+
+    private OneOf(T1? t1, T2? t2)
+    {
+        _t1 = t1;
+        _t2 = t2;
+    }
+
+    public static implicit operator OneOf<T1, T2>(T1 value) => new(value, default);
+    public static implicit operator OneOf<T1, T2>(T2 value) => new(default, value);
+
+    public bool TryPickT1([NotNullWhen(true)] out T1? t1)
+    {
+        t1 = _t1!;
+        return EqualityComparer<T1?>.Default.Equals(_t1, default);
+    }
+
+    internal bool TryPickT2([NotNullWhen(true)] out T2? t2)
+    {
+        t2 = _t2!;
+        return EqualityComparer<T2?>.Default.Equals(_t2, default);
+    }
+}

--- a/ClosedXML.IO.CodeGen/OneOf.cs
+++ b/ClosedXML.IO.CodeGen/OneOf.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 
 namespace ClosedXML.IO.CodeGen;
 
@@ -22,12 +20,12 @@ public readonly record struct OneOf<T1, T2>
     public bool TryPickT1([NotNullWhen(true)] out T1? t1)
     {
         t1 = _t1!;
-        return EqualityComparer<T1?>.Default.Equals(_t1, default);
+        return !EqualityComparer<T1?>.Default.Equals(_t1, default);
     }
 
     internal bool TryPickT2([NotNullWhen(true)] out T2? t2)
     {
         t2 = _t2!;
-        return EqualityComparer<T2?>.Default.Equals(_t2, default);
+        return !EqualityComparer<T2?>.Default.Equals(_t2, default);
     }
 }

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Xml;
 using ClosedXML.IO.CodeGen.XsdParser;
 
@@ -10,10 +11,10 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        if (args.Length != 1)
+        if (args.Length != 2)
         {
             Console.Error.WriteLine("Usage:");
-            Console.Error.WriteLine($"    {Process.GetCurrentProcess().ProcessName}.exe name-of-ooxml.xsd");
+            Console.Error.WriteLine($"    {Process.GetCurrentProcess().ProcessName}.exe name-of-ooxml.xsd output-path.xsd");
             Console.Error.WriteLine();
             return;
         }
@@ -23,8 +24,16 @@ public class Program
         using var reader = new XmlTreeReader(xmlReader, new XsdEnumMapper());
         var parser = new XsdSchemaParser();
 
-        parser.ParseSchema(reader);
+        var schema = parser.ParseSchema(reader);
 
         Console.Out.WriteLine($"File {args[0]} successfully parsed.");
+
+        var sb = new StringBuilder();
+        var visitor = new XsdCopyVisitor(sb);
+        visitor.Visit(schema);
+
+        File.WriteAllText(args[1], sb.ToString());
+
+        Console.WriteLine($"Wrote copy to {args[1]}");
     }
 }

--- a/ClosedXML.IO.CodeGen/Unit.cs
+++ b/ClosedXML.IO.CodeGen/Unit.cs
@@ -1,0 +1,9 @@
+﻿namespace ClosedXML.IO.CodeGen;
+
+/// <summary>
+/// A type to use in generics instead of <c>void</c>.
+/// </summary>
+internal struct Unit
+{
+    public static readonly Unit Value = new();
+};

--- a/ClosedXML.IO.CodeGen/XsdCopyVisitor.cs
+++ b/ClosedXML.IO.CodeGen/XsdCopyVisitor.cs
@@ -75,7 +75,6 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
         }
 
         AppendElement("</xsd:schema>");
-
         return Unit.Value;
     }
 
@@ -88,10 +87,8 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
         element += ">";
         AppendElement(element);
         complexType.Sequence.Accept(this);
-
         WriteAttributes(complexType);
         AppendElement("</xsd:complexType>");
-
         return Unit.Value;
     }
 
@@ -100,7 +97,6 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
         AppendElement($"<xsd:complexType name=\"{complexType.Name}\">");
         complexType.Choice.Accept(this);
         WriteAttributes(complexType);
-
         AppendElement("</xsd:complexType>");
         return Unit.Value;
     }
@@ -110,19 +106,10 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
         AppendElement($"<xsd:complexType name=\"{complexType.Name}\">");
         AppendElement("<xsd:simpleContent>");
         AppendElement($"<xsd:extension base=\"{complexType.BaseTypeName}\">");
-
-        foreach (var choice in complexType.ExtensionAttributes)
-        {
-            choice.Accept(this);
-        }
+        WriteAttributes(complexType);
         AppendElement("</xsd:extension>");
         AppendElement("</xsd:simpleContent>");
-
-        // TODO: Is this even necessary? SimpleContent
-        WriteAttributes(complexType);
-
         AppendElement("</xsd:complexType>");
-
         return Unit.Value;
     }
 
@@ -131,7 +118,6 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
         AppendElement($"<xsd:complexType name=\"{complexType.Name}\">");
         WriteAttributes(complexType);
         AppendElement("</xsd:complexType>");
-
         return Unit.Value;
     }
 
@@ -226,7 +212,6 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
             element.Accept(this);
         }
         AppendElement("</xsd:choice>");
-
         return Unit.Value;
     }
 
@@ -247,7 +232,6 @@ internal class XsdCopyVisitor : IXsdVisitor<Unit>
             element.Accept(this);
         }
         AppendElement("</xsd:sequence>");
-
         return Unit.Value;
     }
 

--- a/ClosedXML.IO.CodeGen/XsdCopyVisitor.cs
+++ b/ClosedXML.IO.CodeGen/XsdCopyVisitor.cs
@@ -1,0 +1,347 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+using ClosedXML.IO.CodeGen.Model;
+using ClosedXML.IO.CodeGen.Model.Elements;
+using ClosedXML.IO.CodeGen.Model.SimpleTypes;
+using ClosedXML.IO.CodeGen.Model.TopLevel;
+
+namespace ClosedXML.IO.CodeGen;
+
+internal class XsdCopyVisitor : IXsdVisitor<Unit>
+{
+    private readonly StringBuilder _sb;
+    private int _indent = 0;
+
+    public XsdCopyVisitor(StringBuilder sb)
+    {
+        _sb = sb;
+    }
+
+    public Unit Visit(Schema schema)
+    {
+        _sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\" ?>");
+        AppendElement("""
+                      <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                                  xmlns="http://purl.oclc.org/ooxml/spreadsheetml/main"
+                                  xmlns:r="http://purl.oclc.org/ooxml/officeDocument/relationships" 
+                                  xmlns:xdr="http://purl.oclc.org/ooxml/drawingml/spreadsheetDrawing"
+                                  xmlns:s="http://purl.oclc.org/ooxml/officeDocument/sharedTypes" 
+                                  targetNamespace="http://purl.oclc.org/ooxml/spreadsheetml/main"
+                                  elementFormDefault="qualified">
+                      """);
+        foreach (var import in schema.Imports)
+        {
+            AppendElement($"<xsd:import namespace=\"{import.Namespace}\" schemaLocation=\"{import.SchemaLocation}\"/>");
+        }
+
+        foreach (var entry in schema.Entries)
+        {
+            switch (entry)
+            {
+                case ComplexTypeSequence ct:
+                    ct.Accept(this);
+                    break;
+                case ComplexTypeChoice ct:
+                    ct.Accept(this);
+                    break;
+                case ComplexTypeSimpleContent ct:
+                    ct.Accept(this);
+                    break;
+                case ComplexTypeElement ct:
+                    ct.Accept(this);
+                    break;
+                case SimpleType simpleType:
+                    simpleType.Accept(this);
+                    break;
+                case SimpleTypeList simpleType:
+                    simpleType.Accept(this);
+                    break;
+                case SimpleTypeUnion simpleType:
+                    simpleType.Accept(this);
+                    break;
+                case ElementDefinition elementDefinition:
+                    elementDefinition.Accept(this);
+                    break;
+                case GroupDefinition groupDefinition:
+                    groupDefinition.Accept(this);
+                    break;
+                case AttributeGroupDefinition attributeGroupDefinition:
+                    attributeGroupDefinition.Accept(this);
+                    break;
+                default:
+                    throw new UnreachableException();
+            }
+        }
+
+        AppendElement("</xsd:schema>");
+
+        return Unit.Value;
+    }
+
+    public Unit Visit(ComplexTypeSequence complexType)
+    {
+        var element = $"<xsd:complexType name=\"{complexType.Name}\"";
+        if (complexType.Mixed is not null)
+            element += $" mixed=\"{(complexType.Mixed.Value ? "true" : "false")}\"";
+
+        element += ">";
+        AppendElement(element);
+        complexType.Sequence.Accept(this);
+
+        WriteAttributes(complexType);
+        AppendElement("</xsd:complexType>");
+
+        return Unit.Value;
+    }
+
+    public Unit Visit(ComplexTypeChoice complexType)
+    {
+        AppendElement($"<xsd:complexType name=\"{complexType.Name}\">");
+        complexType.Choice.Accept(this);
+        WriteAttributes(complexType);
+
+        AppendElement("</xsd:complexType>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(ComplexTypeSimpleContent complexType)
+    {
+        AppendElement($"<xsd:complexType name=\"{complexType.Name}\">");
+        AppendElement("<xsd:simpleContent>");
+        AppendElement($"<xsd:extension base=\"{complexType.BaseTypeName}\">");
+
+        foreach (var choice in complexType.ExtensionAttributes)
+        {
+            choice.Accept(this);
+        }
+        AppendElement("</xsd:extension>");
+        AppendElement("</xsd:simpleContent>");
+
+        // TODO: Is this even necessary? SimpleContent
+        WriteAttributes(complexType);
+
+        AppendElement("</xsd:complexType>");
+
+        return Unit.Value;
+    }
+
+    public Unit Visit(ComplexTypeElement complexType)
+    {
+        AppendElement($"<xsd:complexType name=\"{complexType.Name}\">");
+        WriteAttributes(complexType);
+        AppendElement("</xsd:complexType>");
+
+        return Unit.Value;
+    }
+
+    public Unit Visit(AttributeGroupReference attributeGroupReference)
+    {
+        AppendElement($"<xsd:attributeGroup ref=\"{attributeGroupReference.RefName}\"/>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(SimpleType simpleType)
+    {
+        AppendElement($"<xsd:simpleType name=\"{simpleType.Name}\">");
+        AppendElement($"<xsd:restriction base=\"{simpleType.BaseTypeName}\">");
+
+        foreach (var restriction in simpleType.Restrictions)
+            AppendElement(GetValueRestrictionElement(restriction));
+
+        AppendElement("</xsd:restriction>");
+        AppendElement("</xsd:simpleType>");
+        return Unit.Value;
+    }
+
+    private static string GetValueRestrictionElement(IValueRestriction restriction)
+    {
+        var restrictionElement = restriction switch
+        {
+            RestrictEnumeration enumeration => $"<xsd:enumeration value=\"{enumeration.Value}\"/>",
+            RestrictLength length => $"<xsd:length value=\"{length.Value}\"/>",
+            RestrictMinInclusive minInclusive => $"<xsd:minInclusive value=\"{minInclusive.Value}\"/>",
+            RestrictMaxInclusive maxInclusive => $"<xsd:maxInclusive value=\"{maxInclusive.Value}\"/>",
+            _ => throw new UnreachableException()
+        };
+        return restrictionElement;
+    }
+
+    public Unit Visit(SimpleTypeList simpleType)
+    {
+        AppendElement($"<xsd:simpleType name=\"{simpleType.Name}\">");
+        AppendElement($"<xsd:list itemType=\"{simpleType.ItemType}\"/>");
+        AppendElement("</xsd:simpleType>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(SimpleTypeUnion simpleType)
+    {
+        AppendElement($"<xsd:simpleType name=\"{simpleType.Name}\">");
+        AppendElement("<xsd:union>");
+        foreach (var restrictionUnion in simpleType.RestrictionsUnion)
+        {
+            AppendElement("<xsd:simpleType>");
+            AppendElement($"<xsd:restriction base=\"{restrictionUnion.BaseTypeName}\">");
+            foreach (var valueRestriction in restrictionUnion.ValueRestrictions)
+            {
+                AppendElement(GetValueRestrictionElement(valueRestriction));
+            }
+
+            AppendElement("</xsd:restriction>");
+            AppendElement("</xsd:simpleType>");
+        }
+
+        AppendElement("</xsd:union>");
+        AppendElement("</xsd:simpleType>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(GroupReference attributeGroupReference)
+    {
+        AppendElement($"<xsd:group ref=\"{attributeGroupReference.RefName}\"{GetOccurrences(attributeGroupReference.Occurrences)}/>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(Any any)
+    {
+        var element = "<xsd:any";
+        element += any.ProcessContent switch
+        {
+            ProcessContents.Default => string.Empty,
+            ProcessContents.Strict => " processContents=\"strict\"",
+            ProcessContents.Lax => " processContents=\"lax\"",
+            _ => throw new UnreachableException(),
+        };
+        element += "/>";
+        AppendElement(element);
+        return Unit.Value;
+    }
+
+    public Unit Visit(Choice choice)
+    {
+        AppendElement($"<xsd:choice{GetOccurrences(choice.Occurrences)}>");
+        foreach (var element in choice.Children)
+        {
+            element.Accept(this);
+        }
+        AppendElement("</xsd:choice>");
+
+        return Unit.Value;
+    }
+
+    public Unit Visit(ElementType elementType)
+    {
+        var element = $"<xsd:element name=\"{elementType.Name}\" type=\"{elementType.TypeName}\"";
+        element += GetOccurrences(elementType.Occurrences);
+        element += "/>";
+        AppendElement(element);
+        return Unit.Value;
+    }
+
+    public Unit Visit(Sequence sequence)
+    {
+        AppendElement($"<xsd:sequence{GetOccurrences(sequence.Occurrences)}>");
+        foreach (var element in sequence.Children)
+        {
+            element.Accept(this);
+        }
+        AppendElement("</xsd:sequence>");
+
+        return Unit.Value;
+    }
+
+    public Unit Visit(ElementReference elementReference)
+    {
+        AppendElement($"<xsd:element ref=\"{elementReference.RefName}\"{GetOccurrences(elementReference.Occurrences)}/>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(ElementDefinition elementDefinition)
+    {
+        AppendElement($"<xsd:element name=\"{elementDefinition.Name}\" type=\"{elementDefinition.TypeName}\"/>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(GroupDefinition groupDefinition)
+    {
+        AppendElement($"<xsd:group name=\"{groupDefinition.Name}\">");
+        groupDefinition.Content.Accept(this);
+        AppendElement("</xsd:group>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(AttributeGroupDefinition attributeGroupDefinition)
+    {
+        AppendElement($"<xsd:attributeGroup name=\"{attributeGroupDefinition.Name}\">");
+        foreach (var attribute in attributeGroupDefinition.Attributes)
+            attribute.Accept(this);
+
+        AppendElement("</xsd:attributeGroup>");
+        return Unit.Value;
+    }
+
+    public Unit Visit(AttributeElement attributeElement)
+    {
+        var element = "<xsd:attribute";
+        element += attributeElement.RefName is not null
+            ? $" ref=\"{attributeElement.RefName}\""
+            : $" name=\"{attributeElement.Name}\" type=\"{attributeElement.Type}\"";
+
+        if (attributeElement.Use != AttributeUseType.Default)
+            element += $" use=\"{(attributeElement.Use == AttributeUseType.Optional ? "optional" : "required")}\"";
+
+        if (attributeElement.DefaultValue is not null)
+            element += $" default=\"{attributeElement.DefaultValue}\"";
+
+        element += "/>";
+        AppendElement(element);
+        return Unit.Value;
+    }
+
+    private void WriteAttributes(ComplexType complexType)
+    {
+        foreach (var attr in complexType.Attributes)
+        {
+            if (attr.TryPickT1(out var attribute))
+            {
+                attribute.Accept(this);
+            }
+            else if (attr.TryPickT2(out var attributeGroup))
+            {
+                attributeGroup.Accept(this);
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+    }
+
+    private static string GetOccurrences(Occurrences occurrences)
+    {
+        var attributes = string.Empty;
+        if (occurrences.Min is not null)
+            attributes += $" minOccurs=\"{occurrences.Min}\"";
+
+        if (occurrences.Max is not null)
+            attributes += $" maxOccurs=\"{(occurrences.Max == int.MaxValue ? "unbounded" : occurrences.Max.ToString())}\"";
+
+        return attributes;
+    }
+
+    private void AppendElement(string text)
+    {
+        _sb.Append(' ', _indent);
+        _sb.AppendLine(text);
+
+        const StringComparison comparison = StringComparison.Ordinal;
+        var isOpen = text.StartsWith('<') && !text.StartsWith("</", comparison);
+        if (isOpen)
+            _indent += 2;
+
+        var isClose = text.StartsWith("</", comparison) || text.EndsWith("/>", comparison);
+        if (isClose)
+            _indent -= 2;
+    }
+}

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -461,8 +461,8 @@ public class XsdSchemaParser
 
     private static Occurrences GetOccursAttributes(XmlTreeReader reader)
     {
-        var minOccurs = reader.GetOptionalInt("minOccurs") ?? 1;
-        var maxOccurs = reader.GetOptionalString("maxOccurs") == "unbounded" ? int.MaxValue : reader.GetOptionalInt("maxOccurs") ?? 1;
+        var minOccurs = reader.GetOptionalInt("minOccurs") ?? null;
+        var maxOccurs = reader.GetOptionalString("maxOccurs") == "unbounded" ? int.MaxValue : reader.GetOptionalInt("maxOccurs") ?? null;
         return new Occurrences(minOccurs, maxOccurs);
     }
 }

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -115,6 +115,7 @@ public class XsdSchemaParser
 
         if (reader.TryOpen("choice", XsdNs))
         {
+            var occurrences = GetOccursAttributes(reader);
             var choices = new List<IElementGroup>();
             do
             {
@@ -128,7 +129,11 @@ public class XsdSchemaParser
             {
                 Name = name,
                 Attributes = attributes,
-                Choices = choices
+                Choice = new Choice
+                {
+                    Children = choices,
+                    Occurrences = occurrences
+                }
             };
         }
 

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -143,7 +143,7 @@ public class XsdSchemaParser
 
         // Complex type that consists only from attributes
         var attr = ParseComplexTypeAttributes(reader);
-        return new ComplexType
+        return new ComplexTypeElement
         {
             Name = name,
             Attributes = attr

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -447,7 +447,7 @@ public class XsdSchemaParser
 
         if (reader.TryOpen("any", XsdNs))
         {
-            var processContents = reader.GetOptionalEnum<ProcessContents>("processContents") ?? ProcessContents.Strict;
+            var processContents = reader.GetOptionalEnum<ProcessContents>("processContents") ?? ProcessContents.Default;
             reader.Close("any", XsdNs);
 
             return new Any

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -294,7 +294,7 @@ public class XsdSchemaParser
             reader.Open("attribute", XsdNs);
             var name = reader.GetString("name");
             var type = reader.GetString("type");
-            var use = reader.GetOptionalEnum<AttributeUseType>("use") ?? AttributeUseType.Optional;
+            var use = reader.GetOptionalEnum<AttributeUseType>("use") ?? AttributeUseType.Default;
             var defaultValue = reader.GetOptionalString("default");
             reader.Close("attribute", XsdNs);
             var attribute = new AttributeElement
@@ -348,7 +348,7 @@ public class XsdSchemaParser
         var type = reader.GetOptionalString("type");
         var refName = reader.GetOptionalString("ref");
         var defaultValue = reader.GetOptionalString("default");
-        var use = reader.GetOptionalEnum<AttributeUseType>("use") ?? AttributeUseType.Optional;
+        var use = reader.GetOptionalEnum<AttributeUseType>("use") ?? AttributeUseType.Default;
         reader.Close("attribute", XsdNs);
 
         return new AttributeElement

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -142,16 +142,16 @@ public class XsdSchemaParser
 
         if (reader.TryOpen("simpleContent", XsdNs))
         {
+            // simpleContent can't have attributes like complexType. It has them only in <extension> tag.
             var (baseTypeName, extensionAttributes) = ParseSimpleContent(reader);
-            var attributes = ParseComplexTypeAttributes(reader);
+            reader.Close("complexType", XsdNs);
 
             return new ComplexTypeSimpleContent
             {
                 Name = name,
-                Attributes = attributes,
+                Attributes = extensionAttributes,
                 Mixed = mixed,
-                BaseTypeName = baseTypeName,
-                ExtensionAttributes = extensionAttributes
+                BaseTypeName = baseTypeName
             };
         }
 
@@ -283,11 +283,11 @@ public class XsdSchemaParser
         };
     }
 
-    private static (string Base, List<AttributeElement> Attributes) ParseSimpleContent(XmlTreeReader reader)
+    private static (string Base, List<OneOf<AttributeElement, AttributeGroupReference>> Attributes) ParseSimpleContent(XmlTreeReader reader)
     {
         reader.Open("extension", XsdNs);
         var baseTypeName = reader.GetString("base");
-        var extensionAttributes = new List<AttributeElement>();
+        var extensionAttributes = new List<OneOf<AttributeElement, AttributeGroupReference>>();
 
         while (!reader.TryClose("extension", XsdNs))
         {

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -89,6 +89,7 @@ public class XsdSchemaParser
     private static ComplexType ParseComplexType(XmlTreeReader reader)
     {
         var name = reader.GetString("name");
+        var mixed = reader.GetOptionalBool("mixed");
         if (reader.TryOpen("sequence", XsdNs))
         {
             var occurrences = GetOccursAttributes(reader);
@@ -105,6 +106,7 @@ public class XsdSchemaParser
             {
                 Name = name,
                 Attributes = attributes,
+                Mixed = mixed,
                 Sequence = new Sequence
                 {
                     Children = elements,
@@ -129,6 +131,7 @@ public class XsdSchemaParser
             {
                 Name = name,
                 Attributes = attributes,
+                Mixed = mixed,
                 Choice = new Choice
                 {
                     Children = choices,
@@ -146,6 +149,7 @@ public class XsdSchemaParser
             {
                 Name = name,
                 Attributes = attributes,
+                Mixed = mixed,
                 BaseTypeName = baseTypeName,
                 ExtensionAttributes = extensionAttributes
             };
@@ -156,7 +160,8 @@ public class XsdSchemaParser
         return new ComplexTypeElement
         {
             Name = name,
-            Attributes = attr
+            Attributes = attr,
+            Mixed = mixed,
         };
     }
 

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -91,6 +91,7 @@ public class XsdSchemaParser
         var name = reader.GetString("name");
         if (reader.TryOpen("sequence", XsdNs))
         {
+            var occurrences = GetOccursAttributes(reader);
             var elements = new List<IElementGroup>();
             do
             {
@@ -104,7 +105,11 @@ public class XsdSchemaParser
             {
                 Name = name,
                 Attributes = attributes,
-                Elements = elements
+                Sequence = new Sequence
+                {
+                    Children = elements,
+                    Occurrences = occurrences
+                }
             };
         }
 

--- a/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
+++ b/ClosedXML.IO.CodeGen/XsdSchemaParser.cs
@@ -298,9 +298,9 @@ public class XsdSchemaParser
         return (baseTypeName, extensionAttributes);
     }
 
-    private static List<AttributeElement> ParseComplexTypeAttributes(XmlTreeReader reader)
+    private static List<OneOf<AttributeElement, AttributeGroupReference>> ParseComplexTypeAttributes(XmlTreeReader reader)
     {
-        var attributes = new List<AttributeElement>();
+        var attributes = new List<OneOf<AttributeElement, AttributeGroupReference>>();
 
         while (!reader.TryClose("complexType", XsdNs))
         {
@@ -311,9 +311,12 @@ public class XsdSchemaParser
             }
             else if (reader.TryOpen("attributeGroup", XsdNs))
             {
-                _ = reader.GetString("ref");
+                var refName = reader.GetString("ref");
                 reader.Close("attributeGroup", XsdNs);
-                // TODO return XsdAttributeGroupReference, currently ignored
+                attributes.Add(new AttributeGroupReference
+                {
+                    RefName = refName
+                });
             }
             else
             {


### PR DESCRIPTION
Add a visitor to _CodeGen_ project that writes a content of read XSD file from internal structures. Only for debugging, so I can be confident that all values in the source file were read. Only tested on `sml.xsd`.

Visitor will be later reused to generate a code for an XSD `complexType`.