### PR TITLE
Getting attributes from XmlTreeReader should be error suppressable

### DIFF
--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -298,9 +298,32 @@ public sealed class XmlTreeReader : IDisposable
     public uint? GetOptionalUint(string attributeName)
     {
         ThrowOnNonStartElement();
-        long? number = _reader.MoveToAttribute(attributeName) ? _reader.ReadContentAsLong() : null;
+        long? number = null;
+        if (_reader.MoveToAttribute(attributeName))
+        {
+            try
+            {
+                number = _reader.ReadContentAsLong();
+            }
+            catch (OverflowException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+            catch (XmlException e) when (e.InnerException is FormatException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+        }
+
         if (number is < 0 or > uint.MaxValue)
-            throw PartStructureException.InvalidAttributeFormat(_reader.ReadContentAsString());
+        {
+            if (!_suppressFormatErrors)
+                throw PartStructureException.InvalidAttributeFormat(_reader.ReadContentAsString());
+
+            number = null;
+        }
 
         _reader.MoveToElement();
         return number is not null ? (uint)number : null;

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -107,10 +107,22 @@ public sealed class XmlTreeReader : IDisposable
     /// </summary>
     private bool _inLookup = true;
 
+    /// <summary>
+    /// Should unparseable attributes be treated as errors and throw exception are just return null?
+    /// Excel generally ignores unparseable attributes.
+    /// </summary>
+    private readonly bool _suppressFormatErrors;
+
     public XmlTreeReader(XmlReader reader, IEnumMapper enumMapper)
+        : this(reader, enumMapper, false)
+    {
+    }
+
+    public XmlTreeReader(XmlReader reader, IEnumMapper enumMapper, bool suppressFormatErrors)
     {
         _reader = reader;
         _enumMapper = enumMapper;
+        _suppressFormatErrors = suppressFormatErrors;
     }
 
     /// <summary>
@@ -238,7 +250,20 @@ public sealed class XmlTreeReader : IDisposable
     public bool? GetOptionalBool(string attributeName)
     {
         ThrowOnNonStartElement();
-        bool? result = _reader.MoveToAttribute(attributeName) ? _reader.ReadContentAsBoolean() : null;
+        bool? result = null;
+        if (_reader.MoveToAttribute(attributeName))
+        {
+            try
+            {
+                result = _reader.ReadContentAsBoolean();
+            }
+            catch (XmlException e) when (e.InnerException is FormatException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+        }
+
         _reader.MoveToElement();
         return result;
     }

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -332,7 +332,33 @@ public sealed class XmlTreeReader : IDisposable
     public double? GetOptionalDouble(string attributeName)
     {
         ThrowOnNonStartElement();
-        double? number = _reader.MoveToAttribute(attributeName) ? _reader.ReadContentAsDouble() : null;
+        double? number = null;
+        if (_reader.MoveToAttribute(attributeName))
+        {
+            try
+            {
+                number = _reader.ReadContentAsDouble();
+            }
+            catch (OverflowException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+            catch (XmlException e) when (e.InnerException is FormatException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+        }
+
+        if (number is not null && (double.IsNaN(number.Value) || double.IsInfinity(number.Value)))
+        {
+            if (!_suppressFormatErrors)
+                throw PartStructureException.InvalidAttributeFormat(_reader.ReadContentAsString());
+
+            number = null;
+        }
+
         _reader.MoveToElement();
         return number;
     }

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -272,7 +272,25 @@ public sealed class XmlTreeReader : IDisposable
     {
         ThrowOnNonStartElement();
         _reader.MoveToAttribute(attributeName);
-        int? number = _reader.MoveToAttribute(attributeName) ? _reader.ReadContentAsInt() : null;
+        int? number = null;
+        if (_reader.MoveToAttribute(attributeName))
+        {
+            try
+            {
+                number = _reader.ReadContentAsInt();
+            }
+            catch (OverflowException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+            catch (XmlException e) when (e.InnerException is FormatException)
+            {
+                if (!_suppressFormatErrors)
+                    throw;
+            }
+        }
+
         _reader.MoveToElement();
         return number;
     }

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -380,7 +380,12 @@ public sealed class XmlTreeReader : IDisposable
             return null;
 
         if (!_enumMapper.TryGetEnum<TEnum>(enumString, out var enumValue))
-            throw PartStructureException.InvalidAttributeFormat(enumString);
+        {
+            if (!_suppressFormatErrors)
+                throw PartStructureException.InvalidAttributeFormat(enumString);
+
+            return null;
+        }
 
         return enumValue;
     }

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -64,6 +64,23 @@ internal class XmlTreeReaderAttributesTests
         Assert.That(readValue, Is.EqualTo(expectedValue));
     }
 
+    [TestCase("0", 0)]
+    [TestCase("1.75", 1.75)]
+    [TestCase("-1.75e+10", -1.75e+10)]
+    [TestCase("+1.75E+10", 1.75e+10)]
+    [TestCase("2E+308", null)]
+    [TestCase("-2E+308", null)]
+    [TestCase("number", null)]
+    public void GetOptionalDouble_reads_xsd_compliant_double_values(string xmlText, double? expectedValue)
+    {
+        // Generally speaking, uint is stored as int in the internal representation, because nearly
+        // all API expects int and it is just so much easier to work with.
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalDouble(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
     private static XmlTreeReader CreateReader(string attributeValue, XmlToEnumMapper mapper = null)
     {
         var xmlContext = $"<element {AttributeName}=\"{attributeValue}\"/>";

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using System.Xml;
+using ClosedXML.Excel.IO;
+using ClosedXML.IO;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.IO;
+
+/// <summary>
+/// Test various methods (including extension methods) that reader correctly reads the value of
+/// an attribute.
+/// </summary>
+internal class XmlTreeReaderAttributesTests
+{
+    private const string AttributeName = "test";
+
+    [TestCase("true", true)]
+    [TestCase("1", true)]
+    [TestCase("false", false)]
+    [TestCase("0", false)]
+    [TestCase("some text", null)]
+    [TestCase("TRUE", null)] // xsd says case sensitive, for non-readable values return null
+    [TestCase("FALSE", null)]
+    public void GetOptionalBool_reads_xsd_compliant_bool_values(string xmlText, bool? expectedValue)
+    {
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalBool(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
+    private static XmlTreeReader CreateReader(string attributeValue, XmlToEnumMapper mapper = null)
+    {
+        var xmlContext = $"<element {AttributeName}=\"{attributeValue}\"/>";
+        var xmlReader = XmlReader.Create(new StringReader(xmlContext));
+        mapper ??= new XmlToEnumMapper.Builder().Build();
+        var reader = new XmlTreeReader(xmlReader, mapper, true);
+        reader.Open("element", string.Empty);
+        return reader;
+    }
+}

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -48,6 +48,22 @@ internal class XmlTreeReaderAttributesTests
         Assert.That(readValue, Is.EqualTo(expectedValue));
     }
 
+    [TestCase("0", 0u)]
+    [TestCase("57", 57u)]
+    [TestCase("2147483647", 2147483647u)]
+    [TestCase("4294967295", 4294967295u)]
+    [TestCase("-7", null)]
+    [TestCase("value", null)]
+    [TestCase("4294967296", null)] // One above max value
+    [TestCase("9223372036854775808", null)]
+    public void GetOptionalUint_reads_xsd_compliant_unsignedInt_values(string xmlText, uint? expectedValue)
+    {
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalUint(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
     private static XmlTreeReader CreateReader(string attributeValue, XmlToEnumMapper mapper = null)
     {
         var xmlContext = $"<element {AttributeName}=\"{attributeValue}\"/>";

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -29,6 +29,25 @@ internal class XmlTreeReaderAttributesTests
         Assert.That(readValue, Is.EqualTo(expectedValue));
     }
 
+    [TestCase("0", 0)]
+    [TestCase("17", 17)]
+    [TestCase("2147483647", 2147483647)]
+    [TestCase("-2147483648", -2147483648)]
+    [TestCase("+7", 7)] // Canonical representation forbids plus sign or leading zeros, but they are readable
+    [TestCase("05", 5)]
+    [TestCase("", null)]
+    [TestCase("3.0", null)]
+    [TestCase("2147483648", null)]
+    [TestCase("-2147483649", null)]
+    [TestCase("one", null)]
+    public void GetOptionalInt_reads_xsd_compliant_int_values(string xmlText, int? expectedValue)
+    {
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalInt(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
     private static XmlTreeReader CreateReader(string attributeValue, XmlToEnumMapper mapper = null)
     {
         var xmlContext = $"<element {AttributeName}=\"{attributeValue}\"/>";

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using System.Xml;
 using ClosedXML.Excel.IO;
 using ClosedXML.IO;
@@ -92,6 +94,26 @@ internal class XmlTreeReaderAttributesTests
         var readValue = reader.GetOptionalString(AttributeName);
 
         Assert.That(readValue, Is.EqualTo(@"Dear <user_name> _x0009_ - _x0057_elcome"));
+    }
+
+    [TestCase("def", BindingFlags.Default)]
+    [TestCase("ci", BindingFlags.IgnoreCase)]
+    [TestCase("CI", null)] // Enums names are case sensitive
+    [TestCase("Default", null)] // name is not matched, only configured string
+    [TestCase("", null)]
+    [TestCase("NonExpectedValue", null)]
+    public void GetOptionalEnum_returns_enum_parsed_by_enum_mapper(string xmlText, BindingFlags? enumValue)
+    {
+        var mapper = new XmlToEnumMapper.Builder().Add(new Dictionary<string, BindingFlags>
+        {
+            { "def", BindingFlags.Default },
+            { "ci", BindingFlags.IgnoreCase },
+        }).Build();
+
+        using var reader = CreateReader(xmlText, mapper);
+        var readValue = reader.GetOptionalEnum<BindingFlags>(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(enumValue));
     }
 
     private static XmlTreeReader CreateReader(string attributeValue, XmlToEnumMapper mapper = null)

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -81,6 +81,19 @@ internal class XmlTreeReaderAttributesTests
         Assert.That(readValue, Is.EqualTo(expectedValue));
     }
 
+    [Test]
+    public void GetOptionalString_returns_stored_string_without_XString_decoding()
+    {
+        // 0x9 (tab) is invalid character per XML 1.0.
+        // 0x57 (W) is a valid character per XML 1.0.
+        const string value = @"Dear &lt;user_name&gt; _x0009_ - _x0057_elcome";
+
+        using var reader = CreateReader(value);
+        var readValue = reader.GetOptionalString(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(@"Dear <user_name> _x0009_ - _x0057_elcome"));
+    }
+
     private static XmlTreeReader CreateReader(string attributeValue, XmlToEnumMapper mapper = null)
     {
         var xmlContext = $"<element {AttributeName}=\"{attributeValue}\"/>";

--- a/ClosedXML/Excel/IO/XmlToEnumMapper.cs
+++ b/ClosedXML/Excel/IO/XmlToEnumMapper.cs
@@ -13,50 +13,70 @@ internal sealed class XmlToEnumMapper : IEnumMapper
     /// A collection of all maps. The key is enum type, the value is Dictionary&lt;string,SomeEnum&gt;
     /// Value can't be typed due to generic limitations (no common ancestor).
     /// </summary>
-    private readonly Lazy<Dictionary<Type, object>> _textToEnumMaps = new(CreateMaps);
+    private readonly Dictionary<Type, object> _textToEnumMaps;
 
-    internal static readonly XmlToEnumMapper Instance = new();
+    private static readonly Lazy<XmlToEnumMapper> LazyInstance = new(CreateSpreadsheetMapper);
+
+    internal static XmlToEnumMapper Instance => LazyInstance.Value;
+
+    private XmlToEnumMapper(Dictionary<Type, object> maps)
+    {
+        _textToEnumMaps = maps;
+    }
 
     public bool TryGetEnum<TEnum>(string text, out TEnum enumValue)
         where TEnum : struct, Enum
     {
-        var enumMap = (Dictionary<string, TEnum>)_textToEnumMaps.Value[typeof(TEnum)];
+        var enumMap = (Dictionary<string, TEnum>)_textToEnumMaps[typeof(TEnum)];
         return enumMap.TryGetValue(text, out enumValue);
     }
 
-    private static Dictionary<Type, object> CreateMaps()
+    private static XmlToEnumMapper CreateSpreadsheetMapper()
     {
-        var enumMaps = new Dictionary<Type, object>();
+        var builder = new Builder();
 
         // ST_FontScheme
-        var xlFontScheme = new Dictionary<string, XLFontScheme>
+        builder.Add(new Dictionary<string, XLFontScheme>
         {
             { "none", XLFontScheme.None },
             { "major", XLFontScheme.Major },
             { "minor", XLFontScheme.Minor },
-        };
-        enumMaps.Add(typeof(XLFontScheme), xlFontScheme);
+        });
 
         // ST_UnderlineValues
-        var xlFontUnderline = new Dictionary<string, XLFontUnderlineValues>
+        builder.Add(new Dictionary<string, XLFontUnderlineValues>
         {
             { "double", XLFontUnderlineValues.Double },
             { "doubleAccounting", XLFontUnderlineValues.DoubleAccounting },
             { "none", XLFontUnderlineValues.None },
             { "single", XLFontUnderlineValues.Single },
             { "singleAccounting", XLFontUnderlineValues.SingleAccounting },
-        };
-        enumMaps.Add(typeof(XLFontUnderlineValues), xlFontUnderline);
+        });
 
         // ST_VerticalAlignRun
-        var xlFontVerticalTextAlignmentValues = new Dictionary<string, XLFontVerticalTextAlignmentValues>
+        builder.Add(new Dictionary<string, XLFontVerticalTextAlignmentValues>
         {
             { "baseline", XLFontVerticalTextAlignmentValues.Baseline },
             { "subscript", XLFontVerticalTextAlignmentValues.Subscript },
             { "superscript", XLFontVerticalTextAlignmentValues.Superscript },
-        };
-        enumMaps.Add(typeof(XLFontVerticalTextAlignmentValues), xlFontVerticalTextAlignmentValues);
+        });
 
-        return enumMaps;
+        return builder.Build();
+    }
+
+    internal class Builder
+    {
+        private readonly Dictionary<Type, object> _maps = new();
+
+        public Builder Add<T>(Dictionary<string, T> map)
+        {
+            _maps.Add(typeof(T), map);
+            return this;
+        }
+
+        public XmlToEnumMapper Build()
+        {
+            return new XmlToEnumMapper(_maps);
+        }
     }
 }


### PR DESCRIPTION
We can get incorrect values for attributes (e.g. "one" for number, nonexistent enum value, non-number for double) and
generally speaking, Excel suppresses error values and just treats them as missing.

We do want to be able to copy that behavior if possible (though it might be prudent to write them to log once logging is available). The reading code through XmlTreeReader.Get*() extension method will still throw error on missing attribute, but not if there is a default value.

Example: `<b val="yes" />` is a boolean element checking for bold font. Value is invalid, but default value is `true`. The result should thus be that fond is bold (equivalent of `<b />`).

The behavior is dependent on a property passed to the `XmlTreeReader`. At some point I might add an option for that in `LoadOptions`, but for now the default is to throw errors.