### PR TITLE
Move Xstring decoder to IO

### DIFF
--- a/ClosedXML.IO/ClosedXML.IO.csproj
+++ b/ClosedXML.IO/ClosedXML.IO.csproj
@@ -16,4 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
 </Project>

--- a/ClosedXML.IO/XStringConvert.cs
+++ b/ClosedXML.IO/XStringConvert.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Xml;
 
 namespace ClosedXML.IO;
 
@@ -14,10 +16,21 @@ public class XStringConvert
     /// <summary>
     /// Decode an XString to normal string.
     /// </summary>
+    /// <remarks>
+    /// There is a similar method in dotnet <see cref="XmlConvert.DecodeName"/>. That one however
+    /// also accepts uppercase X (<c>_X????_</c>) which shouldn't be decoded. Hexadecimal digits are
+    /// case insensitive, the <c>x</c> marker is not (<a href="https://github.com/ClosedXML/ClosedXML/issues/1154">#1154</a>).
+    /// Another issue is that <see cref="XmlConvert.DecodeName"/> accepts 8 hex digits (e.g.,
+    /// <c>_xD83DDE43_</c>). That is also not valid for XString.
+    /// </remarks>
     /// <param name="text">Test that might contain XString encoded characters.</param>
     /// <returns>Decoded string.</returns>
-    public static string Decode(string text)
+    [return: NotNullIfNotNull(nameof(text))]
+    public static string? Decode(string? text)
     {
+        if (string.IsNullOrWhiteSpace(text))
+            return text;
+
         // This method is on a hotpath and shouldn't allocate unless necessary.
         // Do lazy initialization, there might not be any pattern at all.
         StringBuilder? sb = null;

--- a/ClosedXML.IO/XStringConvert.cs
+++ b/ClosedXML.IO/XStringConvert.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace ClosedXML.IO;
+
+/// <summary>
+/// Class to deal with encoding and decoding XString. XString decoding doesn't depend on the source
+/// encoding. XString decoding decodes from unicode codepoints (regardless if UTF-8 or UTF-16)
+/// and the decoder replaces XString patterns with decoded codepoints.
+/// </summary>
+public class XStringConvert
+{
+    /// <summary>
+    /// Decode an XString to normal string.
+    /// </summary>
+    /// <param name="text">Test that might contain XString encoded characters.</param>
+    /// <returns>Decoded string.</returns>
+    public static string Decode(string text)
+    {
+        // This method is on a hotpath and shouldn't allocate unless necessary.
+        // Do lazy initialization, there might not be any pattern at all.
+        StringBuilder? sb = null;
+
+        // An index of next character after last encountered XString pattern.
+        // Initial value is 0 because text from that index on is copied.
+        var prevSliceNextCharIndex = 0;
+        var textSpan = text.AsSpan();
+        for (var i = textSpan.IndexOf('_'); i >= 0 && i < text.Length - 6; i = text.IndexOf('_', i + 1))
+        {
+            if (IsPattern(textSpan, i))
+            {
+                sb ??= new StringBuilder(text.Length);
+
+                // Append text from last XString splice
+                sb.Append(text, prevSliceNextCharIndex, i - prevSliceNextCharIndex);
+
+                // Get hex digits from from _xABCD_ patterns. Polyfill doesn't have allocation-free
+                // API, so just decode the hex number.
+                var codepoint = 0;
+                for (var hexIndex = i + 2; hexIndex < i + 6; ++hexIndex)
+                {
+                    var hexDigit = GetHex(textSpan[hexIndex]);
+                    codepoint = (codepoint * 16) + hexDigit;
+                }
+
+                sb.Append((char)codepoint);
+
+                // Move from opening '_' to closing '_' because we have effectively read all that
+                // The loop will add + 1 and moves to the next char of text.
+                i += 6;
+                prevSliceNextCharIndex = i + 1;
+            }
+        }
+
+        // Not even one pattern was actually replaced -> return original text
+        if (sb is null)
+            return text;
+
+        sb.Append(text, prevSliceNextCharIndex, text.Length - prevSliceNextCharIndex);
+        return sb.ToString();
+
+        // Does the XString pattern starts at index i?
+        static bool IsPattern(ReadOnlySpan<char> input, int i)
+        {
+            // Reorder to ensure simplest tests are checked first
+            return i + 6 < input.Length &&
+                   input[i] == '_' &&
+                   input[i + 1] == 'x' &&
+                   input[i + 6] == '_' &&
+                   IsHex(input[i + 2]) &&
+                   IsHex(input[i + 3]) &&
+                   IsHex(input[i + 4]) &&
+                   IsHex(input[i + 5]);
+        }
+
+        static bool IsHex(char c)
+        {
+            return c is >= '0' and <= '9' ||
+                   c is >= 'A' and <= 'F' ||
+                   c is >= 'a' and <= 'f';
+        }
+
+        // We already know that c passed the IsHex method.
+        static int GetHex(char c)
+        {
+            return c switch
+            {
+                >= 'A' and <= 'F' => c - 'A' + 10,
+                >= 'a' and <= 'f' => c - 'a' + 10,
+                >= '0' and <= '9' => c - '0',
+                _ => throw new UnreachableException()
+            };
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XmlEncoderTests.cs
@@ -13,13 +13,6 @@ namespace ClosedXML.Tests.Excel
         {
             Assert.AreEqual("_x0001_ _x0002_ _x0003_ _x0004_", XmlEncoder.EncodeString("\u0001 \u0002 \u0003 \u0004"));
             Assert.AreEqual("_x0005_ _x0006_ _x0007_ _x0008_", XmlEncoder.EncodeString("\u0005 \u0006 \u0007 \u0008"));
-
-            Assert.AreEqual("\u0001 \u0002 \u0003 \u0004", XmlEncoder.DecodeString("_x0001_ _x0002_ _x0003_ _x0004_"));
-            Assert.AreEqual("\u0005 \u0006 \u0007 \u0008", XmlEncoder.DecodeString("_x0005_ _x0006_ _x0007_ _x0008_"));
-            Assert.AreEqual("\uAABB \uAABB", XmlEncoder.DecodeString("_xaaBB_ _xAAbb_"));
-
-            // https://github.com/ClosedXML/ClosedXML/issues/1154
-            Assert.AreEqual("_Xceed_Something", XmlEncoder.DecodeString("_Xceed_Something"));
         }
 
         [Test]

--- a/ClosedXML.Tests/IO/XStringConvertTests.cs
+++ b/ClosedXML.Tests/IO/XStringConvertTests.cs
@@ -16,6 +16,11 @@ internal class XStringConvertTests
     [TestCase("_xD83D__xDE43_", "\ud83d\ude43")] // Astral planes - Upside down smiley face
     [TestCase("Result:_x0009_ _x0057_", "Result:\t W")]
     [TestCase("DE_x005F_xAB50_0161_title", "DE_xAB50_0161_title")]
+    [TestCase("_x0001_ _x0002_ _x0003_ _x0004_", "\u0001 \u0002 \u0003 \u0004")]
+    [TestCase("_x0005_ _x0006_ _x0007_ _x0008_", "\u0005 \u0006 \u0007 \u0008")]
+    [TestCase("_xaaBB_ _xAAbb_", "\uAABB \uAABB")]
+    [TestCase(@"_Xceed_Something", @"_Xceed_Something")] // https://github.com/ClosedXML/ClosedXML/issues/1154
+    [TestCase("_xD83DDE43_", "_xD83DDE43_")] // 8 hex digit name, decoded by XmlConvert.DecodeName, but not by XString
     public void Decodes_encoded_unicode_characters(string sourceText, string expectedText)
     {
         var decodedText = XStringConvert.Decode(sourceText);

--- a/ClosedXML.Tests/IO/XStringConvertTests.cs
+++ b/ClosedXML.Tests/IO/XStringConvertTests.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using ClosedXML.IO;
+
+namespace ClosedXML.Tests.IO;
+
+internal class XStringConvertTests
+{
+    [TestCase("", "")]
+    [TestCase("_x000D_", "\r")]
+    [TestCase("_x30ab_", "カ")] // Hexadecimal numbers are case insensitive
+    [TestCase("_x0009_", "\t")]
+    [TestCase("__x0041__", "_A_")]
+    [TestCase("A_x0042_C", "ABC")]
+    [TestCase("_X0041_", "_X0041_")] // Must be lowercase x in the pattern
+    [TestCase("_x263A_", "\u263a")] // Smiley face
+    [TestCase("_xD83D__xDE43_", "\ud83d\ude43")] // Astral planes - Upside down smiley face
+    [TestCase("Result:_x0009_ _x0057_", "Result:\t W")]
+    [TestCase("DE_x005F_xAB50_0161_title", "DE_xAB50_0161_title")]
+    public void Decodes_encoded_unicode_characters(string sourceText, string expectedText)
+    {
+        var decodedText = XStringConvert.Decode(sourceText);
+
+        Assert.That(decodedText, Is.EqualTo(expectedText));
+    }
+}

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -9,6 +9,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=4386F01B791C56499C7EA059B55FFB54/@KeyIndexDefined">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AARRGGBB/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ABCD/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ACOTH/@EntryIndexedValue">True</s:Boolean>
@@ -69,6 +70,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Halfwidth/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hiragana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HLOOKUP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hotpath/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HSTACK/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HYPGEOM.DIST/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IFERROR/@EntryIndexedValue">True</s:Boolean>
@@ -161,6 +163,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vlookup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Webp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=WEEKNUM/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=XString/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=_xlws/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=YEARFRAC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=YearFrac/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -603,7 +603,7 @@ internal class WorksheetPartReader
         }
 
         if (!hasRuns)
-            xlCell.SetOnlyValue(XmlEncoder.DecodeString(element.Text?.InnerText));
+            xlCell.SetOnlyValue(XStringConvert.Decode(element.Text?.InnerText) ?? string.Empty);
 
         // Load phonetic properties
         var phoneticProperties = element.Elements<PhoneticProperties>();

--- a/ClosedXML/Utils/XmlEncoder.cs
+++ b/ClosedXML/Utils/XmlEncoder.cs
@@ -7,7 +7,6 @@ namespace ClosedXML.Utils
     internal static class XmlEncoder
     {
         private static readonly Regex xHHHHRegex = new Regex("_(x[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
-        private static readonly Regex Uppercase_X_HHHHRegex = new Regex("_(X[\\dA-Fa-f]{4})_", RegexOptions.Compiled);
 
         public static string EncodeString(string encodeStr)
         {
@@ -34,18 +33,6 @@ namespace ClosedXML.Utils
             }
 
             return sb.ToString();
-        }
-
-        public static string DecodeString(string? decodeStr)
-        {
-            if (string.IsNullOrEmpty(decodeStr)) return string.Empty;
-
-            // Strings "escaped" with _X (capital X) should not be treated as escaped
-            // Example: _Xceed_Something
-            // https://github.com/ClosedXML/ClosedXML/issues/1154
-            decodeStr = Uppercase_X_HHHHRegex.Replace(decodeStr, "_x005F_$1_");
-
-            return XmlConvert.DecodeName(decodeStr);
         }
     }
 }


### PR DESCRIPTION
Mainly move XString decoder to the IO project, because decoding should be part of IO. It also replaces the original `XmlConvert.DecodeName` + regexp. The `DecodeName` just doesn't match XString.

`DecodeName` differs at least in:
* it decodes even text with uppercase X (`_XCEED_`) - originally covered by regex, but required extra allocation
* it decodes 8 hex digits (`_xD83DDE43_` - upside down smiley)

