### PR TITLE
performance (XLStyle): Custom GetHashCode to improve performance on XLStyle structs

### DIFF
--- a/ClosedXML/Excel/Style/XLBorderKey.cs
+++ b/ClosedXML/Excel/Style/XLBorderKey.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace ClosedXML.Excel;
 
 internal readonly record struct XLBorderKey
@@ -30,27 +28,28 @@ internal readonly record struct XLBorderKey
 
     public override int GetHashCode()
     {
-        var hash = new HashCode();
-        hash.Add(LeftBorder);
-        hash.Add(RightBorder);
-        hash.Add(TopBorder);
-        hash.Add(BottomBorder);
-        hash.Add(DiagonalBorder);
-        hash.Add(DiagonalUp);
-        hash.Add(DiagonalDown);
+        unchecked
+        {
+            var hash = (int)LeftBorder;
+            hash = (hash * 397) ^ (LeftBorder != XLBorderStyleValues.None ? LeftBorderColor.GetHashCode() : 0);
 
-        if (LeftBorder != XLBorderStyleValues.None)
-            hash.Add(LeftBorderColor);
-        if (RightBorder != XLBorderStyleValues.None)
-            hash.Add(RightBorderColor);
-        if (TopBorder != XLBorderStyleValues.None)
-            hash.Add(TopBorderColor);
-        if (BottomBorder != XLBorderStyleValues.None)
-            hash.Add(BottomBorderColor);
-        if (DiagonalBorder != XLBorderStyleValues.None)
-            hash.Add(DiagonalBorderColor);
+            hash = (hash * 397) ^ (int)RightBorder;
+            hash = (hash * 397) ^ (RightBorder != XLBorderStyleValues.None ? RightBorderColor.GetHashCode() : 0);
 
-        return hash.ToHashCode();
+            hash = (hash * 397) ^ (int)TopBorder;
+            hash = (hash * 397) ^ (TopBorder != XLBorderStyleValues.None ? TopBorderColor.GetHashCode() : 0);
+
+            hash = (hash * 397) ^ (int)BottomBorder;
+            hash = (hash * 397) ^ (BottomBorder != XLBorderStyleValues.None ? BottomBorderColor.GetHashCode() : 0);
+
+            hash = (hash * 397) ^ (int)DiagonalBorder;
+            hash = (hash * 397) ^ (DiagonalBorder != XLBorderStyleValues.None ? DiagonalBorderColor.GetHashCode() : 0);
+
+            hash = (hash * 397) ^ (DiagonalUp ? 1 : 0);
+            hash = (hash * 397) ^ (DiagonalDown ? 1 : 0);
+
+            return hash;
+        }
     }
 
     public bool Equals(XLBorderKey other)
@@ -65,7 +64,7 @@ internal readonly record struct XLBorderKey
             && DiagonalDown == other.DiagonalDown;
     }
 
-    private bool AreEquivalent(
+    private static bool AreEquivalent(
         XLBorderStyleValues borderStyle1, XLColorKey color1,
         XLBorderStyleValues borderStyle2, XLColorKey color2)
     {

--- a/ClosedXML/Excel/Style/XLColorKey.cs
+++ b/ClosedXML/Excel/Style/XLColorKey.cs
@@ -1,78 +1,90 @@
 #nullable disable
-
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+internal struct XLColorKey : IEquatable<XLColorKey>
 {
-    internal struct XLColorKey : IEquatable<XLColorKey>
+    public XLColorType ColorType { get; set; }
+
+    public System.Drawing.Color Color { get; set; }
+
+    public int Indexed { get; set; }
+
+    public XLThemeColor ThemeColor { get; set; }
+
+    public double ThemeTint { get; set; }
+
+    public override int GetHashCode()
     {
-        public XLColorType ColorType { get; set; }
-
-        public System.Drawing.Color Color { get; set; }
-
-        public int Indexed { get; set; }
-
-        public XLThemeColor ThemeColor { get; set; }
-
-        public double ThemeTint { get; set; }
-
-        public override int GetHashCode()
+        unchecked
         {
-            var hashCode = -331517974;
-            hashCode = hashCode * -1521134295 + (int)ColorType;
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Indexed ? Indexed : 0);
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? (int)ThemeColor : 0);
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Theme ? ThemeTint.GetHashCode() : 0);
-            hashCode = hashCode * -1521134295 + (ColorType == XLColorType.Color ? Color.ToArgb() : 0);
-            return hashCode;
-        }
+            var hash = (int)ColorType;
 
-        public bool Equals(XLColorKey other)
-        {
-            if (ColorType == other.ColorType)
-            {
-                if (ColorType == XLColorType.Color)
-                {
-                    // .NET Color.Equals() will return false for Color.FromArgb(255, 255, 255, 255) == Color.White
-                    // Therefore we compare the ToArgb() values
-                    return Color.ToArgb() == other.Color.ToArgb();
-                }
-                if (ColorType == XLColorType.Theme)
-                {
-                    return
-                        ThemeColor == other.ThemeColor
-                     && Math.Abs(ThemeTint - other.ThemeTint) < XLHelper.Epsilon;
-                }
-                return Indexed == other.Indexed;
-            }
-
-            return false;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is XLColorKey)
-                return Equals((XLColorKey)obj);
-            return base.Equals(obj);
-        }
-
-        public override string ToString()
-        {
             switch (ColorType)
             {
-                case XLColorType.Color:
-                    return Color.ToString();
-                case XLColorType.Theme:
-                    return $"{ThemeColor} ({ThemeTint})";
                 case XLColorType.Indexed:
-                    return $"Indexed: {Indexed}";
-                default:
-                    return base.ToString();
+                    hash = (hash * 397) ^ Indexed;
+                    break;
+
+                case XLColorType.Theme:
+                    hash = (hash * 397) ^ (int)ThemeColor;
+
+                    // Normalize ThemeTint so that small float differences don't cause large hash differences
+                    var tintHash = (int)(ThemeTint * 100000); // Multiply to make epsilon differences visible
+                    hash = (hash * 397) ^ tintHash;
+                    break;
+
+                case XLColorType.Color:
+                    hash = (hash * 397) ^ Color.ToArgb();
+                    break;
             }
+
+            return hash;
+        }
+    }
+
+    public bool Equals(XLColorKey other)
+    {
+        if (ColorType == other.ColorType)
+        {
+            if (ColorType == XLColorType.Color)
+            {
+                // .NET Color.Equals() will return false for Color.FromArgb(255, 255, 255, 255) == Color.White
+                // Therefore we compare the ToArgb() values
+                return Color.ToArgb() == other.Color.ToArgb();
+            }
+            if (ColorType == XLColorType.Theme)
+            {
+                return
+                    ThemeColor == other.ThemeColor
+                    && Math.Abs(ThemeTint - other.ThemeTint) < XLHelper.Epsilon;
+            }
+            return Indexed == other.Indexed;
         }
 
-        public static bool operator ==(XLColorKey left, XLColorKey right) => left.Equals(right);
-
-        public static bool operator !=(XLColorKey left, XLColorKey right) => !(left.Equals(right));
+        return false;
     }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is XLColorKey key)
+            return Equals(key);
+        return base.Equals(obj);
+    }
+
+    public override string ToString()
+    {
+        return ColorType switch
+        {
+            XLColorType.Color => Color.ToString(),
+            XLColorType.Theme => $"{ThemeColor} ({ThemeTint})",
+            XLColorType.Indexed => $"Indexed: {Indexed}",
+            _ => base.ToString()
+        };
+    }
+
+    public static bool operator ==(XLColorKey left, XLColorKey right) => left.Equals(right);
+
+    public static bool operator !=(XLColorKey left, XLColorKey right) => !(left.Equals(right));
 }

--- a/ClosedXML/Excel/Style/XLFillKey.cs
+++ b/ClosedXML/Excel/Style/XLFillKey.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace ClosedXML.Excel;
 
 internal readonly record struct XLFillKey
@@ -12,18 +10,23 @@ internal readonly record struct XLFillKey
 
     public override int GetHashCode()
     {
-        var hash = new HashCode();
+        unchecked
+        {
+            var hash = 0;
 
-        if (HasNoFill()) return hash.ToHashCode();
+            if (!HasNoFill())
+            {
+                hash = (int)PatternType;
+                hash = (hash * 397) ^ BackgroundColor.GetHashCode();
 
-        hash.Add(PatternType);
-        hash.Add(BackgroundColor);
+                if (!HasNoForeground())
+                {
+                    hash = (hash * 397) ^ PatternColor.GetHashCode();
+                }
+            }
 
-        if (HasNoForeground()) return hash.ToHashCode();
-                
-        hash.Add(PatternColor);
-            
-        return hash.ToHashCode();
+            return hash;
+        }
     }
 
     public bool Equals(XLFillKey other)

--- a/ClosedXML/Excel/Style/XLFontKey.cs
+++ b/ClosedXML/Excel/Style/XLFontKey.cs
@@ -44,23 +44,33 @@ internal readonly record struct XLFontKey
             && FontScheme == other.FontScheme
             && string.Equals(FontName, other.FontName, StringComparison.OrdinalIgnoreCase);
     }
-
+    
     public override int GetHashCode()
     {
-        var hash = new HashCode();
-        hash.Add(Bold);
-        hash.Add(Italic);
-        hash.Add(Underline);
-        hash.Add(Strikethrough);
-        hash.Add(VerticalAlignment);
-        hash.Add(Shadow);
-        hash.Add(FontSize);
-        hash.Add(FontColor);
-        hash.Add(FontName, StringComparer.OrdinalIgnoreCase);
-        hash.Add(FontFamilyNumbering);
-        hash.Add(FontCharSet);
-        hash.Add(FontScheme);
-        return hash.ToHashCode();
+        unchecked
+        {
+            var hash = Bold ? 1 : 0;
+            hash = (hash * 397) ^ (Italic ? 1 : 0);
+            hash = (hash * 397) ^ (int)Underline;
+            hash = (hash * 397) ^ (Strikethrough ? 1 : 0);
+            hash = (hash * 397) ^ (int)VerticalAlignment;
+            hash = (hash * 397) ^ (Shadow ? 1 : 0);
+
+            // FontSize as long bits (BitConverter ensures stable bit pattern)
+            hash = (hash * 397) ^ BitConverter.DoubleToInt64Bits(FontSize).GetHashCode();
+
+            hash = (hash * 397) ^ FontColor.GetHashCode();
+
+            // FontName with OrdinalIgnoreCase hash
+            if (!string.IsNullOrEmpty(FontName))
+                hash = (hash * 397) ^ StringComparer.OrdinalIgnoreCase.GetHashCode(FontName);
+
+            hash = (hash * 397) ^ (int)FontFamilyNumbering;
+            hash = (hash * 397) ^ (int)FontCharSet;
+            hash = (hash * 397) ^ (int)FontScheme;
+
+            return hash;
+        }
     }
 
     public override string ToString()

--- a/ClosedXML/Excel/Style/XLStyleKey.cs
+++ b/ClosedXML/Excel/Style/XLStyleKey.cs
@@ -49,4 +49,30 @@ internal readonly record struct XLStyleKey
         numberFormat = NumberFormat;
         protection = Protection;
     }
+    
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Alignment.GetHashCode();
+            hash = (hash * 397) ^ Border.GetHashCode();
+            hash = (hash * 397) ^ Fill.GetHashCode();
+            hash = (hash * 397) ^ Font.GetHashCode();
+            hash = (hash * 397) ^ IncludeQuotePrefix.GetHashCode();
+            hash = (hash * 397) ^ NumberFormat.GetHashCode();
+            hash = (hash * 397) ^ Protection.GetHashCode();
+            return hash;
+        }
+    }
+
+    public bool Equals(XLStyleKey other)
+    {
+        return Alignment.Equals(other.Alignment)
+               && Border.Equals(other.Border)
+               && Fill.Equals(other.Fill)
+               && Font.Equals(other.Font)
+               && IncludeQuotePrefix == other.IncludeQuotePrefix
+               && NumberFormat.Equals(other.NumberFormat)
+               && Protection.Equals(other.Protection);
+    }
 }


### PR DESCRIPTION
## Summary
Custom GetHashCode to improve performance on XLStyle structs  Slight reduction in memory allocation.  vs using `HashCode()`


## Benchmarks

**NOTE**: These benchmarks are from when I stacked this PR ontop of #2674 and execute the benchmark test in that PR, but it does illustrate the change.  

#### Before

| Method          | Mean     | Error    | StdDev   | Gen0      | Gen1     | Allocated |
|---------------- |---------:|---------:|---------:|----------:|---------:|----------:|
| CellFillAndCopy | 43.96 ms | 0.875 ms | 0.899 ms | 1700.0000 | 800.0000 |  28.17 MB |

#### After GetHashCode Changes.

| Method          | Mean     | Error    | StdDev   | Gen0      | Gen1     | Allocated |
|---------------- |---------:|---------:|---------:|----------:|---------:|----------:|
| CellFillAndCopy | 41.08 ms | 0.818 ms | 1.475 ms | 1692.3077 | 615.3846 |  27.99 MB |



## Why HashCode may be slower
It has extra state and indirection
HashCode is a mutable struct that maintains internal buffers
Each .`Add()` writes into the buffer
When calling `.ToHashCode()` → it combines state + random salt → extra CPU cost