### PR TITLE
Add methods to read XML attributes (XString, UnsignedIntHex, DateTime)

### DIFF
--- a/ClosedXML.IO/PartStructureException.cs
+++ b/ClosedXML.IO/PartStructureException.cs
@@ -104,7 +104,7 @@ public class PartStructureException : Exception
     /// <param name="reader">Reader to provide info about place where error happened.</param>
     public static Exception MissingAttribute(string attributeName, XmlTreeReader reader)
     {
-        var message = $"The XML schema requires an attribute '{attributeName}', but is is not present.";
+        var message = $"XML doesn't contain a required attribute '{attributeName}'.";
         return new PartStructureException(message, reader);
     }
 

--- a/ClosedXML.IO/XStringConvert.cs
+++ b/ClosedXML.IO/XStringConvert.cs
@@ -84,6 +84,21 @@ public class XStringConvert
 
     }
 
+    internal static bool TryGetHexValue(ReadOnlySpan<char> text, out uint value)
+    {
+        foreach (var c in text)
+        {
+            if (!IsHex(c))
+            {
+                value = 0;
+                return false;
+            }
+        }
+
+        value = GetHexValue(text);
+        return true;
+    }
+
     private static uint GetHexValue(ReadOnlySpan<char> text)
     {
         if (text.Length > 8)

--- a/ClosedXML.IO/XStringConvert.cs
+++ b/ClosedXML.IO/XStringConvert.cs
@@ -50,12 +50,7 @@ public class XStringConvert
 
                 // Get hex digits from from _xABCD_ patterns. Polyfill doesn't have allocation-free
                 // API, so just decode the hex number.
-                var codepoint = 0;
-                for (var hexIndex = i + 2; hexIndex < i + 6; ++hexIndex)
-                {
-                    var hexDigit = GetHex(textSpan[hexIndex]);
-                    codepoint = (codepoint * 16) + hexDigit;
-                }
+                var codepoint = GetHexValue(textSpan.Slice(i + 2, 4));
 
                 sb.Append((char)codepoint);
 
@@ -87,23 +82,39 @@ public class XStringConvert
                    IsHex(input[i + 5]);
         }
 
-        static bool IsHex(char c)
+    }
+
+    private static uint GetHexValue(ReadOnlySpan<char> text)
+    {
+        if (text.Length > 8)
+            throw new ArgumentException();
+
+        var codepoint = 0u;
+        foreach (var c in text)
         {
-            return c is >= '0' and <= '9' ||
-                   c is >= 'A' and <= 'F' ||
-                   c is >= 'a' and <= 'f';
+            var hexDigit = (uint)GetHex(c);
+            codepoint = (codepoint * 16) + hexDigit;
         }
 
-        // We already know that c passed the IsHex method.
-        static int GetHex(char c)
+        return codepoint;
+    }
+
+    private static bool IsHex(char c)
+    {
+        return c is >= '0' and <= '9' ||
+               c is >= 'A' and <= 'F' ||
+               c is >= 'a' and <= 'f';
+    }
+
+    // We already know that c passed the IsHex method.
+    private static int GetHex(char c)
+    {
+        return c switch
         {
-            return c switch
-            {
-                >= 'A' and <= 'F' => c - 'A' + 10,
-                >= 'a' and <= 'f' => c - 'a' + 10,
-                >= '0' and <= '9' => c - '0',
-                _ => throw new UnreachableException()
-            };
-        }
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= '0' and <= '9' => c - '0',
+            _ => throw new UnreachableException()
+        };
     }
 }

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -107,12 +107,6 @@ public sealed class XmlTreeReader : IDisposable
     /// </summary>
     private bool _inLookup = true;
 
-    /// <summary>
-    /// Should unparseable attributes be treated as errors and throw exception are just return null?
-    /// Excel generally ignores unparseable attributes.
-    /// </summary>
-    private readonly bool _suppressFormatErrors;
-
     public XmlTreeReader(XmlReader reader, IEnumMapper enumMapper)
         : this(reader, enumMapper, false)
     {
@@ -122,13 +116,19 @@ public sealed class XmlTreeReader : IDisposable
     {
         _reader = reader;
         _enumMapper = enumMapper;
-        _suppressFormatErrors = suppressFormatErrors;
+        SuppressFormatErrors = suppressFormatErrors;
     }
 
     /// <summary>
     /// Get name of current element (lookup/processing). It includes an alias for ns.
     /// </summary>
     internal string ElementName => _reader.Name;
+
+    /// <summary>
+    /// Should unparseable attributes be treated as errors and throw exception are just return null?
+    /// Excel generally ignores unparseable attributes.
+    /// </summary>
+    internal bool SuppressFormatErrors { get; }
 
     /// <summary>
     /// Read next element. Check lookup element is <paramref name="localName"/>. If it is, open the
@@ -259,7 +259,7 @@ public sealed class XmlTreeReader : IDisposable
             }
             catch (XmlException e) when (e.InnerException is FormatException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
         }
@@ -281,12 +281,12 @@ public sealed class XmlTreeReader : IDisposable
             }
             catch (OverflowException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
             catch (XmlException e) when (e.InnerException is FormatException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
         }
@@ -307,19 +307,19 @@ public sealed class XmlTreeReader : IDisposable
             }
             catch (OverflowException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
             catch (XmlException e) when (e.InnerException is FormatException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
         }
 
         if (number is < 0 or > uint.MaxValue)
         {
-            if (!_suppressFormatErrors)
+            if (!SuppressFormatErrors)
                 throw PartStructureException.InvalidAttributeFormat(_reader.ReadContentAsString());
 
             number = null;
@@ -341,19 +341,19 @@ public sealed class XmlTreeReader : IDisposable
             }
             catch (OverflowException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
             catch (XmlException e) when (e.InnerException is FormatException)
             {
-                if (!_suppressFormatErrors)
+                if (!SuppressFormatErrors)
                     throw;
             }
         }
 
         if (number is not null && (double.IsNaN(number.Value) || double.IsInfinity(number.Value)))
         {
-            if (!_suppressFormatErrors)
+            if (!SuppressFormatErrors)
                 throw PartStructureException.InvalidAttributeFormat(_reader.ReadContentAsString());
 
             number = null;
@@ -381,7 +381,7 @@ public sealed class XmlTreeReader : IDisposable
 
         if (!_enumMapper.TryGetEnum<TEnum>(enumString, out var enumValue))
         {
-            if (!_suppressFormatErrors)
+            if (!SuppressFormatErrors)
                 throw PartStructureException.InvalidAttributeFormat(enumString);
 
             return null;

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -363,6 +363,32 @@ public sealed class XmlTreeReader : IDisposable
         return number;
     }
 
+    /// <summary>
+    /// Try to read <c>xsd:dateTime</c> from an attribute of current element.
+    /// </summary>
+    /// <param name="attributeName">Name of the attribute.</param>
+    /// <returns>Read datetime or null if attribute is not present.</returns>
+    public DateTime? GetOptionalDateTime(string attributeName)
+    {
+        ThrowOnNonStartElement();
+        DateTime? dateTime = null;
+        if (_reader.MoveToAttribute(attributeName))
+        {
+            try
+            {
+                dateTime = _reader.ReadContentAsDateTime();
+            }
+            catch (XmlException e) when (e.InnerException is FormatException)
+            {
+                if (!SuppressFormatErrors)
+                    throw;
+            }
+        }
+
+        _reader.MoveToElement();
+        return dateTime;
+    }
+
     public string? GetOptionalString(string attributeName)
     {
         ThrowOnNonStartElement();

--- a/ClosedXML.IO/XmlTreeReaderExtensions.cs
+++ b/ClosedXML.IO/XmlTreeReaderExtensions.cs
@@ -49,6 +49,17 @@ public static class XmlTreeReaderExtensions
         return reader.GetOptionalEnum<TEnum>(attributeName) ?? defaultValue;
     }
 
+    public static string GetXString(this XmlTreeReader reader, string attributeName)
+    {
+        return GetOptionalXString(reader, attributeName) ?? throw PartStructureException.MissingAttribute(attributeName, reader);
+    }
+
+    public static string? GetOptionalXString(this XmlTreeReader reader, string attributeName)
+    {
+        var text = reader.GetOptionalString(attributeName);
+        return XStringConvert.Decode(text);
+    }
+
     /// <summary>
     /// Get an attribute with <c>ST_UnsignedIntHex</c> content.
     /// </summary>

--- a/ClosedXML.IO/XmlTreeReaderExtensions.cs
+++ b/ClosedXML.IO/XmlTreeReaderExtensions.cs
@@ -48,4 +48,26 @@ public static class XmlTreeReaderExtensions
     {
         return reader.GetOptionalEnum<TEnum>(attributeName) ?? defaultValue;
     }
+
+    /// <summary>
+    /// Get an attribute with <c>ST_UnsignedIntHex</c> content.
+    /// </summary>
+    public static uint? GetOptionalUIntHex(this XmlTreeReader reader, string attributeName)
+    {
+        // XmlReader has ReadContentAsBinHex, but it also requires allocation, so we can just do it
+        // as extension method without polluting reader.
+        var hexString = reader.GetOptionalString(attributeName);
+        if (hexString is null)
+            return null;
+
+        if (hexString.Length != 8 || !XStringConvert.TryGetHexValue(hexString.AsSpan(), out var number))
+        {
+            if (!reader.SuppressFormatErrors)
+                throw PartStructureException.InvalidAttributeFormat(hexString);
+
+            return null;
+        }
+
+        return number;
+    }
 }

--- a/ClosedXML.IO/XmlTreeReaderExtensions.cs
+++ b/ClosedXML.IO/XmlTreeReaderExtensions.cs
@@ -81,4 +81,12 @@ public static class XmlTreeReaderExtensions
 
         return number;
     }
+
+    /// <summary>
+    /// Read <c>xsd:dateTime</c> attribute.
+    /// </summary>
+    public static DateTime GetDateTime(this XmlTreeReader reader, string attributeName)
+    {
+        return reader.GetOptionalDateTime(attributeName) ?? throw PartStructureException.MissingAttribute(attributeName, reader);
+    }
 }

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Xml;
@@ -81,6 +82,18 @@ internal class XmlTreeReaderAttributesTests
         var readValue = reader.GetOptionalDouble(AttributeName);
 
         Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
+    [TestCase("2025-10-25", "2025-10-25T00:00:00")]
+    [TestCase("2004-04-12T13:20:00Z", "2004-04-12T13:20:00Z")]
+    [TestCase("today", null)]
+    public void GetOptionalDateTime_reads_xsd_compliant_dateTime_values(string xmlText, string expectedString)
+    {
+        DateTimeOffset? expectedValue = expectedString is not null ? DateTimeOffset.Parse(expectedString) : null;
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalDateTime(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue?.DateTime));
     }
 
     [Test]

--- a/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
@@ -10,6 +10,28 @@ internal class XmlTreeReaderExtensionsTests
 {
     private const string AttributeName = "test";
 
+    [Test]
+    public void GetXString_throws_when_attribute_is_not_present()
+    {
+        using var reader = CreateReader("dummy");
+
+        var ex = Assert.Throws<PartStructureException>(() => reader.GetXString("nonexistent"));
+        Assert.That(ex, Has.Message.Contain("XML doesn't contain a required attribute 'nonexistent'."));
+    }
+
+
+    [TestCase("&amp;", "&")]
+    [TestCase("_x0009_", "\t")]
+    [TestCase("_X0009_", "_X0009_")]
+    [TestCase("Hello &lt;user&gt; - _x0045__x004F__x004C_", "Hello <user> - EOL")]
+    public void GetOptionalXString_returns_XString_decoded_xml_decoded_text(string xmlText, string expectedValue)
+    {
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalXString(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
     [TestCase("00000000", 0u)]
     [TestCase("0G000000", null)]
     [TestCase(@"FFFFFFFF", 0xFFFFFFFF)]

--- a/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using System.IO;
+using System.Xml;
+using ClosedXML.Excel.IO;
+using ClosedXML.IO;
+
+namespace ClosedXML.Tests.IO;
+
+internal class XmlTreeReaderExtensionsTests
+{
+    private const string AttributeName = "test";
+
+    [TestCase("00000000", 0u)]
+    [TestCase("0G000000", null)]
+    [TestCase(@"FFFFFFFF", 0xFFFFFFFF)]
+    [TestCase(@"FFFFFFFF", 0xFFFFFFFF)]
+    [TestCase("abcdef00", 0xABCDEF00)]
+    [TestCase("0000000", null)]
+    [TestCase(@"", null)]
+    [TestCase(@"hello", null)]
+    public void GetOptionalUIntHex_parses_8_hex_digits(string xmlText, uint? expectedValue)
+    {
+        using var reader = CreateReader(xmlText);
+        var readValue = reader.GetOptionalUIntHex(AttributeName);
+
+        Assert.That(readValue, Is.EqualTo(expectedValue));
+    }
+
+    private static XmlTreeReader CreateReader(string attributeValue)
+    {
+        var xmlContext = $"<element {AttributeName}=\"{attributeValue}\"/>";
+        var xmlReader = XmlReader.Create(new StringReader(xmlContext));
+        var reader = new XmlTreeReader(xmlReader, new XmlToEnumMapper.Builder().Build(), true);
+        reader.Open("element", string.Empty);
+        return reader;
+    }
+}

--- a/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
@@ -11,6 +11,15 @@ internal class XmlTreeReaderExtensionsTests
     private const string AttributeName = "test";
 
     [Test]
+    public void GetDateTime_throws_when_attribute_is_not_present()
+    {
+        using var reader = CreateReader("dummy");
+
+        var ex = Assert.Throws<PartStructureException>(() => reader.GetDateTime("nonexistent"));
+        Assert.That(ex, Has.Message.Contain("XML doesn't contain a required attribute 'nonexistent'."));
+    }
+
+    [Test]
     public void GetXString_throws_when_attribute_is_not_present()
     {
         using var reader = CreateReader("dummy");
@@ -18,7 +27,6 @@ internal class XmlTreeReaderExtensionsTests
         var ex = Assert.Throws<PartStructureException>(() => reader.GetXString("nonexistent"));
         Assert.That(ex, Has.Message.Contain("XML doesn't contain a required attribute 'nonexistent'."));
     }
-
 
     [TestCase("&amp;", "&")]
     [TestCase("_x0009_", "\t")]


### PR DESCRIPTION
These attributes are necessary to read the pivot cache record part.