### PR TITLE
Add pivot cache records reader

### DIFF
--- a/ClosedXML/Excel/IO/PivotTableCacheDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableCacheDefinitionPartReader.cs
@@ -12,44 +12,41 @@ namespace ClosedXML.Excel.IO
 {
     internal class PivotTableCacheDefinitionPartReader
     {
-        internal static void Load(WorkbookPart workbookPart, XLWorkbook workbook)
+        internal static void Load(WorkbookPart workbookPart, PivotTableCacheDefinitionPart pivotTableCacheDefinitionPart, XLWorkbook workbook)
         {
-            foreach (var pivotTableCacheDefinitionPart in workbookPart.GetPartsOfType<PivotTableCacheDefinitionPart>())
+            var cacheDefinition = pivotTableCacheDefinitionPart.PivotCacheDefinition;
+            if (cacheDefinition.CacheSource is not { } cacheSource)
+                throw PartStructureException.RequiredElementIsMissing("cacheSource");
+
+            var pivotSourceReference = ParsePivotSourceReference(cacheSource);
+            var pivotCache = workbook.PivotCachesInternal.Add(pivotSourceReference);
+
+            // If WorkbookCacheRelId already has a value, it means the pivot source is being reused
+            if (string.IsNullOrWhiteSpace(pivotCache.WorkbookCacheRelId))
             {
-                var cacheDefinition = pivotTableCacheDefinitionPart.PivotCacheDefinition;
-                if (cacheDefinition.CacheSource is not { } cacheSource)
-                    throw PartStructureException.RequiredElementIsMissing("cacheSource");
-
-                var pivotSourceReference = ParsePivotSourceReference(cacheSource);
-                var pivotCache = workbook.PivotCachesInternal.Add(pivotSourceReference);
-
-                // If WorkbookCacheRelId already has a value, it means the pivot source is being reused
-                if (string.IsNullOrWhiteSpace(pivotCache.WorkbookCacheRelId))
-                {
-                    pivotCache.WorkbookCacheRelId = workbookPart.GetIdOfPart(pivotTableCacheDefinitionPart);
-                }
-
-                if (cacheDefinition.MissingItemsLimit?.Value is { } missingItemsLimit)
-                {
-                    pivotCache.ItemsToRetainPerField = missingItemsLimit switch
-                    {
-                        0 => XLItemsToRetain.None,
-                        XLHelper.MaxRowNumber => XLItemsToRetain.Max,
-                        _ => XLItemsToRetain.Automatic,
-                    };
-                }
-
-                if (cacheDefinition.CacheFields is { } cacheFields)
-                {
-                    ReadCacheFields(cacheFields, pivotCache);
-                    if (pivotTableCacheDefinitionPart.PivotTableCacheRecordsPart?.PivotCacheRecords is { } recordsPart)
-                    {
-                        ReadRecords(recordsPart, pivotCache);
-                    }
-                }
-
-                pivotCache.SaveSourceData = cacheDefinition.SaveData?.Value ?? true;
+                pivotCache.WorkbookCacheRelId = workbookPart.GetIdOfPart(pivotTableCacheDefinitionPart);
             }
+
+            if (cacheDefinition.MissingItemsLimit?.Value is { } missingItemsLimit)
+            {
+                pivotCache.ItemsToRetainPerField = missingItemsLimit switch
+                {
+                    0 => XLItemsToRetain.None,
+                    XLHelper.MaxRowNumber => XLItemsToRetain.Max,
+                    _ => XLItemsToRetain.Automatic,
+                };
+            }
+
+            if (cacheDefinition.CacheFields is { } cacheFields)
+            {
+                ReadCacheFields(cacheFields, pivotCache);
+                if (pivotTableCacheDefinitionPart.PivotTableCacheRecordsPart?.PivotCacheRecords is { } recordsPart)
+                {
+                    ReadRecords(recordsPart, pivotCache);
+                }
+            }
+
+            pivotCache.SaveSourceData = cacheDefinition.SaveData?.Value ?? true;
         }
 
         internal static IXLPivotSource ParsePivotSourceReference(CacheSource cacheSource)

--- a/ClosedXML/Excel/IO/PivotTableCacheDefinitionPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableCacheDefinitionPartReader.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Excel.IO
 {
     internal class PivotTableCacheDefinitionPartReader
     {
-        internal static void Load(WorkbookPart workbookPart, PivotTableCacheDefinitionPart pivotTableCacheDefinitionPart, XLWorkbook workbook)
+        internal static XLPivotCache Load(WorkbookPart workbookPart, PivotTableCacheDefinitionPart pivotTableCacheDefinitionPart, XLWorkbook workbook)
         {
             var cacheDefinition = pivotTableCacheDefinitionPart.PivotCacheDefinition;
             if (cacheDefinition.CacheSource is not { } cacheSource)
@@ -40,13 +40,10 @@ namespace ClosedXML.Excel.IO
             if (cacheDefinition.CacheFields is { } cacheFields)
             {
                 ReadCacheFields(cacheFields, pivotCache);
-                if (pivotTableCacheDefinitionPart.PivotTableCacheRecordsPart?.PivotCacheRecords is { } recordsPart)
-                {
-                    ReadRecords(recordsPart, pivotCache);
-                }
             }
 
             pivotCache.SaveSourceData = cacheDefinition.SaveData?.Value ?? true;
+            return pivotCache;
         }
 
         internal static IXLPivotSource ParsePivotSourceReference(CacheSource cacheSource)
@@ -326,90 +323,6 @@ namespace ClosedXML.Excel.IO
             }
 
             return sharedItems;
-        }
-
-        private static void ReadRecords(PivotCacheRecords recordsPart, XLPivotCache pivotCache)
-        {
-            // Number of records can be rather large, preallocate capacity to avoid reallocation.
-            var recordCount = recordsPart.Count?.Value is not null
-                ? checked((int)recordsPart.Count.Value)
-                : 0;
-            pivotCache.AllocateRecordCapacity(recordCount);
-
-            var fieldsCount = pivotCache.FieldCount;
-            foreach (var record in recordsPart.Elements<PivotCacheRecord>())
-            {
-                var recordColumns = record.ChildElements.Count;
-                if (recordColumns != fieldsCount)
-                    throw PartStructureException.IncorrectElementsCount();
-
-                for (var fieldIdx = 0; fieldIdx < fieldsCount; ++fieldIdx)
-                {
-                    var fieldValues = pivotCache.GetFieldValues(fieldIdx);
-                    var recordItem = record.ElementAt(fieldIdx);
-
-                    // Don't add values to the shared items of a cache when record value is added, because we want 1:1
-                    // read/write. Read them from definition. Whatever is in shared items now should be written out,
-                    // unless there is a cache refresh. Basically trust the author of the workbook that it is valid.
-                    switch (recordItem)
-                    {
-                        case MissingItem:
-                            fieldValues.AddMissing();
-                            break;
-
-                        case NumberItem numberItem:
-                            if (numberItem.Val?.Value is not { } number)
-                                throw PartStructureException.MissingAttribute();
-
-                            fieldValues.AddNumber(number);
-                            break;
-
-                        case BooleanItem booleanItem:
-                            if (booleanItem.Val?.Value is not { } boolean)
-                                throw PartStructureException.MissingAttribute();
-
-                            fieldValues.AddBoolean(boolean);
-                            break;
-
-                        case ErrorItem errorItem:
-                            if (errorItem.Val?.Value is not { } errorText)
-                                throw PartStructureException.MissingAttribute();
-
-                            if (!XLErrorParser.TryParseError(errorText, out var error))
-                                throw PartStructureException.InvalidAttributeFormat();
-
-                            fieldValues.AddError(error);
-                            break;
-
-                        case StringItem stringItem:
-                            if (stringItem.Val?.Value is not { } text)
-                                throw PartStructureException.MissingAttribute();
-
-                            fieldValues.AddString(text);
-                            break;
-
-                        case DateTimeItem dateTimeItem:
-                            if (dateTimeItem.Val?.Value is not { } dateTime)
-                                throw PartStructureException.MissingAttribute();
-
-                            fieldValues.AddDateTime(dateTime);
-                            break;
-
-                        case FieldItem indexItem:
-                            if (indexItem.Val?.Value is not { } index)
-                                throw PartStructureException.MissingAttribute();
-
-                            if (index >= fieldValues.SharedCount)
-                                throw PartStructureException.InvalidAttributeValue();
-
-                            fieldValues.AddIndex(index);
-                            break;
-
-                        default:
-                            throw PartStructureException.ExpectedElementNotFound();
-                    }
-                }
-            }
         }
     }
 }

--- a/ClosedXML/Excel/IO/PivotTableCacheRecordsPartReader.cs
+++ b/ClosedXML/Excel/IO/PivotTableCacheRecordsPartReader.cs
@@ -1,0 +1,93 @@
+﻿using ClosedXML.Extensions;
+using ClosedXML.IO;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Linq;
+
+namespace ClosedXML.Excel.IO;
+
+internal class PivotTableCacheRecordsPartReader
+{
+    internal static void ReadRecords(PivotCacheRecords recordsPart, XLPivotCache pivotCache)
+    {
+        // Number of records can be rather large, preallocate capacity to avoid reallocation.
+        var recordCount = recordsPart.Count?.Value is not null
+            ? checked((int)recordsPart.Count.Value)
+            : 0;
+        pivotCache.AllocateRecordCapacity(recordCount);
+
+        var fieldsCount = pivotCache.FieldCount;
+        foreach (var record in recordsPart.Elements<PivotCacheRecord>())
+        {
+            var recordColumns = record.ChildElements.Count;
+            if (recordColumns != fieldsCount)
+                throw PartStructureException.IncorrectElementsCount();
+
+            for (var fieldIdx = 0; fieldIdx < fieldsCount; ++fieldIdx)
+            {
+                var fieldValues = pivotCache.GetFieldValues(fieldIdx);
+                var recordItem = record.ElementAt(fieldIdx);
+
+                // Don't add values to the shared items of a cache when record value is added, because we want 1:1
+                // read/write. Read them from definition. Whatever is in shared items now should be written out,
+                // unless there is a cache refresh. Basically trust the author of the workbook that it is valid.
+                switch (recordItem)
+                {
+                    case MissingItem:
+                        fieldValues.AddMissing();
+                        break;
+
+                    case NumberItem numberItem:
+                        if (numberItem.Val?.Value is not { } number)
+                            throw PartStructureException.MissingAttribute();
+
+                        fieldValues.AddNumber(number);
+                        break;
+
+                    case BooleanItem booleanItem:
+                        if (booleanItem.Val?.Value is not { } boolean)
+                            throw PartStructureException.MissingAttribute();
+
+                        fieldValues.AddBoolean(boolean);
+                        break;
+
+                    case ErrorItem errorItem:
+                        if (errorItem.Val?.Value is not { } errorText)
+                            throw PartStructureException.MissingAttribute();
+
+                        if (!XLErrorParser.TryParseError(errorText, out var error))
+                            throw PartStructureException.InvalidAttributeFormat();
+
+                        fieldValues.AddError(error);
+                        break;
+
+                    case StringItem stringItem:
+                        if (stringItem.Val?.Value is not { } text)
+                            throw PartStructureException.MissingAttribute();
+
+                        fieldValues.AddString(text);
+                        break;
+
+                    case DateTimeItem dateTimeItem:
+                        if (dateTimeItem.Val?.Value is not { } dateTime)
+                            throw PartStructureException.MissingAttribute();
+
+                        fieldValues.AddDateTime(dateTime);
+                        break;
+
+                    case FieldItem indexItem:
+                        if (indexItem.Val?.Value is not { } index)
+                            throw PartStructureException.MissingAttribute();
+
+                        if (index >= fieldValues.SharedCount)
+                            throw PartStructureException.InvalidAttributeValue();
+
+                        fieldValues.AddIndex(index);
+                        break;
+
+                    default:
+                        throw PartStructureException.ExpectedElementNotFound();
+                }
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -454,7 +454,11 @@ namespace ClosedXML.Excel
             // Read cache definition before table definition
             foreach (var pivotTableCacheDefinitionPart in workbookPart.GetPartsOfType<PivotTableCacheDefinitionPart>())
             {
-                PivotTableCacheDefinitionPartReader.Load(workbookPart, pivotTableCacheDefinitionPart, this);
+                var pivotCache = PivotTableCacheDefinitionPartReader.Load(workbookPart, pivotTableCacheDefinitionPart, this);
+                if (pivotTableCacheDefinitionPart.PivotTableCacheRecordsPart?.PivotCacheRecords is { } recordsPart)
+                {
+                    PivotTableCacheRecordsPartReader.ReadRecords(recordsPart, pivotCache);
+                }
             }
 
             // Delay loading of pivot tables until all sheets have been loaded

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -451,7 +451,11 @@ namespace ClosedXML.Excel
             }
             LoadDefinedNames(workbook);
 
-            PivotTableCacheDefinitionPartReader.Load(workbookPart, this);
+            // Read cache definition before table definition
+            foreach (var pivotTableCacheDefinitionPart in workbookPart.GetPartsOfType<PivotTableCacheDefinitionPart>())
+            {
+                PivotTableCacheDefinitionPartReader.Load(workbookPart, pivotTableCacheDefinitionPart, this);
+            }
 
             // Delay loading of pivot tables until all sheets have been loaded
             foreach (var dSheet in sheets.OfType<Sheet>())


### PR DESCRIPTION
Move it out of pivot cache definition reader into its own reader. Mostly because I want to try to generate XML parsing code and this is the simplest part we use.