### PR TITLE
Fix ParsingException when inserting columns and workbook DefinedName with an invalid formula

### DIFF
--- a/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
+++ b/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
@@ -2,6 +2,7 @@ using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using ClosedXML.Extensions;
 
 namespace ClosedXML.Tests.Excel
 {
@@ -286,6 +287,17 @@ namespace ClosedXML.Tests.Excel
             Assert.AreEqual(100, ws.Column("C").Width, XLHelper.Epsilon);
             Assert.AreEqual(defaultColumnWidth, ws.Column("G").Width, XLHelper.Epsilon);
             Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+        }
+
+        [Test]
+        public void ColumnsCanBeInsertedWhenDocumentHasDefinedNameWithInvalidFormula()
+        {
+            // Issue 2669: InsertColumnsBefore/After fails with a ParsingException when the workbook has a defined name
+            // with an invalid formula.
+            var wb = new XLWorkbook();
+            wb.DefinedNames.Add("TestName", XLError.NameNotRecognized.ToDisplayString());
+            wb.AddWorksheet().FirstColumn().InsertColumnsAfter(1);
+            wb.AddWorksheet().FirstColumn().InsertColumnsBefore(1);
         }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1481,7 +1481,7 @@ namespace ClosedXML.Excel
         {
             foreach (var definedName in definedNames)
             {
-                if (definedName.SheetReferencesList.Count() > 0)
+                if (definedName.SheetReferencesList.Count > 0)
                 {
                     var newRangeList =
                         definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaRows(r, this, range, rowsShifted)).Where(
@@ -1496,11 +1496,14 @@ namespace ClosedXML.Excel
         {
             foreach (var definedName in definedNames)
             {
-                var newRangeList =
-                    definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaColumns(r, this, range, columnsShifted)).Where(
-                        newReference => newReference.Length > 0).ToList();
-                var unionFormula = string.Join(",", newRangeList);
-                definedName.SetRefersTo(unionFormula);
+                if (definedName.SheetReferencesList.Count > 0)
+                {
+                    var newRangeList =
+                        definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaColumns(r, this, range, columnsShifted)).Where(
+                            newReference => newReference.Length > 0).ToList();
+                    var unionFormula = string.Join(",", newRangeList);
+                    definedName.SetRefersTo(unionFormula);
+                }
             }
         }
 


### PR DESCRIPTION
This is to resolve #2669 where a defined name with an invalid formula causes calls to `InsertColumnsBefore` and `InsertColumnsAfter` to throw a `ParsingException`. This issue doesn't affect inserting rows due a change made to `MoveDefinedNamesRows` by #2425. This PR makes the same change for columns and adds a unit test.