### PR TITLE
Fix issue loading .xlsx files with "Notes" missing textBox

### DIFF
--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -411,8 +411,8 @@ namespace ClosedXML.Excel
                             var clientData = shape.Elements().First(e => e.Name.LocalName == "ClientData");
                             LoadClientData(xlComment, clientData);
 
-                            var textBox = shape.Elements().First(e => e.Name.LocalName == "textbox");
-                            LoadTextBox(xlComment, textBox);
+                            var textBox = shape.Elements().FirstOrDefault(e => e.Name.LocalName == "textbox");
+                            if (textBox is not null) LoadTextBox(xlComment, textBox);
 
                             var alt = shape.Attribute("alt");
                             if (alt != null) xlComment.Style.Web.SetAlternateText(alt.Value);


### PR DESCRIPTION
When opening .xlsx files with Notes, an exception occurred if the textBox was missing. 

To fix this:

- Added a check to see if the textBox exists.