### PR TITLE
Update to NUnit 4

### DIFF
--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -17,11 +17,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTester.cs
@@ -70,7 +70,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 var formattedString = ((XLCell)ws.Cell(row, 1)).GetFormattedString(value);
                 var actualVisible = !ws.Row(row).IsHidden;
                 var expectedVisibility = _values[i].ExpectedVisibility;
-                Assert.AreEqual(expectedVisibility, actualVisible, $"Visibility differs at index {i} for value {value} (formatted '{formattedString}')");
+                Assert.That(actualVisible, Is.EqualTo(expectedVisibility), $"Visibility differs at index {i} for value {value} (formatted '{formattedString}')");
             }
         }
     }

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -212,7 +212,7 @@ namespace ClosedXML.Tests
 
             // Unhide the rows so that the table is out of sync with the filter
             autoFilter.HiddenRows.ForEach(r => r.WorksheetRow().Unhide());
-            Assert.False(autoFilter.HiddenRows.Any());
+            Assert.That(autoFilter.HiddenRows.Any(), Is.False);
 
             autoFilter.Reapply();
             Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(3));

--- a/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/AutoFilterTests.cs
@@ -15,44 +15,43 @@ namespace ClosedXML.Tests
         [Test]
         public void AutoFilterExpandsWithTable()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+
+            ws.FirstCell().SetValue("Categories")
+                .CellBelow().SetValue("1")
+                .CellBelow().SetValue("2");
+
+            IXLTable table = ws.RangeUsed().CreateTable();
+
+            var listOfArr = new List<int>();
+            listOfArr.Add(3);
+            listOfArr.Add(4);
+            listOfArr.Add(5);
+            listOfArr.Add(6);
+
+            table.DataRange.InsertRowsBelow(listOfArr.Count - table.DataRange.RowCount());
+            table.DataRange.FirstCell().InsertData(listOfArr);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-
-                ws.FirstCell().SetValue("Categories")
-                    .CellBelow().SetValue("1")
-                    .CellBelow().SetValue("2");
-
-                IXLTable table = ws.RangeUsed().CreateTable();
-
-                var listOfArr = new List<Int32>();
-                listOfArr.Add(3);
-                listOfArr.Add(4);
-                listOfArr.Add(5);
-                listOfArr.Add(6);
-
-                table.DataRange.InsertRowsBelow(listOfArr.Count - table.DataRange.RowCount());
-                table.DataRange.FirstCell().InsertData(listOfArr);
-
-                Assert.AreEqual("A1:A5", table.AutoFilter.Range.RangeAddress.ToStringRelative());
-                Assert.AreEqual(5, table.AutoFilter.VisibleRows.Count());
-            }
+                Assert.That(table.AutoFilter.Range.RangeAddress.ToStringRelative(), Is.EqualTo("A1:A5"));
+                Assert.That(table.AutoFilter.VisibleRows.Count(), Is.EqualTo(5));
+            });
         }
 
         [Test]
         public void AutoFilterSortWhenNotInFirstRow()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
 
-                ws.Cell(3, 3).SetValue("Names")
-                    .CellBelow().SetValue("Manuel")
-                    .CellBelow().SetValue("Carlos")
-                    .CellBelow().SetValue("Dominic");
-                ws.RangeUsed().SetAutoFilter().Sort();
-                Assert.AreEqual("Carlos", ws.Cell(4, 3).GetText());
-            }
+            ws.Cell(3, 3).SetValue("Names")
+                .CellBelow().SetValue("Manuel")
+                .CellBelow().SetValue("Carlos")
+                .CellBelow().SetValue("Dominic");
+            ws.RangeUsed().SetAutoFilter().Sort();
+            Assert.That(ws.Cell(4, 3).GetText(), Is.EqualTo("Carlos"));
         }
 
         [Test]
@@ -78,52 +77,48 @@ namespace ClosedXML.Tests
         [Test]
         public void CanClearAutoFilter2()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("AutoFilter");
-                ws.Cell("A1").Value = "Names";
-                ws.Cell("A2").Value = "John";
-                ws.Cell("A3").Value = "Hank";
-                ws.Cell("A4").Value = "Dagny";
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("AutoFilter");
+            ws.Cell("A1").Value = "Names";
+            ws.Cell("A2").Value = "John";
+            ws.Cell("A3").Value = "Hank";
+            ws.Cell("A4").Value = "Dagny";
 
-                ws.SetAutoFilter(false);
-                Assert.That(!ws.AutoFilter.IsEnabled);
+            ws.SetAutoFilter(false);
+            Assert.That(!ws.AutoFilter.IsEnabled);
 
-                ws.RangeUsed().SetAutoFilter();
-                Assert.That(ws.AutoFilter.IsEnabled);
+            ws.RangeUsed().SetAutoFilter();
+            Assert.That(ws.AutoFilter.IsEnabled);
 
-                ws.RangeUsed().SetAutoFilter(false);
-                Assert.That(!ws.AutoFilter.IsEnabled);
-            }
+            ws.RangeUsed().SetAutoFilter(false);
+            Assert.That(!ws.AutoFilter.IsEnabled);
         }
 
         [Test]
         public void CanCopyAutoFilterToNewSheetOnNewWorkbook()
         {
-            using (var ms1 = new MemoryStream())
-            using (var ms2 = new MemoryStream())
+            using var ms1 = new MemoryStream();
+            using var ms2 = new MemoryStream();
+            using (var wb1 = new XLWorkbook())
+            using (var wb2 = new XLWorkbook())
             {
-                using (var wb1 = new XLWorkbook())
-                using (var wb2 = new XLWorkbook())
-                {
-                    var ws = wb1.Worksheets.Add("AutoFilter");
-                    ws.Cell("A1").Value = "Names";
-                    ws.Cell("A2").Value = "John";
-                    ws.Cell("A3").Value = "Hank";
-                    ws.Cell("A4").Value = "Dagny";
+                var ws = wb1.Worksheets.Add("AutoFilter");
+                ws.Cell("A1").Value = "Names";
+                ws.Cell("A2").Value = "John";
+                ws.Cell("A3").Value = "Hank";
+                ws.Cell("A4").Value = "Dagny";
 
-                    ws.RangeUsed().SetAutoFilter();
+                ws.RangeUsed().SetAutoFilter();
 
-                    wb1.SaveAs(ms1);
+                wb1.SaveAs(ms1);
 
-                    ws.CopyTo(wb2, ws.Name);
-                    wb2.SaveAs(ms2);
-                }
+                ws.CopyTo(wb2, ws.Name);
+                wb2.SaveAs(ms2);
+            }
 
-                using (var wb2 = new XLWorkbook(ms2))
-                {
-                    Assert.IsTrue(wb2.Worksheets.First().AutoFilter.IsEnabled);
-                }
+            using (var wb2 = new XLWorkbook(ms2))
+            {
+                Assert.That(wb2.Worksheets.First().AutoFilter.IsEnabled, Is.True);
             }
         }
 
@@ -151,81 +146,76 @@ namespace ClosedXML.Tests
         public void AutoFilterRangeRemainsValidOnInsertColumn(string rangeAddress)
         {
             //Arrange
-            using (var ms1 = new MemoryStream())
-            {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.Worksheets.Add("AutoFilter");
-                    ws.Cell("A1").Value = "Ids";
-                    ws.Cell("B1").Value = "Names";
-                    ws.Cell("B2").Value = "John";
-                    ws.Cell("B3").Value = "Hank";
-                    ws.Cell("B4").Value = "Dagny";
-                    ws.Cell("C1").Value = "Phones";
+            using var ms1 = new MemoryStream();
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("AutoFilter");
+            ws.Cell("A1").Value = "Ids";
+            ws.Cell("B1").Value = "Names";
+            ws.Cell("B2").Value = "John";
+            ws.Cell("B3").Value = "Hank";
+            ws.Cell("B4").Value = "Dagny";
+            ws.Cell("C1").Value = "Phones";
 
-                    ws.Range("B1:B4").SetAutoFilter(true);
+            ws.Range("B1:B4").SetAutoFilter(true);
 
-                    //Act
-                    var range = ws.Range(rangeAddress);
-                    range.InsertColumnsBefore(1);
+            //Act
+            var range = ws.Range(rangeAddress);
+            range.InsertColumnsBefore(1);
 
-                    //Assert
-                    Assert.IsTrue(ws.AutoFilter.Range.RangeAddress.IsValid);
-                }
-            }
+            //Assert
+            Assert.That(ws.AutoFilter.Range.RangeAddress.IsValid, Is.True);
         }
 
         [Test]
         public void AutoFilterVisibleRows()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+
+            ws.Cell(3, 3).SetValue("Names")
+                .CellBelow().SetValue("Manuel")
+                .CellBelow().SetValue("Carlos")
+                .CellBelow().SetValue("Dominic");
+
+            var autoFilter = ws.RangeUsed()
+                .SetAutoFilter();
+
+            autoFilter.Column(1).AddFilter("Carlos");
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-
-                ws.Cell(3, 3).SetValue("Names")
-                    .CellBelow().SetValue("Manuel")
-                    .CellBelow().SetValue("Carlos")
-                    .CellBelow().SetValue("Dominic");
-
-                var autoFilter = ws.RangeUsed()
-                    .SetAutoFilter();
-
-                autoFilter.Column(1).AddFilter("Carlos");
-
-                Assert.AreEqual("Carlos", ws.Cell(5, 3).GetText());
-                Assert.AreEqual(2, autoFilter.VisibleRows.Count());
-                Assert.AreEqual(3, autoFilter.VisibleRows.First().WorksheetRow().RowNumber());
-                Assert.AreEqual(5, autoFilter.VisibleRows.Last().WorksheetRow().RowNumber());
-            }
+                Assert.That(ws.Cell(5, 3).GetText(), Is.EqualTo("Carlos"));
+                Assert.That(autoFilter.VisibleRows.Count(), Is.EqualTo(2));
+                Assert.That(autoFilter.VisibleRows.First().WorksheetRow().RowNumber(), Is.EqualTo(3));
+                Assert.That(autoFilter.VisibleRows.Last().WorksheetRow().RowNumber(), Is.EqualTo(5));
+            });
         }
 
         [Test]
         public void ReapplyAutoFilter()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
 
-                ws.Cell(3, 3).SetValue("Names")
-                    .CellBelow().SetValue("Manuel")
-                    .CellBelow().SetValue("Carlos")
-                    .CellBelow().SetValue("Dominic")
-                    .CellBelow().SetValue("Jose");
+            ws.Cell(3, 3).SetValue("Names")
+                .CellBelow().SetValue("Manuel")
+                .CellBelow().SetValue("Carlos")
+                .CellBelow().SetValue("Dominic")
+                .CellBelow().SetValue("Jose");
 
-                var autoFilter = ws.RangeUsed()
-                    .SetAutoFilter();
+            var autoFilter = ws.RangeUsed()
+                .SetAutoFilter();
 
-                autoFilter.Column(1).AddFilter("Carlos");
+            autoFilter.Column(1).AddFilter("Carlos");
 
-                Assert.AreEqual(3, autoFilter.HiddenRows.Count());
+            Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(3));
 
-                // Unhide the rows so that the table is out of sync with the filter
-                autoFilter.HiddenRows.ForEach(r => r.WorksheetRow().Unhide());
-                Assert.False(autoFilter.HiddenRows.Any());
+            // Unhide the rows so that the table is out of sync with the filter
+            autoFilter.HiddenRows.ForEach(r => r.WorksheetRow().Unhide());
+            Assert.False(autoFilter.HiddenRows.Any());
 
-                autoFilter.Reapply();
-                Assert.AreEqual(3, autoFilter.HiddenRows.Count());
-            }
+            autoFilter.Reapply();
+            Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(3));
         }
 
         [Test]
@@ -253,13 +243,16 @@ namespace ClosedXML.Tests
                 {
                     var ws = wb.Worksheets.First();
 
-                    // Regular filter compares values as strings, doesn't convert to XLCellValue,
-                    // so the value is read from the file as a text despite looking like a number.
-                    Assert.AreEqual("10 000.00", ((XLAutoFilter)ws.AutoFilter).Column(1).Single().Value);
-                    Assert.AreEqual(2, ws.AutoFilter.VisibleRows.Count());
+                    Assert.Multiple(() =>
+                    {
+                        // Regular filter compares values as strings, doesn't convert to XLCellValue,
+                        // so the value is read from the file as a text despite looking like a number.
+                        Assert.That(((XLAutoFilter)ws.AutoFilter).Column(1).Single().Value, Is.EqualTo("10 000.00"));
+                        Assert.That(ws.AutoFilter.VisibleRows.Count(), Is.EqualTo(2));
+                    });
 
                     ws.AutoFilter.Reapply();
-                    Assert.AreEqual(2, ws.AutoFilter.VisibleRows.Count());
+                    Assert.That(ws.AutoFilter.VisibleRows.Count(), Is.EqualTo(2));
                 }
 
                 Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
@@ -268,13 +261,13 @@ namespace ClosedXML.Tests
                 using (var wb = new XLWorkbook(stream))
                 {
                     var ws = wb.Worksheets.First();
-                    Assert.AreEqual("10 000.00", ((XLAutoFilter)ws.AutoFilter).Column(1).Single().Value);
+                    Assert.That(((XLAutoFilter)ws.AutoFilter).Column(1).Single().Value, Is.EqualTo("10 000.00"));
 
                     var v = ws.AutoFilter.VisibleRows.Select(r => r.FirstCell().Value).ToList();
-                    Assert.AreEqual(2, ws.AutoFilter.VisibleRows.Count());
+                    Assert.That(ws.AutoFilter.VisibleRows.Count(), Is.EqualTo(2));
 
                     ws.AutoFilter.Reapply();
-                    Assert.AreEqual(1, ws.AutoFilter.VisibleRows.Count());
+                    Assert.That(ws.AutoFilter.VisibleRows.Count(), Is.EqualTo(1));
                 }
             }
             finally
@@ -286,36 +279,34 @@ namespace ClosedXML.Tests
         [Test]
         public void Issue1917NotContainsFilter()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.Worksheets.Add("Test");
+                ws.Cell(1, 1).SetValue("StringCol");
+
+                for (var i = 0; i < 5; i++)
                 {
-                    var ws = wb.Worksheets.Add("Test");
-                    ws.Cell(1, 1).SetValue("StringCol");
-
-                    for (var i = 0; i < 5; i++)
-                    {
-                        ws.Cell(i + 2, 1).SetValue($"String{i}");
-                    }
-
-                    var autoFilter = ws.RangeUsed()
-                        .SetAutoFilter();
-
-                    autoFilter.Column(1).NotContains("String3");
-                    Assert.AreEqual(1, autoFilter.HiddenRows.Count());
-
-                    wb.SaveAs(ms);
+                    ws.Cell(i + 2, 1).SetValue($"String{i}");
                 }
 
-                ms.Position = 0;
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.Worksheet("Test");
-                    var autoFilter = ws.AutoFilter;
+                var autoFilter = ws.RangeUsed()
+                    .SetAutoFilter();
 
-                    autoFilter.Reapply();
-                    Assert.AreEqual(1, autoFilter.HiddenRows.Count());
-                }
+                autoFilter.Column(1).NotContains("String3");
+                Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(1));
+
+                wb.SaveAs(ms);
+            }
+
+            ms.Position = 0;
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.Worksheet("Test");
+                var autoFilter = ws.AutoFilter;
+
+                autoFilter.Reapply();
+                Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(1));
             }
         }
 
@@ -326,51 +317,49 @@ namespace ClosedXML.Tests
         [TestCase("contains")]
         public void NotStringFilter(string type)
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.Worksheets.Add("Test");
+                ws.Cell(1, 1).SetValue("StringCol");
+
+                for (var i = 0; i < 5; i++)
                 {
-                    var ws = wb.Worksheets.Add("Test");
-                    ws.Cell(1, 1).SetValue("StringCol");
-
-                    for (var i = 0; i < 5; i++)
-                    {
-                        ws.Cell(i + 2, 1).SetValue($"{i}-String{i}");
-                    }
-
-                    ws.Columns().AdjustToContents();
-                    var autoFilter = ws.RangeUsed()
-                        .SetAutoFilter();
-
-                    switch (type)
-                    {
-                        case "ends":
-                            autoFilter.Column(1).NotEndsWith("3");
-                            break;
-                        case "begins":
-                            autoFilter.Column(1).NotBeginsWith("3");
-                            break;
-                        case "equal":
-                            autoFilter.Column(1).NotEqualTo("3-String3");
-                            break;
-                        case "contains":
-                            autoFilter.Column(1).NotContains("3-");
-                            break;
-                    }
-                    Assert.AreEqual(1, autoFilter.HiddenRows.Count());
-
-                    wb.SaveAs(ms);
+                    ws.Cell(i + 2, 1).SetValue($"{i}-String{i}");
                 }
 
-                ms.Position = 0;
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.Worksheet("Test");
-                    var autoFilter = ws.AutoFilter;
+                ws.Columns().AdjustToContents();
+                var autoFilter = ws.RangeUsed()
+                    .SetAutoFilter();
 
-                    autoFilter.Reapply();
-                    Assert.AreEqual(1, autoFilter.HiddenRows.Count());
+                switch (type)
+                {
+                    case "ends":
+                        autoFilter.Column(1).NotEndsWith("3");
+                        break;
+                    case "begins":
+                        autoFilter.Column(1).NotBeginsWith("3");
+                        break;
+                    case "equal":
+                        autoFilter.Column(1).NotEqualTo("3-String3");
+                        break;
+                    case "contains":
+                        autoFilter.Column(1).NotContains("3-");
+                        break;
                 }
+                Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(1));
+
+                wb.SaveAs(ms);
+            }
+
+            ms.Position = 0;
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.Worksheet("Test");
+                var autoFilter = ws.AutoFilter;
+
+                autoFilter.Reapply();
+                Assert.That(autoFilter.HiddenRows.Count(), Is.EqualTo(1));
             }
         }
     }

--- a/ClosedXML.Tests/Excel/AutoFilters/DynamicFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/DynamicFilterTests.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 {
                     ws.AutoFilter.Reapply();
                     var filterResult = ws.Rows("2:7").Select(row => !row.IsHidden);
-                    CollectionAssert.AreEqual(new[] { false, false, false, false, true, true }, filterResult);
+                    Assert.That(filterResult, Is.EqualTo(new[] { false, false, false, false, true, true }).AsCollection);
                 });
         }
 

--- a/ClosedXML.Tests/Excel/AutoFilters/RegularFilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/RegularFilterTests.cs
@@ -32,7 +32,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 {
                     ws.AutoFilter.Reapply();
                     var dataVisibility = ws.Rows("2:5").Select(row => !row.IsHidden);
-                    CollectionAssert.AreEqual(new[] { true, false, false, true }, dataVisibility);
+                    Assert.That(dataVisibility, Is.EqualTo(new[] { true, false, false, true }).AsCollection);
                 }, false);
         }
 

--- a/ClosedXML.Tests/Excel/AutoFilters/Top10FilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/Top10FilterTests.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 {
                     ws.AutoFilter.Reapply();
                     var filterResult = ws.Rows("2:7").Select(row => !row.IsHidden);
-                    CollectionAssert.AreEqual(new[] { true, true, false, false, false, true }, filterResult);
+                    Assert.That(filterResult, Is.EqualTo(new[] { true, true, false, false, false, true }).AsCollection);
                 });
         }
 

--- a/ClosedXML.Tests/Excel/AutoFilters/Top10FilterTests.cs
+++ b/ClosedXML.Tests/Excel/AutoFilters/Top10FilterTests.cs
@@ -140,7 +140,7 @@ namespace ClosedXML.Tests.Excel.AutoFilters
                 else
                     filterColumn.Bottom(value);
             })!;
-            StringAssert.Contains("Value must be between 1 and 500.", ex.Message);
+            Assert.That(ex.Message, Does.Contain("Value must be between 1 and 500."));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Caching/SampleRepositoryTests.cs
+++ b/ClosedXML.Tests/Excel/Caching/SampleRepositoryTests.cs
@@ -22,10 +22,13 @@ namespace ClosedXML.Tests.Excel.Caching
             var storedEntity1 = sampleRepository.Store(ref key, entity1);
             var storedEntity2 = sampleRepository.Store(ref key, entity2);
 
-            // Assert
-            Assert.AreSame(entity1, storedEntity1);
-            Assert.AreSame(entity1, storedEntity2);
-            Assert.AreNotSame(entity2, storedEntity2);
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(storedEntity1, Is.SameAs(entity1));
+                Assert.That(storedEntity2, Is.SameAs(entity1));
+            });
+            Assert.That(storedEntity2, Is.Not.SameAs(entity2));
         }
 
         [Test]
@@ -131,7 +134,7 @@ namespace ClosedXML.Tests.Excel.Caching
             var storedEntries = sampleRepository.ToList();
 
             // Assert
-            Assert.AreEqual(countUnique, storedEntries.Count);
+            Assert.That(storedEntries, Has.Count.EqualTo(countUnique));
             Assert.NotNull(entities); // To protect them from GC
         }
 
@@ -151,11 +154,17 @@ namespace ClosedXML.Tests.Excel.Caching
             bool containsNew = sampleRepository.ContainsKey(ref key2, out var _);
             var storedEntity2 = sampleRepository.GetOrCreate(ref key2);
 
-            // Assert
-            Assert.IsFalse(containsOld);
-            Assert.IsTrue(containsNew);
-            Assert.AreSame(entity, storedEntity1);
-            Assert.AreSame(entity, storedEntity2);
+            Assert.Multiple(() =>
+            {
+                // Assert
+                Assert.That(containsOld, Is.False);
+                Assert.That(containsNew, Is.True);
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(storedEntity1, Is.SameAs(entity));
+                Assert.That(storedEntity2, Is.SameAs(entity));
+            });
         }
 
         [Test]
@@ -171,7 +180,7 @@ namespace ClosedXML.Tests.Excel.Caching
                 var val1 = sampleRepository.Replace(ref key, ref modifiedKey);
                 val1.Key = key + 2000;
                 var val2 = sampleRepository.GetOrCreate(ref modifiedKey);
-                Assert.AreSame(val1, val2);
+                Assert.That(val2, Is.SameAs(val1));
             });
         }
 
@@ -188,8 +197,8 @@ namespace ClosedXML.Tests.Excel.Caching
             sampleRepository.Replace(ref key2, ref key3);
             var all = sampleRepository.ToList();
 
-            Assert.AreEqual(1, all.Count);
-            Assert.AreSame(entity, all.First());
+            Assert.That(all, Has.Count.EqualTo(1));
+            Assert.That(all.First(), Is.SameAs(entity));
         }
 
         private SampleRepository CreateSampleRepository()

--- a/ClosedXML.Tests/Excel/Caching/SampleRepositoryTests.cs
+++ b/ClosedXML.Tests/Excel/Caching/SampleRepositoryTests.cs
@@ -135,7 +135,7 @@ namespace ClosedXML.Tests.Excel.Caching
 
             // Assert
             Assert.That(storedEntries, Has.Count.EqualTo(countUnique));
-            Assert.NotNull(entities); // To protect them from GC
+            Assert.That(entities, Is.Not.Null); // To protect them from GC
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("\"\" & \"\"", "")]
         public void Concat_ConcatenateText(string formula, object expectedResult)
         {
-            Assert.AreEqual(expectedResult, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase("A1 & \"\"", "")]
@@ -23,7 +23,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1 & A1", "")]
         public void Concat_ConcatenateBlank(string formula, object expectedResult)
         {
-            Assert.AreEqual(expectedResult, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase("TRUE & \" to text\"", "TRUE to text")]
@@ -33,7 +33,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("TRUE & FALSE", @"TRUEFALSE")]
         public void Concat_ConvertsLogicalToString(string formula, object expectedResult)
         {
-            Assert.AreEqual(expectedResult, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedResult));
         }
 
         [SetCulture("cs-CZ")]
@@ -43,7 +43,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Concat_ConvertsNumberToStringUsingCulture(string formula, object expectedResult)
         {
             var wb = new XLWorkbook();
-            Assert.AreEqual(expectedResult, wb.Evaluate(formula));
+            Assert.That(wb.Evaluate(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase("#DIV/0! & 1", XLError.DivisionByZero)]
@@ -52,7 +52,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("1 & #NAME?", XLError.NameNotRecognized)]
         public void Concat_WithErrorAsOperandReturnsTheError(string formula, XLError expectedError)
         {
-            Assert.AreEqual(expectedError, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedError));
         }
 
         #endregion
@@ -67,7 +67,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("ISBLANK(+A1)", true)]
         public void UnaryPlus_IsNonOpThatKeepsValueAndType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -83,7 +83,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("-A1", 0.0)]
         public void UnaryMinus_ConvertsArgumentBeforeNegating(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -102,7 +102,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1%", 0.0)]
         public void UnaryPercent_ConvertsArgumentBeforePercentOperator(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -171,7 +171,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("5/A1", XLError.DivisionByZero)]
         public void Division_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -190,7 +190,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1 + 7", 7)]
         public void Addition_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -209,7 +209,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1 - 5", -5)]
         public void Subtraction_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -224,7 +224,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = new DateTime(2021, 1, 15);
             ws.Cell("A2").Value = new DateTime(2021, 1, 10);
             ws.Cell("B1").Value = new DateTime(2021, 1, 5);
-            Assert.AreEqual(5, ws.Evaluate("MIN(A1:A2-B1)"));
+            Assert.That(ws.Evaluate("MIN(A1:A2-B1)"), Is.EqualTo(5));
         }
 
         [Test]
@@ -233,54 +233,75 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cells("A1:A2").Value = 1;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("(A1:A1,A1:A2)+1"));
-            Assert.AreEqual(16, ws.Evaluate("TYPE((A1:A1,A1:A2)+1)")); // The result is a scalar error, not an array of errors
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("(A1:A1,A1:A2)+1"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Evaluate("TYPE((A1:A1,A1:A2)+1)"), Is.EqualTo(16)); // The result is a scalar error, not an array of errors
+            });
         }
 
         [Test]
         public void ArrayOperation_SameSizeArrayPerformsOperationIndividually()
         {
-            Assert.AreEqual(6 * 7, XLWorkbook.EvaluateExpr("SUM({1,2,3;4,5,6} + {6,5,4;3,2,1})"));
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("COLUMNS({1,2} + \"A\")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({1,2,3;4,5,6} + {6,5,4;3,2,1})"), Is.EqualTo(6 * 7));
+                Assert.That(XLWorkbook.EvaluateExpr("COLUMNS({1,2} + \"A\")"), Is.EqualTo(2));
+            });
         }
 
         [Test]
         public void ArrayOperation_ArrayPlusScalarUpscalesScalarToSizeOfArray()
         {
-            Assert.AreEqual(18, XLWorkbook.EvaluateExpr("SUM({1,1,1;1,1,1} * 3)"));
-            Assert.AreEqual(15, XLWorkbook.EvaluateExpr("SUM(6 / {2,2,2;3,3,3})"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({1,1,1;1,1,1} * 3)"), Is.EqualTo(18));
+                Assert.That(XLWorkbook.EvaluateExpr("SUM(6 / {2,2,2;3,3,3})"), Is.EqualTo(15));
+            });
         }
 
         [Test]
         public void ArrayOperation_RowOnlyArrayIsRepeatedToHaveSameNumberOfRowsAsOtherArray()
         {
-            // {3,2} is scaled to {3,2;3,2} of second array
-            Assert.AreEqual(14, XLWorkbook.EvaluateExpr("SUM({3,2}+{1,1;1,1})"));
-            Assert.AreEqual(14, XLWorkbook.EvaluateExpr("SUM({1,1;1,1}+{3,2})"));
+            Assert.Multiple(() =>
+            {
+                // {3,2} is scaled to {3,2;3,2} of second array
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({3,2}+{1,1;1,1})"), Is.EqualTo(14));
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({1,1;1,1}+{3,2})"), Is.EqualTo(14));
+            });
         }
 
         [Test]
         public void ArrayOperation_ColumnOnlyArrayIsRepeatedToHaveSameNumberOfColumnsAsOtherArray()
         {
-            // {3;2} is scaled to {3,3;2,2} of second array
-            Assert.AreEqual(16, XLWorkbook.EvaluateExpr("SUM({3;2}*{1,1;2,3})"));
-            Assert.AreEqual(16, XLWorkbook.EvaluateExpr("SUM({1,1;2,3}*{3;2})"));
+            Assert.Multiple(() =>
+            {
+                // {3;2} is scaled to {3,3;2,2} of second array
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({3;2}*{1,1;2,3})"), Is.EqualTo(16));
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({1,1;2,3}*{3;2})"), Is.EqualTo(16));
+            });
         }
 
         [Test]
         public void ArrayOperation_1x1ArrayIsScaledToOtherArray()
         {
-            Assert.AreEqual(20, XLWorkbook.EvaluateExpr("SUM({2}*{1,2;3,4})"));
-            Assert.AreEqual(20, XLWorkbook.EvaluateExpr("SUM({1,2;3,4}*{2})"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({2}*{1,2;3,4})"), Is.EqualTo(20));
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({1,2;3,4}*{2})"), Is.EqualTo(20));
+            });
         }
 
         [Test]
         public void ArrayOperation_DifferentSizedArraysAreUpscaledToContainingSize()
         {
-            // The extra value are #N/A + value, i.e. #N/A, thus the whole sum is #N/A
-            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr("SUM({1,2;3,4;5,6}+{1,2,3;4,5,6})"));
-            Assert.AreEqual(3, XLWorkbook.EvaluateExpr("ROWS({1,2;3,4;5,6}+{1,2,3;4,5,6})"));
-            Assert.AreEqual(3, XLWorkbook.EvaluateExpr("COLUMNS({1,2;3,4;5,6}+{1,2,3;4,5,6})"));
+            Assert.Multiple(() =>
+            {
+                // The extra value are #N/A + value, i.e. #N/A, thus the whole sum is #N/A
+                Assert.That(XLWorkbook.EvaluateExpr("SUM({1,2;3,4;5,6}+{1,2,3;4,5,6})"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(XLWorkbook.EvaluateExpr("ROWS({1,2;3,4;5,6}+{1,2,3;4,5,6})"), Is.EqualTo(3));
+                Assert.That(XLWorkbook.EvaluateExpr("COLUMNS({1,2;3,4;5,6}+{1,2,3;4,5,6})"), Is.EqualTo(3));
+            });
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
@@ -125,7 +125,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1^4", 0.0)]
         public void Exponentiation_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue).Within(XLHelper.Epsilon));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -148,7 +148,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1*10", 0.0)]
         public void Multiplication_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue).Within(XLHelper.Epsilon));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaCalculationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaCalculationTests.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             foreach (var arrayFormulaCell in range.Cells())
             {
-                Assert.AreEqual(1, arrayFormulaCell.Value);
+                Assert.That(arrayFormulaCell.Value, Is.EqualTo(1));
             }
         }
 
@@ -30,8 +30,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             range.FormulaArrayA1 = "TRANSPOSE({1,2})";
 
-            Assert.AreEqual(1, ws.Cell("A1").Value);
-            Assert.AreEqual(2, ws.Cell("A2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -43,10 +46,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             range.FormulaArrayA1 = "{1,2,3,4,5}";
 
-            Assert.AreEqual(1, ws.Cell("A1").Value);
-            Assert.AreEqual(2, ws.Cell("B1").Value);
-            Assert.AreEqual(3, ws.Cell("C1").Value);
-            Assert.AreEqual(Blank.Value, ws.Cell("D1").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("C1").Value, Is.EqualTo(3));
+                Assert.That(ws.Cell("D1").Value, Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
@@ -58,10 +64,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             range.FormulaArrayA1 = "{1;2;3;4;5}";
 
-            Assert.AreEqual(1, ws.Cell("A1").Value);
-            Assert.AreEqual(2, ws.Cell("A2").Value);
-            Assert.AreEqual(3, ws.Cell("A3").Value);
-            Assert.AreEqual(Blank.Value, ws.Cell("A4").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(3));
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
@@ -75,9 +84,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             for (var column = 1; column <= 3; column++)
             {
-                Assert.AreEqual(1, ws.Cell(1, column).Value);
-                Assert.AreEqual(2, ws.Cell(2, column).Value);
-                Assert.AreEqual(XLError.NoValueAvailable, ws.Cell(3, column).Value);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.Cell(1, column).Value, Is.EqualTo(1));
+                    Assert.That(ws.Cell(2, column).Value, Is.EqualTo(2));
+                    Assert.That(ws.Cell(3, column).Value, Is.EqualTo(XLError.NoValueAvailable));
+                });
             }
         }
 
@@ -92,9 +104,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             for (var row = 1; row <= 3; row++)
             {
-                Assert.AreEqual(1, ws.Cell(row, 1).Value);
-                Assert.AreEqual(2, ws.Cell(row, 2).Value);
-                Assert.AreEqual(XLError.NoValueAvailable, ws.Cell(row, 3).Value);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.Cell(row, 1).Value, Is.EqualTo(1));
+                    Assert.That(ws.Cell(row, 2).Value, Is.EqualTo(2));
+                    Assert.That(ws.Cell(row, 3).Value, Is.EqualTo(XLError.NoValueAvailable));
+                });
             }
         }
 
@@ -107,15 +122,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             range.FormulaArrayA1 = "{1,2;3,4}";
 
-            Assert.AreEqual(1, ws.Cell("A1").Value);
-            Assert.AreEqual(2, ws.Cell("B1").Value);
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Cell("C1").Value);
-            Assert.AreEqual(3, ws.Cell("A2").Value);
-            Assert.AreEqual(4, ws.Cell("B2").Value);
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Cell("C2").Value);
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Cell("A3").Value);
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Cell("B3").Value);
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Cell("C3").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("C1").Value, Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(3));
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(4));
+                Assert.That(ws.Cell("C2").Value, Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Cell("B3").Value, Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Cell("C3").Value, Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [Test]
@@ -125,10 +143,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Range("B1:B3").FormulaArrayA1 = "SIGN({-1,2,0})";
 
-            // Uses only -1 for all values
-            Assert.AreEqual(-1, ws.Cell("B1").Value);
-            Assert.AreEqual(-1, ws.Cell("B2").Value);
-            Assert.AreEqual(-1, ws.Cell("B3").Value);
+            Assert.Multiple(() =>
+            {
+                // Uses only -1 for all values
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(-1));
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(-1));
+                Assert.That(ws.Cell("B3").Value, Is.EqualTo(-1));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -77,7 +77,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.Multiple(() =>
                 {
                     Assert.That(cell.Value, Is.EqualTo(Blank.Value));
-                    Assert.False(cell.HasArrayFormula);
+                    Assert.That(cell.HasArrayFormula, Is.False);
                     Assert.That(cell.FormulaA1, Is.Empty);
                     Assert.That(cell.FormulaReference, Is.Null);
                 });
@@ -145,8 +145,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.False(ws.Cell("A1").NeedsRecalculation);
-            Assert.False(ws.Cell("A2").NeedsRecalculation);
+            Assert.That(ws.Cell("A1").NeedsRecalculation, Is.False);
+            Assert.That(ws.Cell("A2").NeedsRecalculation, Is.False);
 
             ws.Range("A1:A2").FormulaArrayA1 = "ABS(-3)";
 

--- a/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -35,8 +35,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 }
 
                 var outsideCell = ws.Cell("A3");
-                Assert.IsEmpty(outsideCell.FormulaA1);
-                Assert.Null(outsideCell.FormulaReference);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(outsideCell.FormulaA1, Is.Empty);
+                    Assert.That(outsideCell.FormulaReference, Is.Null);
+                });
             }, @"Other\Formulas\ArrayFormula.xlsx");
         }
 
@@ -71,10 +74,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             foreach (var cell in arrayFormulaRange.Cells())
             {
-                Assert.That(cell.Value, Is.EqualTo(Blank.Value));
-                Assert.False(cell.HasArrayFormula);
-                Assert.IsEmpty(cell.FormulaA1);
-                Assert.Null(cell.FormulaReference);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(cell.Value, Is.EqualTo(Blank.Value));
+                    Assert.False(cell.HasArrayFormula);
+                    Assert.That(cell.FormulaA1, Is.Empty);
+                    Assert.That(cell.FormulaReference, Is.Null);
+                });
             }
         }
 

--- a/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -27,8 +27,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
                 foreach (var arrayFormulaCell in ws.Range("A1:B2").Cells())
                 {
-                    Assert.AreEqual("1+2", arrayFormulaCell.FormulaA1);
-                    Assert.AreEqual("A1:B2", arrayFormulaCell.FormulaReference.ToStringRelative());
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(arrayFormulaCell.FormulaA1, Is.EqualTo("1+2"));
+                        Assert.That(arrayFormulaCell.FormulaReference.ToStringRelative(), Is.EqualTo("A1:B2"));
+                    });
                 }
 
                 var outsideCell = ws.Cell("A3");
@@ -46,9 +49,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             oneCell.AsRange().FormulaArrayA1 = "2+5";
 
-            Assert.True(oneCell.HasArrayFormula);
-            Assert.AreEqual("2+5", oneCell.FormulaA1);
-            Assert.AreEqual("B3:B3", oneCell.FormulaReference.ToStringRelative());
+            Assert.That(oneCell.HasArrayFormula, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(oneCell.FormulaA1, Is.EqualTo("2+5"));
+                Assert.That(oneCell.FormulaReference.ToStringRelative(), Is.EqualTo("B3:B3"));
+            });
         }
 
         [TestCase("B2:C3")]
@@ -65,7 +71,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             foreach (var cell in arrayFormulaRange.Cells())
             {
-                Assert.AreEqual(Blank.Value, cell.Value);
+                Assert.That(cell.Value, Is.EqualTo(Blank.Value));
                 Assert.False(cell.HasArrayFormula);
                 Assert.IsEmpty(cell.FormulaA1);
                 Assert.Null(cell.FormulaReference);
@@ -138,8 +144,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Range("A1:A2").FormulaArrayA1 = "ABS(-3)";
 
-            Assert.True(ws.Cell("A1").NeedsRecalculation);
-            Assert.True(ws.Cell("A2").NeedsRecalculation);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A2").NeedsRecalculation, Is.True);
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/CalcEngineCellEnumerationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CalcEngineCellEnumerationTests.cs
@@ -8,16 +8,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void CanEnumerateCellsOverEmptySheet()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet1 = wb.AddWorksheet("Sheet1");
-                var sheet2 = wb.AddWorksheet("Sheet2");
+            using var wb = new XLWorkbook();
+            var sheet1 = wb.AddWorksheet("Sheet1");
+            var sheet2 = wb.AddWorksheet("Sheet2");
 
-                var cell = sheet1.FirstCell();
-                cell.FormulaA1 = "=SUMIFS(Sheet2!B:B, Sheet2!C:C, 1)";
+            var cell = sheet1.FirstCell();
+            cell.FormulaA1 = "=SUMIFS(Sheet2!B:B, Sheet2!C:C, 1)";
 
-                Assert.AreEqual(0, cell.Value);
-            }
+            Assert.That(cell.Value, Is.EqualTo(0));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/CalcEngineExceptionTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CalcEngineExceptionTests.cs
@@ -17,24 +17,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void InvalidCharNumber()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("CHAR(-2)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("CHAR(270)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("CHAR(-2)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("CHAR(270)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void DivisionByZero()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("0/0"));
-            Assert.AreEqual(XLError.DivisionByZero, new XLWorkbook().AddWorksheet().Evaluate("0/0"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("0/0"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(new XLWorkbook().AddWorksheet().Evaluate("0/0"), Is.EqualTo(XLError.DivisionByZero));
+            });
         }
 
         [Test]
         public void InvalidFunction()
         {
-            Assert.AreEqual(XLError.NameNotRecognized, XLWorkbook.EvaluateExpr("XXX(A1:A2)"));
+            Assert.That(XLWorkbook.EvaluateExpr("XXX(A1:A2)"), Is.EqualTo(XLError.NameNotRecognized));
 
             var ws = new XLWorkbook().AddWorksheet();
-            Assert.AreEqual(XLError.NameNotRecognized, ws.Evaluate("XXX(A1:A2)"));
+            Assert.That(ws.Evaluate("XXX(A1:A2)"), Is.EqualTo(XLError.NameNotRecognized));
         }
 
         [Test]
@@ -45,7 +51,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").SetFormulaA1("=XXX");
             ws.Cell("A2").SetFormulaA1(@"=IFERROR(A1, ""Success"")");
 
-            Assert.AreEqual("Success", ws.Cell("A2").Value);
+            Assert.That(ws.Cell("A2").Value, Is.EqualTo("Success"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
@@ -15,17 +15,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var sutWs = wb.AddWorksheet();
             sutWs.Cell("A1").FormulaA1 = "new!A1";
-            Assert.AreEqual(XLError.CellReference, sutWs.Cell("A1").Value);
+            Assert.That(sutWs.Cell("A1").Value, Is.EqualTo(XLError.CellReference));
 
             var newWs = wb.AddWorksheet("new");
             newWs.Cell("A1").Value = 5;
 
-            // Cell contains last calculated value
-            Assert.AreEqual(XLError.CellReference, sutWs.Cell("A1").CachedValue);
+            Assert.Multiple(() =>
+            {
+                // Cell contains last calculated value
+                Assert.That(sutWs.Cell("A1").CachedValue, Is.EqualTo(XLError.CellReference));
 
-            // But once asked for real value, it calculates it.
-            Assert.True(sutWs.Cell("A1").NeedsRecalculation);
-            Assert.AreEqual(5.0, sutWs.Cell("A1").Value);
+                // But once asked for real value, it calculates it.
+                Assert.That(sutWs.Cell("A1").NeedsRecalculation, Is.True);
+                Assert.That(sutWs.Cell("A1").Value, Is.EqualTo(5.0));
+            });
         }
 
         [Test]
@@ -37,16 +40,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             deletedWs.Cell("A1").Value = 5;
             keptWs.Cell("A1").FormulaA1 = "deleted!A1";
-            Assert.AreEqual(5.0, keptWs.Cell("A1").Value);
+            Assert.That(keptWs.Cell("A1").Value, Is.EqualTo(5.0));
 
             deletedWs.Delete();
 
-            // Cell contains last calculated value
-            Assert.AreEqual(5.0, keptWs.Cell("A1").CachedValue);
+            Assert.Multiple(() =>
+            {
+                // Cell contains last calculated value
+                Assert.That(keptWs.Cell("A1").CachedValue, Is.EqualTo(5.0));
 
-            // But once asked for real value, it calculates it.
-            Assert.True(keptWs.Cell("A1").NeedsRecalculation);
-            Assert.AreEqual(XLError.CellReference, keptWs.Cell("A1").Value);
+                // But once asked for real value, it calculates it.
+                Assert.That(keptWs.Cell("A1").NeedsRecalculation, Is.True);
+                Assert.That(keptWs.Cell("A1").Value, Is.EqualTo(XLError.CellReference));
+            });
         }
 
         [Test]
@@ -62,15 +68,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Range("A1:B1").InsertRowsAbove(2);
 
-            Assert.AreEqual(12.0, ws.Cell("A3").Value);
+            Assert.That(ws.Cell("A3").Value, Is.EqualTo(12.0));
             Assert.False(ws.Cell("A3").NeedsRecalculation);
             Assert.False(ws.Cell("B3").NeedsRecalculation);
 
             // Dependency tree should pick up the change
             ws.Cell("C1").FormulaA1 = "2+2";
-            Assert.True(ws.Cell("A3").NeedsRecalculation);
-            Assert.True(ws.Cell("B3").NeedsRecalculation);
-            Assert.AreEqual(16.0, ws.Cell("A3").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A3").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("B3").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(16.0));
+            });
         }
 
         [Test]
@@ -86,14 +95,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("A2").InsertCellsBefore(4);
 
-            Assert.AreEqual(12.0, ws.Cell("A1").Value);
+            Assert.That(ws.Cell("A1").Value, Is.EqualTo(12.0));
             Assert.False(ws.Cell("E2").NeedsRecalculation);
 
             // Dependency tree should pick up the change
             ws.Cell("A3").FormulaA1 = "2+2";
-            Assert.True(ws.Cell("E2").NeedsRecalculation);
-            Assert.True(ws.Cell("A1").NeedsRecalculation);
-            Assert.AreEqual(16.0, ws.Cell("A1").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("E2").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A1").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(16.0));
+            });
         }
 
         [Test]
@@ -109,15 +121,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Range("B2:C4").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-            Assert.AreEqual(12.0, ws.Cell("C2").Value);
+            Assert.That(ws.Cell("C2").Value, Is.EqualTo(12.0));
             Assert.False(ws.Cell("B2").NeedsRecalculation);
             Assert.False(ws.Cell("A2").NeedsRecalculation);
 
             // Dependency tree should pick up the change
             ws.Cell("A5").FormulaA1 = "2+2";
-            Assert.True(ws.Cell("B2").NeedsRecalculation);
-            Assert.True(ws.Cell("C2").NeedsRecalculation);
-            Assert.AreEqual(16.0, ws.Cell("C2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("B2").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("C2").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("C2").Value, Is.EqualTo(16.0));
+            });
         }
 
         [Test]
@@ -133,15 +148,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Range("A1:C5").Delete(XLShiftDeletedCells.ShiftCellsLeft);
 
-            Assert.AreEqual(12.0, ws.Cell("A3").Value);
+            Assert.That(ws.Cell("A3").Value, Is.EqualTo(12.0));
             Assert.False(ws.Cell("B2").NeedsRecalculation);
             Assert.False(ws.Cell("A1").NeedsRecalculation);
 
             // Dependency tree should pick up the change
             ws.Cell("A1").FormulaA1 = "2+2";
-            Assert.True(ws.Cell("B2").NeedsRecalculation);
-            Assert.True(ws.Cell("A3").NeedsRecalculation);
-            Assert.AreEqual(16.0, ws.Cell("A3").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("B2").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A3").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(16.0));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CalcEngineListenerTests.cs
@@ -69,8 +69,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Range("A1:B1").InsertRowsAbove(2);
 
             Assert.That(ws.Cell("A3").Value, Is.EqualTo(12.0));
-            Assert.False(ws.Cell("A3").NeedsRecalculation);
-            Assert.False(ws.Cell("B3").NeedsRecalculation);
+            Assert.That(ws.Cell("A3").NeedsRecalculation, Is.False);
+            Assert.That(ws.Cell("B3").NeedsRecalculation, Is.False);
 
             // Dependency tree should pick up the change
             ws.Cell("C1").FormulaA1 = "2+2";
@@ -96,7 +96,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A2").InsertCellsBefore(4);
 
             Assert.That(ws.Cell("A1").Value, Is.EqualTo(12.0));
-            Assert.False(ws.Cell("E2").NeedsRecalculation);
+            Assert.That(ws.Cell("E2").NeedsRecalculation, Is.False);
 
             // Dependency tree should pick up the change
             ws.Cell("A3").FormulaA1 = "2+2";
@@ -122,8 +122,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Range("B2:C4").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
             Assert.That(ws.Cell("C2").Value, Is.EqualTo(12.0));
-            Assert.False(ws.Cell("B2").NeedsRecalculation);
-            Assert.False(ws.Cell("A2").NeedsRecalculation);
+            Assert.That(ws.Cell("B2").NeedsRecalculation, Is.False);
+            Assert.That(ws.Cell("A2").NeedsRecalculation, Is.False);
 
             // Dependency tree should pick up the change
             ws.Cell("A5").FormulaA1 = "2+2";
@@ -149,8 +149,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Range("A1:C5").Delete(XLShiftDeletedCells.ShiftCellsLeft);
 
             Assert.That(ws.Cell("A3").Value, Is.EqualTo(12.0));
-            Assert.False(ws.Cell("B2").NeedsRecalculation);
-            Assert.False(ws.Cell("A1").NeedsRecalculation);
+            Assert.That(ws.Cell("B2").NeedsRecalculation, Is.False);
+            Assert.That(ws.Cell("A1").NeedsRecalculation, Is.False);
 
             // Dependency tree should pick up the change
             ws.Cell("A1").FormulaA1 = "2+2";

--- a/ClosedXML.Tests/Excel/CalcEngine/CompareOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CompareOperatorsTests.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1=B1", true)] // blanks are equal
         public void EqualTo_WithSameType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("1<>1", false)]
@@ -37,7 +37,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1<>B1", false)] // blanks are equal
         public void NotEqualTo_WithSameType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("1>1", false)]
@@ -52,7 +52,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1>A2", false)]
         public void GreaterThen_WithSameType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("1>=1", true)]
@@ -67,7 +67,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1>=A2", true)]
         public void GreaterThenOrEqual_WithSameType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("-5<5", true)]
@@ -84,7 +84,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1<A2", false)]
         public void LessThen_WithSameType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("-5<=5", true)]
@@ -101,7 +101,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1<=A2", true)]
         public void LessThenOrEqual_WithSameType(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("TRUE>-1", true)]
@@ -130,7 +130,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("TRUE<10", false)]
         public void Comparison_LogicalIsAlwaysGreaterThanAnyTextOrNumber(string formula, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase("\"\">10", true)]
@@ -139,7 +139,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("10<\"1\"", true)]
         public void Comparison_TextIsAlwaysGreaterThanAnyNumber(string formula, bool expectedResult)
         {
-            Assert.AreEqual(expectedResult, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase("FALSE=A1")]
@@ -150,7 +150,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1=\"\"")]
         public void Comparison_BlankIsEqualToFalseOrZeroOrEmptyString(string formula)
         {
-            Assert.AreEqual(true, Evaluate(formula));
+            Assert.That(Evaluate(formula), Is.EqualTo(true));
         }
 
         private static XLCellValue Evaluate(string formula)

--- a/ClosedXML.Tests/Excel/CalcEngine/CriteriaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/CriteriaTests.cs
@@ -17,13 +17,13 @@ internal class CriteriaTests
     {
         var criteria = Criteria.Create(selectionCriteria, CultureInfo.CurrentCulture);
         var matchResult = criteria.Match(value);
-        Assert.AreEqual(expectedResult, matchResult);
+        Assert.That(matchResult, Is.EqualTo(expectedResult));
 
         // TallyCriteria skips unused (=blank) cells as an optimization (e.g. SUMIF over whole column/sheet),
         // unless it's possible that blanks will match the criteria. Assert that when tested value matches and
         // is blank, teh TallyCriteria will include blank cells.
         if (matchResult && value.IsBlank)
-            Assert.True(criteria.CanBlankValueMatch);
+            Assert.That(criteria.CanBlankValueMatch, Is.True);
     }
 
     public static IEnumerable<object> CriteriaTestCases

--- a/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DateAndTimeTests.cs
@@ -29,7 +29,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Date_returns_error_when_result_outside_base_date_to_max_date_of_calendar_system(int year, int month, int day)
         {
             var actual = XLWorkbook.EvaluateExpr($"DATE({year},{month},{day})");
-            Assert.AreEqual(XLError.NumberInvalid, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(-1, 32000, 1, ExpectedResult = 973586)]  // Year -1.1 behaves as -2
@@ -66,7 +66,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 expectedResult = DateTime.Parse(iso8601).ToSerialDateTime();
 
             var actual = XLWorkbook.EvaluateExpr($"DATE({year},{month},{day})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase("1/1/2006", "12/12/2010", "Y", ExpectedResult = 4)]
@@ -106,20 +106,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("N")]
         public void DateDif_returns_number_error_on_unexpected_unit(string unit)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"DATEDIF(10,100,\"{unit}\")"));
+            Assert.That(XLWorkbook.EvaluateExpr($"DATEDIF(10,100,\"{unit}\")"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void DateDif_end_date_cant_be_after_start_date()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DATEDIF(40524,38718,\"D\")"));
+            Assert.That(XLWorkbook.EvaluateExpr("DATEDIF(40524,38718,\"D\")"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(-0.1, 100)]
         [TestCase(1, 2958466)]
         public void DateDif_returns_number_error_on_date_out_of_date_system(decimal startDate, decimal endDate)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"DATEDIF({startDate},{endDate},\"D\")"));
+            Assert.That(XLWorkbook.EvaluateExpr($"DATEDIF({startDate},{endDate},\"D\")"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase("8/22/2008", ExpectedResult = 39682)]
@@ -138,14 +138,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // If year isn't provided in string, it should parse as "current year"
             double actual = (double)XLWorkbook.EvaluateExpr("DATEVALUE(\"5-JUL\")");
             double expected = new DateTime(DateTime.Now.Year, 7, 5).ToOADate();
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [TestCase("\"100\"")]
         [TestCase("\"0\"")]
         public void DateValue_doesnt_coerce_number_in_a_text_to_a_date(string arg)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExprCurrent($"DATEVALUE({arg})"));
+            Assert.That(XLWorkbook.EvaluateExprCurrent($"DATEVALUE({arg})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("TRUE")]
@@ -154,13 +154,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("DATE(2006,1,5)")]
         public void DateValue_returns_coercion_error_on_non_text(string arg)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExprCurrent($"DATEVALUE({arg})"));
+            Assert.That(XLWorkbook.EvaluateExprCurrent($"DATEVALUE({arg})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void DateValue_propagates_error()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExprCurrent("DATEVALUE(#DIV/0!)"));
+            Assert.That(XLWorkbook.EvaluateExprCurrent("DATEVALUE(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase(0, ExpectedResult = 0)]
@@ -195,14 +195,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // Test providing just month and day, which should fill the year as "current year"
             double actual = XLWorkbook.EvaluateExpr("DAY(\"8/22\")").GetNumber();
-            Assert.AreEqual(22, actual);
+            Assert.That(actual, Is.EqualTo(22));
         }
 
         [Test]
         public void Day_only_accepts_serial_date_from_0_to_upper_limit_of_calendar_system()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAY(-0.1)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAY(DATE(9999,12,31)+1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("DAY(-0.1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("DAY(DATE(9999,12,31)+1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [SetCulture("eu-ES")]
@@ -233,16 +236,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Days_truncates_passed_arguments()
         {
-            Assert.AreEqual(9, XLWorkbook.EvaluateExpr("DAYS(10.6,1.9)"));
+            Assert.That(XLWorkbook.EvaluateExpr("DAYS(10.6,1.9)"), Is.EqualTo(9));
         }
 
         [Test]
         public void Days_arguments_must_be_in_date_range()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAYS(-0.1,1)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAYS(2958466,1)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAYS(1,-0.1)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("DAYS(1,2958466)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("DAYS(-0.1,1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("DAYS(2958466,1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("DAYS(1,-0.1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("DAYS(1,2958466)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
@@ -252,23 +258,23 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var defaultResult = XLWorkbook.EvaluateExpr(string.Format(formulaFormat, string.Empty));
             var usResult = XLWorkbook.EvaluateExpr(string.Format(formulaFormat, ",FALSE"));
             var euResult = XLWorkbook.EvaluateExpr(string.Format(formulaFormat, ",TRUE"));
-            Assert.AreEqual(1198, defaultResult);
-            Assert.AreEqual(usResult, defaultResult);
-            Assert.AreNotEqual(euResult, defaultResult);
+            Assert.That(defaultResult, Is.EqualTo(1198));
+            Assert.That(defaultResult, Is.EqualTo(usResult));
+            Assert.That(defaultResult, Is.Not.EqualTo(euResult));
         }
 
         [Test]
         public void Days360_Europe1()
         {
             var actual = XLWorkbook.EvaluateExpr("DAYS360(\"1/1/2008\", \"3/31/2008\",TRUE)");
-            Assert.AreEqual(89, actual);
+            Assert.That(actual, Is.EqualTo(89));
         }
 
         [Test]
         public void Days360_Europe2()
         {
             var actual = XLWorkbook.EvaluateExpr("DAYS360(\"3/31/2008\", \"1/1/2008\",TRUE)");
-            Assert.AreEqual(-89, actual);
+            Assert.That(actual, Is.EqualTo(-89));
         }
 
         [TestCase(2002, 2, 3, 2005, 5, 31, ExpectedResult = 1198)]
@@ -320,14 +326,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void EDate_returns_end_date_from_start_date_and_month_offset(string startDate, double monthOffset, string expectedEndDate)
         {
             var actual = XLWorkbook.EvaluateExpr($"EDATE(\"{startDate}\",{monthOffset})");
-            Assert.AreEqual(DateTime.Parse(expectedEndDate).ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(DateTime.Parse(expectedEndDate).ToSerialDateTime()));
         }
 
         [Test]
         public void EDate_returns_number_error_for_non_date_values()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("EDATE(-0.1,0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("EDATE(2958466,0)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("EDATE(-0.1,0)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("EDATE(2958466,0)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase("1900-01-01", -1)]
@@ -335,7 +344,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("9999-07-10", 1E+100)]
         public void EDate_returns_number_error_when_end_date_is_out_of_date_system(string startDate, double monthOffset)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"EDATE(\"{startDate}\",{monthOffset})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"EDATE(\"{startDate}\",{monthOffset})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(1900, 1, 0, 0, ExpectedResult = 31)]
@@ -359,21 +368,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Eomonth_truncates_arguments()
         {
-            Assert.AreEqual(59, XLWorkbook.EvaluateExpr("EOMONTH(60.1,0.9)"));
+            Assert.That(XLWorkbook.EvaluateExpr("EOMONTH(60.1,0.9)"), Is.EqualTo(59));
         }
 
         [Test]
         public void Eomonth_start_date_must_be_in_date_values()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("EOMONTH(-0.1,0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("EOMONTH(DATE(9999,12,31)+1,0)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("EOMONTH(-0.1,0)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("EOMONTH(DATE(9999,12,31)+1,0)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase("1900-01-01", -1)]
         [TestCase("9999-12-10", 1)]
         public void Eomonth_returns_number_error_when_end_date_is_out_of_date_system(string startDate, double monthOffset)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"EOMONTH(\"{startDate}\",{monthOffset})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"EOMONTH(\"{startDate}\",{monthOffset})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase("0", ExpectedResult = 0)]
@@ -405,11 +417,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Hour_accepts_only_serial_time_between_zero_and_upper_limit_of_date_system()
         {
-            Assert.AreEqual(0, XLWorkbook.EvaluateExprCurrent("HOUR(0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("HOUR(-0.1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExprCurrent("HOUR(0)"), Is.EqualTo(0));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("HOUR(-0.1)"), Is.EqualTo(XLError.NumberInvalid));
 
-            Assert.AreEqual(21, XLWorkbook.EvaluateExprCurrent("HOUR(DATE(9999,12,31)+0.9)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("HOUR(DATE(9999,12,31)+1)"));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("HOUR(DATE(9999,12,31)+0.9)"), Is.EqualTo(21));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("HOUR(DATE(9999,12,31)+1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase("0", ExpectedResult = 0)]
@@ -432,11 +447,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Minute_accepts_only_serial_time_between_zero_and_upper_limit_of_date_system()
         {
-            Assert.AreEqual(0, XLWorkbook.EvaluateExprCurrent("MINUTE(0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("MINUTE(-0.1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExprCurrent("MINUTE(0)"), Is.EqualTo(0));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("MINUTE(-0.1)"), Is.EqualTo(XLError.NumberInvalid));
 
-            Assert.AreEqual(36, XLWorkbook.EvaluateExprCurrent("MINUTE(DATE(9999,12,31)+0.9)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("MINUTE(DATE(9999,12,31)+1)"));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("MINUTE(DATE(9999,12,31)+0.9)"), Is.EqualTo(36));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("MINUTE(DATE(9999,12,31)+1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [SetCulture("eu-ES")]
@@ -468,15 +486,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // Test providing just month and day, which should fill the year as "current year"
             double actual = XLWorkbook.EvaluateExpr("MONTH(\"8/22\")").GetNumber();
-            Assert.AreEqual(8, actual);
+            Assert.That(actual, Is.EqualTo(8));
         }
 
         [Test]
         public void Month_serial_date_must_be_between_zero_and_upper_limit_of_date_system()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("MONTH(-0.1)"));
-            Assert.AreEqual(12, XLWorkbook.EvaluateExpr("MONTH(DATE(9999,12,31) + 0.9)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("MONTH(DATE(9999,12,31) + 1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("MONTH(-0.1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("MONTH(DATE(9999,12,31) + 0.9)"), Is.EqualTo(12));
+                Assert.That(XLWorkbook.EvaluateExpr("MONTH(DATE(9999,12,31) + 1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(1900, 1, 0, ExpectedResult = 52)]
@@ -513,7 +534,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 .CellBelow().SetValue(new DateTime(2009, 3, 2)) // Monday holiday just after the last date, shouldn't be counted
                 ;
             var actual = ws.Evaluate("NETWORKDAYS(A2, A3, A4:A11)");
-            Assert.AreEqual(104, actual);
+            Assert.That(actual, Is.EqualTo(104));
         }
 
         [TestCase("2024-10-01", "2024-10-01", 1)] // Tue-Tue
@@ -534,7 +555,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void NetWorkDays_non_full_weeks_are_counted_correctly(string startDate, string endDate, int expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"NETWORKDAYS(\"{startDate}\", \"{endDate}\")");
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -542,10 +563,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void NetWorkDays_with_end_date_earlier_than_start_date()
         {
             var actual = XLWorkbook.EvaluateExpr("NETWORKDAYS(\"3/01/2009\", \"10/01/2008\")");
-            Assert.AreEqual(-108, actual);
+            Assert.That(actual, Is.EqualTo(-108));
 
             actual = XLWorkbook.EvaluateExpr("NETWORKDAYS(\"2016-01-01\", \"2015-12-23\")");
-            Assert.AreEqual(-8, actual);
+            Assert.That(actual, Is.EqualTo(-8));
         }
 
         [Test]
@@ -554,33 +575,36 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var actual = wb.Evaluate("NETWORKDAYS(\"10/01/2008\", \"3/01/2009\", \"11/26/2008\")");
-            Assert.AreEqual(107, actual);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Is.EqualTo(107));
 
-            // Example from specification. Except spec wrong. The value is 1 off from Excel value.
-            Assert.AreEqual(22, wb.Evaluate("NETWORKDAYS(DATE(2006, 1, 1), DATE(2006, 1, 31))"));
-            Assert.AreEqual(-22, wb.Evaluate("NETWORKDAYS(DATE(2006, 1, 31), DATE(2006, 1, 1))"));
-            Assert.AreEqual(21, wb.Evaluate("NETWORKDAYS(DATE(2006, 1, 1), DATE(2006, 2, 1), { \"2006-01-02\", \"2006-01-16\" })"));
+                // Example from specification. Except spec wrong. The value is 1 off from Excel value.
+                Assert.That(wb.Evaluate("NETWORKDAYS(DATE(2006, 1, 1), DATE(2006, 1, 31))"), Is.EqualTo(22));
+                Assert.That(wb.Evaluate("NETWORKDAYS(DATE(2006, 1, 31), DATE(2006, 1, 1))"), Is.EqualTo(-22));
+                Assert.That(wb.Evaluate("NETWORKDAYS(DATE(2006, 1, 1), DATE(2006, 2, 1), { \"2006-01-02\", \"2006-01-16\" })"), Is.EqualTo(21));
 
-            // Scalar number is accepted for holidays
-            Assert.AreEqual(6, wb.Evaluate("NETWORKDAYS(1, 10, 2)"));
+                // Scalar number is accepted for holidays
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, 2)"), Is.EqualTo(6));
 
-            // Scalar logical causes conversion error
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(TRUE, 10)"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(0, TRUE)"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(1, 10, TRUE)"));
+                // Scalar logical causes conversion error
+                Assert.That(wb.Evaluate("NETWORKDAYS(TRUE, 10)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(wb.Evaluate("NETWORKDAYS(0, TRUE)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, TRUE)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Scalar text is converted
-            Assert.AreEqual(6, wb.Evaluate("NETWORKDAYS(\"1\", \"10\", \"2\")"));
-            Assert.AreEqual(6, wb.Evaluate("NETWORKDAYS(1, 10, \"0 4/2\")"));
-            Assert.AreEqual(6, wb.Evaluate("NETWORKDAYS(1, 10, \"1900-01-02\")"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(\"Text\", 10)"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(1, \"Text\")"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(1, 10, \"Text\")"));
+                // Scalar text is converted
+                Assert.That(wb.Evaluate("NETWORKDAYS(\"1\", \"10\", \"2\")"), Is.EqualTo(6));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, \"0 4/2\")"), Is.EqualTo(6));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, \"1900-01-02\")"), Is.EqualTo(6));
+                Assert.That(wb.Evaluate("NETWORKDAYS(\"Text\", 10)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, \"Text\")"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, \"Text\")"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Array accepts numbers and converts text
-            Assert.AreEqual(5, wb.Evaluate("NETWORKDAYS(1, 10, {\"2\", 3})"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(1, 10, {\"Text\"})"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("NETWORKDAYS(1, 10, {TRUE})"));
+                // Array accepts numbers and converts text
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, {\"2\", 3})"), Is.EqualTo(5));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, {\"Text\"})"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, {TRUE})"), Is.EqualTo(XLError.IncompatibleValue));
+            });
 
             // Same conversion logic applies to reference values
             var ws = wb.AddWorksheet();
@@ -591,15 +615,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = "2001-09-12"; // Monday
             ws.Cell("A6").Value = XLError.NoValueAvailable;
 
-            Assert.AreEqual(175, ws.Evaluate("NETWORKDAYS(\"2001-05-01\", \"2001-12-31\", A1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("NETWORKDAYS(\"2001-05-01\", \"2001-12-31\", A1:A3)"));
-            Assert.AreEqual(173, ws.Evaluate("NETWORKDAYS(\"2001-05-01\",\"2001-12-31\", A4:A5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("NETWORKDAYS(\"2001-05-01\", \"2001-12-31\", A1)"), Is.EqualTo(175));
+                Assert.That(ws.Evaluate("NETWORKDAYS(\"2001-05-01\", \"2001-12-31\", A1:A3)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Evaluate("NETWORKDAYS(\"2001-05-01\",\"2001-12-31\", A4:A5)"), Is.EqualTo(173));
 
-            // Errors are propagated
-            Assert.AreEqual(XLError.NoValueAvailable, wb.Evaluate("NETWORKDAYS(#N/A, 10)"));
-            Assert.AreEqual(XLError.NoValueAvailable, wb.Evaluate("NETWORKDAYS(1, #N/A)"));
-            Assert.AreEqual(XLError.NoValueAvailable, wb.Evaluate("NETWORKDAYS(1, 10, {#N/A})"));
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("NETWORKDAYS(1, 10, A6)"));
+                // Errors are propagated
+                Assert.That(wb.Evaluate("NETWORKDAYS(#N/A, 10)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, #N/A)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(wb.Evaluate("NETWORKDAYS(1, 10, {#N/A})"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Evaluate("NETWORKDAYS(1, 10, A6)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [TestCase("0", ExpectedResult = 0)]
@@ -624,11 +651,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Second_accepts_only_serial_time_between_zero_and_upper_limit_of_date_system()
         {
-            Assert.AreEqual(0, XLWorkbook.EvaluateExprCurrent("SECOND(0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("SECOND(-0.1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExprCurrent("SECOND(0)"), Is.EqualTo(0));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("SECOND(-0.1)"), Is.EqualTo(XLError.NumberInvalid));
 
-            Assert.AreEqual(51, XLWorkbook.EvaluateExprCurrent("SECOND(DATE(9999,12,31)+0.9999)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExprCurrent("SECOND(DATE(9999,12,31)+1)"));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("SECOND(DATE(9999,12,31)+0.9999)"), Is.EqualTo(51));
+                Assert.That(XLWorkbook.EvaluateExprCurrent("SECOND(DATE(9999,12,31)+1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(0, 0, 0, ExpectedResult = 0)]
@@ -659,7 +689,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(0, 0, 32768)]
         public void Time_components_must_be_in_zero_to_32767_interval(double hour, double minute, double second)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"TIME({hour},{minute},{second})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"TIME({hour},{minute},{second})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase("2:24 AM", ExpectedResult = 0.1)]
@@ -674,7 +704,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("\"0\"")]
         public void TimeValue_doesnt_coerce_number_in_a_text_to_a_time(string numberText)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExprCurrent($"TIMEVALUE({numberText})"));
+            Assert.That(XLWorkbook.EvaluateExprCurrent($"TIMEVALUE({numberText})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("TRUE")]
@@ -683,20 +713,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("TIME(18,25,48)")]
         public void TimeValue_returns_coercion_error_on_non_text(string nonText)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExprCurrent($"TIMEVALUE({nonText})"));
+            Assert.That(XLWorkbook.EvaluateExprCurrent($"TIMEVALUE({nonText})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void TimeValue_propagates_error()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExprCurrent("TIMEVALUE(#DIV/0!)"));
+            Assert.That(XLWorkbook.EvaluateExprCurrent("TIMEVALUE(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [Test]
         public void Today()
         {
             var actual = (double)XLWorkbook.EvaluateExpr("TODAY()");
-            Assert.AreEqual(DateTime.Today.ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(DateTime.Today.ToSerialDateTime()));
         }
 
         [TestCase("\"2/14/2008\"", 1, 5)]
@@ -712,14 +742,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Weekday_calculates_week_day(string value, int flag, int expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"WEEKDAY({value}, {flag})");
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
         public void Weekday_without_flag()
         {
             var actual = XLWorkbook.EvaluateExpr("WEEKDAY(\"2/14/2008\")");
-            Assert.AreEqual(5, actual);
+            Assert.That(actual, Is.EqualTo(5));
         }
 
         [Test]
@@ -729,35 +759,38 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
 
             ws.Cell("A1").Value = 45577;
-            Assert.AreEqual(7, ws.Evaluate("WEEKDAY(A1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("WEEKDAY(A1)"), Is.EqualTo(7));
 
-            // Time of the day doesn't matter, serial date is truncated
-            Assert.AreEqual(7, XLWorkbook.EvaluateExpr("WEEKDAY(45577.9, 1.9)"));
+                // Time of the day doesn't matter, serial date is truncated
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(45577.9, 1.9)"), Is.EqualTo(7));
 
-            Assert.AreEqual(7, XLWorkbook.EvaluateExpr("WEEKDAY(0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKDAY(-1)"));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(0)"), Is.EqualTo(7));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(-1)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Year 10k
-            Assert.AreEqual(6, XLWorkbook.EvaluateExpr("WEEKDAY(2958465)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKDAY(2958466)"));
+                // Year 10k
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(2958465)"), Is.EqualTo(6));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(2958466)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Convert from logical/text to number
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("WEEKDAY(TRUE)"));
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("WEEKDAY(\"0 2/2\")"));
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("WEEKDAY(1, TRUE)"));
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("WEEKDAY(1, \"1 0/2\")"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("WEEKDAY(\"text\")"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("WEEKDAY(1, \"text\")"));
+                // Convert from logical/text to number
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(TRUE)"), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(\"0 2/2\")"), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, TRUE)"), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, \"1 0/2\")"), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(\"text\")"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, \"text\")"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Flag can only have some values
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKDAY(1, 0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKDAY(1, 4)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKDAY(1, 10)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKDAY(1, 18)"));
+                // Flag can only have some values
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, 0)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, 4)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, 10)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(1, 18)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Error is propagated
-            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr("WEEKDAY(#N/A)"));
-            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr("WEEKDAY(5, #N/A)"));
+                // Error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(#N/A)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKDAY(5, #N/A)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [TestCase(1, 1986, 12, 27, ExpectedResult = 52)]
@@ -861,22 +894,28 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             {
                 var defaultValue = XLWorkbook.EvaluateExpr($"WEEKNUM(DATE(1967,5,{day}))");
                 var sundayValue = XLWorkbook.EvaluateExpr($"WEEKNUM(DATE(1967,5,{day}),1)");
-                Assert.AreEqual(sundayValue, defaultValue);
+                Assert.That(defaultValue, Is.EqualTo(sundayValue));
             }
         }
 
         [TestCase]
         public void Weeknum_match_excel_behavior_and_returns_zero_for_serial_date_zero_when_week_starts_on_sunday()
         {
-            Assert.AreEqual(0, XLWorkbook.EvaluateExpr("WEEKNUM(0,1)"));
-            Assert.AreEqual(0, XLWorkbook.EvaluateExpr("WEEKNUM(0,17)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKNUM(0,1)"), Is.EqualTo(0));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKNUM(0,17)"), Is.EqualTo(0));
+            });
         }
 
         [TestCase]
         public void Weeknum_returns_number_invalid_error_on_non_serial_dates()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKNUM(-0.1)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("WEEKNUM(DATE(9999,12,31)+1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKNUM(-0.1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("WEEKNUM(DATE(9999,12,31)+1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(-5)]
@@ -889,7 +928,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(100)]
         public void Weeknum_returns_number_invalid_error_on_non_specified_flags(double flag)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"WEEKNUM(DATE(200,1,1),{flag})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"WEEKNUM(DATE(200,1,1),{flag})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
@@ -904,24 +943,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 .CellBelow().SetValue(new DateTime(2008, 12, 4))
                 .CellBelow().SetValue(new DateTime(2009, 1, 21));
             var actual = ws.Evaluate("Workday(A2,A3,A4:A6)");
-            Assert.AreEqual(new DateTime(2009, 5, 5).ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(new DateTime(2009, 5, 5).ToSerialDateTime()));
         }
 
         [Test]
         public void Workdays_NoHolidaysGiven()
         {
             var actual = XLWorkbook.EvaluateExpr("Workday(\"10/01/2008\", 151)");
-            Assert.AreEqual(new DateTime(2009, 4, 30).ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(new DateTime(2009, 4, 30).ToSerialDateTime()));
 
             actual = XLWorkbook.EvaluateExpr("Workday(\"2016-01-01\", -10)");
-            Assert.AreEqual(new DateTime(2015, 12, 18).ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(new DateTime(2015, 12, 18).ToSerialDateTime()));
         }
 
         [Test]
         public void Workdays_OneHolidaysGiven()
         {
             var actual = XLWorkbook.EvaluateExpr("Workday(\"10/01/2008\", 152, \"11/26/2008\")");
-            Assert.AreEqual(new DateTime(2009, 5, 4).ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(new DateTime(2009, 5, 4).ToSerialDateTime()));
         }
 
         [TestCase(0, 0, 0)]
@@ -941,7 +980,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Workdays(int startDate, int dayOffset, int expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"WORKDAY({startDate}, {dayOffset})");
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [TestCase(0, 1, new[] { 1 }, 2)]
@@ -959,7 +998,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Workdays_with_holiday(int startDate, int dayOffset, int[] holidays, int expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"WORKDAY({startDate}, {dayOffset}, {{{string.Join(",", holidays)}}})");
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [TestCase("\"8/22/2008\"", 2008)]
@@ -984,7 +1023,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Year(string value, object expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"YEAR({value})");
-            Assert.AreEqual(XLCellValue.FromObject(expected), actual);
+            Assert.That(actual, Is.EqualTo(XLCellValue.FromObject(expected)));
         }
 
         [Test]
@@ -995,7 +1034,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = Blank.Value;
             ws.Cell("A2").FormulaA1 = "YEAR(A1)";
             var valueA2 = ws.Cell("A2").Value;
-            Assert.AreEqual(1900, valueA2);
+            Assert.That(valueA2, Is.EqualTo(1900));
         }
 
         [Test]
@@ -1004,7 +1043,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // Test providing just month and day, which should fill the year as "current year"
             double actual = XLWorkbook.EvaluateExpr("YEAR(\"8/22\")").GetNumber();
-            Assert.AreEqual(DateTime.Now.Year, actual);
+            Assert.That(actual, Is.EqualTo(DateTime.Now.Year));
         }
 
         [DefaultFloatingPointTolerance(XLHelper.Epsilon)]
@@ -1037,15 +1076,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void YearFrac_dates_must_fit_in_date_system_range()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("YEARFRAC(-0.1,10)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("YEARFRAC(0,-0.1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("YEARFRAC(-0.1,10)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("YEARFRAC(0,-0.1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
         public void YearFrac_basis_must_be_between_0_and_4()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("YEARFRAC(0,10,-0.1)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("YEARFRAC(0,10,5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("YEARFRAC(0,10,-0.1)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("YEARFRAC(0,10,5)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -129,7 +129,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var tree = new DependencyTree();
             tree.AddSheetTree(ws);
             var cellFormula = AddFormula(tree, ws, "B3", "=C4");
-            Assert.False(tree.IsEmpty);
+            Assert.That(tree.IsEmpty, Is.False);
 
             // Remove inserted formula removes the dependent and also removes the precedent
             // area from the tree because there is no formula depending on it.
@@ -150,12 +150,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             tree.AddSheetTree(ws);
             var cellFormulaA1 = AddFormula(tree, ws, "A1", "=C4 + B1");
             var cellFormulaA2 = AddFormula(tree, ws, "A2", "=B1 / C4");
-            Assert.False(tree.IsEmpty);
+            Assert.That(tree.IsEmpty, Is.False);
 
             // Remove first formula, but the precedent area is still used
             // by second formula so it is not removed.
             tree.RemoveFormula(cellFormulaA1);
-            Assert.False(tree.IsEmpty);
+            Assert.That(tree.IsEmpty, Is.False);
 
             // Remove second formula
             tree.RemoveFormula(cellFormulaA2);
@@ -324,8 +324,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             });
 
             Recalculate();
-            Assert.False(renamedSheet.Cell("A4").NeedsRecalculation);
-            Assert.False(unchangedSheet.Cell("A4").NeedsRecalculation);
+            Assert.That(renamedSheet.Cell("A4").NeedsRecalculation, Is.False);
+            Assert.That(unchangedSheet.Cell("A4").NeedsRecalculation, Is.False);
 
             // Both depend on Unchanged!A1
             unchangedSheet.Cell("A1").Value = 110;
@@ -357,7 +357,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Only unchanged depends on Unchanged!A3. The renamed formula keeps value.
             unchangedSheet.Cell("A3").Value = 330;
-            Assert.False(renamedSheet.Cell("A4").NeedsRecalculation);
+            Assert.That(renamedSheet.Cell("A4").NeedsRecalculation, Is.False);
             Assert.That(unchangedSheet.Cell("A4").NeedsRecalculation, Is.True);
             Recalculate();
             Assert.Multiple(() =>
@@ -369,7 +369,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Only renamed depends on Renamed!A3. The unchanged formula keeps value.
             renamedSheet.Cell("A3").Value = 403;
             Assert.That(renamedSheet.Cell("A4").NeedsRecalculation, Is.True);
-            Assert.False(unchangedSheet.Cell("A4").NeedsRecalculation);
+            Assert.That(unchangedSheet.Cell("A4").NeedsRecalculation, Is.False);
             Recalculate();
             Assert.Multiple(() =>
             {

--- a/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/DependencyTreeTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Area_dependencies_are_extracted_from_formula(string formula, IReadOnlyList<XLBookArea> expectedAreas)
         {
             var dependencies = GetDependencies(formula);
-            CollectionAssert.AreEquivalent(expectedAreas, dependencies.Areas);
+            Assert.That(dependencies.Areas, Is.EquivalentTo(expectedAreas));
         }
 
         [Test]
@@ -24,7 +24,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Name_dependencies_are_kept_for_dependencies_update(string formula, IReadOnlyList<XLName> expectedNames)
         {
             var dependencies = GetDependencies(formula);
-            CollectionAssert.AreEquivalent(expectedNames, dependencies.Names);
+            Assert.That(dependencies.Names, Is.EquivalentTo(expectedNames));
         }
 
         [Test]
@@ -34,13 +34,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             {
                 wb.DefinedNames.Add("name", "Sheet!$B$4+Sheet!$C$6");
             });
-            CollectionAssert.AreEquivalent(new XLBookArea[]
+            Assert.That(dependencies.Areas, Is.EquivalentTo(new XLBookArea[]
             {
                 new("Sheet", XLSheetRange.Parse("D2")),
                 new("Sheet", XLSheetRange.Parse("B4")),
                 new("Sheet", XLSheetRange.Parse("C6"))
-            }, dependencies.Areas);
-            CollectionAssert.AreEquivalent(new[] { new XLName("name") }, dependencies.Names);
+            }));
+            Assert.That(dependencies.Names, Is.EquivalentTo(new[] { new XLName("name") }));
         }
 
         [Test]
@@ -50,11 +50,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             {
                 wb.DefinedNames.Add("name", "Sheet!$D$7");
             });
-            CollectionAssert.AreEquivalent(new XLBookArea[]
+            Assert.That(dependencies.Areas, Is.EquivalentTo(new XLBookArea[]
             {
                 new("Sheet", XLSheetRange.Parse("B3:D7")),
-            }, dependencies.Areas);
-            CollectionAssert.AreEquivalent(new[] { new XLName("name") }, dependencies.Names);
+            }));
+            Assert.That(dependencies.Names, Is.EquivalentTo(new[] { new XLName("name") }));
         }
 
         [Test]
@@ -65,12 +65,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 wb.DefinedNames.Add("outer", "Sheet!$D$7 + inner");
                 wb.DefinedNames.Add("inner", "Sheet!$B$1");
             });
-            CollectionAssert.AreEquivalent(new XLBookArea[]
+            Assert.That(dependencies.Areas, Is.EquivalentTo(new XLBookArea[]
             {
                 new("Sheet", XLSheetRange.Parse("D7")),
                 new("Sheet", XLSheetRange.Parse("B1")),
-            }, dependencies.Areas);
-            CollectionAssert.AreEquivalent(new[] { new XLName("outer"), new XLName("inner") }, dependencies.Names);
+            }));
+            Assert.That(dependencies.Names, Is.EquivalentTo(new[] { new XLName("outer"), new XLName("inner") }));
         }
 
         [Test]
@@ -80,8 +80,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             {
                 wb.DefinedNames.Add("name", "1+3");
             });
-            CollectionAssert.IsEmpty(dependencies.Areas);
-            CollectionAssert.AreEquivalent(new[] { new XLName("name") }, dependencies.Names);
+            Assert.That(dependencies.Areas, Is.Empty);
+            Assert.That(dependencies.Names, Is.EquivalentTo(new[] { new XLName("name") }));
         }
 
         [Test]
@@ -95,11 +95,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 wb.Worksheet("Sheet").DefinedNames.Add("name", "Sheet!$A$1");
                 wb.DefinedNames.Add("name", "Sheet!$B$10");
             });
-            CollectionAssert.AreEquivalent(new XLBookArea[]
+            Assert.That(dependencies.Areas, Is.EquivalentTo(new XLBookArea[]
             {
                 new("Sheet", XLSheetRange.Parse("A1"))
-            }, dependencies.Areas);
-            CollectionAssert.AreEquivalent(new[] { new XLName("name") }, dependencies.Names);
+            }));
+            Assert.That(dependencies.Names, Is.EquivalentTo(new[] { new XLName("name") }));
         }
 
         [Test]
@@ -110,11 +110,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             {
                 wb.DefinedNames.Add("name", "Sheet!B4"); // equivalent of R[3]C[2]
             });
-            CollectionAssert.AreEquivalent(new XLBookArea[]
+            Assert.That(dependencies.Areas, Is.EquivalentTo(new XLBookArea[]
             {
                 new("Sheet", XLSheetRange.Parse("F7")), // D4 (formula cell) + R[3]C[2] (name relative reference) = F7
-            }, dependencies.Areas);
-            CollectionAssert.AreEquivalent(new[] { new XLName("name") }, dependencies.Names);
+            }));
+            Assert.That(dependencies.Names, Is.EquivalentTo(new[] { new XLName("name") }));
         }
 
         #endregion
@@ -134,11 +134,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Remove inserted formula removes the dependent and also removes the precedent
             // area from the tree because there is no formula depending on it.
             tree.RemoveFormula(cellFormula);
-            Assert.True(tree.IsEmpty);
+            Assert.That(tree.IsEmpty, Is.True);
 
             // Removing already removed formula doesn't throw.
             Assert.DoesNotThrow(() => tree.RemoveFormula(cellFormula));
-            Assert.True(tree.IsEmpty);
+            Assert.That(tree.IsEmpty, Is.True);
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Remove second formula
             tree.RemoveFormula(cellFormulaA2);
-            Assert.True(tree.IsEmpty);
+            Assert.That(tree.IsEmpty, Is.True);
         }
 
         #endregion
@@ -317,8 +317,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             renamedSheet.Name = "Renamed";
 
-            Assert.AreEqual("SUM(Renamed!A1:A2, A3, Unchanged!A1:A2)", renamedSheet.Cell("A4").FormulaA1);
-            Assert.AreEqual("SUM(Unchanged!A1:A2, A3, Renamed!A1:A2)", unchangedSheet.Cell("A4").FormulaA1);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").FormulaA1, Is.EqualTo("SUM(Renamed!A1:A2, A3, Unchanged!A1:A2)"));
+                Assert.That(unchangedSheet.Cell("A4").FormulaA1, Is.EqualTo("SUM(Unchanged!A1:A2, A3, Renamed!A1:A2)"));
+            });
 
             Recalculate();
             Assert.False(renamedSheet.Cell("A4").NeedsRecalculation);
@@ -326,35 +329,53 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Both depend on Unchanged!A1
             unchangedSheet.Cell("A1").Value = 110;
-            Assert.True(renamedSheet.Cell("A4").NeedsRecalculation);
-            Assert.True(unchangedSheet.Cell("A4").NeedsRecalculation);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").NeedsRecalculation, Is.True);
+                Assert.That(unchangedSheet.Cell("A4").NeedsRecalculation, Is.True);
+            });
             Recalculate();
-            Assert.AreEqual(136, renamedSheet.Cell("A4").CachedValue);
-            Assert.AreEqual(163, unchangedSheet.Cell("A4").CachedValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").CachedValue, Is.EqualTo(136));
+                Assert.That(unchangedSheet.Cell("A4").CachedValue, Is.EqualTo(163));
+            });
 
             // Both depend on Renamed!A1
             renamedSheet.Cell("A1").Value = 201;
-            Assert.True(renamedSheet.Cell("A4").NeedsRecalculation);
-            Assert.True(unchangedSheet.Cell("A4").NeedsRecalculation);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").NeedsRecalculation, Is.True);
+                Assert.That(unchangedSheet.Cell("A4").NeedsRecalculation, Is.True);
+            });
             Recalculate();
-            Assert.AreEqual(336, renamedSheet.Cell("A4").CachedValue);
-            Assert.AreEqual(363, unchangedSheet.Cell("A4").CachedValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").CachedValue, Is.EqualTo(336));
+                Assert.That(unchangedSheet.Cell("A4").CachedValue, Is.EqualTo(363));
+            });
 
             // Only unchanged depends on Unchanged!A3. The renamed formula keeps value.
             unchangedSheet.Cell("A3").Value = 330;
             Assert.False(renamedSheet.Cell("A4").NeedsRecalculation);
-            Assert.True(unchangedSheet.Cell("A4").NeedsRecalculation);
+            Assert.That(unchangedSheet.Cell("A4").NeedsRecalculation, Is.True);
             Recalculate();
-            Assert.AreEqual(336, renamedSheet.Cell("A4").CachedValue);
-            Assert.AreEqual(663, unchangedSheet.Cell("A4").CachedValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").CachedValue, Is.EqualTo(336));
+                Assert.That(unchangedSheet.Cell("A4").CachedValue, Is.EqualTo(663));
+            });
 
             // Only renamed depends on Renamed!A3. The unchanged formula keeps value.
             renamedSheet.Cell("A3").Value = 403;
-            Assert.True(renamedSheet.Cell("A4").NeedsRecalculation);
+            Assert.That(renamedSheet.Cell("A4").NeedsRecalculation, Is.True);
             Assert.False(unchangedSheet.Cell("A4").NeedsRecalculation);
             Recalculate();
-            Assert.AreEqual(736, renamedSheet.Cell("A4").CachedValue);
-            Assert.AreEqual(663, unchangedSheet.Cell("A4").CachedValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(renamedSheet.Cell("A4").CachedValue, Is.EqualTo(736));
+                Assert.That(unchangedSheet.Cell("A4").CachedValue, Is.EqualTo(663));
+            });
 
             void Recalculate()
             {
@@ -398,7 +419,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             {
                 foreach (var dirtyCell in ws.Cells(dirtyRange))
                 {
-                    Assert.AreEqual(expectedDirtyFlag, dirtyCell.Formula?.IsDirty);
+                    Assert.That(dirtyCell.Formula?.IsDirty, Is.EqualTo(expectedDirtyFlag));
                 }
             }
         }

--- a/ClosedXML.Tests/Excel/CalcEngine/FinancialTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FinancialTests.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Fv_ReferenceExamplesFromExcelDocumentations(string formula, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedResult, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [TestCase("FV(0,1,1000)", -1000)] // Zero interest rate
@@ -27,25 +27,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Fv_EdgeCases(string formula, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedResult, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [Test]
         public void Fv_DefaultFutureValueIsZero()
         {
-            Assert.AreEqual(XLWorkbook.EvaluateExpr("FV(0.1,2,1000)"), XLWorkbook.EvaluateExpr("FV(0.1,2,1000,0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("FV(0.1,2,1000,0)"), Is.EqualTo(XLWorkbook.EvaluateExpr("FV(0.1,2,1000)")));
         }
 
         [Test]
         public void Fv_DefaultTypeIsZero()
         {
-            Assert.AreEqual(XLWorkbook.EvaluateExpr("FV(0.1,5,1000)"), XLWorkbook.EvaluateExpr("FV(0.1,5,1000,0,0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("FV(0.1,5,1000,0,0)"), Is.EqualTo(XLWorkbook.EvaluateExpr("FV(0.1,5,1000)")));
         }
 
         [Test]
         public void Fv_ZeroPeriodsReturnsPresentValue()
         {
-            Assert.AreEqual(-100, XLWorkbook.EvaluateExpr("FV(0.1,0,1000, 100)"));
+            Assert.That(XLWorkbook.EvaluateExpr("FV(0.1,0,1000, 100)"), Is.EqualTo(-100));
         }
 
         [TestCase("IPMT(0.1/12,1,3*12,8000)", -66.666666666666686)]
@@ -53,7 +53,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Ipmt_ReferenceExamplesFromExcelDocumentations(string formula, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedResult, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [TestCase("IPMT(0,1,1,1000)", 0)] // Zero interest rate
@@ -67,26 +67,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Ipmt_EdgeCases(string formula, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedResult, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [Test]
         public void Ipmt_DefaultFutureValueIsZero()
         {
-            Assert.AreEqual(XLWorkbook.EvaluateExpr("IPMT(0.1,1,2,1000)"), XLWorkbook.EvaluateExpr("IPMT(0.1,1,2,1000,0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("IPMT(0.1,1,2,1000,0)"), Is.EqualTo(XLWorkbook.EvaluateExpr("IPMT(0.1,1,2,1000)")));
         }
 
         [Test]
         public void Ipmt_DefaultTypeIsZero()
         {
-            Assert.AreEqual(XLWorkbook.EvaluateExpr("IPMT(0.1,1,5,1000)"), XLWorkbook.EvaluateExpr("IPMT(0.1,1,5,1000,0,0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("IPMT(0.1,1,5,1000,0,0)"), Is.EqualTo(XLWorkbook.EvaluateExpr("IPMT(0.1,1,5,1000)")));
         }
 
         [Test]
         public void Ipmt_ZeroOrNegativePeriodsReturnsNumError()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("IPMT(0.1,1,0,1000)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("IPMT(0.1,1,-1,1000)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("IPMT(0.1,1,0,1000)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("IPMT(0.1,1,-1,1000)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(-1)]
@@ -94,14 +97,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-100)]
         public void Ipmt_RateLessOrEqualMinusOneReturnsNumError(double rate)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"IPMT({rate},2,3,1000,10000,1)"));
+            Assert.That(XLWorkbook.EvaluateExpr($"IPMT({rate},2,3,1000,10000,1)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Ipmt_PeriodOutOfRangeReturnsNumError()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("IPMT(0.1,0,1,1000)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("IPMT(0.1,2,1,1000)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("IPMT(0.1,0,1,1000)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("IPMT(0.1,2,1,1000)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase("PMT(0.08/12,10,10000)", -1037.03208935915)]
@@ -109,14 +115,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Pmt_ReferenceExamplesFromExcelDocumentations(string formula, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedResult, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [Test]
         public void Pmt_PaymentsMustPayForPrincipalAndFutureValue()
         {
             var actual = (double)XLWorkbook.EvaluateExpr("PMT(0,2,5000,10000)");
-            Assert.AreEqual(-7500, actual);
+            Assert.That(actual, Is.EqualTo(-7500));
         }
 
         [TestCase("PMT(0,1,1000)", -1000)] // Zero interest rate
@@ -130,7 +136,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Pmt_EdgeCases(string formula, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedResult, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [Test]
@@ -142,26 +148,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var oneType = (double)XLWorkbook.EvaluateExpr(string.Format(formulaFormat, "1"));
             var nonZeroType = (double)XLWorkbook.EvaluateExpr(string.Format(formulaFormat, "0.000001"));
 
-            Assert.AreNotEqual(zeroType, oneType);
-            Assert.AreEqual(oneType, nonZeroType);
+            Assert.Multiple(() =>
+            {
+                Assert.That(oneType, Is.Not.EqualTo(zeroType));
+                Assert.That(nonZeroType, Is.EqualTo(oneType));
+            });
         }
 
         [Test]
         public void Pmt_DefaultFutureValueIsZero()
         {
-            Assert.AreEqual(XLWorkbook.EvaluateExpr("PMT(0.1,2,1000)"), XLWorkbook.EvaluateExpr("PMT(0.1,2,1000,0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("PMT(0.1,2,1000,0)"), Is.EqualTo(XLWorkbook.EvaluateExpr("PMT(0.1,2,1000)")));
         }
 
         [Test]
         public void Pmt_DefaultTypeIsZero()
         {
-            Assert.AreEqual(XLWorkbook.EvaluateExpr("PMT(0.1,5,1000)"), XLWorkbook.EvaluateExpr("PMT(0.1,5,1000,0,0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("PMT(0.1,5,1000,0,0)"), Is.EqualTo(XLWorkbook.EvaluateExpr("PMT(0.1,5,1000)")));
         }
 
         [Test]
         public void Pmt_ZeroPeriodsReturnsNumError()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("PMT(0.1,0,1000)"));
+            Assert.That(XLWorkbook.EvaluateExpr("PMT(0.1,0,1000)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(-1)]
@@ -169,7 +178,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-100)]
         public void Pmt_RateLessOrEqualMinusOneReturnsNumError(double rate)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"PMT({rate},1,1000,5000,1)"));
+            Assert.That(XLWorkbook.EvaluateExpr($"PMT({rate},1,1000,5000,1)"), Is.EqualTo(XLError.NumberInvalid));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -11,166 +11,165 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void StaticCellDoesNotNeedRecalculation()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
-                cell.Value = "1234567";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
+            cell.Value = "1234567";
 
-                Assert.IsFalse(cell.NeedsRecalculation);
-            }
+            Assert.That(cell.NeedsRecalculation, Is.False);
         }
 
         [Test]
         public void EditCellInvalidatesDependentCells()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var cell = sheet.Cell(1, 1);
-                var dependentCell = sheet.Cell(2, 1);
-                dependentCell.FormulaA1 = "=A1";
-                var _ = dependentCell.Value;
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var cell = sheet.Cell(1, 1);
+            var dependentCell = sheet.Cell(2, 1);
+            dependentCell.FormulaA1 = "=A1";
+            var _ = dependentCell.Value;
 
-                cell.Value = "1234567";
+            cell.Value = "1234567";
 
-                Assert.IsTrue(dependentCell.NeedsRecalculation);
-            }
+            Assert.That(dependentCell.NeedsRecalculation, Is.True);
         }
 
         [Test]
         public void EditFormulaA1InvalidatesDependentCells()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+            a1.Value = 15;
+
+            var res1 = a4.Value;
+            a2.FormulaA1 = "=A1*20";
+            var res2 = a4.Value;
+
+            Assert.Multiple(() =>
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-                a1.Value = 15;
-
-                var res1 = a4.Value;
-                a2.FormulaA1 = "=A1*20";
-                var res2 = a4.Value;
-
-                Assert.AreEqual(15 + 150 + 1500, res1);
-                Assert.AreEqual(15 + 300 + 3000, res2);
-            }
+                Assert.That(res1, Is.EqualTo(15 + 150 + 1500));
+                Assert.That(res2, Is.EqualTo(15 + 300 + 3000));
+            });
         }
 
         [Test]
         public void EditFormulaR1C1InvalidatesDependentCells()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+            a1.Value = 15;
+
+            var res1 = a4.Value;
+            a2.FormulaR1C1 = "=R[-1]C*2";
+            var res2 = a4.Value;
+
+            Assert.Multiple(() =>
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-                a1.Value = 15;
-
-                var res1 = a4.Value;
-                a2.FormulaR1C1 = "=R[-1]C*2";
-                var res2 = a4.Value;
-
-                Assert.AreEqual(15 + 150 + 1500, res1);
-                Assert.AreEqual(15 + 30 + 300, res2);
-            }
+                Assert.That(res1, Is.EqualTo(15 + 150 + 1500));
+                Assert.That(res2, Is.EqualTo(15 + 30 + 300));
+            });
         }
 
         [Test]
         public void InsertRowInvalidatesValues()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a4 = sheet.Cell("A4");
-                a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a4 = sheet.Cell("A4");
+            a4.FormulaA1 = "=COUNTBLANK(A1:A3)";
 
-                Assert.AreEqual(3, a4.Value);
+            Assert.That(a4.Value, Is.EqualTo(3));
 
-                sheet.Row(2).InsertRowsAbove(2);
+            sheet.Row(2).InsertRowsAbove(2);
 
-                Assert.AreEqual(5, sheet.Cell("A6").Value);
-            }
+            Assert.That(sheet.Cell("A6").Value, Is.EqualTo(5));
         }
 
         [Test]
         public void DeleteRowModifiesFormulaAndInvalidatesValues()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var original = sheet.Cell("A4");
+            original.FormulaA1 = "=COUNTBLANK(A1:A3)";
+
+            Assert.That(original.Value, Is.EqualTo(3));
+
+            sheet.Row(2).Delete();
+
+            var shifted = sheet.Cell("A3");
+            Assert.Multiple(() =>
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var original = sheet.Cell("A4");
-                original.FormulaA1 = "=COUNTBLANK(A1:A3)";
-
-                Assert.AreEqual(3, original.Value);
-
-                sheet.Row(2).Delete();
-
-                var shifted = sheet.Cell("A3");
-                Assert.AreEqual("COUNTBLANK(A1:A2)", shifted.FormulaA1);
-                Assert.AreEqual(2, shifted.Value);
-            }
+                Assert.That(shifted.FormulaA1, Is.EqualTo("COUNTBLANK(A1:A2)"));
+                Assert.That(shifted.Value, Is.EqualTo(2));
+            });
         }
 
         [Test]
         public void ChainedCalculationPreservesIntermediateValues()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+
+            a1.Value = 15;
+            var res = a4.Value;
+
+            Assert.Multiple(() =>
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-
-                a1.Value = 15;
-                var res = a4.Value;
-
-                Assert.AreEqual(15 + 150 + 1500, res);
-                Assert.IsFalse(a4.NeedsRecalculation);
-                Assert.IsFalse(a3.NeedsRecalculation);
-                Assert.IsFalse(a2.NeedsRecalculation);
-                Assert.AreEqual(150, a2.CachedValue);
-                Assert.AreEqual(1500, a3.CachedValue);
-                Assert.AreEqual(15 + 150 + 1500, a4.CachedValue);
-            }
+                Assert.That(res, Is.EqualTo(15 + 150 + 1500));
+                Assert.That(a4.NeedsRecalculation, Is.False);
+                Assert.That(a3.NeedsRecalculation, Is.False);
+                Assert.That(a2.NeedsRecalculation, Is.False);
+                Assert.That(a2.CachedValue, Is.EqualTo(150));
+                Assert.That(a3.CachedValue, Is.EqualTo(1500));
+                Assert.That(a4.CachedValue, Is.EqualTo(15 + 150 + 1500));
+            });
         }
 
         [Test]
         public void EditingAffectsDependentCells()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=SUM(A1:A3)";
+            a1.Value = 15;
+
+            var res1 = a4.Value;
+            a1.Value = 20;
+            var res2 = a4.Value;
+
+            Assert.Multiple(() =>
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=SUM(A1:A3)";
-                a1.Value = 15;
-
-                var res1 = a4.Value;
-                a1.Value = 20;
-                var res2 = a4.Value;
-
-                Assert.AreEqual(15 + 150 + 1500, res1);
-                Assert.AreEqual(20 + 200 + 2000, res2);
-            }
+                Assert.That(res1, Is.EqualTo(15 + 150 + 1500));
+                Assert.That(res2, Is.EqualTo(20 + 200 + 2000));
+            });
         }
 
         [Test]
@@ -181,152 +180,150 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("C2", new string[] { "C5" })]
         public void EditingDoesNotAffectNonDependingCells(string changedCell, string[] affectedCells)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            sheet.Cell("A2").FormulaA1 = "A1+1";
+            sheet.Cell("A3").FormulaA1 = "SUM(A1:A2)";
+            sheet.Cell("A4").FormulaA1 = "SUM(A1:A3)";
+            sheet.Cell("B2").FormulaA1 = "B1+1";
+            sheet.Cell("B3").FormulaA1 = "SUM(B1:B2)";
+            sheet.Cell("B4").FormulaA1 = "SUM(B1:B3)";
+            sheet.Cell("C1").FormulaA1 = "SUM(A1:B1)";
+            sheet.Cell("C2").FormulaA1 = "SUM(A2:B2)";
+            sheet.Cell("C3").FormulaA1 = "SUM(A3:B3)";
+            sheet.Cell("C5").FormulaA1 = "SUM($A$1:$C$4)";
+            sheet.RecalculateAllFormulas();
+            var allCells = sheet.CellsUsed();
+
+            sheet.Cell(changedCell).Value = 100;
+            var modifiedCells = allCells.Where(cell => cell.NeedsRecalculation);
+
+            Assert.That(modifiedCells.Count(), Is.EqualTo(affectedCells.Length));
+            foreach (var cellAddress in affectedCells)
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                sheet.Cell("A2").FormulaA1 = "A1+1";
-                sheet.Cell("A3").FormulaA1 = "SUM(A1:A2)";
-                sheet.Cell("A4").FormulaA1 = "SUM(A1:A3)";
-                sheet.Cell("B2").FormulaA1 = "B1+1";
-                sheet.Cell("B3").FormulaA1 = "SUM(B1:B2)";
-                sheet.Cell("B4").FormulaA1 = "SUM(B1:B3)";
-                sheet.Cell("C1").FormulaA1 = "SUM(A1:B1)";
-                sheet.Cell("C2").FormulaA1 = "SUM(A2:B2)";
-                sheet.Cell("C3").FormulaA1 = "SUM(A3:B3)";
-                sheet.Cell("C5").FormulaA1 = "SUM($A$1:$C$4)";
-                sheet.RecalculateAllFormulas();
-                var allCells = sheet.CellsUsed();
-
-                sheet.Cell(changedCell).Value = 100;
-                var modifiedCells = allCells.Where(cell => cell.NeedsRecalculation);
-
-                Assert.AreEqual(affectedCells.Length, modifiedCells.Count());
-                foreach (var cellAddress in affectedCells)
-                {
-                    Assert.IsTrue(modifiedCells.Any(cell => cell.Address.ToString() == cellAddress),
-                        string.Format("Cell {0} is expected to need recalculation, but it does not", cellAddress));
-                }
+                Assert.That(modifiedCells.Any(cell => cell.Address.ToString() == cellAddress),
+                    Is.True,
+                    string.Format("Cell {0} is expected to need recalculation, but it does not", cellAddress));
             }
         }
 
         [Test]
         public void CircularReferenceFailsCalculating()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
 
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=A3*10";
-                a1.FormulaA1 = "A2+A3+A4";
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=A3*10";
+            a1.FormulaA1 = "A2+A3+A4";
 
-                var getValueA1 = new TestDelegate(() => { var v = a1.Value; });
-                var getValueA2 = new TestDelegate(() => { var v = a2.Value; });
-                var getValueA3 = new TestDelegate(() => { var v = a3.Value; });
-                var getValueA4 = new TestDelegate(() => { var v = a4.Value; });
+            var getValueA1 = new TestDelegate(() => { var v = a1.Value; });
+            var getValueA2 = new TestDelegate(() => { var v = a2.Value; });
+            var getValueA3 = new TestDelegate(() => { var v = a3.Value; });
+            var getValueA4 = new TestDelegate(() => { var v = a4.Value; });
 
-                Assert.Throws(typeof(InvalidOperationException), getValueA1);
-                Assert.Throws(typeof(InvalidOperationException), getValueA2);
-                Assert.Throws(typeof(InvalidOperationException), getValueA3);
-                Assert.Throws(typeof(InvalidOperationException), getValueA4);
-            }
+            Assert.Throws(typeof(InvalidOperationException), getValueA1);
+            Assert.Throws(typeof(InvalidOperationException), getValueA2);
+            Assert.Throws(typeof(InvalidOperationException), getValueA3);
+            Assert.Throws(typeof(InvalidOperationException), getValueA4);
         }
 
         [Test]
         public void CircularReferenceRecalculationNeededDoesNotFail()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+            var a1 = sheet.Cell("A1");
+            var a2 = sheet.Cell("A2");
+            var a3 = sheet.Cell("A3");
+            var a4 = sheet.Cell("A4");
+
+            a2.FormulaA1 = "=A1*10";
+            a3.FormulaA1 = "=A2*10";
+            a4.FormulaA1 = "=A3*10";
+            var _ = a4.Value;
+            a1.FormulaA1 = "=SUM(A2:A4)";
+
+            var recalcNeededA1 = a1.NeedsRecalculation;
+            var recalcNeededA2 = a2.NeedsRecalculation;
+            var recalcNeededA3 = a3.NeedsRecalculation;
+            var recalcNeededA4 = a4.NeedsRecalculation;
+
+            Assert.Multiple(() =>
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-                var a1 = sheet.Cell("A1");
-                var a2 = sheet.Cell("A2");
-                var a3 = sheet.Cell("A3");
-                var a4 = sheet.Cell("A4");
-
-                a2.FormulaA1 = "=A1*10";
-                a3.FormulaA1 = "=A2*10";
-                a4.FormulaA1 = "=A3*10";
-                var _ = a4.Value;
-                a1.FormulaA1 = "=SUM(A2:A4)";
-
-                var recalcNeededA1 = a1.NeedsRecalculation;
-                var recalcNeededA2 = a2.NeedsRecalculation;
-                var recalcNeededA3 = a3.NeedsRecalculation;
-                var recalcNeededA4 = a4.NeedsRecalculation;
-
-                Assert.IsTrue(recalcNeededA1);
-                Assert.IsTrue(recalcNeededA2);
-                Assert.IsTrue(recalcNeededA3);
-                Assert.IsTrue(recalcNeededA4);
-            }
+                Assert.That(recalcNeededA1, Is.True);
+                Assert.That(recalcNeededA2, Is.True);
+                Assert.That(recalcNeededA3, Is.True);
+                Assert.That(recalcNeededA4, Is.True);
+            });
         }
 
         [Test]
         public void DeleteWorksheetInvalidatesValues()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var sheet1 = wb.Worksheets.Add("Sheet1");
+            var sheet2 = wb.Worksheets.Add("Sheet2");
+            var sheet1_a1 = sheet1.Cell("A1");
+            var sheet2_a1 = sheet2.Cell("A1");
+            sheet1_a1.FormulaA1 = "Sheet2!A1";
+            sheet2_a1.Value = "TestValue";
+
+            var valueBeforeDeletion = sheet1_a1.Value;
+            sheet2.Delete();
+            var valueAfterDeletion = sheet1_a1.Value;
+
+            Assert.Multiple(() =>
             {
-                var sheet1 = wb.Worksheets.Add("Sheet1");
-                var sheet2 = wb.Worksheets.Add("Sheet2");
-                var sheet1_a1 = sheet1.Cell("A1");
-                var sheet2_a1 = sheet2.Cell("A1");
-                sheet1_a1.FormulaA1 = "Sheet2!A1";
-                sheet2_a1.Value = "TestValue";
-
-                var valueBeforeDeletion = sheet1_a1.Value;
-                sheet2.Delete();
-                var valueAfterDeletion = sheet1_a1.Value;
-
-                Assert.AreEqual("TestValue", valueBeforeDeletion);
-                Assert.AreEqual(XLError.CellReference, valueAfterDeletion);
-            }
+                Assert.That(valueBeforeDeletion, Is.EqualTo("TestValue"));
+                Assert.That(valueAfterDeletion, Is.EqualTo(XLError.CellReference));
+            });
         }
 
         [Test]
         public void CachedValueToExternalWorkbook()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\ExternalLinks\WorkbookWithExternalLink.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\ExternalLinks\WorkbookWithExternalLink.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            var cell = ws.Cell("B2");
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.First();
-                var cell = ws.Cell("B2");
-                Assert.IsFalse(cell.NeedsRecalculation);
-                Assert.IsTrue(cell.HasFormula);
+                Assert.That(cell.NeedsRecalculation, Is.False);
+                Assert.That(cell.HasFormula, Is.True);
 
                 // This will fail when we start supporting external links
-                Assert.IsTrue(cell.FormulaA1.StartsWith("[1]"));
+                Assert.That(cell.FormulaA1, Does.StartWith("[1]"));
 
-                Assert.AreEqual("hello world", cell.CachedValue);
-                Assert.AreEqual("hello world", cell.Value);
+                Assert.That(cell.CachedValue, Is.EqualTo("hello world"));
+                Assert.That(cell.Value, Is.EqualTo("hello world"));
 
-                Assert.AreEqual(11, ws.Evaluate("LEN(B2)"));
+                Assert.That(ws.Evaluate("LEN(B2)"), Is.EqualTo(11));
+            });
 
-                Assert.Throws(Is.TypeOf<NotImplementedException>().And.Message.EqualTo("References from other files are not yet implemented."), () => wb.RecalculateAllFormulas());
-            }
+            Assert.Throws(Is.TypeOf<NotImplementedException>().And.Message.EqualTo("References from other files are not yet implemented."), () => wb.RecalculateAllFormulas());
         }
 
         [Test]
         public void ChangingValueChangesCachedValue()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Test");
-                var cell = ws.Cell(1, 1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Test");
+            var cell = ws.Cell(1, 1);
 
-                cell.Value = "Hello";
-                Assert.AreEqual("Hello", cell.CachedValue);
+            cell.Value = "Hello";
+            Assert.That(cell.CachedValue, Is.EqualTo("Hello"));
 
-                cell.Value = 74.0;
-                Assert.AreEqual(74.0, cell.CachedValue);
+            cell.Value = 74.0;
+            Assert.That(cell.CachedValue, Is.EqualTo(74.0));
 
-                cell.Value = new DateTime(2019, 1, 1, 14, 0, 0);
-                Assert.AreEqual(new DateTime(2019, 1, 1, 14, 0, 0), cell.CachedValue);
-            }
+            cell.Value = new DateTime(2019, 1, 1, 14, 0, 0);
+            Assert.That(cell.CachedValue, Is.EqualTo(new DateTime(2019, 1, 1, 14, 0, 0)));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaCachingTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaCachingTests.cs
@@ -323,7 +323,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.That(cell.CachedValue, Is.EqualTo(74.0));
 
             cell.Value = new DateTime(2019, 1, 1, 14, 0, 0);
-            Assert.That(cell.CachedValue, Is.EqualTo(new DateTime(2019, 1, 1, 14, 0, 0)));
+            Assert.That(cell.CachedValue.GetDateTime(), Is.EqualTo(new DateTime(2019, 1, 1, 14, 0, 0)));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -184,7 +184,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=PMT(0,1,1000,,1)", -1000)]
         public void Empty_arguments_are_passed_to_function(string formula, object expectedValue)
         {
-            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue).Within(XLHelper.Epsilon));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -18,13 +18,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase]
         public void Formula_string_can_starting_with_an_equal_sign()
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("=1"));
+            Assert.That(XLWorkbook.EvaluateExpr("=1"), Is.EqualTo(1));
         }
 
         [TestCase]
         public void Formula_string_can_omit_starting_equal_sign()
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("1"));
+            Assert.That(XLWorkbook.EvaluateExpr("1"), Is.EqualTo(1));
         }
 
         [TestCase]
@@ -47,7 +47,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = "Text";
-            Assert.AreEqual("Text", ws.Evaluate("=A1"));
+            Assert.That(ws.Evaluate("=A1"), Is.EqualTo("Text"));
         }
 
         [TestCase("=1", 1)]
@@ -55,7 +55,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=TRUE", true)]
         public void Formula_can_be_constant(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("=SUM(1,2)", 3)]
@@ -64,21 +64,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=150%", 1.5)]
         public void Formula_can_be_function_call(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase]
         public void Formula_can_be_constant_array()
         {
             // 1 is determined through implicit intersection (first element)
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("={1,2,3;4,5,6}"));
+            Assert.That(XLWorkbook.EvaluateExpr("={1,2,3;4,5,6}"), Is.EqualTo(1));
         }
 
         [TestCase("=(1)", 1)]
         [TestCase("=(\"text\")", "text")]
         public void Formula_can_be_another_formula_in_parenthesis(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
         #endregion
 
@@ -93,7 +93,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Constant_can_be_number(string formula, double expectedNumber)
         {
             // Irony returns number as an object of various types, e.g. int or double
-            Assert.AreEqual(expectedNumber, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedNumber));
         }
 
         [TestCase("=\"text\"", "text")]
@@ -102,7 +102,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=\"use two double quote \"\" to nest quotes\"", "use two double quote \" to nest quotes")]
         public void Constant_can_be_text(string formula, string expectedText)
         {
-            Assert.AreEqual(expectedText, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedText));
         }
 
         [TestCase("=TRUE", true)]
@@ -110,7 +110,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=tRuE", true)]
         public void Constant_can_be_bool(string formula, bool expectedBool)
         {
-            Assert.AreEqual(expectedBool, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedBool));
         }
 
         // #REF! is converted by a different rule, so it is not here.
@@ -123,7 +123,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Constant_can_be_error(string formula, object expectedError)
         {
             var error = (XLError)XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(expectedError, error);
+            Assert.That(error, Is.EqualTo(expectedError));
         }
         #endregion
 
@@ -134,7 +134,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=SUM(1,2,3)", 6)]
         public void FunctionCall_can_be_excel_predefined_function(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("=+1", 1)]
@@ -142,13 +142,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         //        [TestCase("=@A1", 1)]
         public void FunctionCall_can_be_unary_prefix_operation(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("=75%", 0.75)]
         public void FunctionCall_can_be_unary_postfix_operation(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("=2^3", 8)]
@@ -175,7 +175,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=2<=1", false)]
         public void FunctionCall_can_be_binary_infix_operation(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
         #endregion
 
@@ -202,14 +202,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A2").Value = 5;
             ws.Range("A2:A2").AddToNamed("TestRangeName");
 
-            Assert.AreEqual(expectedValue, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase]
         public void Reference_can_be_reference_function_call()
         {
             // XLParser considers a limited subset of predefined functions (IF, CHOOSE, INDEX...) to be different from other predefined function because they can return reference.
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("=IF(FALSE,1,2)"));
+            Assert.That(XLWorkbook.EvaluateExpr("=IF(FALSE,1,2)"), Is.EqualTo(2));
         }
 
         [TestCase]
@@ -219,7 +219,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = 1;
 
-            Assert.AreEqual(1, ws.Evaluate("=(A1)"));
+            Assert.That(ws.Evaluate("=(A1)"), Is.EqualTo(1));
         }
 
         [TestCase]
@@ -230,7 +230,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws2 = wb.AddWorksheet("Sheet2");
             ws2.Cell("A1").Value = 1;
 
-            Assert.AreEqual(1, ws1.Evaluate("=Sheet2!  A1"));
+            Assert.That(ws1.Evaluate("=Sheet2!  A1"), Is.EqualTo(1));
         }
 
         [TestCase]
@@ -269,7 +269,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase]
         public void Reference_function_call_can_be_reference_function()
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("=IF(TRUE,1,2)"));
+            Assert.That(XLWorkbook.EvaluateExpr("=IF(TRUE,1,2)"), Is.EqualTo(1));
         }
 
         [TestCase]
@@ -286,7 +286,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         // [TestCase("=CHOOSE(2,\"A\",\"B\",73)", "B")] Not implemented
         public void Ref_function_name_can_be_excel_ref_conditional_function(string formula, object expectedValue)
         {
-            Assert.AreEqual(expectedValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         [TestCase("=INDEX(A1:B2,1,2)", "Lemons")]
@@ -300,7 +300,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B1").Value = "Lemons";
             ws.Cell("A2").Value = "Bananas";
             ws.Cell("B2").Value = "Pears";
-            Assert.AreEqual(expectedValue, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -315,7 +315,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = 1;
 
-            Assert.AreEqual(1, ws.Evaluate("=A1"));
+            Assert.That(ws.Evaluate("=A1"), Is.EqualTo(1));
         }
 
         [TestCase("TestRange")]
@@ -326,7 +326,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Range("A1:C4").SetValue(1).AddToNamed(rangeName);
 
-            Assert.AreEqual(12, ws.Evaluate($"=SUM({rangeName})"));
+            Assert.That(ws.Evaluate($"=SUM({rangeName})"), Is.EqualTo(12));
         }
 
         [TestCase]
@@ -336,7 +336,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Range("A1:C4").SetValue(1);
 
-            Assert.AreEqual(8, ws.Evaluate("=SUM(A:B)"));
+            Assert.That(ws.Evaluate("=SUM(A:B)"), Is.EqualTo(8));
         }
 
         [TestCase]
@@ -346,19 +346,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Range("A1:C4").SetValue(1);
 
-            Assert.AreEqual(3, ws.Evaluate("=SUM(2:2)"));
+            Assert.That(ws.Evaluate("=SUM(2:2)"), Is.EqualTo(3));
         }
 
         [TestCase]
         public void Reference_item_can_be_ref_error()
         {
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("#REF!"));
+            Assert.That(XLWorkbook.EvaluateExpr("#REF!"), Is.EqualTo(XLError.CellReference));
         }
 
         [TestCase]
         public void Reference_item_can_be_user_defined_function_call()
         {
-            Assert.AreEqual(XLError.NameNotRecognized, XLWorkbook.EvaluateExpr("CustomFunction(1)"));
+            Assert.That(XLWorkbook.EvaluateExpr("CustomFunction(1)"), Is.EqualTo(XLError.NameNotRecognized));
         }
 
         [TestCase]
@@ -368,7 +368,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").InsertTable(new[] { new { Amount = 1 }, new { Amount = 2 } });
 
-            Assert.AreEqual(3, ws.Evaluate("SUM(Table1[#Data])"));
+            Assert.That(ws.Evaluate("SUM(Table1[#Data])"), Is.EqualTo(3));
         }
 
         #endregion
@@ -401,15 +401,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ast = calcEngine.Parse(formula);
 
             var actual = ((ArrayNode)ast.AstRoot).Value;
-            Assert.AreEqual(expectedArray.Width, actual.Width);
-            Assert.AreEqual(expectedArray.Height, actual.Height);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual.Width, Is.EqualTo(expectedArray.Width));
+                Assert.That(actual.Height, Is.EqualTo(expectedArray.Height));
+            });
             for (var row = 0; row < actual.Height; ++row)
             {
                 for (var col = 0; col < actual.Width; ++col)
                 {
                     var actualElement = actual[row, col];
                     var expectedElement = expectedArray[row, col];
-                    Assert.AreEqual(expectedElement, actualElement);
+                    Assert.That(actualElement, Is.EqualTo(expectedElement));
                 }
             }
         }
@@ -464,7 +467,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet(sheetName);
             ws.Cell("A1").Value = 5;
-            Assert.AreEqual(5, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(5));
         }
 
         [TestCase("=Sheet1:Sheet5!A1")]

--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -380,7 +380,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
             var ex = Assert.Throws<ExpressionParseException>(() => calcEngine.Parse("{1;2,3}"))!;
-            StringAssert.Contains("Rows of an array don't have same size.", ex.Message);
+            Assert.That(ex.Message, Does.Contain("Rows of an array don't have same size."));
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // XLParser allows @ for number through 'PrefixOp + Number'
             var calcEngine = new XLCalcEngine(CultureInfo.InvariantCulture);
             var ex = Assert.Throws<ExpressionParseException>(() => calcEngine.Parse("{@1}"))!;
-            StringAssert.Contains("Unexpected token INTERSECT.", ex.Message);
+            Assert.That(ex.Message, Does.Contain("Unexpected token INTERSECT."));
         }
 
         [TestCaseSource(nameof(ArrayCases))]

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -17,19 +17,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Asc()
         {
-            Object actual;
+            object actual;
 
             actual = XLWorkbook.EvaluateExpr(@"Asc(""Text"")");
-            Assert.AreEqual("Text", actual);
+            Assert.That(actual, Is.EqualTo("Text"));
         }
 
         [Test]
         public void Clean()
         {
-            Object actual;
+            object actual;
 
-            actual = XLWorkbook.EvaluateExpr(String.Format(@"Clean(""A{0}B"")", Environment.NewLine));
-            Assert.AreEqual("AB", actual);
+            actual = XLWorkbook.EvaluateExpr(string.Format(@"Clean(""A{0}B"")", Environment.NewLine));
+            Assert.That(actual, Is.EqualTo("AB"));
         }
 
         [Test]
@@ -37,10 +37,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             object actual = wb.Evaluate("DOLLAR(12345.123)");
-            Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.12", actual);
+            Assert.That(actual, Is.EqualTo(TestHelper.CurrencySymbol + "12,345.12"));
 
             actual = wb.Evaluate("DOLLAR(12345.123, 1)");
-            Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.1", actual);
+            Assert.That(actual, Is.EqualTo(TestHelper.CurrencySymbol + "12,345.1"));
         }
 
         [TestCase("A", "A", true)]
@@ -49,43 +49,49 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Exact(string lhs, string rhs, bool result)
         {
             var actual = XLWorkbook.EvaluateExpr($"EXACT(\"{lhs}\", \"{rhs}\")");
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [Test]
         public void Exact_converts_values_to_text()
         {
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("EXACT(TRUE, \"true\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(TRUE, \"TRUE\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(1, \"1\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(IF(TRUE,), \"\")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("EXACT(TRUE, \"true\")"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("EXACT(TRUE, \"TRUE\")"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("EXACT(1, \"1\")"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("EXACT(IF(TRUE,), \"\")"), Is.EqualTo(true));
+            });
 
             // Check blank cell
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(true, ws.Evaluate("EXACT(A1, \"\")"));
+            Assert.That(ws.Evaluate("EXACT(A1, \"\")"), Is.EqualTo(true));
         }
 
         [Test]
         public void Exact_propagates_errors()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("EXACT(#DIV/0!, \"A\")"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("EXACT(\"A\", #DIV/0!)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("EXACT(#DIV/0!, \"A\")"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(XLWorkbook.EvaluateExpr("EXACT(\"A\", #DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
+            });
         }
 
         [Test]
         public void Fixed()
         {
-            Object actual;
+            object actual;
 
             actual = XLWorkbook.EvaluateExpr("Fixed(12345.123)");
-            Assert.AreEqual("12,345.12", actual);
+            Assert.That(actual, Is.EqualTo("12,345.12"));
 
             actual = XLWorkbook.EvaluateExpr("Fixed(12345.123, 1)");
-            Assert.AreEqual("12,345.1", actual);
+            Assert.That(actual, Is.EqualTo("12,345.1"));
 
             actual = XLWorkbook.EvaluateExpr("Fixed(12345.123, 1, TRUE)");
-            Assert.AreEqual("12345.1", actual);
+            Assert.That(actual, Is.EqualTo("12345.1"));
         }
 
         [Test]
@@ -97,7 +103,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             IXLWorksheet ws2 = wb.AddWorksheet("ws2");
             ws2.FirstCell().SetFormulaA1("ws1!B1 + 1");
             object v = ws2.FirstCell().Value;
-            Assert.AreEqual(3.0, v);
+            Assert.That(v, Is.EqualTo(3.0));
         }
 
         [Test]
@@ -113,17 +119,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("C1").FormulaA1 = "\"The total value is: \" & SUM(A1:B2)";
 
             object r = ws.Cell("C1").Value;
-            Assert.AreEqual("The total value is: 4", r);
+            Assert.That(r, Is.EqualTo("The total value is: 4"));
         }
 
         [Test]
         public void Trim()
         {
-            Assert.AreEqual("Test", XLWorkbook.EvaluateExpr("Trim(\"Test    \")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("Trim(\"Test    \")"), Is.EqualTo("Test"));
 
-            //Should not trim non breaking space
-            //See http://office.microsoft.com/en-us/excel-help/trim-function-HP010062581.aspx
-            Assert.AreEqual("Test\u00A0", XLWorkbook.EvaluateExpr("Trim(\"Test\u00A0 \")"));
+                //Should not trim non breaking space
+                //See http://office.microsoft.com/en-us/excel-help/trim-function-HP010062581.aspx
+                Assert.That(XLWorkbook.EvaluateExpr("Trim(\"Test\u00A0 \")"), Is.EqualTo("Test\u00A0"));
+            });
         }
 
         [Test]
@@ -133,31 +142,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             XLWorkbook wb = new XLWorkbook();
             wb.Worksheets.Add("TallyTests");
             var cell = wb.Worksheet(1).Cell(1, 1).SetFormulaA1("=MAX(D1,D2)");
-            Assert.AreEqual(0, cell.Value);
+            Assert.That(cell.Value, Is.EqualTo(0));
             cell = wb.Worksheet(1).Cell(2, 1).SetFormulaA1("=MIN(D1,D2)");
-            Assert.AreEqual(0, cell.Value);
+            Assert.That(cell.Value, Is.EqualTo(0));
             cell = wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=SUM(D1,D2)");
-            Assert.AreEqual(0, cell.Value);
+            Assert.That(cell.Value, Is.EqualTo(0));
         }
 
         [Test]
         public void TestOmittedParameters()
         {
-            using (var wb = new XLWorkbook())
-            {
-                object value;
-                value = wb.Evaluate("=IF(TRUE,1)");
-                Assert.AreEqual(1, value);
+            using var wb = new XLWorkbook();
+            object value;
+            value = wb.Evaluate("=IF(TRUE,1)");
+            Assert.That(value, Is.EqualTo(1));
 
-                value = wb.Evaluate("=IF(TRUE,1,)");
-                Assert.AreEqual(1, value);
+            value = wb.Evaluate("=IF(TRUE,1,)");
+            Assert.That(value, Is.EqualTo(1));
 
-                value = wb.Evaluate("=ISBLANK(IF(FALSE,1,))");
-                Assert.AreEqual(true, value);
+            value = wb.Evaluate("=ISBLANK(IF(FALSE,1,))");
+            Assert.That(value, Is.EqualTo(true));
 
-                value = wb.Evaluate("=IF(FALSE,,2)");
-                Assert.AreEqual(2, value);
-            }
+            value = wb.Evaluate("=IF(FALSE,,2)");
+            Assert.That(value, Is.EqualTo(2));
         }
 
         [Test]
@@ -165,7 +172,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("TODAY()"));
             Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("_xlfn.TODAY()"));
-            Assert.IsTrue((bool)XLWorkbook.EvaluateExpr("_xlfn.TODAY() = TODAY()"));
+            Assert.That((bool)XLWorkbook.EvaluateExpr("_xlfn.TODAY() = TODAY()"), Is.True);
         }
 
         [TestCase("=1234%", 12.34)]
@@ -180,7 +187,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var res = (double)XLWorkbook.EvaluateExpr(formula);
 
-            Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
+            Assert.That(res, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [TestCase("=--1", 1)]
@@ -191,7 +198,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var res = (double)XLWorkbook.EvaluateExpr(formula);
 
-            Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
+            Assert.That(res, Is.EqualTo(expectedResult).Within(XLHelper.Epsilon));
         }
 
         [TestCase("RIGHT(\"2020\", 2) + 1", 21)]
@@ -203,7 +210,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var actual = XLWorkbook.EvaluateExpr(formula);
 
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -213,7 +220,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").FormulaA1 = "$B$4(5)";
 
-            Assert.AreEqual(XLError.CellReference, ws.Cell("A1").Value);
+            Assert.That(ws.Cell("A1").Value, Is.EqualTo(XLError.CellReference));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/InformationTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate($"ERROR.TYPE({argumentFormula})"));
+            Assert.That(ws.Evaluate($"ERROR.TYPE({argumentFormula})"), Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [TestCase("#NULL!", 1)]
@@ -29,7 +29,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         //[TestCase("#GETTING_DATA", 8)] OLAP Cube not supported
         public void ErrorType_ReturnsNumberForError(string error, int expectedNumber)
         {
-            Assert.AreEqual(expectedNumber, XLWorkbook.EvaluateExpr($"ERROR.TYPE({error})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ERROR.TYPE({error})"), Is.EqualTo(expectedNumber));
         }
 
         #region IsBlank Tests
@@ -40,7 +40,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             var actual = ws.Evaluate("IsBlank(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = "1";
             var actual = ws.Evaluate("IsBlank(A1)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [TestCase("FALSE")]
@@ -62,14 +62,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsBlank_NonEmptyValue_False(string value)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsBlank({value})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [Test]
         public void IsBlank_InlineBlank_True()
         {
             var actual = XLWorkbook.EvaluateExpr("IsBlank(IF(TRUE,,))");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         #endregion IsBlank Tests
@@ -82,7 +82,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsErr_NonErrorValues_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsErr({valueFormula})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [TestCase("#DIV/0!")]
@@ -94,14 +94,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsErr_ErrorsExceptNA_True(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsErr({valueFormula})");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [Test]
         public void IsErr_NA_False()
         {
             var actual = XLWorkbook.EvaluateExpr("IsErr(#N/A)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [TestCase("#DIV/0!")]
@@ -114,7 +114,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsError_Errors_True(string error)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsError({error})");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [TestCase("IF(TRUE,,)")]
@@ -125,7 +125,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsError_NonErrors_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsError({valueFormula})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         #region IsEven Tests
@@ -138,7 +138,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsEven_NumberLikeValue_ConvertedThroughValueSemantic(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsEven({valueFormula})");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [Test]
@@ -152,23 +152,23 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = -2.9;
 
             var actual = ws.Evaluate("=IsEven(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = ws.Evaluate("=IsEven(A2)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = ws.Evaluate("=IsEven(A3)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = ws.Evaluate("=IsEven(A4)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [Test]
         [Ignore("Arrays not yet implemented.")]
         public void IsEven_Array_ReturnsArray()
         {
-            Assert.AreEqual(2.0, XLWorkbook.EvaluateExpr("SUM(N(IsEven({\"2.9\";2;1})))"));
+            Assert.That(XLWorkbook.EvaluateExpr("SUM(N(IsEven({\"2.9\";2;1})))"), Is.EqualTo(2.0));
         }
 
         [Test]
@@ -177,7 +177,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell(1, 2).FormulaA1 = "IsEven(A1:A2)";
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell(1, 2).Value);
+            Assert.That(ws.Cell(1, 2).Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("TRUE", XLError.IncompatibleValue)]
@@ -188,7 +188,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("IF(TRUE,,)", XLError.NoValueAvailable)] // Behaves differently from a reference to a blank cell
         public void IsEven_NonNumberValues_Error(string valueFormula, XLError expectedError)
         {
-            Assert.AreEqual(expectedError, XLWorkbook.EvaluateExpr($"IsEven({valueFormula})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"IsEven({valueFormula})"), Is.EqualTo(expectedError));
         }
 
         #endregion IsEven Tests
@@ -200,7 +200,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsLogical_OnlyLogical_True(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsLogical({valueFormula})");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [TestCase("IF(TRUE,,)")]
@@ -215,7 +215,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsLogical_NonLogicalValue_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsLogical({valueFormula})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = true;
 
             var actual = ws.Evaluate("IsLogical(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         #endregion IsLogical Tests
@@ -236,7 +236,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsNA_NA_True()
         {
             var actual = XLWorkbook.EvaluateExpr("ISNA(#N/A)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [TestCase("IF(TRUE,,)")]
@@ -248,7 +248,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsNA_NonNotAvailableValue_False(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"ISNA({valueFormula})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         #region IsNotText Tests
@@ -259,7 +259,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             var actual = ws.Evaluate("IsNonText(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [TestCase("")]
@@ -271,7 +271,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = text;
             var actual = ws.Evaluate("IsNonText(A1)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [Test]
@@ -285,13 +285,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A4").Value = XLError.IncompatibleValue; //Error value
 
             var actual = ws.Evaluate("IsNonText(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
             actual = ws.Evaluate("IsNonText(A2)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
             actual = ws.Evaluate("IsNonText(A3)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
             actual = ws.Evaluate("IsNonText(A4)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         #endregion IsNotText Tests
@@ -307,9 +307,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A2").Value = true; //Bool Value
 
             var actual = ws.Evaluate("IsNumber(A1)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
             actual = ws.Evaluate("IsNumber(A2)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [Test]
@@ -322,11 +322,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = new TimeSpan(2, 30, 50); //TimeSpan Value
 
             var actual = ws.Evaluate("=IsNumber(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
             actual = ws.Evaluate("=IsNumber(A2)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
             actual = ws.Evaluate("=IsNumber(A3)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [TestCase("TRUE")]
@@ -339,7 +339,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsNumber_NonNumber_False(string nonNumberValue)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsNumber({nonNumberValue})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         #endregion IsNumber Tests
@@ -355,7 +355,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsOdd_SingleValue_ConvertedThroughValueSemantic(string valueFormula)
         {
             var actual = XLWorkbook.EvaluateExpr($"IsOdd({valueFormula})");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [Test]
@@ -369,16 +369,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = -5.9;
 
             var actual = ws.Evaluate("=IsOdd(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = ws.Evaluate("=IsOdd(A2)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = ws.Evaluate("=IsOdd(A3)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = ws.Evaluate("=IsOdd(A4)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [SetCulture("en-US")]
@@ -386,7 +386,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Ignore("Arrays not yet implemented.")]
         public void IsOdd_Array_ReturnsArray()
         {
-            Assert.AreEqual(2.0, XLWorkbook.EvaluateExpr("SUM(N(IsOdd({\"3.2\",7,2})))"));
+            Assert.That(XLWorkbook.EvaluateExpr("SUM(N(IsOdd({\"3.2\",7,2})))"), Is.EqualTo(2.0));
         }
 
         [Test]
@@ -395,7 +395,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell(1, 2).FormulaA1 = "IsOdd(A1:A2)";
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell(1, 2).Value);
+            Assert.That(ws.Cell(1, 2).Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("TRUE", XLError.IncompatibleValue)]
@@ -406,7 +406,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("IF(TRUE,,)", XLError.NoValueAvailable)] // Behaves differently from a reference to a blank cell
         public void IsOdd_NonNumberValues_Error(string valueFormula, XLError expectedError)
         {
-            Assert.AreEqual(expectedError, XLWorkbook.EvaluateExpr($"IsOdd({valueFormula})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"IsOdd({valueFormula})"), Is.EqualTo(expectedError));
         }
 
         #endregion IsOdd Test
@@ -421,7 +421,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("B1").FormulaA1 = $"ISREF({reference})";
 
-            Assert.AreEqual(true, ws.Cell("B1").Value);
+            Assert.That(ws.Cell("B1").Value, Is.EqualTo(true));
         }
 
         [TestCase("IF(TRUE,,)")]
@@ -438,7 +438,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("B1").FormulaA1 = $"ISREF({nonReference})";
 
-            Assert.AreEqual(false, ws.Cell("B1").Value);
+            Assert.That(ws.Cell("B1").Value, Is.EqualTo(false));
         }
 
         #region IsText Tests
@@ -450,7 +450,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("B1").FormulaA1 = "ISTEXT(A1)";
 
-            Assert.AreEqual(false, ws.Cell("B1").Value);
+            Assert.That(ws.Cell("B1").Value, Is.EqualTo(false));
         }
 
         [TestCase("0")]
@@ -461,7 +461,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void IsText_NonText_False(string nonText)
         {
             var actual = XLWorkbook.EvaluateExpr($"ISTEXT({nonText})");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [TestCase("")]
@@ -474,7 +474,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = textValue;
 
             var actual = ws.Evaluate("IsText(A1)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         #endregion IsText Tests
@@ -487,7 +487,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             var actual = ws.Evaluate("N(A1)");
-            Assert.AreEqual(0.0, actual);
+            Assert.That(actual, Is.EqualTo(0.0));
         }
 
         [Test]
@@ -498,7 +498,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var testedDate = DateTime.Now;
             ws.Cell("A1").Value = testedDate;
             var actual = ws.Evaluate("N(A1)");
-            Assert.AreEqual(testedDate.ToSerialDateTime(), actual);
+            Assert.That(actual, Is.EqualTo(testedDate.ToSerialDateTime()));
         }
 
         [Test]
@@ -508,7 +508,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = false;
             var actual = ws.Evaluate("N(A1)");
-            Assert.AreEqual(0, actual);
+            Assert.That(actual, Is.EqualTo(0));
         }
 
         [Test]
@@ -518,7 +518,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = true;
             var actual = ws.Evaluate("N(A1)");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
         }
         [Test]
         public void N_Number_Number()
@@ -528,7 +528,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var testedValue = 123;
             ws.Cell("A1").Value = testedValue;
             var actual = ws.Evaluate("N(A1)");
-            Assert.AreEqual(testedValue, actual);
+            Assert.That(actual, Is.EqualTo(testedValue));
         }
 
         [TestCase("")]
@@ -539,7 +539,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = text;
             var actual = ws.Evaluate("N(A1)");
-            Assert.AreEqual(0, actual);
+            Assert.That(actual, Is.EqualTo(0));
         }
 
         [Test]
@@ -547,7 +547,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void N_Array_ConvertsIndividualItems()
         {
             var actual = XLWorkbook.EvaluateExpr("SUM(N({2,TRUE}))");
-            Assert.AreEqual(3, actual);
+            Assert.That(actual, Is.EqualTo(3));
         }
 
         [TestCase("A1")]
@@ -561,7 +561,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B1").Value = 10;
 
             var actual = ws.Evaluate($"SUM(N({reference}))");
-            Assert.AreEqual(5, actual);
+            Assert.That(actual, Is.EqualTo(5));
         }
 
         #endregion N Tests
@@ -585,7 +585,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").FormulaA1 = $"TYPE({literalValues})";
-            Assert.AreEqual(expectedNumber, ws.Cell("A1").Value);
+            Assert.That(ws.Cell("A1").Value, Is.EqualTo(expectedNumber));
         }
 
         [Ignore("Arrays not implemented")]
@@ -595,7 +595,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Type_Array_HasValue64(string arrayLiteral)
         {
             var actual = XLWorkbook.EvaluateExpr($"TYPE({arrayLiteral})");
-            Assert.AreEqual(64.0, actual);
+            Assert.That(actual, Is.EqualTo(64.0));
         }
 
         [TestCase("A1:A2")]
@@ -605,7 +605,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("C1").FormulaA1 = $"TYPE({reference})";
-            Assert.AreEqual(64.0, ws.Cell("C1").Value);
+            Assert.That(ws.Cell("C1").Value, Is.EqualTo(64.0));
         }
 
         [Test]
@@ -616,7 +616,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = "text";
 
             ws.Cell("C1").FormulaA1 = "TYPE(A1)";
-            Assert.AreEqual(2.0, ws.Cell("C1").Value);
+            Assert.That(ws.Cell("C1").Value, Is.EqualTo(2.0));
         }
 
         [Test]
@@ -627,7 +627,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").Value = "text";
 
             ws.Cell("C1").FormulaA1 = "TYPE((A1,A1))";
-            Assert.AreEqual(16.0, ws.Cell("C1").Value);
+            Assert.That(ws.Cell("C1").Value, Is.EqualTo(16.0));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/LogicalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LogicalTests.cs
@@ -10,15 +10,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void And_IsLogicalConjunction()
         {
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND(TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND(TRUE, TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND(TRUE, TRUE, TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND({TRUE, TRUE}, TRUE)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("AND(TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(TRUE, TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(TRUE, TRUE, TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("AND({TRUE, TRUE}, TRUE)"), Is.EqualTo(true));
 
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND(FALSE)"));
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND(TRUE, FALSE)"));
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND({TRUE, FALSE})"));
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND(TRUE, {TRUE, FALSE})"));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(FALSE)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(TRUE, FALSE)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("AND({TRUE, FALSE})"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(TRUE, {TRUE, FALSE})"), Is.EqualTo(false));
+            });
         }
 
         [TestCase("A1")]
@@ -28,28 +31,31 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate($"AND({range})"));
+            Assert.That(ws.Evaluate($"AND({range})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void And_ScalarArgumentsCoercedFromBlankOrTextOrNumber()
         {
-            // Blank evaluated to false
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND(IF(TRUE,,))"));
+            Assert.Multiple(() =>
+            {
+                // Blank evaluated to false
+                Assert.That(XLWorkbook.EvaluateExpr("AND(IF(TRUE,,))"), Is.EqualTo(false));
 
-            // Number coerced to logical
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND(0)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND(0.1)"));
+                // Number coerced to logical
+                Assert.That(XLWorkbook.EvaluateExpr("AND(0)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(0.1)"), Is.EqualTo(true));
 
-            // Text coerced to logical
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("AND(\"FALSE\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND(\"TRUE\")"));
+                // Text coerced to logical
+                Assert.That(XLWorkbook.EvaluateExpr("AND(\"FALSE\")"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("AND(\"TRUE\")"), Is.EqualTo(true));
+            });
         }
 
         [Test]
         public void And_UnconvertableScalarArgumentsSkipped()
         {
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("AND(TRUE,\"z\")"));
+            Assert.That(XLWorkbook.EvaluateExpr("AND(TRUE,\"z\")"), Is.EqualTo(true));
         }
 
         [Test]
@@ -60,71 +66,71 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // 0 is a number and is converted to logical
             ws.Cell("A1").Value = 0;
-            Assert.AreEqual(false, ws.Evaluate("AND(TRUE,A1)"));
+            Assert.That(ws.Evaluate("AND(TRUE,A1)"), Is.EqualTo(false));
 
             // false is a logical
             ws.Cell("A2").Value = false;
-            Assert.AreEqual(false, ws.Evaluate("AND(TRUE,A2)"));
+            Assert.That(ws.Evaluate("AND(TRUE,A2)"), Is.EqualTo(false));
 
             // Text is not converted and thus skipped for evaluation
             ws.Cell("A3").Value = "FALSE";
-            Assert.AreEqual(true, ws.Evaluate("AND(TRUE,A3)"));
+            Assert.That(ws.Evaluate("AND(TRUE,A3)"), Is.EqualTo(true));
 
             ws.Cell("A4").Value = "some text";
-            Assert.AreEqual(true, ws.Evaluate("AND(TRUE,A4)"));
+            Assert.That(ws.Evaluate("AND(TRUE,A4)"), Is.EqualTo(true));
         }
 
         [Test]
         public void If_2_Params_true()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"if(1 = 1, ""T"")");
-            Assert.AreEqual("T", actual);
+            object actual = XLWorkbook.EvaluateExpr(@"if(1 = 1, ""T"")");
+            Assert.That(actual, Is.EqualTo("T"));
         }
 
         [Test]
         public void If_2_Params_false()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"if(1 = 2, ""T"")");
-            Assert.AreEqual(false, actual);
+            object actual = XLWorkbook.EvaluateExpr(@"if(1 = 2, ""T"")");
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [Test]
         public void If_3_Params_true()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"if(1 = 1, ""T"", ""F"")");
-            Assert.AreEqual("T", actual);
+            object actual = XLWorkbook.EvaluateExpr(@"if(1 = 1, ""T"", ""F"")");
+            Assert.That(actual, Is.EqualTo("T"));
         }
 
         [Test]
         public void If_3_Params_false()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"if(1 = 2, ""T"", ""F"")");
-            Assert.AreEqual("F", actual);
+            object actual = XLWorkbook.EvaluateExpr(@"if(1 = 2, ""T"", ""F"")");
+            Assert.That(actual, Is.EqualTo("F"));
         }
 
         [Test]
         public void If_Comparing_Against_Empty_String()
         {
-            Object actual;
+            object actual;
             actual = XLWorkbook.EvaluateExpr(@"if(date(2016, 1, 1) = """", ""A"",""B"")");
-            Assert.AreEqual("B", actual);
+            Assert.That(actual, Is.EqualTo("B"));
 
             actual = XLWorkbook.EvaluateExpr(@"if("""" = date(2016, 1, 1), ""A"",""B"")");
-            Assert.AreEqual("B", actual);
+            Assert.That(actual, Is.EqualTo("B"));
 
             actual = XLWorkbook.EvaluateExpr(@"if("""" = 123, ""A"",""B"")");
-            Assert.AreEqual("B", actual);
+            Assert.That(actual, Is.EqualTo("B"));
 
             actual = XLWorkbook.EvaluateExpr(@"if("""" = """", ""A"",""B"")");
-            Assert.AreEqual("A", actual);
+            Assert.That(actual, Is.EqualTo("A"));
         }
 
         [Test]
         public void If_Case_Insensitivity()
         {
-            Object actual;
+            object actual;
             actual = XLWorkbook.EvaluateExpr(@"IF(""text""=""TEXT"", 1, 2)");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
         }
 
         [Test]
@@ -132,8 +138,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(true, ws.Evaluate("ISREF(IF(TRUE, A1))"));
-            Assert.AreEqual(true, ws.Evaluate("ISREF(IF(FALSE,, A1))"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("ISREF(IF(TRUE, A1))"), Is.EqualTo(true));
+                Assert.That(ws.Evaluate("ISREF(IF(FALSE,, A1))"), Is.EqualTo(true));
+            });
         }
 
         [Test]
@@ -147,17 +156,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             for (var row = 1; row <= 4; ++row)
                 ws.Cell(row, 4).FormulaA1 = "SUM(IF(C1:C3, A1:A3, B1:B3))";
 
-            // Condition is implicitely intersected, because it's a scalar parameter
-            Assert.AreEqual(6, ws.Cell("D1").Value);
-            Assert.AreEqual(15, ws.Cell("D2").Value);
-            Assert.AreEqual(6, ws.Cell("D3").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("D4").Value);
+            Assert.Multiple(() =>
+            {
+                // Condition is implicitely intersected, because it's a scalar parameter
+                Assert.That(ws.Cell("D1").Value, Is.EqualTo(6));
+                Assert.That(ws.Cell("D2").Value, Is.EqualTo(15));
+                Assert.That(ws.Cell("D3").Value, Is.EqualTo(6));
+                Assert.That(ws.Cell("D4").Value, Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void If_ConditionError_ReturnError()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"IF(1/0, ""T"", ""F"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"IF(1/0, ""T"", ""F"")"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [Test]
@@ -165,46 +177,58 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual("F", ws.Evaluate(@"IF(A1, ""T"", ""F"")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate(@"IF(A1, ""T"", ""F"")"), Is.EqualTo("F"));
 
-            Assert.AreEqual("T", ws.Evaluate(@"IF(""TRUE"", ""T"", ""F"")"));
-            Assert.AreEqual("F", ws.Evaluate(@"IF(""FALSE"", ""T"", ""F"")"));
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(@"IF(""text"", ""T"", ""F"")"));
+                Assert.That(ws.Evaluate(@"IF(""TRUE"", ""T"", ""F"")"), Is.EqualTo("T"));
+                Assert.That(ws.Evaluate(@"IF(""FALSE"", ""T"", ""F"")"), Is.EqualTo("F"));
+                Assert.That(ws.Evaluate(@"IF(""text"", ""T"", ""F"")"), Is.EqualTo(XLError.IncompatibleValue));
 
-            Assert.AreEqual("T", ws.Evaluate(@"IF(1, ""T"", ""F"")"));
-            Assert.AreEqual("F", ws.Evaluate(@"IF(0, ""T"", ""F"")"));
+                Assert.That(ws.Evaluate(@"IF(1, ""T"", ""F"")"), Is.EqualTo("T"));
+                Assert.That(ws.Evaluate(@"IF(0, ""T"", ""F"")"), Is.EqualTo("F"));
+            });
         }
 
         [Test]
         public void If_MissingValues_ReturnBlank()
         {
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr(@"ISBLANK(IF(TRUE,,))"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr(@"ISBLANK(IF(FALSE,,))"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr(@"ISBLANK(IF(TRUE,,))"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr(@"ISBLANK(IF(FALSE,,))"), Is.EqualTo(true));
+            });
         }
 
         [Test]
         public void IfError_FirstArgumentNonError_ReturnFirstArgument()
         {
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("ISBLANK(IFERROR(IF(TRUE,), 5))"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("ISBLANK(IFERROR(IF(TRUE,), 5))"), Is.EqualTo(true));
 
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("IFERROR(FALSE, 5)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("IFERROR(TRUE, 5)"));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(FALSE, 5)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(TRUE, 5)"), Is.EqualTo(true));
 
-            Assert.AreEqual(0.0, XLWorkbook.EvaluateExpr("IFERROR(0, 5)"));
-            Assert.AreEqual(-2.0, XLWorkbook.EvaluateExpr("IFERROR(-2, 5)"));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(0, 5)"), Is.EqualTo(0.0));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(-2, 5)"), Is.EqualTo(-2.0));
 
-            Assert.AreEqual(string.Empty, XLWorkbook.EvaluateExpr("IFERROR(\"\", 5)"));
-            Assert.AreEqual("text", XLWorkbook.EvaluateExpr("IFERROR(\"text\", 5)"));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(\"\", 5)"), Is.EqualTo(""));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(\"text\", 5)"), Is.EqualTo("text"));
+            });
         }
 
         [Test]
         public void IfError_FirstArgumentError_ReturnSecondArgument()
         {
-            Assert.AreEqual("text", XLWorkbook.EvaluateExpr("IFERROR(1/0, \"text\")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(1/0, \"text\")"), Is.EqualTo("text"));
 
-            Assert.AreEqual(XLError.NameNotRecognized, XLWorkbook.EvaluateExpr("IFERROR(#REF!, #NAME?)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("IFERROR(#NULL!, TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("ISBLANK(IFERROR(#VALUE!,IF(TRUE,)))"));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(#REF!, #NAME?)"), Is.EqualTo(XLError.NameNotRecognized));
+                Assert.That(XLWorkbook.EvaluateExpr("IFERROR(#NULL!, TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("ISBLANK(IFERROR(#VALUE!,IF(TRUE,)))"), Is.EqualTo(true));
+            });
         }
 
         [Test]
@@ -213,7 +237,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Unlike IF, IFERROR doesn't return reference
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(false, ws.Evaluate("ISREF(IFERROR(#VALUE!, A1))"));
+            Assert.That(ws.Evaluate("ISREF(IFERROR(#VALUE!, A1))"), Is.EqualTo(false));
         }
 
         [TestCase("TRUE", false)]
@@ -226,21 +250,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("1/0", XLError.DivisionByZero)]
         public void Not(string valueFormula, object expectedResult)
         {
-            Assert.AreEqual(expectedResult, XLWorkbook.EvaluateExpr($"NOT({valueFormula})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"NOT({valueFormula})"), Is.EqualTo(expectedResult));
         }
 
         [Test]
         public void Or_IsLogicalDisjunction()
         {
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR(TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR(TRUE, TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR(TRUE, FALSE, TRUE)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR({FALSE, TRUE}, FALSE)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("OR(TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(TRUE, TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(TRUE, FALSE, TRUE)"), Is.EqualTo(true));
+                Assert.That(XLWorkbook.EvaluateExpr("OR({FALSE, TRUE}, FALSE)"), Is.EqualTo(true));
 
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR(FALSE)"));
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR(FALSE, FALSE)"));
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR({FALSE, FALSE})"));
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR(FALSE, {FALSE, FALSE})"));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(FALSE)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(FALSE, FALSE)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("OR({FALSE, FALSE})"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(FALSE, {FALSE, FALSE})"), Is.EqualTo(false));
+            });
         }
 
         [TestCase("A1")]
@@ -250,28 +277,31 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate($"OR({range})"));
+            Assert.That(ws.Evaluate($"OR({range})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Or_ScalarArgumentsCoercedFromBlankOrTextOrNumber()
         {
-            // Blank evaluated to false
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR(IF(TRUE,,))"));
+            Assert.Multiple(() =>
+            {
+                // Blank evaluated to false
+                Assert.That(XLWorkbook.EvaluateExpr("OR(IF(TRUE,,))"), Is.EqualTo(false));
 
-            // Number coerced to logical
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR(0)"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR(0.1)"));
+                // Number coerced to logical
+                Assert.That(XLWorkbook.EvaluateExpr("OR(0)"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(0.1)"), Is.EqualTo(true));
 
-            // Text coerced to logical
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("OR(\"FALSE\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR(\"TRUE\")"));
+                // Text coerced to logical
+                Assert.That(XLWorkbook.EvaluateExpr("OR(\"FALSE\")"), Is.EqualTo(false));
+                Assert.That(XLWorkbook.EvaluateExpr("OR(\"TRUE\")"), Is.EqualTo(true));
+            });
         }
 
         [Test]
         public void Or_UnconvertableScalarArgumentsSkipped()
         {
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("OR(TRUE,\"z\")"));
+            Assert.That(XLWorkbook.EvaluateExpr("OR(TRUE,\"z\")"), Is.EqualTo(true));
         }
 
         [Test]
@@ -282,18 +312,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // 1 is a number and is converted to logical
             ws.Cell("A1").Value = 1;
-            Assert.AreEqual(true, ws.Evaluate("OR(FALSE,A1)"));
+            Assert.That(ws.Evaluate("OR(FALSE,A1)"), Is.EqualTo(true));
 
             // false is a logical
             ws.Cell("A2").Value = true;
-            Assert.AreEqual(true, ws.Evaluate("OR(FALSE,A2)"));
+            Assert.That(ws.Evaluate("OR(FALSE,A2)"), Is.EqualTo(true));
 
             // Text is not converted and thus skipped for evaluation
             ws.Cell("A3").Value = "TRUE";
-            Assert.AreEqual(false, ws.Evaluate("OR(FALSE,A3)"));
+            Assert.That(ws.Evaluate("OR(FALSE,A3)"), Is.EqualTo(false));
 
             ws.Cell("A4").Value = "some text";
-            Assert.AreEqual(false, ws.Evaluate("OR(FALSE,A4)"));
+            Assert.That(ws.Evaluate("OR(FALSE,A4)"), Is.EqualTo(false));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
@@ -93,40 +93,43 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet("Data");
             wb.AddWorksheet("Other");
 
-            // If no argument, function uses the address of the cell that contains the formula
-            Assert.AreEqual(4, ws.Cell("D1").SetFormulaA1("COLUMN()").Value);
+            Assert.Multiple(() =>
+            {
+                // If no argument, function uses the address of the cell that contains the formula
+                Assert.That(ws.Cell("D1").SetFormulaA1("COLUMN()").Value, Is.EqualTo(4));
 
-            // With a reference, it returns the column number
-            Assert.AreEqual(26, ws.Cell("A1").SetFormulaA1("COLUMN(Z14)").Value);
+                // With a reference, it returns the column number
+                Assert.That(ws.Cell("A1").SetFormulaA1("COLUMN(Z14)").Value, Is.EqualTo(26));
 
-            // If a single column is used, return the column number 
-            Assert.AreEqual(3, ws.Cell("A2").SetFormulaA1("COLUMN(C:C)").Value);
+                // If a single column is used, return the column number 
+                Assert.That(ws.Cell("A2").SetFormulaA1("COLUMN(C:C)").Value, Is.EqualTo(3));
 
-            // Return a horizontal array for multiple columns. Use SUM to verify content of an array since ROWS/COLUMNS don't work yet.
-            Assert.AreEqual(3 + 4, ws.Cell("A3").SetFormulaA1("SUM(COLUMN(C:D))").Value);
-            Assert.AreEqual(5 + 6 + 7, ws.Cell("A3").SetFormulaA1("SUM(COLUMN(E1:G10))").Value);
+                // Return a horizontal array for multiple columns. Use SUM to verify content of an array since ROWS/COLUMNS don't work yet.
+                Assert.That(ws.Cell("A3").SetFormulaA1("SUM(COLUMN(C:D))").Value, Is.EqualTo(3 + 4));
+                Assert.That(ws.Cell("A3").SetFormulaA1("SUM(COLUMN(E1:G10))").Value, Is.EqualTo(5 + 6 + 7));
 
-            // Not contiguous range (multiple areas) returns #REF!
-            Assert.AreEqual(XLError.CellReference, ws.Cell("A4").SetFormulaA1("COLUMN((D5:G10,I8:K12))").Value);
+                // Not contiguous range (multiple areas) returns #REF!
+                Assert.That(ws.Cell("A4").SetFormulaA1("COLUMN((D5:G10,I8:K12))").Value, Is.EqualTo(XLError.CellReference));
 
-            // Invalid references return #REF!
-            Assert.AreEqual(XLError.CellReference, ws.Cell("A5").SetFormulaA1("COLUMN(NonExistent!F10)").Value);
+                // Invalid references return #REF!
+                Assert.That(ws.Cell("A5").SetFormulaA1("COLUMN(NonExistent!F10)").Value, Is.EqualTo(XLError.CellReference));
 
-            // Return column number even for different worksheet
-            Assert.AreEqual(5, ws.Cell("A6").SetFormulaA1("COLUMN(Other!E7)").Value);
+                // Return column number even for different worksheet
+                Assert.That(ws.Cell("A6").SetFormulaA1("COLUMN(Other!E7)").Value, Is.EqualTo(5));
 
-            // Unexpected types return error
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A8").SetFormulaA1("COLUMN(TRUE)").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A7").SetFormulaA1("COLUMN(5)").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A8").SetFormulaA1("COLUMN(\"C5\")").Value);
-            Assert.AreEqual(XLError.DivisionByZero, ws.Cell("A9").SetFormulaA1("COLUMN(#DIV/0!)").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A10").SetFormulaA1("COLUMN(\"C5\")").Value);
+                // Unexpected types return error
+                Assert.That(ws.Cell("A8").SetFormulaA1("COLUMN(TRUE)").Value, Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Cell("A7").SetFormulaA1("COLUMN(5)").Value, Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Cell("A8").SetFormulaA1("COLUMN(\"C5\")").Value, Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Cell("A9").SetFormulaA1("COLUMN(#DIV/0!)").Value, Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(ws.Cell("A10").SetFormulaA1("COLUMN(\"C5\")").Value, Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Columns_Blank_ReturnsValueError()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("COLUMNS(IF(TRUE,,))"));
+            Assert.That(XLWorkbook.EvaluateExpr("COLUMNS(IF(TRUE,,))"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("0")]
@@ -140,13 +143,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("\"Hello World\"")]
         public void Columns_ScalarValues_ReturnsOne(string value)
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr($"COLUMNS({value})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"COLUMNS({value})"), Is.EqualTo(1));
         }
 
         [Test]
         public void Columns_Error_ReturnsError()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COLUMNS(#DIV/0!)"));
+            Assert.That(XLWorkbook.EvaluateExpr("COLUMNS(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase("{1}", 1)]
@@ -155,7 +158,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("{TRUE,\"Z\";#DIV/0!,4}", 2)]
         public void Columns_Arrays_ReturnsNumberOfColumns(string array, int expectedColumnCount)
         {
-            Assert.AreEqual(expectedColumnCount, XLWorkbook.EvaluateExpr($"COLUMNS({array})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"COLUMNS({array})"), Is.EqualTo(expectedColumnCount));
         }
 
         [TestCase("A1", 1)]
@@ -166,14 +169,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var sheet = wb.AddWorksheet();
-            Assert.AreEqual(expectedColumnCount, sheet.Evaluate($"COLUMNS({range})"));
+            Assert.That(sheet.Evaluate($"COLUMNS({range})"), Is.EqualTo(expectedColumnCount));
         }
 
         [Test]
         public void Columns_NonContiguousReferences_ReturnsReferenceError()
         {
             // Spec says #NULL!, but Excel says #REF!
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("COLUMNS((A1,C3))"));
+            Assert.That(XLWorkbook.EvaluateExpr("COLUMNS((A1,C3))"), Is.EqualTo(XLError.CellReference));
         }
 
         [Test]
@@ -190,49 +193,55 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Range lookup false = exact match
             var value = sheet.Evaluate(@"HLOOKUP(3,B2:E3,2,FALSE)");
-            Assert.AreEqual("B", value);
+            Assert.That(value, Is.EqualTo("B"));
 
             // Text values are looked up case insensitive.
             value = sheet.Evaluate(@"HLOOKUP(""c"",B3:E3,1,FALSE)");
-            Assert.AreEqual("C", value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(value, Is.EqualTo("C"));
 
-            // Value not present in the range for exact search
-            // Empty string is not same as blank.
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP("""",A2:E2,1,FALSE)"));
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP(50,B2:E3,1,FALSE)"));
+                // Value not present in the range for exact search
+                // Empty string is not same as blank.
+                Assert.That(ws.Evaluate(@"HLOOKUP("""",A2:E2,1,FALSE)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Evaluate(@"HLOOKUP(50,B2:E3,1,FALSE)"), Is.EqualTo(XLError.NoValueAvailable));
 
-            // Value in approximate search that is lower than first element
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP(-10,B2:E3,2,TRUE)"));
+                // Value in approximate search that is lower than first element
+                Assert.That(ws.Evaluate(@"HLOOKUP(-10,B2:E3,2,TRUE)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [Test]
         public void Hlookup_UnexpectedArguments()
         {
-            // Lookup value can't be an error
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"HLOOKUP(#DIV/0!,{1,2},1)"));
+            Assert.Multiple(() =>
+            {
+                // Lookup value can't be an error
+                Assert.That(XLWorkbook.EvaluateExpr(@"HLOOKUP(#DIV/0!,{1,2},1)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Text value can't be over 255 chars
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"HLOOKUP(\"{new string('A', 256)}\",{{\"A\"}},1)"));
+                // Text value can't be over 255 chars
+                Assert.That(XLWorkbook.EvaluateExpr($"HLOOKUP(\"{new string('A', 256)}\",{{\"A\"}},1)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Range can only be array or a reference. If other type, it returns the error #N/A
-            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr(@"HLOOKUP(""value"",1,1)"));
-            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr(@"HLOOKUP(""value"",TRUE,1)"));
+                // Range can only be array or a reference. If other type, it returns the error #N/A
+                Assert.That(XLWorkbook.EvaluateExpr(@"HLOOKUP(""value"",1,1)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(XLWorkbook.EvaluateExpr(@"HLOOKUP(""value"",TRUE,1)"), Is.EqualTo(XLError.NoValueAvailable));
 
-            // If range is a non-contiguous range, #N/A
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"HLOOKUP(""Units"",(B2:I5,B6:I10),1)"));
+                // If range is a non-contiguous range, #N/A
+                Assert.That(ws.Evaluate(@"HLOOKUP(""Units"",(B2:I5,B6:I10),1)"), Is.EqualTo(XLError.NoValueAvailable));
 
-            // The row index number must be at most the same as height of the range. It is 5 here, but range is 4 cell high.
-            Assert.AreEqual(XLError.CellReference, ws.Evaluate(@"HLOOKUP(""value"",B2:I5,5,FALSE)"));
+                // The row index number must be at most the same as height of the range. It is 5 here, but range is 4 cell high.
+                Assert.That(ws.Evaluate(@"HLOOKUP(""value"",B2:I5,5,FALSE)"), Is.EqualTo(XLError.CellReference));
 
-            // The row index number must be at least 1. It is 0 here.
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"HLOOKUP(1,{1,2},0,FALSE)"));
+                // The row index number must be at least 1. It is 0 here.
+                Assert.That(XLWorkbook.EvaluateExpr(@"HLOOKUP(1,{1,2},0,FALSE)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Hlookup_truncates_row_index_number_parameter()
         {
             // If row index number is not a whole number, it is truncated, so here 1.9 is truncated to 1
-            Assert.AreEqual(7, ws.Evaluate(@"HLOOKUP(7,{5,7,9},1.9)"));
+            Assert.That(ws.Evaluate(@"HLOOKUP(7,{5,7,9},1.9)"), Is.EqualTo(7));
         }
 
         [Test]
@@ -248,7 +257,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             var actual = worksheet.Evaluate("HLOOKUP(IF(TRUE,,),A1:C2,2)");
 
-            Assert.AreEqual("zero", actual);
+            Assert.That(actual, Is.EqualTo("zero"));
         }
 
         [Test]
@@ -266,7 +275,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             worksheet.Cell("A2").InsertData(Enumerable.Range(1, 7).Select(x => $"Column {x}"), true);
 
             var actual = worksheet.Evaluate("HLOOKUP(1.9,A1:G2,2,TRUE)");
-            Assert.AreEqual("Column 3", actual);
+            Assert.That(actual, Is.EqualTo("Column 3"));
         }
 
         [Test]
@@ -275,7 +284,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var sheet = wb.AddWorksheet();
             sheet.Cell("A1").Value = "text";
-            Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate("HLOOKUP(1,A1,1,TRUE)"));
+            Assert.That(sheet.Evaluate("HLOOKUP(1,A1,1,TRUE)"), Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [Test]
@@ -291,11 +300,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // If there is a section of values with same value, return the value at the highest column
             var actual = sheet.Evaluate("HLOOKUP(3, A1:H2, 2, TRUE)");
-            Assert.AreEqual("G", actual);
+            Assert.That(actual, Is.EqualTo("G"));
 
             // If the last value is in the highest column, just return value outright
             actual = sheet.Evaluate("HLOOKUP(3, B1:G2, 2, TRUE)");
-            Assert.AreEqual("G", actual);
+            Assert.That(actual, Is.EqualTo("G"));
         }
 
         [Test]
@@ -306,17 +315,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             var cell = sheet.Cell("B3");
             cell.FormulaA1 = "HYPERLINK(\"http://github.com/ClosedXML/ClosedXML\")";
-            Assert.AreEqual("http://github.com/ClosedXML/ClosedXML", cell.Value);
+            Assert.That(cell.Value, Is.EqualTo("http://github.com/ClosedXML/ClosedXML"));
             Assert.False(cell.HasHyperlink);
 
             cell = sheet.Cell("B4");
             cell.FormulaA1 = "HYPERLINK(\"mailto:jsmith@github.com\", \"jsmith@github.com\")";
-            Assert.AreEqual("jsmith@github.com", cell.Value);
+            Assert.That(cell.Value, Is.EqualTo("jsmith@github.com"));
             Assert.False(cell.HasHyperlink);
 
             cell = sheet.Cell("B5");
             cell.FormulaA1 = "HYPERLINK(\"[Test.xlsx]Sheet1!A5\", \"Cell A5\")";
-            Assert.AreEqual("Cell A5", cell.Value);
+            Assert.That(cell.Value, Is.EqualTo("Cell A5"));
             Assert.False(cell.HasHyperlink);
         }
 
@@ -357,10 +366,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             void AssertIndex(string formula, int rows, int cols, XLCellValue value)
             {
-                Assert.AreEqual(value, sheet.Evaluate($"INDEX({formula},1,1)"));
-                Assert.AreEqual(rows, sheet.Evaluate($"ROWS({formula})"));
-                Assert.AreEqual(cols, sheet.Evaluate($"COLUMNS({formula})"));
-                Assert.AreEqual(true, sheet.Evaluate($"ISREF({formula})"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sheet.Evaluate($"INDEX({formula},1,1)"), Is.EqualTo(value));
+                    Assert.That(sheet.Evaluate($"ROWS({formula})"), Is.EqualTo(rows));
+                    Assert.That(sheet.Evaluate($"COLUMNS({formula})"), Is.EqualTo(cols));
+                    Assert.That(sheet.Evaluate($"ISREF({formula})"), Is.EqualTo(true));
+                });
             }
         }
 
@@ -370,17 +382,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var sheet = wb.AddWorksheet();
 
-            // Row bounds
-            Assert.AreEqual(XLError.IncompatibleValue, sheet.Evaluate("INDEX(A1, -1, 1)"));
-            Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDEX(B3:C5, 4, 1)"));
+            Assert.Multiple(() =>
+            {
+                // Row bounds
+                Assert.That(sheet.Evaluate("INDEX(A1, -1, 1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(sheet.Evaluate("INDEX(B3:C5, 4, 1)"), Is.EqualTo(XLError.CellReference));
 
-            // Column bounds
-            Assert.AreEqual(XLError.IncompatibleValue, sheet.Evaluate("INDEX(A1, 1, -1)"));
-            Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDEX(B3:C5, 1, 3)"));
+                // Column bounds
+                Assert.That(sheet.Evaluate("INDEX(A1, 1, -1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(sheet.Evaluate("INDEX(B3:C5, 1, 3)"), Is.EqualTo(XLError.CellReference));
 
-            // Area bounds
-            Assert.AreEqual(XLError.IncompatibleValue, sheet.Evaluate("INDEX((A1, B1, C1), 1, 1, 0)"));
-            Assert.AreEqual(XLError.CellReference, sheet.Evaluate("INDEX((A1, B1, C1),1, 1, 4)"));
+                // Area bounds
+                Assert.That(sheet.Evaluate("INDEX((A1, B1, C1), 1, 1, 0)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(sheet.Evaluate("INDEX((A1, B1, C1),1, 1, 4)"), Is.EqualTo(XLError.CellReference));
+            });
         }
 
         [Test]
@@ -410,43 +425,52 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             void AssertIndex(string formula, int rows, int cols, XLCellValue value)
             {
-                Assert.AreEqual(value, XLWorkbook.EvaluateExpr(formula));
-                Assert.AreEqual(rows, XLWorkbook.EvaluateExpr($"ROWS({formula})"));
-                Assert.AreEqual(cols, XLWorkbook.EvaluateExpr($"COLUMNS({formula})"));
-                Assert.AreEqual(false, XLWorkbook.EvaluateExpr($"ISREF({formula})"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(value));
+                    Assert.That(XLWorkbook.EvaluateExpr($"ROWS({formula})"), Is.EqualTo(rows));
+                    Assert.That(XLWorkbook.EvaluateExpr($"COLUMNS({formula})"), Is.EqualTo(cols));
+                    Assert.That(XLWorkbook.EvaluateExpr($"ISREF({formula})"), Is.EqualTo(false));
+                });
             }
         }
 
         [Test]
         public void Index_array_errors()
         {
-            // Row bounds
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX({1}, -1, 1)"));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDEX({1,2;3,4;5,6}, 4, 1)"));
+            Assert.Multiple(() =>
+            {
+                // Row bounds
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX({1}, -1, 1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX({1,2;3,4;5,6}, 4, 1)"), Is.EqualTo(XLError.CellReference));
 
-            // Column bounds
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX({1}, 1, -1)"));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDEX({1,2;3,4;5,6}, 1, 3)"));
+                // Column bounds
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX({1}, 1, -1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX({1,2;3,4;5,6}, 1, 3)"), Is.EqualTo(XLError.CellReference));
 
-            // Area bounds
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX({1}, 1, 1, 0)"));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDEX({1}, 1, 1, 2)"));
+                // Area bounds
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX({1}, 1, 1, 0)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX({1}, 1, 1, 2)"), Is.EqualTo(XLError.CellReference));
+            });
         }
 
         [Test]
         public void Index_scalar()
         {
-            Assert.AreEqual("Text", XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 1)"));
-            Assert.AreEqual("Text", XLWorkbook.EvaluateExpr("INDEX(\"Text\", 0, 0)"));
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("TYPE(INDEX(\"Text\", 1, 1))"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX(IF(TRUE,), 1, 1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 1)"), Is.EqualTo("Text"));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 0, 0)"), Is.EqualTo("Text"));
+                Assert.That(XLWorkbook.EvaluateExpr("TYPE(INDEX(\"Text\", 1, 1))"), Is.EqualTo(2));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(IF(TRUE,), 1, 1)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX(\"Text\", -1, 1)"));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDEX(\"Text\", 2, 1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, -1)"));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 2)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 1, 0)"));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 1, 2)"));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", -1, 1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 2, 1)"), Is.EqualTo(XLError.CellReference));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, -1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 2)"), Is.EqualTo(XLError.CellReference));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 1, 0)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("INDEX(\"Text\", 1, 1, 2)"), Is.EqualTo(XLError.CellReference));
+            });
         }
 
         [TestCase(@"MATCH(""Rep"", B2:I2, 0)", 4)]
@@ -470,15 +494,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Match_demo_sheet(string formula, object result)
         {
             var actual = ws.Evaluate(formula);
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [Test]
         public void Match_examples()
         {
-            // Examples from specification
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("MATCH(39,{25,38,40,41},1)"));
-            Assert.AreEqual(4, XLWorkbook.EvaluateExpr("MATCH(41,{25,38,40,41},0)"));
+            Assert.Multiple(() =>
+            {
+                // Examples from specification
+                Assert.That(XLWorkbook.EvaluateExpr("MATCH(39,{25,38,40,41},1)"), Is.EqualTo(2));
+                Assert.That(XLWorkbook.EvaluateExpr("MATCH(41,{25,38,40,41},0)"), Is.EqualTo(4));
+            });
 
             // Example from office website
             using var wb = new XLWorkbook();
@@ -492,9 +519,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 ("Pears", 41),
             });
 
-            Assert.AreEqual(2, sheet.Evaluate("MATCH(39,B2:B5,1)"));
-            Assert.AreEqual(4, sheet.Evaluate("MATCH(41,B2:B5,0)"));
-            Assert.AreEqual(XLError.NoValueAvailable, sheet.Evaluate("MATCH(40,B2:B5,-1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sheet.Evaluate("MATCH(39,B2:B5,1)"), Is.EqualTo(2));
+                Assert.That(sheet.Evaluate("MATCH(41,B2:B5,0)"), Is.EqualTo(4));
+                Assert.That(sheet.Evaluate("MATCH(40,B2:B5,-1)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [TestCase("MATCH(5, {10,5,4,5,5,5,5,5}, -1)", 2)] // Doesn't use bisection, otherwise it would pick later position
@@ -510,7 +540,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Match_from_descending(string formula, object result)
         {
             var actual = XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [TestCase("MATCH(35,{25,38,24,35,70},0)", 4)] // Finds value even in unsorted
@@ -522,7 +552,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Match_from_unsorted(string formula, object result)
         {
             var actual = XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [TestCase("MATCH(39,{25,38,38,38,40,41},1)", 4)] // When there is a sequence of target values, return last one
@@ -533,7 +563,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Match_from_ascending(string formula, object result)
         {
             var actual = XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [TestCase("MATCH(17, {14;5;3;5;11;12;11;13;13;4})", 10)]
@@ -546,7 +576,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // non-ascending data and checking the result against Excel result. Use random
             // generator to generate formulas + compare with Excel when modifying the algorithm.
             var actual = XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [TestCase("MATCH(#DIV/0!,{1,2,3},1)", XLError.DivisionByZero)] // Scalar argument is error -> propagate
@@ -561,7 +591,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Match_edge_conditions(string formula, object result)
         {
             var actual = XLWorkbook.EvaluateExpr(formula);
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [Test]
@@ -570,7 +600,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var sheet = wb.AddWorksheet();
             sheet.Cell("A1").Value = 5;
-            Assert.AreEqual(1, sheet.Evaluate("MATCH(5, A1)"));
+            Assert.That(sheet.Evaluate("MATCH(5, A1)"), Is.EqualTo(1));
         }
 
         [Test]
@@ -580,44 +610,50 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet("Data");
             wb.AddWorksheet("Other");
 
-            // If no argument, function uses the address of the cell that contains the formula
-            Assert.AreEqual(60, ws.Cell("M60").SetFormulaA1("ROW()").Value);
+            Assert.Multiple(() =>
+            {
+                // If no argument, function uses the address of the cell that contains the formula
+                Assert.That(ws.Cell("M60").SetFormulaA1("ROW()").Value, Is.EqualTo(60));
 
-            // With a reference, it returns the row number
-            Assert.AreEqual(12, ws.Cell("A1").SetFormulaA1("ROW(C12)").Value);
+                // With a reference, it returns the row number
+                Assert.That(ws.Cell("A1").SetFormulaA1("ROW(C12)").Value, Is.EqualTo(12));
 
-            // If a full row reference to a single row is used, return the row number 
-            Assert.AreEqual(40, ws.Cell("A2").SetFormulaA1("ROW(40:40)").Value);
+                // If a full row reference to a single row is used, return the row number 
+                Assert.That(ws.Cell("A2").SetFormulaA1("ROW(40:40)").Value, Is.EqualTo(40));
 
-            // Return a vertical array for multiple rows. Use SUM to verify content of an array since ROWS/COLUMNS don't work yet.
-            Assert.AreEqual(4 + 5 + 6 + 7, ws.Cell("A3").SetFormulaA1("SUM(ROW(4:7))").Value);
-            Assert.AreEqual(2 + 3 + 4, ws.Cell("A4").SetFormulaA1("SUM(ROW(C2:Z4))").Value);
+                // Return a vertical array for multiple rows. Use SUM to verify content of an array since ROWS/COLUMNS don't work yet.
+                Assert.That(ws.Cell("A3").SetFormulaA1("SUM(ROW(4:7))").Value, Is.EqualTo(4 + 5 + 6 + 7));
+                Assert.That(ws.Cell("A4").SetFormulaA1("SUM(ROW(C2:Z4))").Value, Is.EqualTo(2 + 3 + 4));
 
-            // Not contiguous range (multiple areas) returns #REF!
-            Assert.AreEqual(XLError.CellReference, ws.Cell("A5").SetFormulaA1("ROW((D5:G10,I8:K12))").Value);
+                // Not contiguous range (multiple areas) returns #REF!
+                Assert.That(ws.Cell("A5").SetFormulaA1("ROW((D5:G10,I8:K12))").Value, Is.EqualTo(XLError.CellReference));
 
-            // Invalid references return #REF!
-            Assert.AreEqual(XLError.CellReference, ws.Cell("A6").SetFormulaA1("ROW(NonExistent!F10)").Value);
+                // Invalid references return #REF!
+                Assert.That(ws.Cell("A6").SetFormulaA1("ROW(NonExistent!F10)").Value, Is.EqualTo(XLError.CellReference));
 
-            // Return row number even for different worksheet
-            Assert.AreEqual(14, ws.Cell("A7").SetFormulaA1("ROW(Other!E14)").Value);
+                // Return row number even for different worksheet
+                Assert.That(ws.Cell("A7").SetFormulaA1("ROW(Other!E14)").Value, Is.EqualTo(14));
 
-            // Unexpected types return error
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A8").SetFormulaA1("ROW(IF(TRUE,TRUE))").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A9").SetFormulaA1("ROW(IF(TRUE,5))").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A10").SetFormulaA1("ROW(IF(TRUE,\"G15\"))").Value);
-            Assert.AreEqual(XLError.DivisionByZero, ws.Cell("A11").SetFormulaA1("ROW(#DIV/0!)").Value);
+                // Unexpected types return error
+                Assert.That(ws.Cell("A8").SetFormulaA1("ROW(IF(TRUE,TRUE))").Value, Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Cell("A9").SetFormulaA1("ROW(IF(TRUE,5))").Value, Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Cell("A10").SetFormulaA1("ROW(IF(TRUE,\"G15\"))").Value, Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Cell("A11").SetFormulaA1("ROW(#DIV/0!)").Value, Is.EqualTo(XLError.DivisionByZero));
+            });
 
             // Properly works even in array formulas, where border between references and arrays blurs.
             ws.Range("A12:A13").FormulaArrayA1 = "ROW(2:3)";
-            Assert.AreEqual(2, ws.Cell("A12").Value);
-            Assert.AreEqual(3, ws.Cell("A13").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A12").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("A13").Value, Is.EqualTo(3));
+            });
         }
 
         [Test]
         public void Rows_Blank_ReturnsValueError()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROWS(IF(TRUE,,))"));
+            Assert.That(XLWorkbook.EvaluateExpr("ROWS(IF(TRUE,,))"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("0")]
@@ -631,13 +667,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("\"Hello World\"")]
         public void Rows_ScalarValues_ReturnsOne(string value)
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr($"ROWS({value})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ROWS({value})"), Is.EqualTo(1));
         }
 
         [Test]
         public void Rows_Error_ReturnsError()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("ROWS(#DIV/0!)"));
+            Assert.That(XLWorkbook.EvaluateExpr("ROWS(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase("{1}", 1)]
@@ -646,7 +682,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("{TRUE;#DIV/0!}", 2)]
         public void Rows_Arrays_ReturnsNumberOfRows(string array, int expectedColumnCount)
         {
-            Assert.AreEqual(expectedColumnCount, XLWorkbook.EvaluateExpr($"ROWS({array})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ROWS({array})"), Is.EqualTo(expectedColumnCount));
         }
 
         [TestCase("C3", 1)]
@@ -656,14 +692,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var sheet = wb.AddWorksheet();
-            Assert.AreEqual(expectedColumnCount, sheet.Evaluate($"ROWS({range})"));
+            Assert.That(sheet.Evaluate($"ROWS({range})"), Is.EqualTo(expectedColumnCount));
         }
 
         [Test]
         public void Rows_NonContiguousReferences_ReturnsReferenceError()
         {
             // Spec says #NULL!, but Excel says #REF!
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("ROWS((A1,C3))"));
+            Assert.That(XLWorkbook.EvaluateExpr("ROWS((A1,C3))"), Is.EqualTo(XLError.CellReference));
         }
 
         [Test]
@@ -671,76 +707,85 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // Range lookup false = exact match
             var value = ws.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,3,FALSE)");
-            Assert.AreEqual("Central", value);
+            Assert.That(value, Is.EqualTo("Central"));
 
             value = ws.Evaluate("=VLOOKUP(DATE(2015,5,22),Data!C:I,7,FALSE)");
-            Assert.AreEqual(63.68, value);
+            Assert.That(value, Is.EqualTo(63.68));
 
             value = ws.Evaluate(@"=VLOOKUP(""Central"",Data!D:E,2,FALSE)");
-            Assert.AreEqual("Kivell", value);
+            Assert.That(value, Is.EqualTo("Kivell"));
 
             // Case insensitive lookup
             value = ws.Evaluate(@"=VLOOKUP(""central"",Data!D:E,2,FALSE)");
-            Assert.AreEqual("Kivell", value);
+            Assert.That(value, Is.EqualTo("Kivell"));
 
             // Range lookup true = approximate match
             value = ws.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,8,TRUE)");
-            Assert.AreEqual(179.64, value);
+            Assert.That(value, Is.EqualTo(179.64));
 
             value = ws.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,8)");
-            Assert.AreEqual(179.64, value);
+            Assert.That(value, Is.EqualTo(179.64));
 
             value = ws.Evaluate("=VLOOKUP(3,Data!$B$2:$I$71,8,)");
-            Assert.AreEqual(179.64, value);
+            Assert.That(value, Is.EqualTo(179.64));
 
             value = ws.Evaluate("=VLOOKUP(14.5,Data!$B$2:$I$71,8,TRUE)");
-            Assert.AreEqual(174.65, value);
+            Assert.That(value, Is.EqualTo(174.65));
 
             value = ws.Evaluate("=VLOOKUP(50,Data!$B$2:$I$71,8,TRUE)");
-            Assert.AreEqual(139.72, value);
+            Assert.That(value, Is.EqualTo(139.72));
         }
 
         [Test]
         public void Vlookup_ElementNotFound_ReturnsNotAvailableError()
         {
-            // Value not present in the range for exact search
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"=VLOOKUP("""",Data!$B$2:$I$71,3,FALSE)"));
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"=VLOOKUP(50,Data!$B$2:$I$71,3,FALSE)"));
+            Assert.Multiple(() =>
+            {
+                // Value not present in the range for exact search
+                Assert.That(ws.Evaluate(@"=VLOOKUP("""",Data!$B$2:$I$71,3,FALSE)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Evaluate(@"=VLOOKUP(50,Data!$B$2:$I$71,3,FALSE)"), Is.EqualTo(XLError.NoValueAvailable));
 
-            // Value in approximate search that is lower than first element
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate(@"=VLOOKUP(-1,Data!$B$2:$I$71,2,TRUE)"));
+                // Value in approximate search that is lower than first element
+                Assert.That(ws.Evaluate(@"=VLOOKUP(-1,Data!$B$2:$I$71,2,TRUE)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [Test]
         public void Vlookup_UnexpectedArguments()
         {
-            // Lookup value can't be an error
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("=VLOOKUP(#DIV/0!,B2:I71,1)"));
+            Assert.Multiple(() =>
+            {
+                // Lookup value can't be an error
+                Assert.That(ws.Evaluate("=VLOOKUP(#DIV/0!,B2:I71,1)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Text value can't be over 255 chars
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate($"=VLOOKUP(\"{new string('A', 256)}\",B2:I71,1)"));
+                // Text value can't be over 255 chars
+                Assert.That(ws.Evaluate($"=VLOOKUP(\"{new string('A', 256)}\",B2:I71,1)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Range can only be array or a reference. If other type, it returns the error #N/A
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("=VLOOKUP(1,1,1)"));
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("=VLOOKUP(1,TRUE,1)"));
+                // Range can only be array or a reference. If other type, it returns the error #N/A
+                Assert.That(ws.Evaluate("=VLOOKUP(1,1,1)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Evaluate("=VLOOKUP(1,TRUE,1)"), Is.EqualTo(XLError.NoValueAvailable));
 
-            // If range is a non-contiguous range, #N/A
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("=VLOOKUP(1,(B2:I5,B6:I10),1)"));
+                // If range is a non-contiguous range, #N/A
+                Assert.That(ws.Evaluate("=VLOOKUP(1,(B2:I5,B6:I10),1)"), Is.EqualTo(XLError.NoValueAvailable));
 
-            // The column index must be at most the same as width of the range. It is 9 here, but range is 8 cell wide.
-            Assert.AreEqual(XLError.CellReference, ws.Evaluate("=VLOOKUP(20,B2:I71,9,FALSE)"));
-            // The column index must be at least 1. It is 0 here.
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("=VLOOKUP(20,B2:I71,0,FALSE)"));
+                // The column index must be at most the same as width of the range. It is 9 here, but range is 8 cell wide.
+                Assert.That(ws.Evaluate("=VLOOKUP(20,B2:I71,9,FALSE)"), Is.EqualTo(XLError.CellReference));
+                // The column index must be at least 1. It is 0 here.
+                Assert.That(ws.Evaluate("=VLOOKUP(20,B2:I71,0,FALSE)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Vlookup_ColumnIndexParameter_UsesValueSemantic()
         {
-            // If column index is not a whole number, it is truncated, so here 1.9 is truncated to 1
-            Assert.AreEqual(14.0, ws.Evaluate("=VLOOKUP(14,B2:I71,1.9)"));
+            Assert.Multiple(() =>
+            {
+                // If column index is not a whole number, it is truncated, so here 1.9 is truncated to 1
+                Assert.That(ws.Evaluate("=VLOOKUP(14,B2:I71,1.9)"), Is.EqualTo(14.0));
 
-            // Column index is evaluated using a VALUE semantic
-            Assert.AreEqual(@"Jardine", ws.Evaluate("=VLOOKUP(3,B2:I71,\"2 5/2\")"));
+                // Column index is evaluated using a VALUE semantic
+                Assert.That(ws.Evaluate("=VLOOKUP(3,B2:I71,\"2 5/2\")"), Is.EqualTo(@"Jardine"));
+            });
         }
 
         [TestCase("\"TRUE\"")]
@@ -748,7 +793,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("TRUE")]
         public void Vlookup_FlagParameter_CoercedToBoolean(string flagValue)
         {
-            Assert.AreEqual(5.0, ws.Evaluate($"VLOOKUP(5,B2:I71,1,{flagValue})"));
+            Assert.That(ws.Evaluate($"VLOOKUP(5,B2:I71,1,{flagValue})"), Is.EqualTo(5.0));
         }
 
         [Test]
@@ -760,7 +805,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             var actual = worksheet.Evaluate("VLOOKUP(IF(TRUE,,),A1:B10,2)");
 
-            Assert.AreEqual("Row with value 0", actual);
+            Assert.That(actual, Is.EqualTo("Row with value 0"));
         }
 
         [Test]
@@ -778,7 +823,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             worksheet.Cell("B1").InsertData(Enumerable.Range(1, 7).Select(x => $"Row {x}"));
 
             var actual = worksheet.Evaluate("VLOOKUP(1.9,A1:B7,2,TRUE)");
-            Assert.AreEqual("Row 3", actual);
+            Assert.That(actual, Is.EqualTo("Row 3"));
         }
 
         [Test]
@@ -786,7 +831,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var worksheet = wb.AddWorksheet();
-            Assert.AreEqual(XLError.NoValueAvailable, worksheet.Evaluate("VLOOKUP(1,A1,1,TRUE)"));
+            Assert.That(worksheet.Evaluate("VLOOKUP(1,A1,1,TRUE)"), Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [Test]
@@ -796,7 +841,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var worksheet = wb.AddWorksheet();
             worksheet.Cell("A3").Value = 5;
 
-            Assert.AreEqual(5, worksheet.Evaluate("VLOOKUP(6,A1:A5,1,TRUE)"));
+            Assert.That(worksheet.Evaluate("VLOOKUP(6,A1:A5,1,TRUE)"), Is.EqualTo(5));
         }
 
         [Test]
@@ -809,7 +854,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             worksheet.Cell("A3").Value = 3;
             worksheet.Cell("A4").Value = Blank.Value;
 
-            Assert.AreEqual(3, worksheet.Evaluate("VLOOKUP(3,A1:A4,1,TRUE)"));
+            Assert.That(worksheet.Evaluate("VLOOKUP(3,A1:A4,1,TRUE)"), Is.EqualTo(3));
         }
 
         [Test]
@@ -829,17 +874,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // If there is a section of values with same value, return the value at the highest row
             var actual = sheet.Evaluate("VLOOKUP(3, A1:B8, 2, TRUE)");
-            Assert.AreEqual(7, actual);
+            Assert.That(actual, Is.EqualTo(7));
 
             // If the last value is in the highest row, just return value outright
             actual = sheet.Evaluate("VLOOKUP(3, A2:B7, 2, TRUE)");
-            Assert.AreEqual(7, actual);
+            Assert.That(actual, Is.EqualTo(7));
         }
 
         [Test]
         public void Vlookup_CanSearchArrays()
         {
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("VLOOKUP(4, {1,2; 3,2; 5,3; 7,4}, 2)"));
+            Assert.That(XLWorkbook.EvaluateExpr("VLOOKUP(4, {1,2; 3,2; 5,3; 7,4}, 2)"), Is.EqualTo(2));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/LookupTests.cs
@@ -316,17 +316,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var cell = sheet.Cell("B3");
             cell.FormulaA1 = "HYPERLINK(\"http://github.com/ClosedXML/ClosedXML\")";
             Assert.That(cell.Value, Is.EqualTo("http://github.com/ClosedXML/ClosedXML"));
-            Assert.False(cell.HasHyperlink);
+            Assert.That(cell.HasHyperlink, Is.False);
 
             cell = sheet.Cell("B4");
             cell.FormulaA1 = "HYPERLINK(\"mailto:jsmith@github.com\", \"jsmith@github.com\")";
             Assert.That(cell.Value, Is.EqualTo("jsmith@github.com"));
-            Assert.False(cell.HasHyperlink);
+            Assert.That(cell.HasHyperlink, Is.False);
 
             cell = sheet.Cell("B5");
             cell.FormulaA1 = "HYPERLINK(\"[Test.xlsx]Sheet1!A5\", \"Cell A5\")";
             Assert.That(cell.Value, Is.EqualTo("Cell A5"));
-            Assert.False(cell.HasHyperlink);
+            Assert.That(cell.HasHyperlink, Is.False);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -18,14 +18,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Abs_ReturnsItselfOnPositiveNumbers([Range(0, 10, 0.1)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ABS({0})", input.ToString(CultureInfo.InvariantCulture)));
-            Assert.AreEqual(input, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(input).Within(tolerance * 10));
         }
 
         [Theory]
         public void Abs_ReturnsTheCorrectValueOnNegativeInput([Range(-10, -0.1, 0.1)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr(string.Format(@"ABS({0})", input.ToString(CultureInfo.InvariantCulture)));
-            Assert.AreEqual(-input, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(-input).Within(tolerance * 10));
         }
 
         [TestCase(-1, 3.141592654)]
@@ -52,21 +52,24 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Acos_ReturnsCorrectValue(double input, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ACOS({input})");
-            Assert.AreEqual(expectedResult, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance * 10));
         }
 
         [Theory]
         public void Acos_returns_error_when_number_outside_range([Range(1.1, 3, 0.1)] double input)
         {
-            // checking input and it's additive inverse as both are outside range.
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({input})"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOS({-input})"));
+            Assert.Multiple(() =>
+            {
+                // checking input and it's additive inverse as both are outside range.
+                Assert.That(XLWorkbook.EvaluateExpr($"ACOS({input})"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr($"ACOS({-input})"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Theory]
         public void Acosh_NumbersBelow1ThrowNumberException([Range(-1, 0.9, 0.1)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOSH({input})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ACOSH({input})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(1.2, 0.622362504)]
@@ -90,7 +93,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Acosh_returns_correct_number(double angle, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ACOSH({angle})");
-            Assert.AreEqual(expectedResult, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance * 10));
         }
 
         [TestCase(-10, 3.041924001)]
@@ -117,13 +120,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Acot_returns_correct_number(double angle, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ACOT({angle})");
-            Assert.AreEqual(expectedResult, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance * 10));
         }
 
         [Theory]
         public void Acoth_returns_error_for_absolute_angle_smaller_than_one([Range(-0.9, 0.9, 0.1)] double angle)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ACOTH({angle})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ACOTH({angle})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(-10, -0.100335348)]
@@ -148,7 +151,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Acoth_returns_correct_number(double angle, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ACOTH({angle})");
-            Assert.AreEqual(expectedResult, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance * 10));
         }
 
         [TestCase("LVII", 57)]
@@ -164,27 +167,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Arabic_returns_correct_number(string roman, int arabic)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ARABIC(\"{roman}\")");
-            Assert.AreEqual(arabic, actual);
+            Assert.That(actual, Is.EqualTo(arabic));
         }
 
         [Test]
         public void Arabic_solitary_minus_is_not_valid_roman_number()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("ARABIC(\"-\")"));
+            Assert.That(XLWorkbook.EvaluateExpr("ARABIC(\"-\")"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Arabic_can_have_at_most_255_chars()
         {
-            Assert.AreEqual(255000, XLWorkbook.EvaluateExpr($"ARABIC(\"{new string('M', 255)}\")"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"ARABIC(\"{new string('M', 256)}\")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr($"ARABIC(\"{new string('M', 255)}\")"), Is.EqualTo(255000));
+                Assert.That(XLWorkbook.EvaluateExpr($"ARABIC(\"{new string('M', 256)}\")"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [TestCase("- I")]
         [TestCase("roman")]
         public void Arabic_returns_conversion_error_on_invalid_numbers(string invalidRoman)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"ARABIC(\"{invalidRoman}\")"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ARABIC(\"{invalidRoman}\")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(-1, -1.570796327)]
@@ -211,14 +217,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Asin_ReturnsCorrectResult(double input, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ASIN({input})");
-            Assert.AreEqual(expectedResult, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance * 10));
         }
 
         [Theory]
         public void Asin_ThrowsNumberExceptionWhenAbsOfInputGreaterThan1([Range(-3, -1.1, 0.1)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ASIN({input})"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ASIN({-input})"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr($"ASIN({input})"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr($"ASIN({-input})"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(0, 0)]
@@ -239,9 +248,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Asinh_ReturnsCorrectResult(double input, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ASINH({input})");
-            Assert.AreEqual(expectedResult, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
             var minusActual = (double)XLWorkbook.EvaluateExpr($"ASINH({-input})");
-            Assert.AreEqual(-expectedResult, minusActual, tolerance);
+            Assert.That(minusActual, Is.EqualTo(-expectedResult).Within(tolerance));
         }
 
         [TestCase(0, 0)]
@@ -262,16 +271,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Atan_ReturnsCorrectResult(double input, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN({input})");
-            Assert.AreEqual(expectedResult, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
             var minusActual = (double)XLWorkbook.EvaluateExpr($"ATAN({-input})");
-            Assert.AreEqual(-expectedResult, minusActual, tolerance);
+            Assert.That(minusActual, Is.EqualTo(-expectedResult).Within(tolerance));
         }
 
         [Test]
         public void Atan2_Returns0OnSecond0AndFirstGreater0([Range(0.1, 5, 0.4)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, 0)");
-            Assert.AreEqual(0, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(0).Within(tolerance));
         }
 
         [TestCase(1, 2, 1.10714871779409)]
@@ -296,7 +305,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             for (int i = 1; i < 5; i++)
             {
                 var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({x * i}, {y * i})");
-                Assert.AreEqual(expectedResult, actual, tolerance);
+                Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
             }
         }
 
@@ -304,41 +313,41 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Atan2_ReturnsHalfPiOn0AsFirstInputWhenSecondGreater0([Range(0.1, 5, 0.4)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2(0, {input})");
-            Assert.AreEqual(0.5 * Math.PI, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(0.5 * Math.PI).Within(tolerance));
         }
 
         [Test]
         public void Atan2_ReturnsMinus3QuartersOfPiWhenFirstSmaller0AndSecondItsNegative([Range(-5, -0.1, 0.3)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, {input})");
-            Assert.AreEqual(-0.75 * Math.PI, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(-0.75 * Math.PI).Within(tolerance));
         }
 
         [Test]
         public void Atan2_ReturnsMinusHalfPiOn0AsFirstInputWhenSecondSmaller0([Range(-5, -0.1, 0.4)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2(0, {input})");
-            Assert.AreEqual(-0.5 * Math.PI, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(-0.5 * Math.PI).Within(tolerance));
         }
 
         [Test]
         public void Atan2_ReturnsPiOn0AsSecondInputWhenFirstSmaller0([Range(-5, -0.1, 0.4)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, 0)");
-            Assert.AreEqual(Math.PI, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(Math.PI).Within(tolerance));
         }
 
         [Test]
         public void Atan2_ReturnsQuarterOfPiWhenInputsAreEqualAndGreater0([Range(0.1, 5, 0.3)] double input)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATAN2({input}, {input})");
-            Assert.AreEqual(0.25 * Math.PI, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(0.25 * Math.PI).Within(tolerance));
         }
 
         [Test]
         public void Atan2_ThrowsDiv0ExceptionOn0And0()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("ATAN2(0, 0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("ATAN2(0, 0)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase(-0.99, -2.64665241236225)]
@@ -358,14 +367,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Atanh_ReturnsCorrectResults(double input, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"ATANH({input})");
-            Assert.AreEqual(expectedResult, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance * 10));
         }
 
         [Theory]
         public void Atanh_ThrowsNumberExceptionWhenAbsOfInput1OrGreater([Range(1, 5, 0.2)] double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ATANH({input})"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"ATANH({-input})"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr($"ATANH({input})"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr($"ATANH({-input})"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(0, 36, "0")]
@@ -410,7 +422,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Base_returns_number_in_specified_base(int input, int radix, string expectedResult)
         {
             var actual = (string)XLWorkbook.EvaluateExpr($"BASE({input},{radix})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase(255, 2, 3, "11111111")]
@@ -421,13 +433,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Base_returns_text_of_at_least_minimal_length(int input, int radix, int minLength, string expectedResult)
         {
             var actual = (string)XLWorkbook.EvaluateExpr($"BASE({input},{radix},{minLength})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [Test]
         public void Base_min_length_must_be_at_most_255()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("BASE(0,2,256)"));
+            Assert.That(XLWorkbook.EvaluateExpr("BASE(0,2,256)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(@"""x""", "2", "2")]
@@ -435,26 +447,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("0", "2", @"""x""")]
         public void Base_coercion(string input, string radix, string minLength)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"BASE({input},{radix},{minLength})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"BASE({input},{radix},{minLength})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Theory]
         public void Base_radix_must_be_between_2_and_36([Range(-2, 1), Range(37, 40)] int radix)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"BASE(0,{radix})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"BASE(0,{radix})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Theory]
         public void Base_number_must_be_zero_or_positive([Range(-5, -1)] int input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"BASE({input},2)"));
+            Assert.That(XLWorkbook.EvaluateExpr($"BASE({input},2)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Theory]
         public void Base_number_must_fit_in_double_without_precision_loss()
         {
-            Assert.AreEqual(@"2GOPQOE5GCG", XLWorkbook.EvaluateExpr("BASE(9.007E+15,36)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("BASE(9.008E+15,36)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("BASE(9.007E+15,36)"), Is.EqualTo(@"2GOPQOE5GCG"));
+                Assert.That(XLWorkbook.EvaluateExpr("BASE(9.008E+15,36)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(24.3, 5, 25)]
@@ -473,7 +488,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Ceiling(double input, double significance, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})");
-            Assert.AreEqual(expectedResult, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase(6.7, -1)]
@@ -482,7 +497,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // Spec says "if x and significance have different signs, #NUM! is returned.",
             // but in reality it only happens when number is positive and step negative.
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"CEILING({input}, {significance})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(24.3, 5, null, 25)]
@@ -520,27 +535,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             }
 
             var actual = (double)XLWorkbook.EvaluateExpr($"CEILING.MATH({parameters})");
-            Assert.AreEqual(expectedResult, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [Test]
         public void Combin()
         {
             var actual1 = XLWorkbook.EvaluateExpr("COMBIN(200, 2)");
-            Assert.AreEqual(19900.0, actual1);
+            Assert.That(actual1, Is.EqualTo(19900.0));
 
             var actual2 = XLWorkbook.EvaluateExpr("COMBIN(20.1, 2.9)");
-            Assert.AreEqual(190.0, actual2);
+            Assert.That(actual2, Is.EqualTo(190.0));
         }
 
         [Theory]
         public void Combin_returns_1_for_k_is_0_or_k_equals_n([Range(0, 10)] int n)
         {
             var actual = XLWorkbook.EvaluateExpr($"COMBIN({n}, 0)");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
 
             var actual2 = XLWorkbook.EvaluateExpr($"COMBIN({n}, {n})");
-            Assert.AreEqual(1, actual2);
+            Assert.That(actual2, Is.EqualTo(1));
         }
 
         [TestCase(0, 0, 1)]
@@ -555,38 +570,44 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Combin_calculates_combinations(int n, int k, int expectedResult)
         {
             var actual = XLWorkbook.EvaluateExpr($"COMBIN({n}, {k})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
 
             var actual2 = XLWorkbook.EvaluateExpr($"COMBIN({n}, {n - k})");
-            Assert.AreEqual(expectedResult, actual2);
+            Assert.That(actual2, Is.EqualTo(expectedResult));
         }
 
         [Theory]
         public void Combin_returns_n_for_k_is_1_or_k_is_n_minus_1([Range(1, 10)] int n)
         {
             var actual = XLWorkbook.EvaluateExpr($"COMBIN({n}, 1)");
-            Assert.AreEqual(n, actual);
+            Assert.That(actual, Is.EqualTo(n));
 
             var actual2 = XLWorkbook.EvaluateExpr($"COMBIN({n}, {n - 1})");
-            Assert.AreEqual(n, actual2);
+            Assert.That(actual2, Is.EqualTo(n));
         }
 
         [Test]
         public void Combin_returns_num_error_when_k_is_larger_than_n()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("COMBIN(5, 6)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("COMBIN(5, 6)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Values are floored, so this is COMBIN(5, 5).
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("COMBIN(5, 5.5)"));
+                // Values are floored, so this is COMBIN(5, 5).
+                Assert.That(XLWorkbook.EvaluateExpr("COMBIN(5, 5.5)"), Is.EqualTo(1));
+            });
         }
 
         [Test]
         public void Combin_returns_num_error_when_value_is_too_large()
         {
-            // Maximum int - 1 is maximum computable value in Excel.
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("COMBIN(2147483647, 2147483647)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("COMBIN(5E+301, 6)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("COMBIN(6, 5E+301)"));
+            Assert.Multiple(() =>
+            {
+                // Maximum int - 1 is maximum computable value in Excel.
+                Assert.That(XLWorkbook.EvaluateExpr("COMBIN(2147483647, 2147483647)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("COMBIN(5E+301, 6)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("COMBIN(6, 5E+301)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase(-4)]
@@ -595,25 +616,31 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-0.1)]
         public void Combin_returns_num_error_for_any_argument_smaller_than_0(double smaller0)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"COMBIN({0}, {1})",
-                    smaller0.ToString(CultureInfo.InvariantCulture),
-                    (-smaller0).ToString(CultureInfo.InvariantCulture))));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr(
+                            string.Format(
+                                @"COMBIN({0}, {1})",
+                                smaller0.ToString(CultureInfo.InvariantCulture),
+                                (-smaller0).ToString(CultureInfo.InvariantCulture))), Is.EqualTo(XLError.NumberInvalid));
 
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr(
-                string.Format(
-                    @"COMBIN({0}, {1})",
-                    (-smaller0).ToString(CultureInfo.InvariantCulture),
-                    smaller0.ToString(CultureInfo.InvariantCulture))));
+                Assert.That(XLWorkbook.EvaluateExpr(
+                    string.Format(
+                        @"COMBIN({0}, {1})",
+                        (-smaller0).ToString(CultureInfo.InvariantCulture),
+                        smaller0.ToString(CultureInfo.InvariantCulture))), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase("\"no number\"")]
         [TestCase("\"\"")]
         public void Combin_returns_value_error_for_any_non_numeric_argument(string input)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"COMBIN({input}, 1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"COMBIN(1, {input})"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr($"COMBIN({input}, 1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr($"COMBIN(1, {input})"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [TestCase(4, 3, 20)]
@@ -624,14 +651,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Combina_calculates_correct_values(int number, int chosen, int expectedResult)
         {
             var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})");
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         [Theory]
         public void Combina_returns_one_when_chosen_is_zero([Range(0, 10)] int number)
         {
             var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, 0)");
-            Assert.AreEqual(1, actualResult);
+            Assert.That(actualResult, Is.EqualTo(1));
         }
 
         [TestCase(-1, 2)]
@@ -640,7 +667,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(int.MaxValue + 1d, 1)]
         public void Combina_returns_error_on_invalid_values(double number, int chosen)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(4.23, 3, 20)]
@@ -649,7 +676,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Combina_truncates_numbers_to_zero(double number, double chosen, int expectedResult)
         {
             var actualResult = XLWorkbook.EvaluateExpr($"COMBINA({number}, {chosen})");
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         [TestCase(0, 1)]
@@ -677,7 +704,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Cos_ReturnsCorrectResult(double input, double expectedResult)
         {
             var actualResult = (double)XLWorkbook.EvaluateExpr($"COS({input})");
-            Assert.AreEqual(expectedResult, actualResult, tolerance);
+            Assert.That(actualResult, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase(0, 1)]
@@ -705,9 +732,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Cosh_ReturnsCorrectResult(double input, double expectedResult)
         {
             var actualResult = (double)XLWorkbook.EvaluateExpr($"COSH({input})");
-            Assert.AreEqual(expectedResult, actualResult, tolerance);
+            Assert.That(actualResult, Is.EqualTo(expectedResult).Within(tolerance));
             var actualResult2 = (double)XLWorkbook.EvaluateExpr($"COSH({-input})");
-            Assert.AreEqual(expectedResult, actualResult2, tolerance);
+            Assert.That(actualResult2, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase(711)]
@@ -715,7 +742,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(100000)]
         public void Cosh_too_large_returns_error(double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"COSH({input})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"COSH({input})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(1, 0.642092616)]
@@ -736,19 +763,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Cot(double angle, double expected)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"COT({angle})");
-            Assert.AreEqual(expected, actual, tolerance * 10.0);
+            Assert.That(actual, Is.EqualTo(expected).Within(tolerance * 10.0));
         }
 
         [Test]
         public void Cot_returns_division_by_zero_error_on_angle_zero()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COT(0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("COT(0)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [Test]
         public void Coth_returns_division_by_zero_error_on_angle_zero()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("COTH(0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("COTH(0)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase(-10, -1.000000004)]
@@ -774,13 +801,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Coth_returns_correct_number(double angle, double expected)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"COTH({angle})");
-            Assert.AreEqual(expected, actual, tolerance * 10.0);
+            Assert.That(actual, Is.EqualTo(expected).Within(tolerance * 10.0));
         }
 
         [Test]
         public void Csc_returns_division_by_zero_on_angle_zero()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("CSC(0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("CSC(0)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase(-10, 1.838163961)]
@@ -806,7 +833,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Csc_returns_correct_number(double angle, double expected)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"CSC({angle})");
-            Assert.AreEqual(expected, actual, tolerance * 10);
+            Assert.That(actual, Is.EqualTo(expected).Within(tolerance * 10));
         }
 
         [TestCase(1, 0.850918128)]
@@ -822,13 +849,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(11, 0.0000334034)]
         public void Csch_calculates_correct_values(double input, double expectedOutput)
         {
-            Assert.AreEqual(expectedOutput, (double)XLWorkbook.EvaluateExpr($"CSCH({input})"), 0.000000001);
+            Assert.That((double)XLWorkbook.EvaluateExpr($"CSCH({input})"), Is.EqualTo(expectedOutput).Within(0.000000001));
         }
 
         [Test]
         public void Csch_returns_division_error_on_angle_zero()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("CSCH(0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("CSCH(0)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase("FF", 16, 255)]
@@ -841,46 +868,49 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Decimal(string inputString, double radix, object expectedResult)
         {
             var actualResult = XLWorkbook.EvaluateExpr($"DECIMAL(\"{inputString}\", {radix})");
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         [Theory]
         public void Decimal_radix_must_be_between_2_and_36([Range(37, 255), Range(-5, 1)] int radix)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"DECIMAL(\"0\", {radix})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"DECIMAL(\"0\", {radix})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Decimal_zero_is_zero_in_any_radix([Range(2, 36)] int radix)
         {
-            Assert.AreEqual(0, XLWorkbook.EvaluateExpr($"DECIMAL(\"0\", {radix})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"DECIMAL(\"0\", {radix})"), Is.EqualTo(0));
         }
 
         [Test]
         public void Decimal_text_must_be_less_than_256_chars_long()
         {
             var text = new string('0', 256);
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"DECIMAL(\"{text}\", 10)"));
+            Assert.That(XLWorkbook.EvaluateExpr($"DECIMAL(\"{text}\", 10)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Decimal_returns_number_invalid_when_result_out_of_bounds()
         {
-            Assert.AreEqual(1.4057081148316923E+308d, (double)XLWorkbook.EvaluateExpr($"DECIMAL(\"{new string('Z', 198)}\", 36)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"DECIMAL(\"{new string('Z', 199)}\", 36)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)XLWorkbook.EvaluateExpr($"DECIMAL(\"{new string('Z', 198)}\", 36)"), Is.EqualTo(1.4057081148316923E+308d));
+                Assert.That(XLWorkbook.EvaluateExpr($"DECIMAL(\"{new string('Z', 199)}\", 36)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase("101", "\"1 2/2\"", 5)] // 101 in binary is 5
         public void Decimal_coercion(string input, string radix, object expectedResult)
         {
-            Assert.AreEqual(expectedResult, XLWorkbook.EvaluateExpr($"DECIMAL({input}, {radix})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"DECIMAL({input}, {radix})"), Is.EqualTo(expectedResult));
         }
 
         [Test]
         public void Degrees()
         {
             var actual = (double)XLWorkbook.EvaluateExpr("DEGREES(PI())");
-            Assert.AreEqual(180, actual, XLHelper.Epsilon);
+            Assert.That(actual, Is.EqualTo(180).Within(XLHelper.Epsilon));
         }
 
         [TestCase(0, 0)]
@@ -903,7 +933,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Degrees_ReturnsCorrectResult(double input, double expected)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"DEGREES({input})");
-            Assert.AreEqual(expected, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expected).Within(tolerance));
         }
 
         [TestCase(3, 4)]
@@ -918,7 +948,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Even(double number, double expectedResult)
         {
             var actual = XLWorkbook.EvaluateExpr($"EVEN({number})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase(0, 1)]
@@ -938,20 +968,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Exp_returns_correct_results(double input, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"EXP({input})");
-            Assert.AreEqual(expectedResult, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase(710)]
         public void Exp_with_too_large_result_return_error(double input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"EXP({input})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"EXP({input})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Fact()
         {
             object actual = XLWorkbook.EvaluateExpr("Fact(5.9)");
-            Assert.AreEqual(120.0, actual);
+            Assert.That(actual, Is.EqualTo(120.0));
         }
 
         [TestCase(0, 1d)]
@@ -978,7 +1008,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Fact_calculates_factorial(double input, double expectedResult)
         {
             var actual = XLWorkbook.EvaluateExpr($@"FACT({input.ToString(CultureInfo.InvariantCulture)})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase(-10)]
@@ -988,7 +1018,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Fact_returns_error_for_negative_input(double input)
         {
             var actual = XLWorkbook.EvaluateExpr($@"FACT({input.ToString(CultureInfo.InvariantCulture)})");
-            Assert.AreEqual(XLError.NumberInvalid, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(171)]
@@ -996,13 +1026,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Fact_returns_error_for_too_large_result(int input)
         {
             var actual = XLWorkbook.EvaluateExpr($@"FACT({input})");
-            Assert.AreEqual(XLError.NumberInvalid, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Fact_coercion_fails_for_non_numeric_input()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FACT(""x"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FACT(""x"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(0, 1L)]
@@ -1031,26 +1061,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void FactDouble_ReturnsCorrectResult(double input, long expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"FACTDOUBLE({input})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase(301)]
         [TestCase(1e+100)]
         public void FactDouble_returns_error_on_too_large_value(double n)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FACTDOUBLE({n})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"FACTDOUBLE({n})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Theory]
         public void FactDouble_ThrowsNumberExceptionForInputSmallerThanMinus1([Range(-10, -2)] int input)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FACTDOUBLE({input})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"FACTDOUBLE({input})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void FactDouble_ThrowsValueExceptionForNonNumericInput()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FACTDOUBLE(""x"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FACTDOUBLE(""x"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(0, 0, 0)]
@@ -1064,20 +1094,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Floor(double input, double significance, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})");
-            Assert.AreEqual(expectedResult, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase(6.7, 0)]
         [TestCase(-6.7, 0)]
         public void Floor_ThrowsDivisionByZeroOnZeroSignificance(double input, double significance)
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase(6.7, -1)]
         public void Floor_ThrowsNumberExceptionOnInvalidInput(double input, double significance)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"FLOOR({input}, {significance})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
@@ -1116,7 +1146,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             }
 
             var actual = (double)XLWorkbook.EvaluateExpr($"FLOOR.MATH({parameters})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase("24,36", ExpectedResult = 12)]
@@ -1141,31 +1171,37 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 (120, 240),
                 ("60", "150"),
             });
-            Assert.AreEqual(30, ws.Evaluate("GCD(A1:A2,B1:B2)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("GCD(A1:A2,B1:B2)"), Is.EqualTo(30));
 
-            // Blank is considered 0
-            Assert.AreEqual(60, ws.Evaluate("GCD(A1:A3)"));
+                // Blank is considered 0
+                Assert.That(ws.Evaluate("GCD(A1:A3)"), Is.EqualTo(60));
+            });
 
             // Logical are not converted
             ws.Cell("A3").Value = true;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("GCD(A1:A3)"));
+            Assert.That(ws.Evaluate("GCD(A1:A3)"), Is.EqualTo(XLError.IncompatibleValue));
 
             // Unconvertable text causes error
             ws.Cell("A3").Value = "one";
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("GCD(A1:A3)"));
+            Assert.That(ws.Evaluate("GCD(A1:A3)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase]
         public void Gcd_numbers_must_fit_in_double_without_precision_loss()
         {
-            Assert.AreEqual(9.007E+15, XLWorkbook.EvaluateExpr("GCD(9.007E+15)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("GCD(9.008E+15)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("GCD(9.007E+15)"), Is.EqualTo(9.007E+15));
+                Assert.That(XLWorkbook.EvaluateExpr("GCD(9.008E+15)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase]
         public void Gcd_numbers_must_be_zero_or_positive()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("GCD(-1)"));
+            Assert.That(XLWorkbook.EvaluateExpr("GCD(-1)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(8.9, 8)]
@@ -1173,7 +1209,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Int(double input, double expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"INT({input})");
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [TestCase("24, 36", ExpectedResult = 72)]
@@ -1199,31 +1235,37 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 (1, 2, 3),
                 ("4", "5", "6"),
             });
-            Assert.AreEqual(60, ws.Evaluate("LCM(A1:B2,C1:C2)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("LCM(A1:B2,C1:C2)"), Is.EqualTo(60));
 
-            // Blank is considered 0
-            Assert.AreEqual(0, ws.Evaluate("LCM(A1:A3)"));
+                // Blank is considered 0
+                Assert.That(ws.Evaluate("LCM(A1:A3)"), Is.EqualTo(0));
+            });
 
             // Logical are not converted
             ws.Cell("A3").Value = true;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("LCM(A1:A3)"));
+            Assert.That(ws.Evaluate("LCM(A1:A3)"), Is.EqualTo(XLError.IncompatibleValue));
 
             // Unconvertable text causes error
             ws.Cell("A3").Value = "one";
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("LCM(A1:A3)"));
+            Assert.That(ws.Evaluate("LCM(A1:A3)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase]
         public void Lcm_numbers_must_fit_in_double_without_precision_loss()
         {
-            Assert.AreEqual(9.007E+15, XLWorkbook.EvaluateExpr("LCM(9.007E+15)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LCM(9.008E+15)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("LCM(9.007E+15)"), Is.EqualTo(9.007E+15));
+                Assert.That(XLWorkbook.EvaluateExpr("LCM(9.008E+15)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [TestCase]
         public void Lcm_numbers_must_be_zero_or_positive()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LCM(-1)"));
+            Assert.That(XLWorkbook.EvaluateExpr("LCM(-1)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(86, 4.4543472962)]
@@ -1231,7 +1273,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(20.085536923, 3)]
         public void Ln_calculates_logarithm(double x, double ln)
         {
-            Assert.AreEqual(ln, (double)XLWorkbook.EvaluateExpr($"LN({x})"), tolerance);
+            Assert.That((double)XLWorkbook.EvaluateExpr($"LN({x})"), Is.EqualTo(ln).Within(tolerance));
         }
 
         [TestCase(0)]
@@ -1239,7 +1281,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-10)]
         public void Ln_non_positive_returns_error(double x)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"LN({x})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"LN({x})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(10, 10, 1)]
@@ -1247,22 +1289,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(86, 2.7182818, 4.4543473428883)]
         public void Log_calculates_logarithm(double x, double @base, double result)
         {
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"LOG({x}, {@base})"), tolerance);
+            Assert.That((double)XLWorkbook.EvaluateExpr($"LOG({x}, {@base})"), Is.EqualTo(result).Within(tolerance));
         }
 
         [Test]
         public void Log_default_base_is_10()
         {
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("LOG(100)"));
+            Assert.That(XLWorkbook.EvaluateExpr("LOG(100)"), Is.EqualTo(2));
         }
 
         [Test]
         public void Log_error_conditions()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LOG(0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LOG(1,0)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("LOG(0,0)"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("LOG(10,1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("LOG(0)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("LOG(1,0)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("LOG(0,0)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("LOG(10,1)"), Is.EqualTo(XLError.DivisionByZero));
+            });
         }
 
         [TestCase(86, 1.93449845124)]
@@ -1270,7 +1315,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1E5, 5)]
         public void Log10_calculates_logarithm(double x, double expectedResult)
         {
-            Assert.AreEqual(expectedResult, (double)XLWorkbook.EvaluateExpr($"LOG10({x})"), tolerance);
+            Assert.That((double)XLWorkbook.EvaluateExpr($"LOG10({x})"), Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase(0)]
@@ -1278,14 +1323,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-0.5)]
         public void Log10_error_conditions(double x)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"LOG10({x})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"LOG10({x})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Log10_is_detected_inside_expression()
         {
             // Because LOG10 is extracted from CellFunction, make sure it is properly read even in the middle of expression.
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("0 + LOG10(10)"));
+            Assert.That(XLWorkbook.EvaluateExpr("0 + LOG10(10)"), Is.EqualTo(1));
         }
 
         [Test]
@@ -1302,24 +1347,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("A5").FormulaA1 = "MDETERM(A1:B2)";
             var actual = ws.Cell("A5").Value;
-            Assert.AreEqual(-2, (double)actual);
+            Assert.That((double)actual, Is.EqualTo(-2));
 
             ws.Cell("A6").FormulaA1 = "SUM(A5)";
             actual = ws.Cell("A6").Value;
-            Assert.AreEqual(-2, (double)actual);
+            Assert.That((double)actual, Is.EqualTo(-2));
 
             ws.Cell("A7").FormulaA1 = "SUM(MDETERM(A1:B2))";
             actual = ws.Cell("A7").Value;
-            Assert.AreEqual(-2, (double)actual);
+            Assert.That((double)actual, Is.EqualTo(-2));
         }
 
         [Test]
         [DefaultFloatingPointTolerance(tolerance)]
         public void MDeterm_examples()
         {
-            // Examples from spec
-            Assert.AreEqual(1, (double)XLWorkbook.EvaluateExpr("MDETERM({3,6,1;1,1,0;3,10,2})"));
-            Assert.AreEqual(-3, XLWorkbook.EvaluateExpr("MDETERM({3,6;1,1})"));
+            Assert.Multiple(() =>
+            {
+                // Examples from spec
+                Assert.That((double)XLWorkbook.EvaluateExpr("MDETERM({3,6,1;1,1,0;3,10,2})"), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr("MDETERM({3,6;1,1})"), Is.EqualTo(-3));
+            });
 
             // Example from office website
             using var wb = new XLWorkbook();
@@ -1332,19 +1380,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 (1, 1, 1, 0),
                 (7, 3, 10, 2),
             });
-            Assert.AreEqual(88, (double)ws.Evaluate("MDETERM(A2:D5)"));
+            Assert.That((double)ws.Evaluate("MDETERM(A2:D5)"), Is.EqualTo(88));
         }
 
         [Test]
         public void MDeterm_requires_equal_number_of_rows_and_columns()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("MDETERM({1,2})"));
+            Assert.That(XLWorkbook.EvaluateExpr("MDETERM({1,2})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void MDeterm_singular_matrix_returns_zero()
         {
-            Assert.AreEqual(0, XLWorkbook.EvaluateExpr("MDETERM({1,2;1,2})"));
+            Assert.That(XLWorkbook.EvaluateExpr("MDETERM({1,2;1,2})"), Is.EqualTo(0));
         }
 
         [Test]
@@ -1359,16 +1407,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             });
 
             ws.Cell("B2").Value = Blank.Value;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MDETERM(A1:B2)"));
+            Assert.That(ws.Evaluate("MDETERM(A1:B2)"), Is.EqualTo(XLError.IncompatibleValue));
 
             ws.Cell("B2").Value = "1";
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MDETERM(A1:B2)"));
+            Assert.That(ws.Evaluate("MDETERM(A1:B2)"), Is.EqualTo(XLError.IncompatibleValue));
 
             ws.Cell("B2").Value = true;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MDETERM(A1:B2)"));
+            Assert.That(ws.Evaluate("MDETERM(A1:B2)"), Is.EqualTo(XLError.IncompatibleValue));
 
             ws.Cell("B2").Value = XLError.NameNotRecognized;
-            Assert.AreEqual(XLError.NameNotRecognized, ws.Evaluate("MDETERM(A1:B2)"));
+            Assert.That(ws.Evaluate("MDETERM(A1:B2)"), Is.EqualTo(XLError.NameNotRecognized));
         }
 
         [Test]
@@ -1386,15 +1434,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("A5").FormulaA1 = "MINVERSE(A1:C3)";
             var actual = ws.Cell("A5").Value;
-            Assert.AreEqual(0.25, (double)actual);
+            Assert.That((double)actual, Is.EqualTo(0.25));
 
             ws.Cell("A6").FormulaA1 = "SUM(A5)";
             actual = ws.Cell("A6").Value;
-            Assert.AreEqual(0.25, (double)actual);
+            Assert.That((double)actual, Is.EqualTo(0.25));
 
             ws.Cell("A7").FormulaA1 = "SUM(MINVERSE(A1:C3))";
             actual = ws.Cell("A7").Value;
-            Assert.AreEqual(0.5, (double)actual);
+            Assert.That((double)actual, Is.EqualTo(0.5));
         }
 
         [Test]
@@ -1407,13 +1455,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 (1, 2),
                 (1, 2),
             });
-            Assert.AreEqual(XLError.NumberInvalid, ws.Evaluate("MINVERSE(A1:B2)"));
+            Assert.That(ws.Evaluate("MINVERSE(A1:B2)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void MInverse_requires_square_matrix()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("MINVERSE({1,2,3;7,5,5})"));
+            Assert.That(XLWorkbook.EvaluateExpr("MINVERSE({1,2,3;7,5,5})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
@@ -1428,16 +1476,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             });
 
             ws.Cell("B2").Value = Blank.Value;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MINVERSE(A1:B2)"));
+            Assert.That(ws.Evaluate("MINVERSE(A1:B2)"), Is.EqualTo(XLError.IncompatibleValue));
 
             ws.Cell("B2").Value = true;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MINVERSE(A1:B2)"));
+            Assert.That(ws.Evaluate("MINVERSE(A1:B2)"), Is.EqualTo(XLError.IncompatibleValue));
 
             ws.Cell("B2").Value = "1";
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MINVERSE(A1:B2)"));
+            Assert.That(ws.Evaluate("MINVERSE(A1:B2)"), Is.EqualTo(XLError.IncompatibleValue));
 
             ws.Cell("B2").Value = XLError.DivisionByZero;
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("MINVERSE(A1:B2)"));
+            Assert.That(ws.Evaluate("MINVERSE(A1:B2)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [Test]
@@ -1455,15 +1503,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("A5").FormulaA1 = "MMULT(A1:B2, A3:B4)";
             var actual = ws.Cell("A5").Value;
-            Assert.AreEqual(16.0, actual);
+            Assert.That(actual, Is.EqualTo(16.0));
 
             ws.Cell("A6").FormulaA1 = "SUM(A5)";
             actual = ws.Cell("A6").Value;
-            Assert.AreEqual(16.0, actual);
+            Assert.That(actual, Is.EqualTo(16.0));
 
             ws.Cell("A7").FormulaA1 = "SUM(MMULT(A1:B2, A3:B4))";
             actual = ws.Cell("A7").Value;
-            Assert.AreEqual(102.0, actual);
+            Assert.That(actual, Is.EqualTo(102.0));
         }
 
         [Test]
@@ -1487,11 +1535,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // 136, 172, 208, 244
             ws.Cell("A6").FormulaA1 = "MMult(A1:C2, A3:D5)";
             var actual = ws.Cell("A6").Value;
-            Assert.AreEqual(103.0, actual);
+            Assert.That(actual, Is.EqualTo(103.0));
 
             ws.Cell("A7").FormulaA1 = "Sum(MMult(A1:C2, A3:D5))";
             actual = ws.Cell("A7").Value;
-            Assert.AreEqual(1334, actual);
+            Assert.That(actual, Is.EqualTo(1334));
         }
 
         [TestCase("A2:C2", "A3:C3")] // 1x3 and 1x3
@@ -1507,7 +1555,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("A1").FormulaA1 = $"MMULT({array1Range},{array2Range})";
 
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A1").Value);
+            Assert.That(ws.Cell("A1").Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("")]
@@ -1527,7 +1575,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             ws.Cell("A6").FormulaA1 = "MMULT(A1:C2,A3:D4)";
 
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A6").Value);
+            Assert.That(ws.Cell("A6").Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(1.5, 1, 0.5)]
@@ -1541,15 +1589,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mod(double x, double y, double result)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"MOD({x}, {y})");
-            Assert.AreEqual(result, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(result).Within(tolerance));
         }
 
         [Test]
         public void Mod_divisor_zero_returns_error()
         {
-            // Spec says that "If y is 0, the return value is unspecified", but Excel says #DIV/0!, so let's go with that.
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("MOD(1, 0)"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("MOD(0, 0)"));
+            Assert.Multiple(() =>
+            {
+                // Spec says that "If y is 0, the return value is unspecified", but Excel says #DIV/0!, so let's go with that.
+                Assert.That(XLWorkbook.EvaluateExpr("MOD(1, 0)"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(XLWorkbook.EvaluateExpr("MOD(0, 0)"), Is.EqualTo(XLError.DivisionByZero));
+            });
         }
 
         [TestCase(10, 3, ExpectedResult = 9.0)]
@@ -1583,16 +1634,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(-123456.123, 5)]
         public void MRoundExceptions(double number, double multiple)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"MROUND({number}, {multiple})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"MROUND({number}, {multiple})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void Multinomial()
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("MULTINOMIAL(2)"));
-            Assert.AreEqual(10, XLWorkbook.EvaluateExpr("MULTINOMIAL(2,3)"));
-            Assert.AreEqual(1260, XLWorkbook.EvaluateExpr("MULTINOMIAL(2,3,4)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("MULTINOMIAL(1E+100)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("MULTINOMIAL(2)"), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr("MULTINOMIAL(2,3)"), Is.EqualTo(10));
+                Assert.That(XLWorkbook.EvaluateExpr("MULTINOMIAL(2,3,4)"), Is.EqualTo(1260));
+                Assert.That(XLWorkbook.EvaluateExpr("MULTINOMIAL(1E+100)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
@@ -1603,13 +1657,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B2").InsertData(new[] { 2, 0, 5 });
             ws.Cell("A5").InsertData(new[] { 3, 6 });
 
-            Assert.AreEqual(3087564480d, ws.Evaluate("MULTINOMIAL(B:XFD, 2, A5:A6)"));
+            Assert.That(ws.Evaluate("MULTINOMIAL(B:XFD, 2, A5:A6)"), Is.EqualTo(3087564480d));
         }
 
         [Test]
         public void Multinomial_doesnt_accept_negative_values()
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("MULTINOMIAL(5, -1)"));
+            Assert.That(XLWorkbook.EvaluateExpr("MULTINOMIAL(5, -1)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
@@ -1622,17 +1676,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "1 2/2";
             ws.Cell("A4").Value = "one";
 
-            // True is not converted
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MULTINOMIAL(A1:A2)"));
+            Assert.Multiple(() =>
+            {
+                // True is not converted
+                Assert.That(ws.Evaluate("MULTINOMIAL(A1:A2)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Text is coerced
-            Assert.AreEqual(21, ws.Evaluate("MULTINOMIAL(A2:A3)"));
+                // Text is coerced
+                Assert.That(ws.Evaluate("MULTINOMIAL(A2:A3)"), Is.EqualTo(21));
 
-            // Text is coerced, errors are propagates
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("MULTINOMIAL(A2:A4)"));
+                // Text is coerced, errors are propagates
+                Assert.That(ws.Evaluate("MULTINOMIAL(A2:A4)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Errors are propagates
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("MULTINOMIAL(5, #DIV/0!)"));
+                // Errors are propagates
+                Assert.That(ws.Evaluate("MULTINOMIAL(5, #DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
+            });
         }
 
         [TestCase(1.5, ExpectedResult = 3)]
@@ -1651,7 +1708,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Pi()
         {
-            Assert.AreEqual(Math.PI, XLWorkbook.EvaluateExpr("PI()"));
+            Assert.That(XLWorkbook.EvaluateExpr("PI()"), Is.EqualTo(Math.PI));
         }
 
         [TestCase(2, 3, ExpectedResult = 8)]
@@ -1667,48 +1724,54 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Power_errors()
         {
-            // Negative base and fractional exponent
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("POWER(-5, 0.5)"));
+            Assert.Multiple(() =>
+            {
+                // Negative base and fractional exponent
+                Assert.That(XLWorkbook.EvaluateExpr("POWER(-5, 0.5)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Spec says this should be #DIV/0!, but Excel says #NUM!
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("POWER(0, 0)"));
+                // Spec says this should be #DIV/0!, but Excel says #NUM!
+                Assert.That(XLWorkbook.EvaluateExpr("POWER(0, 0)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // base is zero and exponent is negative -> #NUM!
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("POWER(0, -5)"));
+                // base is zero and exponent is negative -> #NUM!
+                Assert.That(XLWorkbook.EvaluateExpr("POWER(0, -5)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Result is not representable (e.g. out fo range)
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("POWER(1e+100, 1e+100)"));
+                // Result is not representable (e.g. out fo range)
+                Assert.That(XLWorkbook.EvaluateExpr("POWER(1e+100, 1e+100)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
         public void Product()
         {
-            Assert.AreEqual(24d, XLWorkbook.EvaluateExpr("PRODUCT(2,3,4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(2,3,4)"), Is.EqualTo(24d));
 
-            // Examples from specification
-            Assert.AreEqual(1d, XLWorkbook.EvaluateExpr("PRODUCT(1)"));
-            Assert.AreEqual(120d, XLWorkbook.EvaluateExpr("PRODUCT(1,2,3,4,5)"));
-            Assert.AreEqual(24d, XLWorkbook.EvaluateExpr("PRODUCT({1,2;3,4})"));
-            Assert.AreEqual(120d, XLWorkbook.EvaluateExpr("PRODUCT({2,3},4,\"5\")"));
+                // Examples from specification
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(1)"), Is.EqualTo(1d));
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(1,2,3,4,5)"), Is.EqualTo(120d));
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT({1,2;3,4})"), Is.EqualTo(24d));
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT({2,3},4,\"5\")"), Is.EqualTo(120d));
 
-            // If no arguments are passed, return 0
-            Assert.AreEqual(0, XLWorkbook.EvaluateExpr("PRODUCT({\"hello\"})"));
+                // If no arguments are passed, return 0
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT({\"hello\"})"), Is.EqualTo(0));
 
-            // Scalar blank is skipped
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("PRODUCT(IF(TRUE,), 1)"));
+                // Scalar blank is skipped
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(IF(TRUE,), 1)"), Is.EqualTo(1));
 
-            // Scalar logical is converted to number
-            Assert.AreEqual(0, XLWorkbook.EvaluateExpr("PRODUCT(FALSE, 1)"));
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr("PRODUCT(2, TRUE)"));
+                // Scalar logical is converted to number
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(FALSE, 1)"), Is.EqualTo(0));
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(2, TRUE)"), Is.EqualTo(2));
 
-            // Scalar text is converted to number
-            Assert.AreEqual(5, XLWorkbook.EvaluateExpr("PRODUCT(\"5\")"));
+                // Scalar text is converted to number
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(\"5\")"), Is.EqualTo(5));
 
-            // Scalar text that is not convertible return error
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("PRODUCT(1, \"Hello\")"));
+                // Scalar text that is not convertible return error
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(1, \"Hello\")"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(5, XLWorkbook.EvaluateExpr("PRODUCT({5, \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT({5, \"Hello\", FALSE, TRUE})"), Is.EqualTo(5));
+            });
 
             // Reference argument only uses number, ignores blanks, logical and text
             using var wb = new XLWorkbook();
@@ -1719,17 +1782,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A4").Value = "hello";
             ws.Cell("A5").Value = 2;
             ws.Cell("A6").Value = 3;
-            Assert.AreEqual(6, ws.Evaluate("PRODUCT(A1:A6)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("PRODUCT(A1:A6)"), Is.EqualTo(6));
 
-            // Scalar error is propagated
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr("PRODUCT(1, #NULL!)"));
+                // Scalar error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT(1, #NULL!)"), Is.EqualTo(XLError.NullValue));
 
-            // Array error is propagated
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr("PRODUCT({1, #NULL!})"));
+                // Array error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr("PRODUCT({1, #NULL!})"), Is.EqualTo(XLError.NullValue));
+            });
 
             // Reference error is propagated
             ws.Cell("A1").Value = XLError.NoValueAvailable;
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("PRODUCT(A1)"));
+            Assert.That(ws.Evaluate("PRODUCT(A1)"), Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [TestCase(5, 2, ExpectedResult = 2)]
@@ -1745,7 +1811,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Quotient_errors()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("QUOTIENT(1, 0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("QUOTIENT(1, 0)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [TestCase(270, ExpectedResult = 4.71238898038469)]
@@ -1775,10 +1841,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.That(randomNumber, Is.GreaterThanOrEqualTo(10).And.LessThanOrEqualTo(20));
             }
 
-            Assert.AreEqual(101, (double)XLWorkbook.EvaluateExpr("RANDBETWEEN(100.5, 100.9)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("RANDBETWEEN(100.9, 100.5)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("RANDBETWEEN(20, 5)"));
-            Assert.That((double)XLWorkbook.EvaluateExpr("RANDBETWEEN(1E+100, 1E+110)"), Is.GreaterThanOrEqualTo(1E+100).And.LessThanOrEqualTo(1E+110));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)XLWorkbook.EvaluateExpr("RANDBETWEEN(100.5, 100.9)"), Is.EqualTo(101));
+                Assert.That(XLWorkbook.EvaluateExpr("RANDBETWEEN(100.9, 100.5)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That(XLWorkbook.EvaluateExpr("RANDBETWEEN(20, 5)"), Is.EqualTo(XLError.NumberInvalid));
+                Assert.That((double)XLWorkbook.EvaluateExpr("RANDBETWEEN(1E+100, 1E+110)"), Is.GreaterThanOrEqualTo(1E+100).And.LessThanOrEqualTo(1E+110));
+            });
         }
 
         [TestCase(1, 0, ExpectedResult = "I")]
@@ -1798,27 +1867,33 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Roman_value_0_is_empty_string()
         {
-            Assert.AreEqual(string.Empty, XLWorkbook.EvaluateExpr("ROMAN(0, 0)"));
+            Assert.That(XLWorkbook.EvaluateExpr("ROMAN(0, 0)"), Is.EqualTo(""));
         }
 
         [Test]
         public void Roman_has_optional_second_argument_with_default_value_0()
         {
-            Assert.AreEqual(@"CMXCIX", XLWorkbook.EvaluateExpr("ROMAN(999)"));
+            Assert.That(XLWorkbook.EvaluateExpr("ROMAN(999)"), Is.EqualTo(@"CMXCIX"));
         }
 
         [Test]
         public void Roman_form_must_be_between_0_and_4()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(1, -1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(1, 5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("ROMAN(1, -1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("ROMAN(1, 5)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Roman_value_must_be_between_0_and_3999()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(-1, 0)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("ROMAN(4000, 0)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("ROMAN(-1, 0)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("ROMAN(4000, 0)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [TestCase(2.15, 1, ExpectedResult = 2.2)]
@@ -1898,7 +1973,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Sinh(string arg, object result)
         {
             var actual = XLWorkbook.EvaluateExpr($"SINH({arg})");
-            Assert.AreEqual(result, actual);
+            Assert.That(actual, Is.EqualTo(result));
         }
 
         [TestCase(0, 1)]
@@ -1945,11 +2020,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Sec_returns_correct_number(double angle, double expectedOutput)
         {
             var result = (double)XLWorkbook.EvaluateExpr($"SEC({angle})");
-            Assert.AreEqual(expectedOutput, result, 0.00001);
+            Assert.That(result, Is.EqualTo(expectedOutput).Within(0.00001));
 
             // as the secant is symmetric for positive and negative numbers, let's assert twice:
             var resultForNegative = (double)XLWorkbook.EvaluateExpr($"SEC({-angle})");
-            Assert.AreEqual(expectedOutput, resultForNegative, 0.00001);
+            Assert.That(resultForNegative, Is.EqualTo(expectedOutput).Within(0.00001));
         }
 
         [TestCase(-9, 0.00024682)]
@@ -1967,18 +2042,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Sech_returns_correct_number(double angle, double expectedOutput)
         {
             var result = (double)XLWorkbook.EvaluateExpr($"SECH({angle})");
-            Assert.AreEqual(expectedOutput, result, 0.00001);
+            Assert.That(result, Is.EqualTo(expectedOutput).Within(0.00001));
 
             // as the secant is symmetric for positive and negative numbers, let's assert twice:
             var resultForNegative = (double)XLWorkbook.EvaluateExpr($"SECH({-angle})");
-            Assert.AreEqual(expectedOutput, resultForNegative, 0.00001);
+            Assert.That(resultForNegative, Is.EqualTo(expectedOutput).Within(0.00001));
         }
 
         [Test]
         [DefaultFloatingPointTolerance(tolerance)]
         public void SeriesSum()
         {
-            Assert.AreEqual(40.0, XLWorkbook.EvaluateExpr("SERIESSUM(2,3,4,5)"));
+            Assert.That(XLWorkbook.EvaluateExpr("SERIESSUM(2,3,4,5)"), Is.EqualTo(40.0));
 
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet1");
@@ -1989,7 +2064,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A6").FormulaA1 = "-1/FACT(6)";
 
             var actual = ws.Evaluate("SERIESSUM(A2,0,2,A3:A6)");
-            Assert.AreEqual(0.70710321482284566, actual);
+            Assert.That(actual, Is.EqualTo(0.70710321482284566));
         }
 
         [TestCase("{1,2,3;4,5,6}")]
@@ -1997,7 +2072,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("{1,2;3,4;5,6}")]
         public void SeriesSum_takes_coefficients_row_by_row_left_to_right(string array)
         {
-            Assert.AreEqual(1284, XLWorkbook.EvaluateExpr($"SERIESSUM(2,2,1,{array})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"SERIESSUM(2,2,1,{array})"), Is.EqualTo(1284));
         }
 
         [Test]
@@ -2006,8 +2081,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").InsertData(new object[] { 1, 2, 3, 4, 5 });
-            Assert.AreEqual(3E+300, ws.Evaluate("SERIESSUM(10,100,100,A1:A3)"));
-            Assert.AreEqual(XLError.NumberInvalid, ws.Evaluate("SERIESSUM(10,100,100,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("SERIESSUM(10,100,100,A1:A3)"), Is.EqualTo(3E+300));
+                Assert.That(ws.Evaluate("SERIESSUM(10,100,100,A1:A4)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
@@ -2016,10 +2094,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // For some weird reason, SERIESSUM doesn't convert logical
             foreach (var invalidValue in new[] { "\"\"", "TRUE" })
             {
-                Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"SERIESSUM({invalidValue},1,1,1)"));
-                Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"SERIESSUM(1,{invalidValue},1,1)"));
-                Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"SERIESSUM(1,1,{invalidValue},1)"));
-                Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"SERIESSUM(1,1,1,{invalidValue})"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(XLWorkbook.EvaluateExpr($"SERIESSUM({invalidValue},1,1,1)"), Is.EqualTo(XLError.IncompatibleValue));
+                    Assert.That(XLWorkbook.EvaluateExpr($"SERIESSUM(1,{invalidValue},1,1)"), Is.EqualTo(XLError.IncompatibleValue));
+                    Assert.That(XLWorkbook.EvaluateExpr($"SERIESSUM(1,1,{invalidValue},1)"), Is.EqualTo(XLError.IncompatibleValue));
+                    Assert.That(XLWorkbook.EvaluateExpr($"SERIESSUM(1,1,1,{invalidValue})"), Is.EqualTo(XLError.IncompatibleValue));
+                });
             }
 
             // Blank and text values are coerced to a number
@@ -2027,20 +2108,23 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             foreach (var validArg in new[] { "A1", "\"0 0/2\"" })
             {
-                Assert.AreEqual(0, ws.Evaluate($"SERIESSUM({validArg},1,1,1)"));
-                Assert.AreEqual(1, ws.Evaluate($"SERIESSUM(1,{validArg},1,1)"));
-                Assert.AreEqual(1, ws.Evaluate($"SERIESSUM(1,1,{validArg},1)"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.Evaluate($"SERIESSUM({validArg},1,1,1)"), Is.EqualTo(0));
+                    Assert.That(ws.Evaluate($"SERIESSUM(1,{validArg},1,1)"), Is.EqualTo(1));
+                    Assert.That(ws.Evaluate($"SERIESSUM(1,1,{validArg},1)"), Is.EqualTo(1));
+                });
             }
 
             // Text is not converted in an area and causes conversion error
             ws.Cell("B2").Value = "0";
             ws.Cell("B3").Value = 5;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SERIESSUM(1,1,1,B2:B3)"));
+            Assert.That(ws.Evaluate("SERIESSUM(1,1,1,B2:B3)"), Is.EqualTo(XLError.IncompatibleValue));
 
             // Blank is interpreted as 0
             ws.Cell("C1").Value = Blank.Value;
             ws.Cell("C2").Value = 2;
-            Assert.AreEqual(2, ws.Evaluate("SERIESSUM(1,1,1,C1:C2)"));
+            Assert.That(ws.Evaluate("SERIESSUM(1,1,1,C1:C2)"), Is.EqualTo(2));
         }
 
         [TestCase(0, 0)]
@@ -2049,26 +2133,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1E+300, 1E+150)]
         public void Sqrt(double x, double result)
         {
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"SQRT({x})"), tolerance);
+            Assert.That((double)XLWorkbook.EvaluateExpr($"SQRT({x})"), Is.EqualTo(result).Within(tolerance));
         }
 
         [TestCase(-1)]
         [TestCase(-0.0001)]
         public void Sqrt_returns_invalid_number_for_negative_numbers(double x)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"SQRT({x})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"SQRT({x})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
         public void SqrtPi()
         {
             var actual = (double)XLWorkbook.EvaluateExpr("SQRTPI(1)");
-            Assert.AreEqual(1.7724538509055159, actual, tolerance);
+            Assert.That(actual, Is.EqualTo(1.7724538509055159).Within(tolerance));
 
             actual = (double)XLWorkbook.EvaluateExpr("SQRTPI(2)");
-            Assert.AreEqual(2.5066282746310002, actual, tolerance);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Is.EqualTo(2.5066282746310002).Within(tolerance));
 
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("SQRTPI(-1)"));
+                Assert.That(XLWorkbook.EvaluateExpr("SQRTPI(-1)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
@@ -2077,12 +2164,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Non-existent functions return error
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUBTOTAL(0, A1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUBTOTAL(0.9, A1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUBTOTAL(12, A1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUBTOTAL(100.9, A1)"));
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUBTOTAL(112, A1)"));
+            Assert.Multiple(() =>
+            {
+                // Non-existent functions return error
+                Assert.That(ws.Evaluate("SUBTOTAL(0, A1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Evaluate("SUBTOTAL(0.9, A1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Evaluate("SUBTOTAL(12, A1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Evaluate("SUBTOTAL(100.9, A1)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(ws.Evaluate("SUBTOTAL(112, A1)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
@@ -2095,11 +2185,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").FormulaA1 = "SUBTOTAL(1,A1,A2)";
             ws.Cell("A4").Value = "A";
 
-            Assert.AreEqual(2.5, ws.Cell("A3").Value);
-            Assert.AreEqual(2.5, ws.Evaluate("SUBTOTAL(1, A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(2.5));
+                Assert.That(ws.Evaluate("SUBTOTAL(1, A1:A4)"), Is.EqualTo(2.5));
+            });
 
             ws.Row(2).Hide();
-            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(101, A1:A4)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(101, A1:A4)"), Is.EqualTo(2));
         }
 
         [Test]
@@ -2152,22 +2245,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A41").FormulaA1 = "PRODUCT(SUBTOTAL(A4+1, A35:A40), 2)"; // formula with link as parameter in subtotal
             ws.Cell("A42").FormulaA1 = "PRODUCT(SUBTOTAL(A4+1, A35:A40), 2) + SUBTOTAL(A4+1, A35:A40)"; // two subtotals in one formula
 
-            Assert.AreEqual(6, ws.Cell("A3").Value);
-            Assert.AreEqual(24, ws.Cell("A6").Value);
-            Assert.AreEqual(192, ws.Cell("A12").Value);
-            Assert.AreEqual(1118, ws.Cell("A14").Value);
-            Assert.AreEqual(3114, ws.Cell("A17").Value);
-            Assert.AreEqual(7168, ws.Cell("A19").Value);
-            Assert.AreEqual(57344, ws.Cell("A23").Value);
-            Assert.AreEqual(245760, ws.Cell("A26").Value);
-            Assert.AreEqual(131072, ws.Cell("A29").Value);
-            Assert.AreEqual(786432, ws.Cell("A30").Value);
-            Assert.AreEqual(1097728, ws.Cell("A33").Value);
-            Assert.AreEqual(16834654, ws.Cell("A34").Value);
-            Assert.AreEqual(1835008, ws.Cell("A36").Value);
-            Assert.AreEqual(6291456, ws.Cell("A39").Value);
-            Assert.AreEqual(31457280, ws.Cell("A41").Value);
-            Assert.AreEqual(47185920, ws.Cell("A42").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(6));
+                Assert.That(ws.Cell("A6").Value, Is.EqualTo(24));
+                Assert.That(ws.Cell("A12").Value, Is.EqualTo(192));
+                Assert.That(ws.Cell("A14").Value, Is.EqualTo(1118));
+                Assert.That(ws.Cell("A17").Value, Is.EqualTo(3114));
+                Assert.That(ws.Cell("A19").Value, Is.EqualTo(7168));
+                Assert.That(ws.Cell("A23").Value, Is.EqualTo(57344));
+                Assert.That(ws.Cell("A26").Value, Is.EqualTo(245760));
+                Assert.That(ws.Cell("A29").Value, Is.EqualTo(131072));
+                Assert.That(ws.Cell("A30").Value, Is.EqualTo(786432));
+                Assert.That(ws.Cell("A33").Value, Is.EqualTo(1097728));
+                Assert.That(ws.Cell("A34").Value, Is.EqualTo(16834654));
+                Assert.That(ws.Cell("A36").Value, Is.EqualTo(1835008));
+                Assert.That(ws.Cell("A39").Value, Is.EqualTo(6291456));
+                Assert.That(ws.Cell("A41").Value, Is.EqualTo(31457280));
+                Assert.That(ws.Cell("A42").Value, Is.EqualTo(47185920));
+            });
         }
 
         [Test]
@@ -2198,12 +2294,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Row(2).Hide();
             ws.Row(5).Hide();
 
-            Assert.AreEqual(1, ws.Cell("A3").Value);
-            Assert.AreEqual(2, ws.Cell("B3").Value);
-            Assert.AreEqual(0, ws.Cell("C3").Value);
-            Assert.AreEqual(17, ws.Cell("A6").Value);
-            Assert.AreEqual(34, ws.Cell("B6").Value);
-            Assert.AreEqual(64, ws.Cell("C6").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("B3").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("C3").Value, Is.EqualTo(0));
+                Assert.That(ws.Cell("A6").Value, Is.EqualTo(17));
+                Assert.That(ws.Cell("B6").Value, Is.EqualTo(34));
+                Assert.That(ws.Cell("C6").Value, Is.EqualTo(64));
+            });
         }
 
         [Test]
@@ -2216,11 +2315,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(2,A1:A3)";
 
-            Assert.AreEqual(2, ws.Cell("A4").Value);
-            Assert.AreEqual(1, ws.Evaluate("SUBTOTAL(2,A2:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(2));
+                Assert.That(ws.Evaluate("SUBTOTAL(2,A2:A4)"), Is.EqualTo(1));
+            });
 
             ws.Row(2).Hide();
-            Assert.AreEqual(1, ws.Evaluate("SUBTOTAL(102,A1:A4)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(102,A1:A4)"), Is.EqualTo(1));
         }
 
         [Test]
@@ -2233,11 +2335,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = string.Empty;
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(3,A1,A2,A3)";
 
-            Assert.AreEqual(3, ws.Cell("A4").Value);
-            Assert.AreEqual(3, ws.Evaluate("SUBTOTAL(3,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(3));
+                Assert.That(ws.Evaluate("SUBTOTAL(3,A1:A4)"), Is.EqualTo(3));
+            });
 
             ws.Row(1).Hide();
-            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(103,A1:A4)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(103,A1:A4)"), Is.EqualTo(2));
         }
 
         [Test]
@@ -2250,12 +2355,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(4,A1,A2,A3) + 10";
 
-            Assert.AreEqual(13, ws.Cell("A4").Value);
-            Assert.AreEqual(3, ws.Evaluate("SUBTOTAL(4,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(13));
+                Assert.That(ws.Evaluate("SUBTOTAL(4,A1:A4)"), Is.EqualTo(3));
+            });
 
             ws.Cell("A5").Value = 2.5;
             ws.Row(2).Hide();
-            Assert.AreEqual(2.5, ws.Evaluate("SUBTOTAL(104,A1:A5)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(104,A1:A5)"), Is.EqualTo(2.5));
         }
 
         [Test]
@@ -2268,12 +2376,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(5,A1,A2,A3) - 10";
 
-            Assert.AreEqual(-8, ws.Cell("A4").Value);
-            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(5,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(-8));
+                Assert.That(ws.Evaluate("SUBTOTAL(5,A1:A4)"), Is.EqualTo(2));
+            });
 
             ws.Cell("A5").Value = 2.5;
             ws.Row(1).Hide();
-            Assert.AreEqual(2.5, ws.Evaluate("SUBTOTAL(105,A1:A5)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(105,A1:A5)"), Is.EqualTo(2.5));
         }
 
         [Test]
@@ -2286,12 +2397,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(6,A1,A2,A3)";
 
-            Assert.AreEqual(6, ws.Cell("A4").Value);
-            Assert.AreEqual(6, ws.Evaluate("SUBTOTAL(6,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(6));
+                Assert.That(ws.Evaluate("SUBTOTAL(6,A1:A4)"), Is.EqualTo(6));
+            });
 
             ws.Row(2).Hide();
             ws.Cell("A5").Value = 4;
-            Assert.AreEqual(8, ws.Evaluate("SUBTOTAL(106,A1:A5)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(106,A1:A5)"), Is.EqualTo(8));
         }
 
         [Test]
@@ -2306,11 +2420,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(7,A1:A3,A5)";
             ws.Cell("A5").Value = 5;
 
-            Assert.AreEqual(1.5275252316, (double)ws.Cell("A4").Value);
-            Assert.AreEqual(1.5275252316, (double)ws.Evaluate("SUBTOTAL(7,A1:A5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)ws.Cell("A4").Value, Is.EqualTo(1.5275252316));
+                Assert.That((double)ws.Evaluate("SUBTOTAL(7,A1:A5)"), Is.EqualTo(1.5275252316));
+            });
 
             ws.Row(2).Hide();
-            Assert.AreEqual(2.1213203435, (double)ws.Evaluate("SUBTOTAL(107,A1:A5)"));
+            Assert.That((double)ws.Evaluate("SUBTOTAL(107,A1:A5)"), Is.EqualTo(2.1213203435));
         }
 
         [Test]
@@ -2323,12 +2440,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(8,A1,A2,A3)";
 
-            Assert.AreEqual(0.5, ws.Cell("A4").Value);
-            Assert.AreEqual(0.5, ws.Evaluate("SUBTOTAL(8,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(0.5));
+                Assert.That(ws.Evaluate("SUBTOTAL(8,A1:A4)"), Is.EqualTo(0.5));
+            });
 
             ws.Row(2).Hide();
             ws.Cell("A5").Value = 3;
-            Assert.AreEqual(0.5, ws.Evaluate("SUBTOTAL(108,A1:A5)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(108,A1:A5)"), Is.EqualTo(0.5));
         }
 
         [Test]
@@ -2341,12 +2461,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(9,A1,A2,A3)";
 
-            Assert.AreEqual(5, ws.Cell("A4").Value);
-            Assert.AreEqual(5, ws.Evaluate("SUBTOTAL(9,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(5));
+                Assert.That(ws.Evaluate("SUBTOTAL(9,A1:A4)"), Is.EqualTo(5));
+            });
 
             ws.Row(2).Hide();
 
-            Assert.AreEqual(2, ws.Evaluate("SUBTOTAL(109, A1:A4)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(109, A1:A4)"), Is.EqualTo(2));
         }
 
         [Test]
@@ -2361,12 +2484,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = 5;
             ws.Cell("A6").FormulaA1 = "SUBTOTAL(10,A1:A5)";
 
-            Assert.AreEqual(3, ws.Cell("A6").Value);
-            Assert.AreEqual(3, ws.Evaluate("SUBTOTAL(10,A1:A6)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A6").Value, Is.EqualTo(3));
+                Assert.That(ws.Evaluate("SUBTOTAL(10,A1:A6)"), Is.EqualTo(3));
+            });
 
             ws.Row(1).Hide();
             ws.Row(5).Hide();
-            Assert.AreEqual(8, ws.Evaluate("SUBTOTAL(110,A1:A6)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(110,A1:A6)"), Is.EqualTo(8));
         }
 
         [Test]
@@ -2379,12 +2505,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "A";
             ws.Cell("A4").FormulaA1 = "SUBTOTAL(11,A1,A2,A3)";
 
-            Assert.AreEqual(0.25, ws.Cell("A4").Value);
-            Assert.AreEqual(0.25, ws.Evaluate("SUBTOTAL(11,A1:A4)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(0.25));
+                Assert.That(ws.Evaluate("SUBTOTAL(11,A1:A4)"), Is.EqualTo(0.25));
+            });
 
             ws.Row(2).Hide();
             ws.Cell("A5").Value = 4;
-            Assert.AreEqual(1, ws.Evaluate("SUBTOTAL(111,A1:A5)"));
+            Assert.That(ws.Evaluate("SUBTOTAL(111,A1:A5)"), Is.EqualTo(1));
         }
 
         [Test]
@@ -2394,23 +2523,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             IXLCell fCell = cell.SetValue(1).CellBelow().SetValue(2).CellBelow();
             fCell.FormulaA1 = "sum(A1:A2)";
 
-            Assert.AreEqual(3.0, fCell.Value);
+            Assert.That(fCell.Value, Is.EqualTo(3.0));
         }
 
         [Test]
         public void SumDateTimeAndNumber()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").Value = 1;
-                ws.Cell("A2").Value = new DateTime(2018, 1, 1);
-                Assert.AreEqual(43102, ws.Evaluate("SUM(A1:A2)"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = new DateTime(2018, 1, 1);
+            Assert.That(ws.Evaluate("SUM(A1:A2)"), Is.EqualTo(43102));
 
-                ws.Cell("A1").Value = 2;
-                ws.Cell("A2").FormulaA1 = "DATE(2018,1,1)";
-                Assert.AreEqual(43103, ws.Evaluate("SUM(A1:A2)"));
-            }
+            ws.Cell("A1").Value = 2;
+            ws.Cell("A2").FormulaA1 = "DATE(2018,1,1)";
+            Assert.That(ws.Evaluate("SUM(A1:A2)"), Is.EqualTo(43103));
         }
 
         [TestCase(9, "SUMIF(A:B, \"A*\", C:C)")]
@@ -2429,7 +2556,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             };
             ws.Cell("A1").InsertTable(data);
 
-            Assert.AreEqual(expectedOutcome, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expectedOutcome));
         }
 
         /// <summary>
@@ -2444,24 +2571,22 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(28000, "SUMIF(A1:A4, \">\" &C1, B1:B4)")]
         public void SumIf_ReturnsCorrectValues_ReferenceExample1FromMicrosoft(int expectedOutcome, string formula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                wb.ReferenceStyle = XLReferenceStyle.A1;
+            using var wb = new XLWorkbook();
+            wb.ReferenceStyle = XLReferenceStyle.A1;
 
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell(1, 1).Value = 100000;
-                ws.Cell(1, 2).Value = 7000;
-                ws.Cell(2, 1).Value = 200000;
-                ws.Cell(2, 2).Value = 14000;
-                ws.Cell(3, 1).Value = 300000;
-                ws.Cell(3, 2).Value = 21000;
-                ws.Cell(4, 1).Value = 400000;
-                ws.Cell(4, 2).Value = 28000;
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell(1, 1).Value = 100000;
+            ws.Cell(1, 2).Value = 7000;
+            ws.Cell(2, 1).Value = 200000;
+            ws.Cell(2, 2).Value = 14000;
+            ws.Cell(3, 1).Value = 300000;
+            ws.Cell(3, 2).Value = 21000;
+            ws.Cell(4, 1).Value = 400000;
+            ws.Cell(4, 2).Value = 28000;
 
-                ws.Cell(1, 3).Value = 300000;
+            ws.Cell(1, 3).Value = 300000;
 
-                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
-            }
+            Assert.That((double)ws.Evaluate(formula), Is.EqualTo(expectedOutcome));
         }
 
         /// <summary>
@@ -2476,81 +2601,75 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(400, "SUMIF(A2:A7, \"\", C2:C7)")]
         public void SumIf_ReturnsCorrectValues_ReferenceExample2FromMicrosoft(int expectedOutcome, string formula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                wb.ReferenceStyle = XLReferenceStyle.A1;
+            using var wb = new XLWorkbook();
+            wb.ReferenceStyle = XLReferenceStyle.A1;
 
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell(2, 1).Value = "Vegetables";
-                ws.Cell(3, 1).Value = "Vegetables";
-                ws.Cell(4, 1).Value = "Fruits";
-                ws.Cell(5, 1).Value = "";
-                ws.Cell(6, 1).Value = "Vegetables";
-                ws.Cell(7, 1).Value = "Fruits";
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell(2, 1).Value = "Vegetables";
+            ws.Cell(3, 1).Value = "Vegetables";
+            ws.Cell(4, 1).Value = "Fruits";
+            ws.Cell(5, 1).Value = "";
+            ws.Cell(6, 1).Value = "Vegetables";
+            ws.Cell(7, 1).Value = "Fruits";
 
-                ws.Cell(2, 2).Value = "Tomatoes";
-                ws.Cell(3, 2).Value = "Celery";
-                ws.Cell(4, 2).Value = "Oranges";
-                ws.Cell(5, 2).Value = "Butter";
-                ws.Cell(6, 2).Value = "Carrots";
-                ws.Cell(7, 2).Value = "Apples";
+            ws.Cell(2, 2).Value = "Tomatoes";
+            ws.Cell(3, 2).Value = "Celery";
+            ws.Cell(4, 2).Value = "Oranges";
+            ws.Cell(5, 2).Value = "Butter";
+            ws.Cell(6, 2).Value = "Carrots";
+            ws.Cell(7, 2).Value = "Apples";
 
-                ws.Cell(2, 3).Value = 2300;
-                ws.Cell(3, 3).Value = 5500;
-                ws.Cell(4, 3).Value = 800;
-                ws.Cell(5, 3).Value = 400;
-                ws.Cell(6, 3).Value = 4200;
-                ws.Cell(7, 3).Value = 1200;
+            ws.Cell(2, 3).Value = 2300;
+            ws.Cell(3, 3).Value = 5500;
+            ws.Cell(4, 3).Value = 800;
+            ws.Cell(5, 3).Value = 400;
+            ws.Cell(6, 3).Value = 4200;
+            ws.Cell(7, 3).Value = 1200;
 
-                ws.Cell(1, 3).Value = 300000;
+            ws.Cell(1, 3).Value = 300000;
 
-                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
-            }
+            Assert.That((double)ws.Evaluate(formula), Is.EqualTo(expectedOutcome));
         }
 
         [Test]
         public void SumIf_ReturnsCorrectValues_WhenCalledOnFullColumn()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Data");
+            var data = new object[]
             {
-                var ws = wb.AddWorksheet("Data");
-                var data = new object[]
-                {
-                    new { Id = "A", Value = 2},
-                    new { Id = "B", Value = 3},
-                    new { Id = "C", Value = 2},
-                    new { Id = "A", Value = 1},
-                    new { Id = "B", Value = 4}
-                };
-                ws.Cell("A1").InsertTable(data);
-                var formula = "=SUMIF(A:A,\"=A\",B:B)";
-                var value = ws.Evaluate(formula);
-                Assert.AreEqual(3, value);
-            }
+                new { Id = "A", Value = 2},
+                new { Id = "B", Value = 3},
+                new { Id = "C", Value = 2},
+                new { Id = "A", Value = 1},
+                new { Id = "B", Value = 4}
+            };
+            ws.Cell("A1").InsertTable(data);
+            var formula = "=SUMIF(A:A,\"=A\",B:B)";
+            var value = ws.Evaluate(formula);
+            Assert.That(value, Is.EqualTo(3));
         }
 
         [Test]
         public void SumIf_ReturnsCorrectValues_WhenFormulaBelongToSameRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Data");
+            var data = new object[]
             {
-                var ws = wb.AddWorksheet("Data");
-                var data = new object[]
-                {
-                    new { Id = "A", Value = 2},
-                    new { Id = "B", Value = 3},
-                    new { Id = "C", Value = 2},
-                    new { Id = "A", Value = 1},
-                    new { Id = "B", Value = 4},
-                };
-                ws.Cell("A1").InsertTable(data);
-                ws.Cell("A7").SetValue("Sum A");
-                // SUMIF formula
-                var formula = "=SUMIF(A:A,\"=A\",B:B)";
-                ws.Cell("B7").SetFormulaA1(formula);
-                var value = ws.Cell("B7").Value;
-                Assert.AreEqual(3, value);
-            }
+                new { Id = "A", Value = 2},
+                new { Id = "B", Value = 3},
+                new { Id = "C", Value = 2},
+                new { Id = "A", Value = 1},
+                new { Id = "B", Value = 4},
+            };
+            ws.Cell("A1").InsertTable(data);
+            ws.Cell("A7").SetValue("Sum A");
+            // SUMIF formula
+            var formula = "=SUMIF(A:A,\"=A\",B:B)";
+            ws.Cell("B7").SetFormulaA1(formula);
+            var value = ws.Cell("B7").Value;
+            Assert.That(value, Is.EqualTo(3));
         }
 
         [Test]
@@ -2566,7 +2685,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 (40, 25, 4, 8),
                 (50, 30, 5, 10),
             });
-            Assert.AreEqual(30, ws.Evaluate("SUMIFS(C1:D5,A1:B5,\">20\")"));
+            Assert.That(ws.Evaluate("SUMIFS(C1:D5,A1:B5,\">20\")"), Is.EqualTo(30));
         }
 
         /// <summary>
@@ -2582,35 +2701,33 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(400, "SUMIFS(C2:C7, A2:A7, \"\")")]
         public void SumIfs_ReturnsCorrectValues_ReferenceExample2FromMicrosoft(int expectedResult, string formula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell(2, 1).Value = "Vegetables";
-                ws.Cell(3, 1).Value = "Vegetables";
-                ws.Cell(4, 1).Value = "Fruits";
-                ws.Cell(5, 1).Value = "";
-                ws.Cell(6, 1).Value = "Vegetables";
-                ws.Cell(7, 1).Value = "Fruits";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell(2, 1).Value = "Vegetables";
+            ws.Cell(3, 1).Value = "Vegetables";
+            ws.Cell(4, 1).Value = "Fruits";
+            ws.Cell(5, 1).Value = "";
+            ws.Cell(6, 1).Value = "Vegetables";
+            ws.Cell(7, 1).Value = "Fruits";
 
-                ws.Cell(2, 2).Value = "Tomatoes";
-                ws.Cell(3, 2).Value = "Celery";
-                ws.Cell(4, 2).Value = "Oranges";
-                ws.Cell(5, 2).Value = "Butter";
-                ws.Cell(6, 2).Value = "Carrots";
-                ws.Cell(7, 2).Value = "Apples";
+            ws.Cell(2, 2).Value = "Tomatoes";
+            ws.Cell(3, 2).Value = "Celery";
+            ws.Cell(4, 2).Value = "Oranges";
+            ws.Cell(5, 2).Value = "Butter";
+            ws.Cell(6, 2).Value = "Carrots";
+            ws.Cell(7, 2).Value = "Apples";
 
-                ws.Cell(2, 3).Value = 2300;
-                ws.Cell(3, 3).Value = 5500;
-                ws.Cell(4, 3).Value = 800;
-                ws.Cell(5, 3).Value = 400;
-                ws.Cell(6, 3).Value = 4200;
-                ws.Cell(7, 3).Value = 1200;
+            ws.Cell(2, 3).Value = 2300;
+            ws.Cell(3, 3).Value = 5500;
+            ws.Cell(4, 3).Value = 800;
+            ws.Cell(5, 3).Value = 400;
+            ws.Cell(6, 3).Value = 4200;
+            ws.Cell(7, 3).Value = 1200;
 
-                ws.Cell(1, 3).Value = 300000;
+            ws.Cell(1, 3).Value = 300000;
 
-                var actualResult = (double)ws.Evaluate(formula);
-                Assert.AreEqual(expectedResult, actualResult);
-            }
+            var actualResult = (double)ws.Evaluate(formula);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         /// <summary>
@@ -2625,22 +2742,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(28000, "SUMIFS(B1:B4, A1:A4, \">\" &C1)")]
         public void SumIfs_ReturnsCorrectValues_ReferenceExampleForSumIf1FromMicrosoft(int expectedOutcome, string formula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell(1, 1).Value = 100000;
-                ws.Cell(1, 2).Value = 7000;
-                ws.Cell(2, 1).Value = 200000;
-                ws.Cell(2, 2).Value = 14000;
-                ws.Cell(3, 1).Value = 300000;
-                ws.Cell(3, 2).Value = 21000;
-                ws.Cell(4, 1).Value = 400000;
-                ws.Cell(4, 2).Value = 28000;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell(1, 1).Value = 100000;
+            ws.Cell(1, 2).Value = 7000;
+            ws.Cell(2, 1).Value = 200000;
+            ws.Cell(2, 2).Value = 14000;
+            ws.Cell(3, 1).Value = 300000;
+            ws.Cell(3, 2).Value = 21000;
+            ws.Cell(4, 1).Value = 400000;
+            ws.Cell(4, 2).Value = 28000;
 
-                ws.Cell(1, 3).Value = 300000;
+            ws.Cell(1, 3).Value = 300000;
 
-                Assert.AreEqual(expectedOutcome, (double)ws.Evaluate(formula));
-            }
+            Assert.That((double)ws.Evaluate(formula), Is.EqualTo(expectedOutcome));
         }
 
         /// <summary>
@@ -2653,55 +2768,53 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             int expectedResult,
             string formula)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                var row = 2;
+            var row = 2;
 
-                ws.Cell(row, 1).Value = 5;
-                ws.Cell(row, 2).Value = "Apples";
-                ws.Cell(row, 3).Value = "Tom";
-                row++;
+            ws.Cell(row, 1).Value = 5;
+            ws.Cell(row, 2).Value = "Apples";
+            ws.Cell(row, 3).Value = "Tom";
+            row++;
 
-                ws.Cell(row, 1).Value = 4;
-                ws.Cell(row, 2).Value = "Apples";
-                ws.Cell(row, 3).Value = "Sarah";
-                row++;
+            ws.Cell(row, 1).Value = 4;
+            ws.Cell(row, 2).Value = "Apples";
+            ws.Cell(row, 3).Value = "Sarah";
+            row++;
 
-                ws.Cell(row, 1).Value = 15;
-                ws.Cell(row, 2).Value = "Artichokes";
-                ws.Cell(row, 3).Value = "Tom";
-                row++;
+            ws.Cell(row, 1).Value = 15;
+            ws.Cell(row, 2).Value = "Artichokes";
+            ws.Cell(row, 3).Value = "Tom";
+            row++;
 
-                ws.Cell(row, 1).Value = 3;
-                ws.Cell(row, 2).Value = "Artichokes";
-                ws.Cell(row, 3).Value = "Sarah";
-                row++;
+            ws.Cell(row, 1).Value = 3;
+            ws.Cell(row, 2).Value = "Artichokes";
+            ws.Cell(row, 3).Value = "Sarah";
+            row++;
 
-                ws.Cell(row, 1).Value = 22;
-                ws.Cell(row, 2).Value = "Bananas";
-                ws.Cell(row, 3).Value = "Tom";
-                row++;
+            ws.Cell(row, 1).Value = 22;
+            ws.Cell(row, 2).Value = "Bananas";
+            ws.Cell(row, 3).Value = "Tom";
+            row++;
 
-                ws.Cell(row, 1).Value = 12;
-                ws.Cell(row, 2).Value = "Bananas";
-                ws.Cell(row, 3).Value = "Sarah";
-                row++;
+            ws.Cell(row, 1).Value = 12;
+            ws.Cell(row, 2).Value = "Bananas";
+            ws.Cell(row, 3).Value = "Sarah";
+            row++;
 
-                ws.Cell(row, 1).Value = 10;
-                ws.Cell(row, 2).Value = "Carrots";
-                ws.Cell(row, 3).Value = "Tom";
-                row++;
+            ws.Cell(row, 1).Value = 10;
+            ws.Cell(row, 2).Value = "Carrots";
+            ws.Cell(row, 3).Value = "Tom";
+            row++;
 
-                ws.Cell(row, 1).Value = 33;
-                ws.Cell(row, 2).Value = "Carrots";
-                ws.Cell(row, 3).Value = "Sarah";
+            ws.Cell(row, 1).Value = 33;
+            ws.Cell(row, 2).Value = "Carrots";
+            ws.Cell(row, 3).Value = "Sarah";
 
-                var actualResult = ws.Evaluate(formula);
+            var actualResult = ws.Evaluate(formula);
 
-                Assert.AreEqual(expectedResult, (double)actualResult, tolerance);
-            }
+            Assert.That((double)actualResult, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [TestCase("SUMIFS(D1:E5,A1:B5,\"A*\",C1:C5,\">2\")")]
@@ -2711,7 +2824,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("SUMIFS(A1:A3, B1:B3,\"<>B\")", 11)]
@@ -2727,7 +2840,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B2").Value = string.Empty;
             ws.Cell("B3").Value = "B";
 
-            Assert.AreEqual(expectedSum, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expectedSum));
         }
 
         [Test]
@@ -2739,43 +2852,49 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.FirstCell().InsertData(Enumerable.Range(1, 10));
             ws.FirstCell().CellRight().InsertData(Enumerable.Range(1, 10).Reverse());
 
-            Assert.AreEqual(2, ws.Evaluate("SUMPRODUCT(A2)"));
-            Assert.AreEqual(55, ws.Evaluate("SUMPRODUCT(A1:A10)"));
-            Assert.AreEqual(220, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("SUMPRODUCT(A2)"), Is.EqualTo(2));
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1:A10)"), Is.EqualTo(55));
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"), Is.EqualTo(220));
 
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B5)"));
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1:A10, B1:B5)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Scalar, one element array and single cell area are compatible
-            Assert.AreEqual(60, ws.Evaluate("SUMPRODUCT(A5, 4, {3})"));
+                // Scalar, one element array and single cell area are compatible
+                Assert.That(ws.Evaluate("SUMPRODUCT(A5, 4, {3})"), Is.EqualTo(60));
 
-            // An array can be an argument
-            Assert.AreEqual(10, ws.Evaluate("SUMPRODUCT(A1:A3, {3;2;1})"));
+                // An array can be an argument
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1:A3, {3;2;1})"), Is.EqualTo(10));
 
-            // An array must have correct orientation, otherwise dimensions don't match
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUMPRODUCT(A1:A3, {3,2,1})"));
+                // An array must have correct orientation, otherwise dimensions don't match
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1:A3, {3,2,1})"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Anything but number is counted as zero. The second array is zero for all values = result is 0.
-            Assert.AreEqual(0, ws.Evaluate("SUMPRODUCT({1,2,3,4}, {TRUE,FALSE,\"1\",\"\"})"));
+                // Anything but number is counted as zero. The second array is zero for all values = result is 0.
+                Assert.That(ws.Evaluate("SUMPRODUCT({1,2,3,4}, {TRUE,FALSE,\"1\",\"\"})"), Is.EqualTo(0));
 
-            // Any error returns error
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("SUMPRODUCT({1,2}, {1,#N/A})"));
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("SUMPRODUCT(A1, #N/A)"));
+                // Any error returns error
+                Assert.That(ws.Evaluate("SUMPRODUCT({1,2}, {1,#N/A})"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1, #N/A)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
             ws.Cell("A2").Value = XLError.NoValueAvailable;
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("SUMPRODUCT(A2, 5)"));
+            Assert.That(ws.Evaluate("SUMPRODUCT(A2, 5)"), Is.EqualTo(XLError.NoValueAvailable));
 
             // Blank cells and cells with text should be treated as zeros
             ws.Range("A1:A5").Clear();
-            Assert.AreEqual(110, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"));
+            Assert.That(ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"), Is.EqualTo(110));
 
             // Non-number values are treated as zero
             ws.Range("A1:A5").SetValue("asdf");
-            Assert.AreEqual(110, ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("SUMPRODUCT(A1:A10, B1:B10)"), Is.EqualTo(110));
 
-            // Blank cell is considered as a blank and cause #VALUE! error
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUMPRODUCT(Z1, 5)"));
+                // Blank cell is considered as a blank and cause #VALUE! error
+                Assert.That(ws.Evaluate("SUMPRODUCT(Z1, 5)"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Blank value will cause #VALUE! error
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("SUMPRODUCT(IF(TRUE,,), 5)"));
+                // Blank value will cause #VALUE! error
+                Assert.That(ws.Evaluate("SUMPRODUCT(IF(TRUE,,), 5)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
@@ -2784,28 +2903,31 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Examples from specification
-            Assert.AreEqual(4.0, XLWorkbook.EvaluateExpr("SUMSQ(2)"));
-            Assert.AreEqual(19.21, XLWorkbook.EvaluateExpr("SUMSQ(2.5, -3.6)"));
-            Assert.AreEqual(24.97, XLWorkbook.EvaluateExpr("SUMSQ({ 2.5, -3.6}, 2.4)"));
+            Assert.Multiple(() =>
+            {
+                // Examples from specification
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(2)"), Is.EqualTo(4.0));
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(2.5, -3.6)"), Is.EqualTo(19.21));
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ({ 2.5, -3.6}, 2.4)"), Is.EqualTo(24.97));
 
-            // Scalar blank is converted to 0
-            Assert.AreEqual(16, XLWorkbook.EvaluateExpr("SUMSQ(IF(TRUE,), 4)"));
+                // Scalar blank is converted to 0
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(IF(TRUE,), 4)"), Is.EqualTo(16));
 
-            // Scalar logical is converted to number
-            Assert.AreEqual(10, XLWorkbook.EvaluateExpr("SUMSQ(3, TRUE)"));
+                // Scalar logical is converted to number
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(3, TRUE)"), Is.EqualTo(10));
 
-            // Scalar text is converted to number
-            Assert.AreEqual(25, XLWorkbook.EvaluateExpr("SUMSQ(\"4\", \"3\")"));
+                // Scalar text is converted to number
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(\"4\", \"3\")"), Is.EqualTo(25));
 
-            // Scalar text that is not convertible return error
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("SUMSQ(1, \"Hello\")"));
+                // Scalar text that is not convertible return error
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(1, \"Hello\")"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Array logical arguments are ignored
-            Assert.AreEqual(4, XLWorkbook.EvaluateExpr("SUMSQ({2,TRUE,TRUE,FALSE,FALSE})"));
+                // Array logical arguments are ignored
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ({2,TRUE,TRUE,FALSE,FALSE})"), Is.EqualTo(4));
 
-            // Array text arguments are ignored
-            Assert.AreEqual(20, XLWorkbook.EvaluateExpr("SUMSQ({4, 2, \"hello\", \"10\" })"));
+                // Array text arguments are ignored
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ({4, 2, \"hello\", \"10\" })"), Is.EqualTo(20));
+            });
 
             // Blank, logical and text from reference are ignored
             ws.Cell("A1").Value = Blank.Value;
@@ -2814,17 +2936,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A4").Value = "hello";
             ws.Cell("A5").Value = 1;
             ws.Cell("A6").Value = 4;
-            Assert.AreEqual(17, ws.Evaluate("SUMSQ(A1:A6)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("SUMSQ(A1:A6)"), Is.EqualTo(17));
 
-            // Scalar error is propagated
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr("SUMSQ(1, #NULL!)"));
+                // Scalar error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ(1, #NULL!)"), Is.EqualTo(XLError.NullValue));
 
-            // Array error is propagated
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr("SUMSQ({1, #NULL!})"));
+                // Array error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr("SUMSQ({1, #NULL!})"), Is.EqualTo(XLError.NullValue));
+            });
 
             // Reference error is propagated
             ws.Cell("A1").Value = XLError.NoValueAvailable;
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("SUMSQ(A1)"));
+            Assert.That(ws.Evaluate("SUMSQ(A1)"), Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [TestCase(-1, ExpectedResult = -1.5574077247)]
@@ -2843,7 +2968,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1E+100)]
         public void Tan_returns_invalid_number_for_radians_outside_limit(double radians)
         {
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr($"TAN({radians})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"TAN({radians})"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [TestCase(-1, -0.761594156)]
@@ -2854,7 +2979,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(tolerance)]
         public void Tanh(double number, double result)
         {
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"TANH({number})"));
+            Assert.That((double)XLWorkbook.EvaluateExpr($"TANH({number})"), Is.EqualTo(result));
         }
 
         [TestCase(27.64799257, null, 27)]
@@ -2871,7 +2996,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Trunc(double number, double? digits, object expectedResult)
         {
             var formula = digits is null ? $"TRUNC({number})" : $"TRUNC({number}, {digits})";
-            Assert.AreEqual(expectedResult, (double)XLWorkbook.EvaluateExpr(formula));
+            Assert.That((double)XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase(27.64799257, -1, 20)]
@@ -2881,7 +3006,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Trunc_Specify_Digits(double input, int digits, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"TRUNC({input.ToString(CultureInfo.InvariantCulture)}, {digits})");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/ReferenceOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ReferenceOperatorsTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B3").Value = -1;
             ws.Cell("D5").FormulaA1 = "ABS(B3:B3)";
 
-            Assert.AreEqual(1, ws.Cell("D5").Value);
+            Assert.That(ws.Cell("D5").Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -27,7 +27,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B3").Value = -1;
             ws.Cell("D3").FormulaA1 = "ABS(B1:B10)";
 
-            Assert.AreEqual(1, ws.Cell("D3").Value);
+            Assert.That(ws.Cell("D3").Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B3").Value = -1;
             ws.Cell("B5").FormulaA1 = "ABS(A3:Z3)";
 
-            Assert.AreEqual(1, ws.Cell("B5").Value);
+            Assert.That(ws.Cell("B5").Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var sheet2 = wb.AddWorksheet("Sheet2");
             sheet2.Cell("D3").FormulaA1 = "ABS(Sheet1!B1:B10)";
 
-            Assert.AreEqual(1, sheet2.Cell("D3").Value);
+            Assert.That(sheet2.Cell("D3").Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B3").Value = -1;
             ws.Cell("D5").FormulaA1 = "ABS(B1:B4)";
 
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("D5").Value);
+            Assert.That(ws.Cell("D5").Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B3").Value = -1;
             ws.Cell("D3").FormulaA1 = "ABS((B1:B2,B3:B5))"; // A continous range made of two areas
 
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("D3").Value);
+            Assert.That(ws.Cell("D3").Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
@@ -84,11 +84,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B3").Value = -1;
             var horizontalIntersectionCell = ws.Cell("D3");
             horizontalIntersectionCell.FormulaA1 = "ABS(A1:B5)";
-            Assert.AreEqual(XLError.IncompatibleValue, horizontalIntersectionCell.Value);
+            Assert.That(horizontalIntersectionCell.Value, Is.EqualTo(XLError.IncompatibleValue));
 
             var verticalIntersectionCell = ws.Cell("B5");
             verticalIntersectionCell.FormulaA1 = "ABS(A3:C4)";
-            Assert.AreEqual(XLError.IncompatibleValue, verticalIntersectionCell.Value);
+            Assert.That(verticalIntersectionCell.Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         #endregion
@@ -113,7 +113,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cells("A1:Z100").Value = 1;
 
             var referenceCells = ws.Evaluate($"SUM({referenceFormula})");
-            Assert.AreEqual(expectedCellCount, referenceCells);
+            Assert.That(referenceCells, Is.EqualTo(expectedCellCount));
         }
 
         [TestCase("Sheet1!A1:C5")]
@@ -127,7 +127,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var secondSheet = wb.AddWorksheet("Sheet2");
             secondSheet.Cell("A1").FormulaA1 = $"=SUM({formula})";
 
-            Assert.AreEqual(15, secondSheet.Cell("A1").Value);
+            Assert.That(secondSheet.Cell("A1").Value, Is.EqualTo(15));
         }
 
         [TestCase("Current!A1:Other!B2")]
@@ -143,7 +143,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var formulaSheet = wb.AddWorksheet("Current");
             wb.AddWorksheet("Other");
 
-            Assert.AreEqual(XLError.IncompatibleValue, formulaSheet.Evaluate($"SUM({referenceFormula})"));
+            Assert.That(formulaSheet.Evaluate($"SUM({referenceFormula})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("A1:IF(TRUE,1,)")]
@@ -155,7 +155,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var sheet = wb.AddWorksheet();
 
-            Assert.AreEqual(XLError.IncompatibleValue, sheet.Evaluate($"SUM({referenceFormula})"));
+            Assert.That(sheet.Evaluate($"SUM({referenceFormula})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         #endregion
@@ -183,7 +183,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Not extra braces, so the comma is interpreted as union and not an extra argument
             var value = currentSheet.Evaluate($"SUM(({formula}))");
 
-            Assert.AreEqual(expectedSum, value);
+            Assert.That(value, Is.EqualTo(expectedSum));
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StatisticalTests.cs
@@ -11,27 +11,37 @@ namespace ClosedXML.Tests.Excel.CalcEngine
     {
         private const double tolerance = 1e-6;
         private XLWorkbook workbook;
+        
+        [TearDown]
+        public void Cleanup()
+        {
+            workbook.Dispose();
+        }
+        
 
         [Test]
         public void Average()
         {
             double value;
             value = (double)workbook.Evaluate("AVERAGE(-27.5,93.93,64.51,-70.56)");
-            Assert.AreEqual(15.095, value, tolerance);
+            Assert.That(value, Is.EqualTo(15.095).Within(tolerance));
 
             var ws = workbook.Worksheets.First();
             value = (double)ws.Evaluate("AVERAGE(G3:G45)");
-            Assert.AreEqual(49.3255814, value, tolerance);
+            Assert.Multiple(() =>
+            {
+                Assert.That(value, Is.EqualTo(49.3255814).Within(tolerance));
 
-            // Column D contains only strings - no average, because non-number types are skipped
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("AVERAGE(D3:D45)"));
+                // Column D contains only strings - no average, because non-number types are skipped
+                Assert.That(ws.Evaluate("AVERAGE(D3:D45)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Non-numbers in array are skipped instead of being converted
-            Assert.AreEqual(-1, ws.Evaluate("AVERAGE({FALSE, TRUE, \"1\", \"0 0/2\", -1})"));
+                // Non-numbers in array are skipped instead of being converted
+                Assert.That(ws.Evaluate("AVERAGE({FALSE, TRUE, \"1\", \"0 0/2\", -1})"), Is.EqualTo(-1));
+            });
 
             // Blank value in references are skipped
             ws.Cell("Z1").Value = Blank.Value;
-            Assert.AreEqual(1, ws.Evaluate("AVERAGE(Z1,1)"));
+            Assert.That(ws.Evaluate("AVERAGE(Z1,1)"), Is.EqualTo(1));
 
             AssertScalarToNumberConversion("AVERAGE", 0.5);
             AssertAnyErrorIsPropagated("AVERAGE");
@@ -45,20 +55,23 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Examples from specification
             ws.Cell("E1").Value = Blank.Value;
-            Assert.AreEqual(10, ws.Evaluate("AVERAGEA(10, E1)"));
+            Assert.That(ws.Evaluate("AVERAGEA(10, E1)"), Is.EqualTo(10));
             ws.Cell("E2").Value = true;
-            Assert.AreEqual(5.5, ws.Evaluate("AVERAGEA(10, E2)"));
+            Assert.That(ws.Evaluate("AVERAGEA(10, E2)"), Is.EqualTo(5.5));
             ws.Cell("E3").Value = false;
-            Assert.AreEqual(5, ws.Evaluate("AVERAGEA(10, E3)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("AVERAGEA(10, E3)"), Is.EqualTo(5));
 
-            // Make sure multiple values not in an array work as intended
-            Assert.AreEqual(15.095, (double)workbook.Evaluate("AVERAGEA(-27.5,93.93,64.51,-70.56)"), tolerance);
+                // Make sure multiple values not in an array work as intended
+                Assert.That((double)workbook.Evaluate("AVERAGEA(-27.5,93.93,64.51,-70.56)"), Is.EqualTo(15.095).Within(tolerance));
 
-            // Array logical arguments are ignored
-            Assert.AreEqual(2, workbook.Evaluate("AVERAGEA({2,TRUE,TRUE,FALSE,FALSE})"));
+                // Array logical arguments are ignored
+                Assert.That(workbook.Evaluate("AVERAGEA({2,TRUE,TRUE,FALSE,FALSE})"), Is.EqualTo(2));
 
-            // Array text arguments are counted as zero (4+2+0+0)/4
-            Assert.AreEqual(1.5, workbook.Evaluate("AVERAGEA({4, 2, \"hello\", \"10\" })"));
+                // Array text arguments are counted as zero (4+2+0+0)/4
+                Assert.That(workbook.Evaluate("AVERAGEA({4, 2, \"hello\", \"10\" })"), Is.EqualTo(1.5));
+            });
 
             // Reference argument only counts logical as 0/1, text as 0 and ignores blanks.
             ws.Cell("Z1").Value = Blank.Value; // Not counted
@@ -67,7 +80,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = "hello"; // 0
             ws.Cell("Z5").Value = 0; // 0
             ws.Cell("Z6").Value = 4; // 4
-            Assert.AreEqual(1, (double)ws.Evaluate("AVERAGEA(Z1:Z6)"));
+            Assert.That((double)ws.Evaluate("AVERAGEA(Z1:Z6)"), Is.EqualTo(1));
 
             AssertScalarToNumberConversion("AVERAGEA", 0.5);
             AssertAnyErrorIsPropagated("AVERAGEA");
@@ -87,7 +100,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var nString = n.ToInvariantString();
             var pString = p.ToInvariantString();
             var result = (double)XLWorkbook.EvaluateExpr($"BINOMDIST({kString}, {nString}, {pString}, FALSE)");
-            Assert.AreEqual(expected, result, tolerance);
+            Assert.That(result, Is.EqualTo(expected).Within(tolerance));
         }
 
         [TestCase(6, 10, 0.5, 0.828125)]
@@ -103,7 +116,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var nString = n.ToInvariantString();
             var pString = p.ToInvariantString();
             var result = (double)XLWorkbook.EvaluateExpr($"BINOMDIST({kString}, {nString}, {pString}, TRUE)");
-            Assert.AreEqual(expected, result, tolerance);
+            Assert.That(result, Is.EqualTo(expected).Within(tolerance));
         }
 
         [TestCase(5, 4, 0.5)] // Five successes out of 4 attempts
@@ -118,7 +131,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var nString = n.ToInvariantString();
             var pString = p.ToInvariantString();
             var result = XLWorkbook.EvaluateExpr($"BINOMDIST({kString}, {nString}, {pString}, FALSE)");
-            Assert.AreEqual(XLError.NumberInvalid, result);
+            Assert.That(result, Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
@@ -127,39 +140,45 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
             XLCellValue value;
             value = ws.Evaluate("COUNT(D3:D45)");
-            Assert.AreEqual(0, value);
+            Assert.That(value, Is.EqualTo(0));
 
             value = ws.Evaluate("COUNT(G3:G45)");
-            Assert.AreEqual(43, value);
+            Assert.That(value, Is.EqualTo(43));
 
             value = ws.Evaluate("COUNT(G:G)");
-            Assert.AreEqual(43, value);
+            Assert.That(value, Is.EqualTo(43));
 
             value = workbook.Evaluate("COUNT(Data!G:G)");
-            Assert.AreEqual(43, value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(value, Is.EqualTo(43));
 
-            // Scalar blank, logical and text is counted as numbers
-            Assert.AreEqual(4, ws.Evaluate("COUNT(IF(TRUE,,),TRUE, FALSE, \"1\")"));
+                // Scalar blank, logical and text is counted as numbers
+                Assert.That(ws.Evaluate("COUNT(IF(TRUE,,),TRUE, FALSE, \"1\")"), Is.EqualTo(4));
 
-            // Non-number values in arrays are not counted as numbers.
-            Assert.AreEqual(0, ws.Evaluate("COUNT({TRUE,FALSE,\"1\"})"));
+                // Non-number values in arrays are not counted as numbers.
+                Assert.That(ws.Evaluate("COUNT({TRUE,FALSE,\"1\"})"), Is.EqualTo(0));
 
-            // Text is not counted as number.
-            Assert.AreEqual(0, ws.Evaluate("COUNT(\"Hello\")"));
+                // Text is not counted as number.
+                Assert.That(ws.Evaluate("COUNT(\"Hello\")"), Is.EqualTo(0));
+            });
 
             // Blank cells are not counted as numbers
             ws.Cell("Z1").Value = Blank.Value;
-            Assert.AreEqual(0, ws.Evaluate("COUNT(Z1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("COUNT(Z1)"), Is.EqualTo(0));
 
-            // Scalar errors are not propagated
-            Assert.AreEqual(1, ws.Evaluate("COUNT(1, #NULL!)"));
+                // Scalar errors are not propagated
+                Assert.That(ws.Evaluate("COUNT(1, #NULL!)"), Is.EqualTo(1));
 
-            // Array errors are not propagated
-            Assert.AreEqual(1, ws.Evaluate("COUNT({1, #NULL!})"));
+                // Array errors are not propagated
+                Assert.That(ws.Evaluate("COUNT({1, #NULL!})"), Is.EqualTo(1));
+            });
 
             // Reference errors are not propagated
             ws.Cell("Z1").Value = XLError.NullValue;
-            Assert.AreEqual(0, ws.Evaluate("COUNT(Z1)"));
+            Assert.That(ws.Evaluate("COUNT(Z1)"), Is.EqualTo(0));
         }
 
         [Test]
@@ -167,16 +186,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheets.First();
             var value = ws.Evaluate("COUNTA(D3:D45)");
-            Assert.AreEqual(43, value);
+            Assert.That(value, Is.EqualTo(43));
 
             value = ws.Evaluate("COUNTA(G3:G45)");
-            Assert.AreEqual(43, value);
+            Assert.That(value, Is.EqualTo(43));
 
             value = ws.Evaluate("COUNTA(G:G)");
-            Assert.AreEqual(44, value);
+            Assert.That(value, Is.EqualTo(44));
 
             value = workbook.Evaluate("COUNTA(Data!G:G)");
-            Assert.AreEqual(44, value);
+            Assert.That(value, Is.EqualTo(44));
         }
 
         [Test]
@@ -193,21 +212,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A7").Value = true;
             ws.Cell("A8").Value = XLError.DivisionByZero;
             ws.Cell("A9").FormulaA1 = "COUNTA(A1:B8)";
-            Assert.AreEqual(7, ws.Cell("A9").Value);
+            Assert.That(ws.Cell("A9").Value, Is.EqualTo(7));
         }
 
         [Test]
         public void CountA_on_examples_from_spec()
         {
-            Assert.AreEqual(5, XLWorkbook.EvaluateExpr("COUNTA(1,2,3,4,5)"));
-            Assert.AreEqual(5, XLWorkbook.EvaluateExpr("COUNTA(1,2,3,4,5)"));
-            Assert.AreEqual(7, XLWorkbook.EvaluateExpr("COUNTA({1,2,3,4,5},6,\"7\")"));
+            Assert.That(XLWorkbook.EvaluateExpr("COUNTA(1,2,3,4,5)"), Is.EqualTo(5));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("COUNTA(1,2,3,4,5)"), Is.EqualTo(5));
+                Assert.That(XLWorkbook.EvaluateExpr("COUNTA({1,2,3,4,5},6,\"7\")"), Is.EqualTo(7));
+            });
 
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("E2").Value = true;
-            Assert.AreEqual(1, ws.Evaluate("COUNTA(10, E1)"));
-            Assert.AreEqual(2, ws.Evaluate("COUNTA(10, E2)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("COUNTA(10, E1)"), Is.EqualTo(1));
+                Assert.That(ws.Evaluate("COUNTA(10, E2)"), Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -217,7 +242,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = wb.AddWorksheet();
             ws.Cell("A2").Value = 7;
             ws.Cell("B5").Value = false;
-            Assert.AreEqual(2, ws.Evaluate("COUNTA((A1:A4,B4:B7))"));
+            Assert.That(ws.Evaluate("COUNTA((A1:A4,B4:B7))"), Is.EqualTo(2));
         }
 
         [Test]
@@ -225,19 +250,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(0, ws.Evaluate("COUNTA(A1)"));
+            Assert.That(ws.Evaluate("COUNTA(A1)"), Is.EqualTo(0));
         }
 
         [Test]
         public void CountA_counts_blank_argument()
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr("COUNTA(IF(TRUE,,))"));
+            Assert.That(XLWorkbook.EvaluateExpr("COUNTA(IF(TRUE,,))"), Is.EqualTo(1));
         }
 
         [Test]
         public void CountA_counts_error_arguments()
         {
-            Assert.AreEqual(7, XLWorkbook.EvaluateExpr("COUNTA(#NULL!, #DIV/0!, #VALUE!, #REF!, #NAME?, #NUM!, #N/A)"));
+            Assert.That(XLWorkbook.EvaluateExpr("COUNTA(#NULL!, #DIV/0!, #VALUE!, #REF!, #NAME?, #NUM!, #N/A)"), Is.EqualTo(7));
         }
 
         [Test]
@@ -246,7 +271,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").Value = string.Empty;
-            Assert.AreEqual(2, ws.Evaluate("COUNTA(A1, \"\")"));
+            Assert.That(ws.Evaluate("COUNTA(A1, \"\")"), Is.EqualTo(2));
         }
 
         [Test]
@@ -263,24 +288,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A7").Value = "Text";
             ws.Cell("A8").Value = XLError.DivisionByZero;
 
-            // Blank and empty text value is counted as blank
-            Assert.AreEqual(1, ws.Evaluate("COUNTBLANK(A1)"));
-            Assert.AreEqual(string.Empty, ws.Cell("A6").Value);
-            Assert.AreEqual(1, ws.Evaluate("COUNTBLANK(A6)"));
+            Assert.Multiple(() =>
+            {
+                // Blank and empty text value is counted as blank
+                Assert.That(ws.Evaluate("COUNTBLANK(A1)"), Is.EqualTo(1));
+                Assert.That(ws.Cell("A6").Value, Is.EqualTo(""));
+                Assert.That(ws.Evaluate("COUNTBLANK(A6)"), Is.EqualTo(1));
 
-            // Anything else isn't counted as blank
-            Assert.AreEqual(2, ws.Evaluate("COUNTBLANK(A1:A8)"));
+                // Anything else isn't counted as blank
+                Assert.That(ws.Evaluate("COUNTBLANK(A1:A8)"), Is.EqualTo(2));
 
-            Assert.AreEqual(17179869178d, ws.Evaluate("COUNTBLANK(A:XFD)"));
+                Assert.That(ws.Evaluate("COUNTBLANK(A:XFD)"), Is.EqualTo(17179869178d));
 
-            // Check that all others argument types. The Excel grammar doesn't allow that,
-            // so use IF workaround for that.
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("COUNTBLANK(IF(TRUE,))")); // Blank
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("COUNTBLANK(IF(TRUE,FALSE))")); // Logical
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("COUNTBLANK(IF(TRUE,1))")); // Number
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("COUNTBLANK(IF(TRUE,\"\"))")); // Text
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("COUNTBLANK(IF(TRUE,#DIV/0!))")); // Error
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("COUNTBLANK(IF(TRUE,{1}))")); // Array
+                // Check that all others argument types. The Excel grammar doesn't allow that,
+                // so use IF workaround for that.
+                Assert.That(ws.Evaluate("COUNTBLANK(IF(TRUE,))"), Is.EqualTo(XLError.IncompatibleValue)); // Blank
+                Assert.That(ws.Evaluate("COUNTBLANK(IF(TRUE,FALSE))"), Is.EqualTo(XLError.IncompatibleValue)); // Logical
+                Assert.That(ws.Evaluate("COUNTBLANK(IF(TRUE,1))"), Is.EqualTo(XLError.IncompatibleValue)); // Number
+                Assert.That(ws.Evaluate("COUNTBLANK(IF(TRUE,\"\"))"), Is.EqualTo(XLError.IncompatibleValue)); // Text
+                Assert.That(ws.Evaluate("COUNTBLANK(IF(TRUE,#DIV/0!))"), Is.EqualTo(XLError.DivisionByZero)); // Error
+                Assert.That(ws.Evaluate("COUNTBLANK(IF(TRUE,{1}))"), Is.EqualTo(XLError.IncompatibleValue)); // Array
+            });
         }
 
         [Test]
@@ -289,13 +317,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
             XLCellValue value;
             value = ws.Evaluate(@"=COUNTIF(D3:D45,""Central"")");
-            Assert.AreEqual(24, value);
+            Assert.That(value, Is.EqualTo(24));
 
             value = ws.Evaluate(@"=COUNTIF(D:D,""Central"")");
-            Assert.AreEqual(24, value);
+            Assert.That(value, Is.EqualTo(24));
 
             value = workbook.Evaluate(@"=COUNTIF(Data!D:D,""Central"")");
-            Assert.AreEqual(24, value);
+            Assert.That(value, Is.EqualTo(24));
         }
 
         [TestCase(@"=COUNTIF(Data!E:E, ""J*"")", 13)]
@@ -311,7 +339,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
 
             var value = ws.Evaluate(formula);
-            Assert.AreEqual(expectedResult, value);
+            Assert.That(value, Is.EqualTo(expectedResult));
         }
 
         [TestCase(@"=COUNTIF(A1:A10, 1)", 1)]
@@ -327,7 +355,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Excel treats 1 and TRUE as unequal, but 3 and "3" as equal
             // LibreOffice Calc handles some SUMIF and COUNTIF differently, e.g. it treats 1 and TRUE as equal, but 3 and "3" differently
             var ws = workbook.Worksheet("MixedData");
-            Assert.AreEqual(expected, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expected));
         }
 
         [TestCase("x", @"=COUNTIF(A1:A1, ""?"")", 1)]
@@ -347,14 +375,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("~xyz", @"=COUNTIF(A1:A1, ""~~*"")", 1)]
         public void CountIf_MoreWildcards(string cellContent, string formula, int expectedResult)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                ws.Cell(1, 1).Value = cellContent;
+            ws.Cell(1, 1).Value = cellContent;
 
-                Assert.AreEqual(expectedResult, (double)ws.Evaluate(formula));
-            }
+            Assert.That((double)ws.Evaluate(formula), Is.EqualTo(expectedResult));
         }
 
         [TestCase("=COUNTIFS(B1:D1, \"=Yes\")", 1)]
@@ -364,32 +390,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             string formula,
             int expectedOutcome)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                ws.Cell(1, 1).Value = "Davidoski";
-                ws.Cell(1, 2).Value = "Yes";
-                ws.Cell(1, 3).Value = "No";
-                ws.Cell(1, 4).Value = "No";
+            ws.Cell(1, 1).Value = "Davidoski";
+            ws.Cell(1, 2).Value = "Yes";
+            ws.Cell(1, 3).Value = "No";
+            ws.Cell(1, 4).Value = "No";
 
-                ws.Cell(2, 1).Value = "Burke";
-                ws.Cell(2, 2).Value = "Yes";
-                ws.Cell(2, 3).Value = "Yes";
-                ws.Cell(2, 4).Value = "No";
+            ws.Cell(2, 1).Value = "Burke";
+            ws.Cell(2, 2).Value = "Yes";
+            ws.Cell(2, 3).Value = "Yes";
+            ws.Cell(2, 4).Value = "No";
 
-                ws.Cell(3, 1).Value = "Sundaram";
-                ws.Cell(3, 2).Value = "Yes";
-                ws.Cell(3, 3).Value = "Yes";
-                ws.Cell(3, 4).Value = "Yes";
+            ws.Cell(3, 1).Value = "Sundaram";
+            ws.Cell(3, 2).Value = "Yes";
+            ws.Cell(3, 3).Value = "Yes";
+            ws.Cell(3, 4).Value = "Yes";
 
-                ws.Cell(4, 1).Value = "Levitan";
-                ws.Cell(4, 2).Value = "No";
-                ws.Cell(4, 3).Value = "Yes";
-                ws.Cell(4, 4).Value = "Yes";
+            ws.Cell(4, 1).Value = "Levitan";
+            ws.Cell(4, 2).Value = "No";
+            ws.Cell(4, 3).Value = "Yes";
+            ws.Cell(4, 4).Value = "Yes";
 
-                Assert.AreEqual(expectedOutcome, ws.Evaluate(formula));
-            }
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expectedOutcome));
         }
 
         [Test]
@@ -398,13 +422,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
             XLCellValue value;
             value = ws.Evaluate(@"=COUNTIFS(D3:D45,""Central"")");
-            Assert.AreEqual(24, value);
+            Assert.That(value, Is.EqualTo(24));
 
             value = ws.Evaluate(@"=COUNTIFS(D:D,""Central"")");
-            Assert.AreEqual(24, value);
+            Assert.That(value, Is.EqualTo(24));
 
             value = workbook.Evaluate(@"=COUNTIFS(Data!D:D,""Central"")");
-            Assert.AreEqual(24, value);
+            Assert.That(value, Is.EqualTo(24));
         }
 
         [TestCase(@"=COUNTIFS(Data!E:E, ""J*"")", 13)]
@@ -420,7 +444,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
 
             var value = ws.Evaluate(formula);
-            Assert.AreEqual(expectedResult, value);
+            Assert.That(value, Is.EqualTo(expectedResult));
         }
 
         [TestCase("COUNTIFS(H1:I3, 1, D1:F2, 2)")]
@@ -429,7 +453,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [OneTimeTearDown]
@@ -468,24 +492,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-8)]
         public void Geomean()
         {
-            // Example from the specification
-            Assert.AreEqual(5.4444547024966, (double)XLWorkbook.EvaluateExpr("GEOMEAN(10.5,5.3,2.9)"));
-            Assert.AreEqual(6.6337805880630, (double)XLWorkbook.EvaluateExpr("GEOMEAN(10.5,{5.3,2.9},\"12\")"));
+            Assert.Multiple(() =>
+            {
+                // Example from the specification
+                Assert.That((double)XLWorkbook.EvaluateExpr("GEOMEAN(10.5,5.3,2.9)"), Is.EqualTo(5.4444547024966));
+                Assert.That((double)XLWorkbook.EvaluateExpr("GEOMEAN(10.5,{5.3,2.9},\"12\")"), Is.EqualTo(6.6337805880630));
 
-            // GEOMEAN isn't limited by double scale, i.e. it doesn't use naive algorithm for large number.
-            Assert.AreEqual(1.0000000000000231E+307d, (double)XLWorkbook.EvaluateExpr("GEOMEAN(1E+307, 1E+307)"));
+                // GEOMEAN isn't limited by double scale, i.e. it doesn't use naive algorithm for large number.
+                Assert.That((double)XLWorkbook.EvaluateExpr("GEOMEAN(1E+307, 1E+307)"), Is.EqualTo(1.0000000000000231E+307d));
 
-            // Scalar blank is counted as a 0
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("GEOMEAN(IF(TRUE,), 1)"));
+                // Scalar blank is counted as a 0
+                Assert.That(XLWorkbook.EvaluateExpr("GEOMEAN(IF(TRUE,), 1)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Scalar logical and text is converted to numbers
-            Assert.AreEqual(2.236067977, (double)XLWorkbook.EvaluateExpr("GEOMEAN(TRUE, \"5\")"));
+                // Scalar logical and text is converted to numbers
+                Assert.That((double)XLWorkbook.EvaluateExpr("GEOMEAN(TRUE, \"5\")"), Is.EqualTo(2.236067977));
 
-            // Non-number values in arrays are ignored.
-            Assert.AreEqual(5.916079783, (double)XLWorkbook.EvaluateExpr("GEOMEAN({TRUE, FALSE, \"1\", 7}, 5)"));
+                // Non-number values in arrays are ignored.
+                Assert.That((double)XLWorkbook.EvaluateExpr("GEOMEAN({TRUE, FALSE, \"1\", 7}, 5)"), Is.EqualTo(5.916079783));
 
-            // Scalar non-number text causes an error due to conversion.
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("GEOMEAN(\"Hello\", 5)"));
+                // Scalar non-number text causes an error due to conversion.
+                Assert.That(XLWorkbook.EvaluateExpr("GEOMEAN(\"Hello\", 5)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
 
             // Reference non-number arguments are ignored
             var ws = workbook.Worksheets.First();
@@ -495,7 +522,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = false;
             ws.Cell("Z5").Value = true;
             ws.Cell("Z6").Value = 5;
-            Assert.AreEqual(5, (double)ws.Evaluate("GEOMEAN(Z1:Z6)"));
+            Assert.That((double)ws.Evaluate("GEOMEAN(Z1:Z6)"), Is.EqualTo(5));
 
             AssertAnyErrorIsPropagated("GEOMEAN");
         }
@@ -536,15 +563,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [DefaultFloatingPointTolerance(1e-10)]
         public void Devsq_is_calculated_from_numbers()
         {
-            Assert.AreEqual(6.90666666666666, (double)XLWorkbook.EvaluateExpr("DEVSQ(5.6, 8.2, 9.2)"));
-            Assert.AreEqual(6.90666666666666, (double)XLWorkbook.EvaluateExpr("DEVSQ({ 5.6, 8.2, 9.2})"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)XLWorkbook.EvaluateExpr("DEVSQ(5.6, 8.2, 9.2)"), Is.EqualTo(6.90666666666666));
+                Assert.That((double)XLWorkbook.EvaluateExpr("DEVSQ({ 5.6, 8.2, 9.2})"), Is.EqualTo(6.90666666666666));
 
-            // Array logical arguments are ignored
-            Assert.AreEqual(0, workbook.Evaluate("DEVSQ({2,TRUE,TRUE,FALSE,FALSE})"));
-            Assert.AreEqual(2.8, (double)workbook.Evaluate("DEVSQ({2, 1, 1, 0, 0})"));
+                // Array logical arguments are ignored
+                Assert.That(workbook.Evaluate("DEVSQ({2,TRUE,TRUE,FALSE,FALSE})"), Is.EqualTo(0));
+                Assert.That((double)workbook.Evaluate("DEVSQ({2, 1, 1, 0, 0})"), Is.EqualTo(2.8));
 
-            // Array text arguments are ignored
-            Assert.AreEqual(2, workbook.Evaluate("DEVSQ({4, 2, \"hello\", \"10\" })"));
+                // Array text arguments are ignored
+                Assert.That(workbook.Evaluate("DEVSQ({4, 2, \"hello\", \"10\" })"), Is.EqualTo(2));
+            });
 
             // Non-numerical reference values are ignored.
             using var wb = new XLWorkbook();
@@ -555,7 +585,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A4").Value = "hello"; // Ignored
             ws.Cell("A5").Value = 2; // Included
             ws.Cell("A6").Value = 4; // Included
-            Assert.AreEqual(2, ws.Evaluate("DEVSQ(A1:A6)"));
+            Assert.That(ws.Evaluate("DEVSQ(A1:A6)"), Is.EqualTo(2));
 
             AssertScalarToNumberConversion("DEVSQ", 0.5);
             AssertAnyErrorIsPropagated("DEVSQ");
@@ -592,28 +622,28 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
             XLCellValue value;
             value = ws.Evaluate(@"=MAX(D3:D45)");
-            Assert.AreEqual(0, value);
+            Assert.That(value, Is.EqualTo(0));
 
             value = ws.Evaluate(@"=MAX(G3:G45)");
-            Assert.AreEqual(96, value);
+            Assert.That(value, Is.EqualTo(96));
 
             value = ws.Evaluate(@"=MAX(G:G)");
-            Assert.AreEqual(96, value);
+            Assert.That(value, Is.EqualTo(96));
 
             value = workbook.Evaluate(@"=MAX(Data!G:G)");
-            Assert.AreEqual(96, value);
+            Assert.That(value, Is.EqualTo(96));
 
             // Although in most cases blank cells are considered 0, MAX just ignores them.
             value = workbook.Evaluate(@"MAX(-10, Data!X:Z)");
-            Assert.AreEqual(-10, value);
+            Assert.That(value, Is.EqualTo(-10));
 
             // Arrays - numbers are used
             value = workbook.Evaluate(@"MAX(-10, { -6, -5, 7 })");
-            Assert.AreEqual(7, value);
+            Assert.That(value, Is.EqualTo(7));
 
             // Arrays - non-number and non-error values are skipped.
             value = workbook.Evaluate(@"MAX(-10, { TRUE, FALSE, ""100"" })");
-            Assert.AreEqual(-10, value);
+            Assert.That(value, Is.EqualTo(-10));
 
             // Reference argument ignores everything but number.
             ws.Cell("Z1").Value = Blank.Value;
@@ -621,7 +651,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z3").Value = "100";
             ws.Cell("Z4").Value = "hello";
             ws.Cell("Z5").Value = -4;
-            Assert.AreEqual(-4, ws.Evaluate("MAX(Z1:Z5)"));
+            Assert.That(ws.Evaluate("MAX(Z1:Z5)"), Is.EqualTo(-4));
 
             AssertScalarToNumberConversion("MAX", 1);
             AssertAnyErrorIsPropagated("MAX");
@@ -633,20 +663,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Examples from specification
-            Assert.AreEqual(12.6, ws.Evaluate("MAXA(10.4,-3.5,12.6)"));
-            Assert.AreEqual(12.6, ws.Evaluate("MAXA(10.4,{-3.5,12.6})"));
-            Assert.AreEqual(0, ws.Evaluate("MAXA({\"ABC\",TRUE})"));
+            Assert.Multiple(() =>
+            {
+                // Examples from specification
+                Assert.That(ws.Evaluate("MAXA(10.4,-3.5,12.6)"), Is.EqualTo(12.6));
+                Assert.That(ws.Evaluate("MAXA(10.4,{-3.5,12.6})"), Is.EqualTo(12.6));
+                Assert.That(ws.Evaluate("MAXA({\"ABC\",TRUE})"), Is.EqualTo(0));
+            });
             ws.Cell("B3").Value = Blank.Value;
-            Assert.AreEqual(-10, ws.Evaluate("MAX(-10,-12,-15,B3)"));
+            Assert.That(ws.Evaluate("MAX(-10,-12,-15,B3)"), Is.EqualTo(-10));
             ws.Cell("B3").Value = 0;
-            Assert.AreEqual(0, ws.Evaluate("MAXA(-10,-12,-15,B3)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MAXA(-10,-12,-15,B3)"), Is.EqualTo(0));
 
-            // Array logical arguments are ignored
-            Assert.AreEqual(-2, workbook.Evaluate("MAXA({-2, TRUE, TRUE, FALSE, FALSE})"));
+                // Array logical arguments are ignored
+                Assert.That(workbook.Evaluate("MAXA({-2, TRUE, TRUE, FALSE, FALSE})"), Is.EqualTo(-2));
 
-            // Array text arguments are ignored
-            Assert.AreEqual(-2, workbook.Evaluate("MAXA({-4, -2, \"hello\", \"10\" })"));
+                // Array text arguments are ignored
+                Assert.That(workbook.Evaluate("MAXA({-4, -2, \"hello\", \"10\" })"), Is.EqualTo(-2));
+            });
 
             // Reference argument only counts logical as 0/1, text as 0 and ignores blanks.
             ws.Cell("A1").Value = Blank.Value;
@@ -654,8 +690,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "100";
             ws.Cell("A4").Value = "hello";
             ws.Cell("A5").Value = -4;
-            Assert.AreEqual(1, ws.Evaluate("MAXA(A1:A5)"));
-            Assert.AreEqual(0, ws.Evaluate("MAXA(A3:A5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MAXA(A1:A5)"), Is.EqualTo(1));
+                Assert.That(ws.Evaluate("MAXA(A3:A5)"), Is.EqualTo(0));
+            });
 
             AssertScalarToNumberConversion("MAXA", 1);
             AssertAnyErrorIsPropagated("MAXA");
@@ -667,7 +706,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
 
             // Column D contains names of regions
-            Assert.AreEqual(XLError.NumberInvalid, ws.Evaluate("MEDIAN(D3:D45)"));
+            Assert.That(ws.Evaluate("MEDIAN(D3:D45)"), Is.EqualTo(XLError.NumberInvalid));
         }
 
         [Test]
@@ -680,7 +719,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var value = (double)ws.Evaluate("MEDIAN(I3:I10)");
 
             //Assert
-            Assert.AreEqual(244.225, value, tolerance);
+            Assert.That(value, Is.EqualTo(244.225).Within(tolerance));
         }
 
         [Test]
@@ -690,7 +729,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var value = (double)workbook.Evaluate("MEDIAN(-27.5,93.93,64.51,-70.56)");
 
             //Assert
-            Assert.AreEqual(18.505, value, tolerance);
+            Assert.That(value, Is.EqualTo(18.505).Within(tolerance));
         }
 
         [Test]
@@ -703,7 +742,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var value = (double)ws.Evaluate("MEDIAN(I3:I11)");
 
             //Assert
-            Assert.AreEqual(189.05, value, tolerance);
+            Assert.That(value, Is.EqualTo(189.05).Within(tolerance));
         }
 
         [Test]
@@ -713,7 +752,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var value = (double)workbook.Evaluate("MEDIAN(-27.5,93.93,64.51,-70.56,101.65)");
 
             //Assert
-            Assert.AreEqual(64.51, value, tolerance);
+            Assert.That(value, Is.EqualTo(64.51).Within(tolerance));
         }
 
         [Test]
@@ -722,17 +761,23 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Examples from specification
-            Assert.AreEqual(15, ws.Evaluate("MEDIAN(10, 20)"));
-            Assert.AreEqual(-1.05, ws.Evaluate("MEDIAN(-3.5, 1.4, 6.9, -4.5)"));
-            Assert.AreEqual(-1.05, ws.Evaluate("MEDIAN({ -3.5,1.4,6.9},-4.5)"));
+            Assert.Multiple(() =>
+            {
+                // Examples from specification
+                Assert.That(ws.Evaluate("MEDIAN(10, 20)"), Is.EqualTo(15));
+                Assert.That(ws.Evaluate("MEDIAN(-3.5, 1.4, 6.9, -4.5)"), Is.EqualTo(-1.05));
+                Assert.That(ws.Evaluate("MEDIAN({ -3.5,1.4,6.9},-4.5)"), Is.EqualTo(-1.05));
+            });
 
             // Reference with no value will return error
             ws.Cell("A1").Value = Blank.Value;
-            Assert.AreEqual(XLError.NumberInvalid, ws.Evaluate("MEDIAN(A1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MEDIAN(A1)"), Is.EqualTo(XLError.NumberInvalid));
 
-            // Array non-number values are ignored
-            Assert.AreEqual(7, ws.Evaluate("MEDIAN({7, TRUE,FALSE,\"1\"})"));
+                // Array non-number values are ignored
+                Assert.That(ws.Evaluate("MEDIAN({7, TRUE,FALSE,\"1\"})"), Is.EqualTo(7));
+            });
 
             // Only numbers are used from reference, rest is ignored
             ws.Cell("A1").Value = Blank.Value;
@@ -742,7 +787,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = 0;
             ws.Cell("A6").Value = 4;
             ws.Cell("A7").Value = 5;
-            Assert.AreEqual(4, ws.Evaluate("MEDIAN(A1:A7)"));
+            Assert.That(ws.Evaluate("MEDIAN(A1:A7)"), Is.EqualTo(4));
 
             AssertScalarToNumberConversion("MEDIAN", 0.5);
             AssertAnyErrorIsPropagated("MEDIAN");
@@ -752,13 +797,16 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Min()
         {
             var ws = workbook.Worksheets.First();
-            Assert.AreEqual(0, ws.Evaluate("MIN(D3:D45)"));
-            Assert.AreEqual(2, ws.Evaluate("MIN(G3:G45)"));
-            Assert.AreEqual(2, ws.Evaluate("MIN(G:G)"));
-            Assert.AreEqual(2, workbook.Evaluate("MIN(Data!G:G)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MIN(D3:D45)"), Is.EqualTo(0));
+                Assert.That(ws.Evaluate("MIN(G3:G45)"), Is.EqualTo(2));
+                Assert.That(ws.Evaluate("MIN(G:G)"), Is.EqualTo(2));
+                Assert.That(workbook.Evaluate("MIN(Data!G:G)"), Is.EqualTo(2));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(5, workbook.Evaluate("MIN({5, TRUE, FALSE, \"1\", \"hello\"})"));
+                // Array non-number arguments are ignored
+                Assert.That(workbook.Evaluate("MIN({5, TRUE, FALSE, \"1\", \"hello\"})"), Is.EqualTo(5));
+            });
 
             // Reference non-number arguments are ignored
             ws.Cell("Z1").Value = Blank.Value;
@@ -767,10 +815,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = false;
             ws.Cell("Z5").Value = true;
             ws.Cell("Z6").Value = 5;
-            Assert.AreEqual(5, ws.Evaluate("MIN(Z1:Z6)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MIN(Z1:Z6)"), Is.EqualTo(5));
 
-            // If there is no value, return 0
-            Assert.AreEqual(0, ws.Evaluate("MIN({\"hello\"})"));
+                // If there is no value, return 0
+                Assert.That(ws.Evaluate("MIN({\"hello\"})"), Is.EqualTo(0));
+            });
 
             AssertScalarToNumberConversion("MIN", 0);
             AssertAnyErrorIsPropagated("MIN");
@@ -782,24 +833,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Examples from specification
-            Assert.AreEqual(-3.5, ws.Evaluate("MINA(10.4, -3.5, 12.6)"));
-            Assert.AreEqual(-3.5, ws.Evaluate("MINA(10.4, {-3.5, 12.6})"));
-            Assert.AreEqual(0, ws.Evaluate("MINA({\"ABC\", TRUE})"));
+            Assert.Multiple(() =>
+            {
+                // Examples from specification
+                Assert.That(ws.Evaluate("MINA(10.4, -3.5, 12.6)"), Is.EqualTo(-3.5));
+                Assert.That(ws.Evaluate("MINA(10.4, {-3.5, 12.6})"), Is.EqualTo(-3.5));
+                Assert.That(ws.Evaluate("MINA({\"ABC\", TRUE})"), Is.EqualTo(0));
+            });
             ws.Cell("B3").Value = Blank.Value;
-            Assert.AreEqual(10, ws.Evaluate("MINA(10, 12, 15, B3)"));
+            Assert.That(ws.Evaluate("MINA(10, 12, 15, B3)"), Is.EqualTo(10));
             ws.Cell("B3").Value = "Text";
-            Assert.AreEqual(0, ws.Evaluate("MINA(10, 12, 15, B3)"));
+            Assert.That(ws.Evaluate("MINA(10, 12, 15, B3)"), Is.EqualTo(0));
 
             // Blanks in references are ignored and when MINA doesn't have any values, it returns 0
             ws.Cell("A1").Value = Blank.Value;
-            Assert.AreEqual(0, ws.Evaluate("MINA(A1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MINA(A1)"), Is.EqualTo(0));
 
-            // Array logical arguments are ignored
-            Assert.AreEqual(2, wb.Evaluate("MINA({2, TRUE, TRUE, FALSE, FALSE})"));
+                // Array logical arguments are ignored
+                Assert.That(wb.Evaluate("MINA({2, TRUE, TRUE, FALSE, FALSE})"), Is.EqualTo(2));
 
-            // Array text arguments are ignored
-            Assert.AreEqual(2, wb.Evaluate("MINA({4, 2, \"hello\", \"1\"})"));
+                // Array text arguments are ignored
+                Assert.That(wb.Evaluate("MINA({4, 2, \"hello\", \"1\"})"), Is.EqualTo(2));
+            });
 
             // Reference argument only counts logical as 0/1, text as 0 and ignores blanks.
             ws.Cell("A1").Value = Blank.Value; // Ignores
@@ -807,9 +864,12 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A3").Value = "100"; // Considers 0
             ws.Cell("A4").Value = "hello"; // Considers 0
             ws.Cell("A5").Value = -4; // Included
-            Assert.AreEqual(1, ws.Evaluate("MINA(A1:A2)"));
-            Assert.AreEqual(0, ws.Evaluate("MINA(A1:A3)"));
-            Assert.AreEqual(-4, ws.Evaluate("MINA(A1:A5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("MINA(A1:A2)"), Is.EqualTo(1));
+                Assert.That(ws.Evaluate("MINA(A1:A3)"), Is.EqualTo(0));
+                Assert.That(ws.Evaluate("MINA(A1:A5)"), Is.EqualTo(-4));
+            });
 
             AssertScalarToNumberConversion("MINA", 0);
             AssertAnyErrorIsPropagated("MINA");
@@ -822,25 +882,28 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var ws = workbook.Worksheets.First();
 
             // Only non-convertible text in D column, thus less than 2 samples will return error
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("STDEV(D3:D45)"));
+            Assert.That(ws.Evaluate("STDEV(D3:D45)"), Is.EqualTo(XLError.DivisionByZero));
 
             // Calculate StDev from numeric values (reference contains only numbers)
             var value = (double)ws.Evaluate("STDEV(H3:H45)");
-            Assert.AreEqual(47.34511769, value, tolerance);
+            Assert.That(value, Is.EqualTo(47.34511769).Within(tolerance));
 
             // Ignores text values in the H column and only uses numeric ones, same as reference with only number
             value = (double)ws.Evaluate("STDEV(H:H)");
-            Assert.AreEqual(47.34511769, value, tolerance);
+            Assert.That(value, Is.EqualTo(47.34511769).Within(tolerance));
 
             value = (double)workbook.Evaluate("STDEV(Data!H:H)");
-            Assert.AreEqual(47.34511769, value, tolerance);
+            Assert.Multiple(() =>
+            {
+                Assert.That(value, Is.EqualTo(47.34511769).Within(tolerance));
 
-            // Need at least two values, otherwise returns error
-            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("STDEV(1)"));
-            Assert.AreEqual(0, workbook.Evaluate("STDEV(0, 0)"));
+                // Need at least two values, otherwise returns error
+                Assert.That(workbook.Evaluate("STDEV(1)"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(workbook.Evaluate("STDEV(0, 0)"), Is.EqualTo(0));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(0.707106781, (double)workbook.Evaluate("STDEV({0, 1, \"Hello\", FALSE, TRUE})"), tolerance);
+                // Array non-number arguments are ignored
+                Assert.That((double)workbook.Evaluate("STDEV({0, 1, \"Hello\", FALSE, TRUE})"), Is.EqualTo(0.707106781).Within(tolerance));
+            });
 
             // Reference argument only uses number, ignores blanks, logical and text
             ws.Cell("Z1").Value = Blank.Value;
@@ -849,7 +912,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = "hello";
             ws.Cell("Z5").Value = 0;
             ws.Cell("Z6").Value = 1;
-            Assert.AreEqual(0.707106781, (double)ws.Evaluate("STDEV(Z1:Z6)"), tolerance);
+            Assert.That((double)ws.Evaluate("STDEV(Z1:Z6)"), Is.EqualTo(0.707106781).Within(tolerance));
 
             AssertScalarToNumberConversion("STDEV", 0.707106781);
             AssertAnyErrorIsPropagated("STDEV");
@@ -862,11 +925,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Example from specification
-            Assert.AreEqual(23.72902583, (double)ws.Evaluate("STDEVA(123, 134, 143, 173, 112, 109)"));
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That((double)ws.Evaluate("STDEVA(123, 134, 143, 173, 112, 109)"), Is.EqualTo(23.72902583));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(0.707106781, (double)ws.Evaluate("STDEVA({0, 1, \"9\", \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That((double)ws.Evaluate("STDEVA({0, 1, \"9\", \"Hello\", FALSE, TRUE})"), Is.EqualTo(0.707106781));
+            });
 
             // Reference argument ignores blanks, uses numbers, logical and text as zero
             ws.Cell("A1").Value = Blank.Value; // Ignore
@@ -876,10 +942,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = "hello"; // Consider 0
             ws.Cell("A6").Value = 5;
             ws.Cell("A7").Value = 7;
-            Assert.AreEqual(3.060501048, (double)ws.Evaluate("STDEVA(A1:A7)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)ws.Evaluate("STDEVA(A1:A7)"), Is.EqualTo(3.060501048));
 
-            // Need at least one sample, otherwise returns error (text in array is ignored)
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("STDEVA({\"hello\"})"));
+                // Need at least one sample, otherwise returns error (text in array is ignored)
+                Assert.That(ws.Evaluate("STDEVA({\"hello\"})"), Is.EqualTo(XLError.DivisionByZero));
+            });
 
             AssertScalarToNumberConversion("STDEVA", 0.707106781);
             AssertAnyErrorIsPropagated("STDEVA");
@@ -890,26 +959,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheets.First();
 
-            // Example from specification
-            Assert.AreEqual(21.66153785, (double)ws.Evaluate("STDEVP(123, 134, 143, 173, 112, 109)"), tolerance);
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That((double)ws.Evaluate("STDEVP(123, 134, 143, 173, 112, 109)"), Is.EqualTo(21.66153785).Within(tolerance));
 
-            // Column D contains only region names (non-convertible text), thus reference contains less than 1 sample that is required
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("STDEVP(D3:D45)"));
+                // Column D contains only region names (non-convertible text), thus reference contains less than 1 sample that is required
+                Assert.That(ws.Evaluate("STDEVP(D3:D45)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Calculate StDevP from numeric values (reference contains only numbers)
-            Assert.AreEqual(46.79135458, (double)ws.Evaluate("STDEVP(H3:H45)"), tolerance);
+                // Calculate StDevP from numeric values (reference contains only numbers)
+                Assert.That((double)ws.Evaluate("STDEVP(H3:H45)"), Is.EqualTo(46.79135458).Within(tolerance));
 
-            // StDevP ignores text values/blanks in the H column and only uses numeric ones, the result is same as the reference above that contains only numbers
-            Assert.AreEqual(46.79135458, (double)ws.Evaluate("STDEVP(H:H)"), tolerance);
+                // StDevP ignores text values/blanks in the H column and only uses numeric ones, the result is same as the reference above that contains only numbers
+                Assert.That((double)ws.Evaluate("STDEVP(H:H)"), Is.EqualTo(46.79135458).Within(tolerance));
 
-            Assert.AreEqual(46.79135458, (double)workbook.Evaluate("STDEVP(Data!H:H)"), tolerance);
+                Assert.That((double)workbook.Evaluate("STDEVP(Data!H:H)"), Is.EqualTo(46.79135458).Within(tolerance));
 
-            // If sample size is 0, return error
-            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("STDEVP({TRUE})"));
-            Assert.AreEqual(0, workbook.Evaluate("STDEVP(100)"));
+                // If sample size is 0, return error
+                Assert.That(workbook.Evaluate("STDEVP({TRUE})"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(workbook.Evaluate("STDEVP(100)"), Is.EqualTo(0));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(0.5, workbook.Evaluate("STDEVP({0, 1, \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That(workbook.Evaluate("STDEVP({0, 1, \"Hello\", FALSE, TRUE})"), Is.EqualTo(0.5));
+            });
 
             // Reference argument only uses numbers, ignores blanks, logical and text
             ws.Cell("Z1").Value = Blank.Value;
@@ -918,7 +990,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = "hello";
             ws.Cell("Z5").Value = 0;
             ws.Cell("Z6").Value = 1;
-            Assert.AreEqual(0.5, ws.Evaluate("STDEVP(Z1:Z6)"));
+            Assert.That(ws.Evaluate("STDEVP(Z1:Z6)"), Is.EqualTo(0.5));
 
             AssertScalarToNumberConversion("STDEVP", 0.5);
             AssertAnyErrorIsPropagated("STDEVP");
@@ -931,11 +1003,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Example from specification
-            Assert.AreEqual(21.66153785, (double)ws.Evaluate("STDEVPA(123, 134, 143, 173, 112, 109)"));
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That((double)ws.Evaluate("STDEVPA(123, 134, 143, 173, 112, 109)"), Is.EqualTo(21.66153785));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(0.5, (double)ws.Evaluate("STDEVPA({0, 1, \"9\", \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That((double)ws.Evaluate("STDEVPA({0, 1, \"9\", \"Hello\", FALSE, TRUE})"), Is.EqualTo(0.5));
+            });
 
             // Reference argument ignores blanks, uses numbers, logical and text as zero
             ws.Cell("A1").Value = Blank.Value; // Ignore
@@ -945,10 +1020,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = "hello"; // Consider 0
             ws.Cell("A6").Value = 5;
             ws.Cell("A7").Value = 7;
-            Assert.AreEqual(2.793842436, (double)ws.Evaluate("STDEVPA(A1:A7)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)ws.Evaluate("STDEVPA(A1:A7)"), Is.EqualTo(2.793842436));
 
-            // Need at least one sample, otherwise returns error (text in array is ignored)
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("STDEVPA({\"hello\"})"));
+                // Need at least one sample, otherwise returns error (text in array is ignored)
+                Assert.That(ws.Evaluate("STDEVPA({\"hello\"})"), Is.EqualTo(XLError.DivisionByZero));
+            });
 
             AssertScalarToNumberConversion("STDEVPA", 0.5);
             AssertAnyErrorIsPropagated("STDEVPA");
@@ -967,7 +1045,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Excel treats 1 and TRUE as unequal, but 3 and "3" as equal
             // LibreOffice Calc handles some SUMIF and COUNTIF differently, e.g. it treats 1 and TRUE as equal, but 3 and "3" differently
             var ws = workbook.Worksheet("MixedData");
-            Assert.AreEqual(expected, ws.Evaluate(formula));
+            Assert.That(ws.Evaluate(formula), Is.EqualTo(expected));
         }
 
         [Test]
@@ -981,15 +1059,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("C1").Value = 7;
             ws.Cell("D1").Value = 10;
 
-            Assert.AreEqual(20, ws.Evaluate("SUMIF(A1:D1,\"=10\")"));
-            Assert.AreEqual(27, ws.Evaluate("SUMIF(A1:D1,\">5\")"));
-            Assert.AreEqual(10, ws.Evaluate("SUMIF(A1:D1,\"<>10\")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("SUMIF(A1:D1,\"=10\")"), Is.EqualTo(20));
+                Assert.That(ws.Evaluate("SUMIF(A1:D1,\">5\")"), Is.EqualTo(27));
+                Assert.That(ws.Evaluate("SUMIF(A1:D1,\"<>10\")"), Is.EqualTo(10));
+            });
 
             ws.Cell("A2").Value = "apples";
             ws.Cell("B2").Value = "melons";
             ws.Cell("C2").Value = 10;
             ws.Cell("D2").Value = 15;
-            Assert.AreEqual(10, ws.Evaluate("SUMIF(A2:B2,\"*es\",C2:D2)"));
+            Assert.That(ws.Evaluate("SUMIF(A2:B2,\"*es\",C2:D2)"), Is.EqualTo(10));
         }
 
         [Test]
@@ -1006,17 +1087,15 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("SUMIFS(H:H,G:G,50,I:I,\">900\")", 19.99d, Description = "SUMIFS columns")]
         public void TallySkipsEmptyCells(string formulaA1, double expectedResult)
         {
-            using (var wb = SetupWorkbook())
-            {
-                var ws = wb.Worksheets.First();
-                //Let's pre-initialize cells we need so they didn't affect the result
-                ws.Range("A1:J45").Style.Fill.BackgroundColor = XLColor.Amber;
-                ws.Cell("ZZ1000").Value = 1;
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+            //Let's pre-initialize cells we need so they didn't affect the result
+            ws.Range("A1:J45").Style.Fill.BackgroundColor = XLColor.Amber;
+            ws.Cell("ZZ1000").Value = 1;
 
-                var actualResult = (double)ws.Evaluate(formulaA1);
+            var actualResult = (double)ws.Evaluate(formulaA1);
 
-                Assert.AreEqual(expectedResult, actualResult, tolerance);
-            }
+            Assert.That(actualResult, Is.EqualTo(expectedResult).Within(tolerance));
         }
 
         [Test]
@@ -1024,26 +1103,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheets.First();
 
-            // Example from specification
-            Assert.AreEqual(2683.2, ws.Evaluate("VAR(1202,1220,1323,1254,1302)"));
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That(ws.Evaluate("VAR(1202,1220,1323,1254,1302)"), Is.EqualTo(2683.2));
 
-            // Only non-convertible text in D column, thus less than 2 samples.
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("VAR(D3:D45)"));
+                // Only non-convertible text in D column, thus less than 2 samples.
+                Assert.That(ws.Evaluate("VAR(D3:D45)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Calculate VAR from numeric values (reference contains only numbers)
-            Assert.AreEqual(2241.560169, (double)ws.Evaluate("VAR(H3:H45)"), tolerance);
+                // Calculate VAR from numeric values (reference contains only numbers)
+                Assert.That((double)ws.Evaluate("VAR(H3:H45)"), Is.EqualTo(2241.560169).Within(tolerance));
 
-            // Ignores text values in the H column and only uses numeric ones, same as reference with only number
-            Assert.AreEqual(2241.560169, (double)ws.Evaluate("VAR(H:H)"), tolerance);
-            Assert.AreEqual(2241.560169, (double)workbook.Evaluate("VAR(Data!H:H)"), tolerance);
+                // Ignores text values in the H column and only uses numeric ones, same as reference with only number
+                Assert.That((double)ws.Evaluate("VAR(H:H)"), Is.EqualTo(2241.560169).Within(tolerance));
+                Assert.That((double)workbook.Evaluate("VAR(Data!H:H)"), Is.EqualTo(2241.560169).Within(tolerance));
 
-            // Need at least two samples, otherwise returns error
-            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("VAR({\"hello\"})"));
-            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("VAR(5)"));
-            Assert.AreEqual(0.5, workbook.Evaluate("VAR(5, 6)"));
+                // Need at least two samples, otherwise returns error
+                Assert.That(workbook.Evaluate("VAR({\"hello\"})"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(workbook.Evaluate("VAR(5)"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(workbook.Evaluate("VAR(5, 6)"), Is.EqualTo(0.5));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(0.5, workbook.Evaluate("VAR({0, 1, \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That(workbook.Evaluate("VAR({0, 1, \"Hello\", FALSE, TRUE})"), Is.EqualTo(0.5));
+            });
 
             // Reference argument only uses number, ignores blanks, logical and text
             ws.Cell("Z1").Value = Blank.Value;
@@ -1052,7 +1134,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = "hello";
             ws.Cell("Z5").Value = 0;
             ws.Cell("Z6").Value = 1;
-            Assert.AreEqual(0.5, ws.Evaluate("VAR(Z1:Z6)"));
+            Assert.That(ws.Evaluate("VAR(Z1:Z6)"), Is.EqualTo(0.5));
 
             AssertScalarToNumberConversion("VAR", 0.5);
             AssertAnyErrorIsPropagated("VAR");
@@ -1065,11 +1147,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Example from specification
-            Assert.AreEqual(2683.2, ws.Evaluate("VARA(1202, 1220, 1323, 1254, 1302)"));
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That(ws.Evaluate("VARA(1202, 1220, 1323, 1254, 1302)"), Is.EqualTo(2683.2));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(2, ws.Evaluate("VARA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That(ws.Evaluate("VARA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"), Is.EqualTo(2));
+            });
 
             // Reference argument ignores blanks, uses numbers, logical and text as zero
             ws.Cell("A1").Value = Blank.Value; // Ignore
@@ -1079,10 +1164,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = "hello"; // Consider 0
             ws.Cell("A6").Value = 5;
             ws.Cell("A7").Value = 7;
-            Assert.AreEqual(9.366666667, (double)ws.Evaluate("VARA(A1:A7)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)ws.Evaluate("VARA(A1:A7)"), Is.EqualTo(9.366666667));
 
-            // Need at least one sample, otherwise returns error (text in array is ignored)
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("VARA({\"hello\"})"));
+                // Need at least one sample, otherwise returns error (text in array is ignored)
+                Assert.That(ws.Evaluate("VARA({\"hello\"})"), Is.EqualTo(XLError.DivisionByZero));
+            });
 
             AssertScalarToNumberConversion("VARA", 0.5);
             AssertAnyErrorIsPropagated("VARA");
@@ -1093,25 +1181,28 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheets.First();
 
-            // Example from specification
-            Assert.AreEqual(2146.56, (double)ws.Evaluate("VARP(1202,1220,1323,1254,1302)"), tolerance);
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That((double)ws.Evaluate("VARP(1202,1220,1323,1254,1302)"), Is.EqualTo(2146.56).Within(tolerance));
 
-            // Only non-convertible text in D column, thus less than 1 sample.
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("VARP(D3:D45)"));
+                // Only non-convertible text in D column, thus less than 1 sample.
+                Assert.That(ws.Evaluate("VARP(D3:D45)"), Is.EqualTo(XLError.DivisionByZero));
 
-            // Calculate VARP from numeric values (reference contains only numbers)
-            Assert.AreEqual(2189.430863, (double)ws.Evaluate("VARP(H3:H45)"), tolerance);
+                // Calculate VARP from numeric values (reference contains only numbers)
+                Assert.That((double)ws.Evaluate("VARP(H3:H45)"), Is.EqualTo(2189.430863).Within(tolerance));
 
-            // Ignores text values in the H column and only uses numeric ones, same as reference with only number
-            Assert.AreEqual(2189.430863, (double)ws.Evaluate("VARP(H:H)"), tolerance);
-            Assert.AreEqual(2189.430863, (double)workbook.Evaluate("VARP(Data!H:H)"), tolerance);
+                // Ignores text values in the H column and only uses numeric ones, same as reference with only number
+                Assert.That((double)ws.Evaluate("VARP(H:H)"), Is.EqualTo(2189.430863).Within(tolerance));
+                Assert.That((double)workbook.Evaluate("VARP(Data!H:H)"), Is.EqualTo(2189.430863).Within(tolerance));
 
-            // Need at least one sample, otherwise returns error
-            Assert.AreEqual(XLError.DivisionByZero, workbook.Evaluate("VARP({\"hello\"})"));
-            Assert.AreEqual(0, workbook.Evaluate("VARP(5)"));
+                // Need at least one sample, otherwise returns error
+                Assert.That(workbook.Evaluate("VARP({\"hello\"})"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(workbook.Evaluate("VARP(5)"), Is.EqualTo(0));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(0.25, workbook.Evaluate("VARP({0, 1, \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That(workbook.Evaluate("VARP({0, 1, \"Hello\", FALSE, TRUE})"), Is.EqualTo(0.25));
+            });
 
             // Reference argument only uses number, ignores blanks, logical and text
             ws.Cell("Z1").Value = Blank.Value;
@@ -1120,7 +1211,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("Z4").Value = "hello";
             ws.Cell("Z5").Value = 0;
             ws.Cell("Z6").Value = 1;
-            Assert.AreEqual(0.25, ws.Evaluate("VARP(Z1:Z6)"));
+            Assert.That(ws.Evaluate("VARP(Z1:Z6)"), Is.EqualTo(0.25));
 
             AssertScalarToNumberConversion("VARP", 0.25);
             AssertAnyErrorIsPropagated("VARP");
@@ -1133,11 +1224,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
 
-            // Example from specification
-            Assert.AreEqual(2146.56, ws.Evaluate("VARPA(1202, 1220, 1323, 1254, 1302)"));
+            Assert.Multiple(() =>
+            {
+                // Example from specification
+                Assert.That(ws.Evaluate("VARPA(1202, 1220, 1323, 1254, 1302)"), Is.EqualTo(2146.56));
 
-            // Array non-number arguments are ignored
-            Assert.AreEqual(1, ws.Evaluate("VARPA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"));
+                // Array non-number arguments are ignored
+                Assert.That(ws.Evaluate("VARPA({5, 7, \"9\", \"Hello\", FALSE, TRUE})"), Is.EqualTo(1));
+            });
 
             // Reference argument ignores blanks, uses numbers, logical and text as zero
             ws.Cell("A1").Value = Blank.Value; // Ignore
@@ -1147,10 +1241,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A5").Value = "hello"; // Consider 0
             ws.Cell("A6").Value = 5;
             ws.Cell("A7").Value = 7;
-            Assert.AreEqual(7.805555556, (double)ws.Evaluate("VARPA(A1:A7)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)ws.Evaluate("VARPA(A1:A7)"), Is.EqualTo(7.805555556));
 
-            // Need at least one sample, otherwise returns error (text in array is ignored)
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("VARPA({\"hello\"})"));
+                // Need at least one sample, otherwise returns error (text in array is ignored)
+                Assert.That(ws.Evaluate("VARPA({\"hello\"})"), Is.EqualTo(XLError.DivisionByZero));
+            });
 
             AssertScalarToNumberConversion("VARPA", 0.25);
             AssertAnyErrorIsPropagated("VARPA");
@@ -1161,54 +1258,54 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var ws = workbook.Worksheet("Data");
             var value = ws.Evaluate("LARGE(G1:G45, 1)");
-            Assert.AreEqual(96, value);
+            Assert.That(value, Is.EqualTo(96));
 
             value = ws.Evaluate("LARGE(G1:G45, 7)");
-            Assert.AreEqual(87, value);
+            Assert.That(value, Is.EqualTo(87));
 
             value = ws.Evaluate("LARGE(G1:G45, 0)");
-            Assert.AreEqual(XLError.NumberInvalid, value);
+            Assert.That(value, Is.EqualTo(XLError.NumberInvalid));
 
             value = ws.Evaluate("LARGE(G1:G45, -1)");
-            Assert.AreEqual(XLError.NumberInvalid, value);
+            Assert.That(value, Is.EqualTo(XLError.NumberInvalid));
 
             value = ws.Evaluate("LARGE(G1:G45,\"test\")");
-            Assert.AreEqual(XLError.IncompatibleValue, value);
+            Assert.That(value, Is.EqualTo(XLError.IncompatibleValue));
 
             value = ws.Evaluate("LARGE(C:C,7)");
-            Assert.AreEqual(42623, value);
+            Assert.That(value, Is.EqualTo(42623));
 
             value = ws.Evaluate("LARGE(D:D,7)");
-            Assert.AreEqual(XLError.NumberInvalid, value);
+            Assert.That(value, Is.EqualTo(XLError.NumberInvalid));
 
             ws = workbook.Worksheet("MixedData");
 
             value = ws.Evaluate("LARGE(A1:A7,6)");
-            Assert.AreEqual(XLError.NumberInvalid, value);
+            Assert.That(value, Is.EqualTo(XLError.NumberInvalid));
 
             // Ignores non-numbers.
             value = ws.Evaluate("LARGE(A1:A7,5)");
-            Assert.AreEqual(1, value);
+            Assert.That(value, Is.EqualTo(1));
 
             // Accepts non-area references.
             value = ws.Evaluate("LARGE((A1:A2,A4:A6),2)");
-            Assert.AreEqual(3, value);
+            Assert.That(value, Is.EqualTo(3));
 
             // Errors are returned.
             value = ws.Evaluate("LARGE({ 1, 2, #N/A }, 1)");
-            Assert.AreEqual(XLError.NoValueAvailable, value);
+            Assert.That(value, Is.EqualTo(XLError.NoValueAvailable));
 
             // Uses ceiling logic for number (1.1 -> 2) + can use arrays.
             value = ws.Evaluate("LARGE({ 1, 2 }, 1.1)");
-            Assert.AreEqual(1, value);
+            Assert.That(value, Is.EqualTo(1));
 
             // If a scalar number-like value supplied, it is converted to number.
             value = ws.Evaluate("LARGE(\"1 1/2\", 1)");
-            Assert.AreEqual(1.5, value);
+            Assert.That(value, Is.EqualTo(1.5));
 
             // When the scalar can't be converted, return conversion error.
             value = ws.Evaluate("LARGE(\"test\", 1)");
-            Assert.AreEqual(XLError.IncompatibleValue, value);
+            Assert.That(value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         private XLWorkbook SetupWorkbook()
@@ -1275,20 +1372,23 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         private static void AssertScalarToNumberConversion(string functionName, double result)
         {
-            // Scalar blank is converted to 0
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"{functionName}(IF(TRUE,), 1)"));
+            Assert.Multiple(() =>
+            {
+                // Scalar blank is converted to 0
+                Assert.That((double)XLWorkbook.EvaluateExpr($"{functionName}(IF(TRUE,), 1)"), Is.EqualTo(result));
 
-            // Scalar logical is converted to a number
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"{functionName}(FALSE, TRUE)"));
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"{functionName}(0, TRUE)"));
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"{functionName}(FALSE, 1)"));
+                // Scalar logical is converted to a number
+                Assert.That((double)XLWorkbook.EvaluateExpr($"{functionName}(FALSE, TRUE)"), Is.EqualTo(result));
+                Assert.That((double)XLWorkbook.EvaluateExpr($"{functionName}(0, TRUE)"), Is.EqualTo(result));
+                Assert.That((double)XLWorkbook.EvaluateExpr($"{functionName}(FALSE, 1)"), Is.EqualTo(result));
 
-            // Scalar text is converted to a number
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"{functionName}(\"0\", \"1\")"));
-            Assert.AreEqual(result, (double)XLWorkbook.EvaluateExpr($"{functionName}(\"1\", \"0 0/2\")"));
+                // Scalar text is converted to a number
+                Assert.That((double)XLWorkbook.EvaluateExpr($"{functionName}(\"0\", \"1\")"), Is.EqualTo(result));
+                Assert.That((double)XLWorkbook.EvaluateExpr($"{functionName}(\"1\", \"0 0/2\")"), Is.EqualTo(result));
 
-            // Scalar text that is not convertible returns error
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"{functionName}(5, \"Hello\")"));
+                // Scalar text that is not convertible returns error
+                Assert.That(XLWorkbook.EvaluateExpr($"{functionName}(5, \"Hello\")"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         /// <summary>
@@ -1297,19 +1397,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         /// <param name="functionName">Name of a function that accepts any value as argument.</param>
         private static void AssertAnyErrorIsPropagated(string functionName)
         {
-            // Scalar error is propagated
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr($"{functionName}(1, #NULL!)"));
+            Assert.Multiple(() =>
+            {
+                // Scalar error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr($"{functionName}(1, #NULL!)"), Is.EqualTo(XLError.NullValue));
 
-            // Array error is propagated
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr($"{functionName}({{1, #NULL!}})"));
+                // Array error is propagated
+                Assert.That(XLWorkbook.EvaluateExpr($"{functionName}({{1, #NULL!}})"), Is.EqualTo(XLError.NullValue));
+            });
 
             // Reference error is propagated
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("B1").Value = XLError.NoValueAvailable;
             ws.Cell("B2").Value = 1;
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate($"{functionName}(B1)"));
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate($"{functionName}(B1:B2)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate($"{functionName}(B1)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(ws.Evaluate($"{functionName}(B1:B2)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/StructuredReferenceTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StructuredReferenceTests.cs
@@ -149,17 +149,20 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var table = Add4X3Table(ws, "E7");
             table.ShowTotalsRow = true;
 
-            // Right above header row
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula, "D6"));
+            Assert.Multiple(() =>
+            {
+                // Right above header row
+                Assert.That(ws.Evaluate(formula, "D6"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Header row
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula, "D7"));
+                // Header row
+                Assert.That(ws.Evaluate(formula, "D7"), Is.EqualTo(XLError.IncompatibleValue));
 
-            // Whether there is a totals row or not, the result is #VALUE!
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula, "D11"));
+                // Whether there is a totals row or not, the result is #VALUE!
+                Assert.That(ws.Evaluate(formula, "D11"), Is.EqualTo(XLError.IncompatibleValue));
+            });
 
             table.ShowTotalsRow = false;
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula, "D11"));
+            Assert.That(ws.Evaluate(formula, "D11"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         private static IXLTable Add4X3Table(IXLWorksheet ws, string origin)
@@ -192,15 +195,18 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             if (expectedArea == "#REF!")
             {
-                Assert.AreEqual(XLError.CellReference, ws.Evaluate(structureReference, formulaAddress));
+                Assert.That(ws.Evaluate(structureReference, formulaAddress), Is.EqualTo(XLError.CellReference));
                 return;
             }
 
             var expected = XLSheetRange.Parse(expectedArea);
-            Assert.AreEqual(expected.LeftColumn, ws.Evaluate($"COLUMN({structureReference})", formulaAddress));
-            Assert.AreEqual(expected.TopRow, ws.Evaluate($"ROW({structureReference})", formulaAddress));
-            Assert.AreEqual(expected.Height, ws.Evaluate($"ROWS({structureReference})", formulaAddress));
-            Assert.AreEqual(expected.Width, ws.Evaluate($"COLUMNS({structureReference})", formulaAddress));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate($"COLUMN({structureReference})", formulaAddress), Is.EqualTo(expected.LeftColumn));
+                Assert.That(ws.Evaluate($"ROW({structureReference})", formulaAddress), Is.EqualTo(expected.TopRow));
+                Assert.That(ws.Evaluate($"ROWS({structureReference})", formulaAddress), Is.EqualTo(expected.Height));
+                Assert.That(ws.Evaluate($"COLUMNS({structureReference})", formulaAddress), Is.EqualTo(expected.Width));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextTests.cs
@@ -18,14 +18,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(@"―‘’”、。「」゛゜・ー￥", @"ｰ`'""､｡｢｣ﾞﾟ･ｰ\")]
         public void Asc_converts_fullwidth_characters_to_halfwidth_characters(string input, string expected)
         {
-            Assert.AreEqual(expected, XLWorkbook.EvaluateExpr($"ASC(\"{input}\")"));
+            Assert.That(XLWorkbook.EvaluateExpr($"ASC(\"{input}\")"), Is.EqualTo(expected));
         }
 
         [Test]
         public void Char_returns_error_on_empty_string()
         {
             // Calc engine tries to coerce it to number and fails. It never even reaches the functions.
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"CHAR("""")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"CHAR("""")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(0)]
@@ -33,7 +33,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(9797)]
         public void Char_number_must_be_between_1_and_255(int number)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"CHAR({number})"));
+            Assert.That(XLWorkbook.EvaluateExpr($"CHAR({number})"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(48, '0')]
@@ -48,29 +48,29 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Char_interprets_number_as_win1252(double number, char expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"CHAR({number})");
-            Assert.AreEqual(expected.ToString(), actual);
+            Assert.That(actual, Is.EqualTo(expected.ToString()));
         }
 
         [Test]
         public void Clean_empty_string_is_empty_string()
         {
-            Assert.AreEqual("", XLWorkbook.EvaluateExpr(@"CLEAN("""")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"CLEAN("""")"), Is.EqualTo(""));
         }
 
         [Test]
         public void Clean_removes_control_characters()
         {
             var actual = XLWorkbook.EvaluateExpr(@"CLEAN(CHAR(9)&""Monthly report""&CHAR(10))");
-            Assert.AreEqual("Monthly report", actual);
+            Assert.That(actual, Is.EqualTo("Monthly report"));
 
             actual = XLWorkbook.EvaluateExpr(@"CLEAN(""   "")");
-            Assert.AreEqual("   ", actual);
+            Assert.That(actual, Is.EqualTo("   "));
         }
 
         [Test]
         public void Code_returns_error_on_empty_string()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"CODE("""")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"CODE("""")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("A", 65)]
@@ -80,14 +80,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Code_returns_win1252_codepoint_of_first_character(string text, int expected)
         {
             var actual = XLWorkbook.EvaluateExpr($"CODE(\"{text}\")");
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
         public void Code_is_inverse_to_char()
         {
             for (var i = 1; i < 256; ++i)
-                Assert.AreEqual(i, XLWorkbook.EvaluateExpr($"CODE(CHAR({i}))"));
+                Assert.That(XLWorkbook.EvaluateExpr($"CODE(CHAR({i}))"), Is.EqualTo(i));
         }
 
         [TestCase("π")]
@@ -99,8 +99,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var expected = XLWorkbook.EvaluateExpr("CODE(\"?\")");
             var actual = XLWorkbook.EvaluateExpr($"CODE(\"{text}\")");
-            Assert.AreEqual(63, expected);
-            Assert.AreEqual(expected, actual);
+            Assert.Multiple(() =>
+            {
+                Assert.That(expected, Is.EqualTo(63));
+                Assert.That(actual, Is.EqualTo(expected));
+            });
         }
 
         [Test]
@@ -110,10 +113,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             var actual = ws.Evaluate(@"CONCAT(""ABC"",123,TRUE,IF(TRUE,),1.25)");
-            Assert.AreEqual("ABC123TRUE1,25", actual);
+            Assert.That(actual, Is.EqualTo("ABC123TRUE1,25"));
 
             actual = ws.Evaluate(@"CONCAT("""",""123"")");
-            Assert.AreEqual("123", actual);
+            Assert.That(actual, Is.EqualTo("123"));
 
             ws.FirstCell().SetValue(20.5)
                 .CellBelow().SetValue("AB")
@@ -121,13 +124,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 .CellBelow().SetFormulaA1("CONCAT(A1:A3)");
 
             actual = ws.Cell("A4").Value;
-            Assert.AreEqual("20,5AB43466", actual);
+            Assert.That(actual, Is.EqualTo("20,5AB43466"));
         }
 
         [Test]
         public void Concat_concatenates_array_values()
         {
-            Assert.AreEqual("ABC0123456789Z", XLWorkbook.EvaluateExpr(@"CONCAT({""A"",""B"",""C""},{0,1},{2;3},{4,5,6;7,8,9},""Z"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"CONCAT({""A"",""B"",""C""},{0,1},{2;3},{4,5,6;7,8,9},""Z"")"), Is.EqualTo("ABC0123456789Z"));
         }
 
         [Test]
@@ -141,13 +144,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 (1, 2, 3, 4),
                 (5, 6, 7, 8),
             });
-            Assert.AreEqual("ABC12345678AZ", ws.Evaluate("CONCAT(C2:E2,C3:F4,C2,\"Z\")"));
+            Assert.That(ws.Evaluate("CONCAT(C2:E2,C3:F4,C2,\"Z\")"), Is.EqualTo("ABC12345678AZ"));
         }
 
         [Test]
         public void Concat_has_limit_of_32767_characters()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("CONCAT(REPT(\"A\",32768))"));
+            Assert.That(XLWorkbook.EvaluateExpr("CONCAT(REPT(\"A\",32768))"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
@@ -156,25 +159,28 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Only areas are accepted, not unions
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate("CONCAT((C2:E2,C3:F4),C2,\"Z\")"));
+            Assert.That(ws.Evaluate("CONCAT((C2:E2,C3:F4),C2,\"Z\")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Concat_propagates_error_values()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"",#DIV/0!,5)"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"",{""D"",#DIV/0!,7},5)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"",#DIV/0!,5)"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"",{""D"",#DIV/0!,7},5)"), Is.EqualTo(XLError.DivisionByZero));
+            });
 
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("B5").SetValue(XLError.DivisionByZero).CellBelow().SetValue(5);
-            Assert.AreEqual(XLError.DivisionByZero, ws.Evaluate("CONCAT(\"ABC\",B5:B6)"));
+            Assert.That(ws.Evaluate("CONCAT(\"ABC\",B5:B6)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [Test]
         public void Concat_treats_blanks_as_empty_string()
         {
-            Assert.AreEqual("ABC123", XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"",,""123"",)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"CONCAT(""ABC"",,""123"",)"), Is.EqualTo("ABC123"));
         }
 
         [Test]
@@ -183,10 +189,10 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var actual = wb.Evaluate(@"CONCATENATE(""ABC"",123,4.56,IF(TRUE,),TRUE)");
-            Assert.AreEqual("ABC1234,56TRUE", actual);
+            Assert.That(actual, Is.EqualTo("ABC1234,56TRUE"));
 
             actual = wb.Evaluate(@"CONCATENATE("""",""123"")");
-            Assert.AreEqual("123", actual);
+            Assert.That(actual, Is.EqualTo("123"));
         }
 
         [Test]
@@ -200,20 +206,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("C1").FormulaA1 = "CONCATENATE(A1:A2,\" \",B1:B2)";
             ws.Cell("A3").FormulaA1 = "CONCATENATE(A1:A2,\" \",B1:B2)";
 
-            Assert.AreEqual("Hello World", ws.Evaluate(@"CONCATENATE(A1,"" "",B1)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate(@"CONCATENATE(A1,"" "",B1)"), Is.EqualTo("Hello World"));
 
-            // The result on C1 is on the same row (only one intersected cell) means implicit intersection
-            // results in a one value per intersection and thus correct value. The A3 intersects two cells
-            // and thus results in #VALUE! error.
-            Assert.AreEqual("Hello World", ws.Cell("C1").Value);
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A3").Value);
+                // The result on C1 is on the same row (only one intersected cell) means implicit intersection
+                // results in a one value per intersection and thus correct value. The A3 intersects two cells
+                // and thus results in #VALUE! error.
+                Assert.That(ws.Cell("C1").Value, Is.EqualTo("Hello World"));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Concatenate_has_limit_of_32767_characters()
         {
-            Assert.AreNotEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("CONCATENATE(REPT(\"A\",32767))"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("CONCATENATE(REPT(\"A\",32768))"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("CONCATENATE(REPT(\"A\",32767))"), Is.Not.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("CONCATENATE(REPT(\"A\",32768))"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
@@ -227,26 +239,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Calling cell is 1st row, so formula should return A1
             ws.Cell("B1").SetFormulaA1("CONCATENATE(A1:A3)");
-            Assert.AreEqual("20", ws.Cell("B1").Value);
+            Assert.That(ws.Cell("B1").Value, Is.EqualTo("20"));
 
             // Calling cell is 2nd row, so formula should return A2
             ws.Cell("B2").SetFormulaA1("CONCATENATE(A1:A3)");
-            Assert.AreEqual("AB", ws.Cell("B2").Value);
+            Assert.That(ws.Cell("B2").Value, Is.EqualTo("AB"));
 
             // Calling cell is 3rd row, so formula should return A3's textual representation
             ws.Cell("B3").SetFormulaA1("CONCATENATE(A1:A3)");
-            Assert.AreEqual("43466", ws.Cell("B3").Value);
+            Assert.That(ws.Cell("B3").Value, Is.EqualTo("43466"));
 
             // Calling cell doesn't share row with any cell in parameter range.
             ws.Cell("A4").SetFormulaA1("CONCATENATE(A1:A3)");
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A4").Value);
+            Assert.That(ws.Cell("A4").Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Dollar_coercion()
         {
             // Empty string is not coercible to number
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("DOLLAR(\"\", 3)"));
+            Assert.That(XLWorkbook.EvaluateExpr("DOLLAR(\"\", 3)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         // en-US culture differs between .NET Fx and Core for negative currency -> no test for negative
@@ -288,166 +300,178 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var actual = wb.Evaluate("DOLLAR(123.543)");
-            Assert.AreEqual("$123.54", actual);
+            Assert.That(actual, Is.EqualTo("$123.54"));
         }
 
         [Test]
         public void Dollar_can_have_at_most_127_decimal_places()
         {
             using var wb = new XLWorkbook();
-            Assert.AreEqual("$1." + new string('0', 99), wb.Evaluate("DOLLAR(1,99)"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("DOLLAR(1,128)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Evaluate("DOLLAR(1,99)"), Is.EqualTo("$1." + new string('0', 99)));
+                Assert.That(wb.Evaluate("DOLLAR(1,128)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Exact_Empty_Input_String()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Exact("""", """")");
-            Assert.AreEqual(true, actual);
+            object actual = XLWorkbook.EvaluateExpr(@"Exact("""", """")");
+            Assert.That(actual, Is.EqualTo(true));
         }
 
         [Test]
         public void Exact_Value()
         {
-            Object actual = XLWorkbook.EvaluateExpr(@"Exact(""asdf"", ""asdf"")");
-            Assert.AreEqual(true, actual);
+            object actual = XLWorkbook.EvaluateExpr(@"Exact(""asdf"", ""asdf"")");
+            Assert.That(actual, Is.EqualTo(true));
 
             actual = XLWorkbook.EvaluateExpr(@"Exact(""asdf"", ""ASDF"")");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
 
             actual = XLWorkbook.EvaluateExpr(@"Exact(123, 123)");
-            Assert.AreEqual(true, actual);
+            Assert.That(actual, Is.EqualTo((true)));
 
             actual = XLWorkbook.EvaluateExpr(@"Exact(321, 123)");
-            Assert.AreEqual(false, actual);
+            Assert.That(actual, Is.EqualTo(false));
         }
 
         [Test]
         public void Find_Empty_Pattern_And_Empty_Text()
         {
-            // Different behavior from SEARCH
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr(@"FIND("""", """")"));
+            Assert.Multiple(() =>
+            {
+                // Different behavior from SEARCH
+                Assert.That(XLWorkbook.EvaluateExpr(@"FIND("""", """")"), Is.EqualTo(1));
 
-            Assert.AreEqual(2, XLWorkbook.EvaluateExpr(@"FIND("""", ""a"", 2)"));
+                Assert.That(XLWorkbook.EvaluateExpr(@"FIND("""", ""a"", 2)"), Is.EqualTo(2));
+            });
         }
 
         [Test]
         public void Find_Empty_Search_Pattern_Returns_Start_Of_Text()
         {
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr(@"FIND("""", ""asdf"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND("""", ""asdf"")"), Is.EqualTo(1));
         }
 
         [Test]
         public void Find_Looks_Only_From_Start_Position_Onward()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FIND(""This"", ""This is some text"", 2)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND(""This"", ""This is some text"", 2)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_Start_Position_Too_Large()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FIND(""abc"", ""abcdef"", 10)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND(""abc"", ""abcdef"", 10)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_Start_Position_Too_Small()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FIND(""text"", ""This is some text"", 0)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND(""text"", ""This is some text"", 0)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_Empty_Searched_Text_Returns_Error()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FIND(""abc"", """")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND(""abc"", """")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_String_Not_Found()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FIND(""123"", ""asdf"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND(""123"", ""asdf"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_Case_Sensitive_String_Not_Found()
         {
             // Find is case-sensitive
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"FIND(""excel"", ""Microsoft Excel 2010"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"FIND(""excel"", ""Microsoft Excel 2010"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_Value()
         {
             var actual = XLWorkbook.EvaluateExpr(@"FIND(""Tuesday"", ""Today is Tuesday"")");
-            Assert.AreEqual(10, actual);
+            Assert.That(actual, Is.EqualTo(10));
 
             // Doesnt support wildcards
             actual = XLWorkbook.EvaluateExpr(@"FIND(""T*y"", ""Today is Tuesday"")");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Find_Arguments_Are_Converted_To_Expected_Types()
         {
             var actual = XLWorkbook.EvaluateExpr(@"FIND(1.2, ""A1.2B"")");
-            Assert.AreEqual(2, actual);
+            Assert.That(actual, Is.EqualTo(2));
 
             actual = XLWorkbook.EvaluateExpr(@"FIND(TRUE, ""ATRUE"")");
-            Assert.AreEqual(2, actual);
+            Assert.That(actual, Is.EqualTo(2));
 
             actual = XLWorkbook.EvaluateExpr(@"FIND(23, 1.2345)");
-            Assert.AreEqual(3, actual);
+            Assert.That(actual, Is.EqualTo(3));
 
             actual = XLWorkbook.EvaluateExpr(@"FIND(""a"", ""aaaaa"", ""2 1/2"")");
-            Assert.AreEqual(2, actual);
+            Assert.That(actual, Is.EqualTo(2));
         }
 
         [Test]
         public void Find_Error_Arguments_Return_The_Error()
         {
             var actual = XLWorkbook.EvaluateExpr(@"FIND(#N/A, ""a"")");
-            Assert.AreEqual(XLError.NoValueAvailable, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NoValueAvailable));
 
             actual = XLWorkbook.EvaluateExpr(@"FIND("""", #N/A)");
-            Assert.AreEqual(XLError.NoValueAvailable, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NoValueAvailable));
 
             actual = XLWorkbook.EvaluateExpr(@"FIND(""a"", ""a"", #N/A)");
-            Assert.AreEqual(XLError.NoValueAvailable, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [Test]
         public void Fixed_coercion()
         {
             using var wb = new XLWorkbook();
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("""FIXED("asdf")"""));
-            Assert.AreEqual("1234.0", wb.Evaluate("""FIXED(1234,1,"TRUE")"""));
-            Assert.AreEqual("1,234.0", wb.Evaluate("""FIXED(1234,1,"FALSE")"""));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("""FIXED(1234,1,"0")"""));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Evaluate("""FIXED("asdf")"""), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(wb.Evaluate("""FIXED(1234,1,"TRUE")"""), Is.EqualTo("1234.0"));
+                Assert.That(wb.Evaluate("""FIXED(1234,1,"FALSE")"""), Is.EqualTo("1,234.0"));
+                Assert.That(wb.Evaluate("""FIXED(1234,1,"0")"""), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Fixed_examples()
         {
             using var wb = new XLWorkbook();
-            Assert.AreEqual("1,234,567.00", wb.Evaluate("FIXED(1234567)"));
-            Assert.AreEqual("1234567.5556", wb.Evaluate("FIXED(1234567.555555,4,TRUE)"));
-            Assert.AreEqual("0.5555550000", wb.Evaluate("FIXED(.555555,10)"));
-            Assert.AreEqual("1,235,000", wb.Evaluate("FIXED(1234567,-3)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Evaluate("FIXED(1234567)"), Is.EqualTo("1,234,567.00"));
+                Assert.That(wb.Evaluate("FIXED(1234567.555555,4,TRUE)"), Is.EqualTo("1234567.5556"));
+                Assert.That(wb.Evaluate("FIXED(.555555,10)"), Is.EqualTo("0.5555550000"));
+                Assert.That(wb.Evaluate("FIXED(1234567,-3)"), Is.EqualTo("1,235,000"));
+            });
         }
 
         [Test]
         public void Fixed_en()
         {
             var actual = XLWorkbook.EvaluateExpr("FIXED(17300.67,4)");
-            Assert.AreEqual("17,300.6700", actual);
+            Assert.That(actual, Is.EqualTo("17,300.6700"));
 
             actual = XLWorkbook.EvaluateExpr("FIXED(17300.67,2,TRUE)");
-            Assert.AreEqual("17300.67", actual);
+            Assert.That(actual, Is.EqualTo("17300.67"));
 
             actual = XLWorkbook.EvaluateExpr("FIXED(17300.67)");
-            Assert.AreEqual("17,300.67", actual);
+            Assert.That(actual, Is.EqualTo("17,300.67"));
 
             actual = XLWorkbook.EvaluateExpr("FIXED(1,-1E+300)");
-            Assert.AreEqual("0", actual);
+            Assert.That(actual, Is.EqualTo("0"));
         }
 
         [Test]
@@ -456,48 +480,51 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var actual = wb.Evaluate("FIXED(17300.67,4)");
-            Assert.AreEqual("17 300,6700", actual);
+            Assert.That(actual, Is.EqualTo("17 300,6700"));
 
             actual = wb.Evaluate("FIXED(17300.67,2,TRUE)");
-            Assert.AreEqual("17300,67", actual);
+            Assert.That(actual, Is.EqualTo("17300,67"));
 
             actual = wb.Evaluate("FIXED(17300.67)");
-            Assert.AreEqual("17 300,67", actual);
+            Assert.That(actual, Is.EqualTo("17 300,67"));
         }
 
         [Test]
         public void Fixed_can_have_at_most_127_decimal_places()
         {
             using var wb = new XLWorkbook();
-            Assert.AreEqual("1." + new string('0', 99), wb.Evaluate("FIXED(1,99)"));
-            Assert.AreEqual(XLError.IncompatibleValue, wb.Evaluate("FIXED(1,128)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Evaluate("FIXED(1,99)"), Is.EqualTo("1." + new string('0', 99)));
+                Assert.That(wb.Evaluate("FIXED(1,128)"), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Left_returns_whole_text_when_requested_length_is_greater_than_text_length()
         {
             var actual = XLWorkbook.EvaluateExpr(@"LEFT(""ABC"", 5)");
-            Assert.AreEqual("ABC", actual);
+            Assert.That(actual, Is.EqualTo("ABC"));
         }
 
         [Test]
         public void Left_takes_one_character_by_default()
         {
             var actual = XLWorkbook.EvaluateExpr("""LEFT("ABC")""");
-            Assert.AreEqual("A", actual);
+            Assert.That(actual, Is.EqualTo("A"));
         }
 
         [Test]
         public void Left_returns_error_on_negative_number_of_chars()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""LEFT("ABC", -1)"""));
+            Assert.That(XLWorkbook.EvaluateExpr("""LEFT("ABC", -1)"""), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Left_returns_empty_string_on_empty_input()
         {
             var actual = XLWorkbook.EvaluateExpr("""LEFT("")""");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [TestCase("ABC", 2, ExpectedResult = "AB")]
@@ -546,14 +573,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mid_returns_rest_of_text_when_end_is_out_of_text_bounds()
         {
             var actual = XLWorkbook.EvaluateExpr("""MID("ABC",1,5)""");
-            Assert.AreEqual("ABC", actual);
+            Assert.That(actual, Is.EqualTo("ABC"));
         }
 
         [Test]
         public void Mid_when_start_is_after_end_of_text_return_empty_string()
         {
             var actual = XLWorkbook.EvaluateExpr("""MID("ABC",5,5)""");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [TestCase(0.9)]
@@ -564,7 +591,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mid_start_must_be_at_least_one_and_at_most_max_int(double start)
         {
             var actual = XLWorkbook.EvaluateExpr($"""MID("ABC",{start},1)""");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase(-0.1)]
@@ -574,7 +601,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Mid_length_must_be_at_least_zero_and_at_most_max_int(double length)
         {
             var actual = XLWorkbook.EvaluateExpr($"""MID("ABC",1,{length})""");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("", 1, 1, ExpectedResult = "")]
@@ -591,11 +618,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Mid_uses_code_units()
         {
-            // MID returns unpaired surrogates
-            Assert.AreEqual("😊\uD83D", XLWorkbook.EvaluateExpr("""MID("😊😊😊",1,3)"""));
-            Assert.AreEqual("😊😊", XLWorkbook.EvaluateExpr("""MID("😊😊😊",1,4)"""));
-            Assert.AreEqual("\uDE0A😊\uD83D", XLWorkbook.EvaluateExpr("""MID("😊😊😊",2,4)"""));
-            Assert.AreEqual(3, XLWorkbook.EvaluateExpr("""LEN(MID("😊😊😊",1,3))"""));
+            Assert.Multiple(() =>
+            {
+                // MID returns unpaired surrogates
+                Assert.That(XLWorkbook.EvaluateExpr("""MID("😊😊😊",1,3)"""), Is.EqualTo("😊\uD83D"));
+                Assert.That(XLWorkbook.EvaluateExpr("""MID("😊😊😊",1,4)"""), Is.EqualTo("😊😊"));
+                Assert.That(XLWorkbook.EvaluateExpr("""MID("😊😊😊",2,4)"""), Is.EqualTo("\uDE0A😊\uD83D"));
+                Assert.That(XLWorkbook.EvaluateExpr("""LEN(MID("😊😊😊",1,3))"""), Is.EqualTo(3));
+            });
         }
 
         [TestCase("", 0d)]
@@ -623,7 +653,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void NumberValue_converts_text_to_number(string text, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExprCurrent($"NUMBERVALUE(\"{text}\")");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -631,7 +661,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void NumberValue_takes_separators_from_current_culture()
         {
             var actual = (double)XLWorkbook.EvaluateExprCurrent("NUMBERVALUE(\"10.0.00.0,25\")");
-            Assert.AreEqual(100000.25, actual);
+            Assert.That(actual, Is.EqualTo(100000.25));
         }
 
         [TestCase("1,234.56", ".", ",", 1234.56d)]
@@ -640,7 +670,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void NumberValue_optional_parameters_can_set_decimal_and_group_separators(string text, string @decimal, string group, double expectedResult)
         {
             var actual = (double)XLWorkbook.EvaluateExpr($"NUMBERVALUE(\"{text}\",\"{@decimal}\",\"{group}\")");
-            Assert.AreEqual(expectedResult, actual);
+            Assert.That(actual, Is.EqualTo(expectedResult));
         }
 
         [TestCase("NUMBERVALUE(\"123.45\", \".\", \".\")")] // Group separator same as decimal separator
@@ -656,7 +686,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("NUMBERVALUE(\"1\",\"\",\",\")")] // Empty decimal separators
         public void NumberValue_returns_error_on_unparsable_texts_out_of_range(string expression)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(expression));
+            Assert.That(XLWorkbook.EvaluateExpr(expression), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("", ExpectedResult = "")]
@@ -679,7 +709,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Replace_beyond_limit_appends_replacement(int startPos, int length)
         {
             var actual = XLWorkbook.EvaluateExpr($"""REPLACE("",{startPos},{length},"new text")""");
-            Assert.AreEqual("new text", actual);
+            Assert.That(actual, Is.EqualTo("new text"));
         }
 
         [TestCase("Here is some obsolete text to replace.", 14, 13, "new text", ExpectedResult = "Here is some new text to replace.")]
@@ -703,27 +733,33 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Replace_start_position_must_be_from_1_to_32767()
         {
-            Assert.AreEqual(@"DABC", XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,0,"D")"""));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""REPLACE("ABC",0.9,0,"D")"""));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""REPLACE("ABC",-1,0,"D")"""));
-            Assert.AreEqual("D", XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,32767.9,"D")"""));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,32768,"D")"""));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,0,"D")"""), Is.EqualTo(@"DABC"));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",0.9,0,"D")"""), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",-1,0,"D")"""), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,32767.9,"D")"""), Is.EqualTo("D"));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,32768,"D")"""), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Replace_length_must_be_from_0_to_32767()
         {
-            Assert.AreEqual("ABC", XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,0,"")"""));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,-0.1,"D")"""));
-            Assert.AreEqual("D", XLWorkbook.EvaluateExpr("""REPLACE("ABC",1, 32767.9,"D")"""));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""REPLACE("ABC",1, 32768,"D")"""));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,0,"")"""), Is.EqualTo("ABC"));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1,-0.1,"D")"""), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1, 32767.9,"D")"""), Is.EqualTo("D"));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPLACE("ABC",1, 32768,"D")"""), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [Test]
         public void Rept_returns_empty_string_when_text_is_empty_string()
         {
             var actual = XLWorkbook.EvaluateExpr("""REPT("",3)""");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [TestCase(-1)]
@@ -731,14 +767,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(2147483648)]
         public void Rept_returns_error_when_count_is_negative_or_greater_than_max_int(double count)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr($"""REPT("",{count})"""));
+            Assert.That(XLWorkbook.EvaluateExpr($"""REPT("",{count})"""), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Rept_limits_output_text_length_to_32767()
         {
-            Assert.AreEqual(new string('A', 32767), XLWorkbook.EvaluateExpr("""REPT("A",32767)"""));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""REPT("A",32768)"""));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("""REPT("A",32767)"""), Is.EqualTo(new string('A', 32767)));
+                Assert.That(XLWorkbook.EvaluateExpr("""REPT("A",32768)"""), Is.EqualTo(XLError.IncompatibleValue));
+            });
         }
 
         [TestCase("ABC", 3, ExpectedResult = @"ABCABCABC")]
@@ -755,27 +794,27 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Right_returns_whole_text_when_requested_length_is_greater_than_text_length(int length)
         {
             var actual = XLWorkbook.EvaluateExpr($"""RIGHT("ABC",{length})""");
-            Assert.AreEqual("ABC", actual);
+            Assert.That(actual, Is.EqualTo("ABC"));
         }
 
         [Test]
         public void Right_takes_one_character_by_default()
         {
             var actual = XLWorkbook.EvaluateExpr("""RIGHT("ABC")""");
-            Assert.AreEqual("C", actual);
+            Assert.That(actual, Is.EqualTo("C"));
         }
 
         [Test]
         public void Right_returns_error_on_negative_number_of_chars()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("""RIGHT("ABC",-1)"""));
+            Assert.That(XLWorkbook.EvaluateExpr("""RIGHT("ABC",-1)"""), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Right_returns_empty_string_on_empty_input()
         {
             var actual = XLWorkbook.EvaluateExpr("""RIGHT("")""");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [TestCase("ABC", 0, ExpectedResult = "")]
@@ -795,50 +834,50 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Search_Empty_Pattern_And_Empty_Text()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH("""", """")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH("""", """")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Empty_Search_Pattern_Returns_Start_Of_Text()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SEARCH("""", ""asdf"")");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
         }
 
         [Test]
         public void Search_Looks_Only_From_Start_Position_Onward()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH(""This"", ""This is some text"", 2)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH(""This"", ""This is some text"", 2)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Start_Position_Too_Large()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH(""abc"", ""abcdef"", 10)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH(""abc"", ""abcdef"", 10)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Start_Position_Too_Small()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH(""text"", ""This is some text"", 0)"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH(""text"", ""This is some text"", 0)"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Empty_Searched_Text_Returns_Error()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH(""abc"", """")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH(""abc"", """")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Text_Not_Found()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH(""123"", ""asdf"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH(""123"", ""asdf"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Wildcard_String_Not_Found()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"SEARCH(""soft?2010"", ""Microsoft Excel 2010"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"SEARCH(""soft?2010"", ""Microsoft Excel 2010"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         // http://www.excel-easy.com/examples/find-vs-search.html
@@ -846,108 +885,108 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Search_Value()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SEARCH(""Tuesday"", ""Today is Tuesday"")");
-            Assert.AreEqual(10, actual);
+            Assert.That(actual, Is.EqualTo(10));
 
             // The search is case-insensitive
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""excel"", ""Microsoft Excel 2010"")");
-            Assert.AreEqual(11, actual);
+            Assert.That(actual, Is.EqualTo(11));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""soft*2010"", ""Microsoft Excel 2010"")");
-            Assert.AreEqual(6, actual);
+            Assert.That(actual, Is.EqualTo(6));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""Excel 20??"", ""Microsoft Excel 2010"")");
-            Assert.AreEqual(11, actual);
+            Assert.That(actual, Is.EqualTo(11));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""text"", ""This is some text"", 14)");
-            Assert.AreEqual(14, actual);
+            Assert.That(actual, Is.EqualTo(14));
         }
 
         [Test]
         public void Search_Tilde_Escapes_Next_Char()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SEARCH(""~a~b~"", ""ab"")");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""a~*"", ""a*"")");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""a~*"", ""ab"")");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""a~?"", ""a?"")");
-            Assert.AreEqual(1, actual);
+            Assert.That(actual, Is.EqualTo(1));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""a~?"", ""ab"")");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Search_Arguments_Are_Converted_To_Expected_Types()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SEARCH(1.2, ""A1.2B"")");
-            Assert.AreEqual(2, actual);
+            Assert.That(actual, Is.EqualTo(2));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(TRUE, ""ATRUE"")");
-            Assert.AreEqual(2, actual);
+            Assert.That(actual, Is.EqualTo(2));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(23, 1.2345)");
-            Assert.AreEqual(3, actual);
+            Assert.That(actual, Is.EqualTo(3));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""a"", ""aaaaa"", ""2 1/2"")");
-            Assert.AreEqual(2, actual);
+            Assert.That(actual, Is.EqualTo(2));
         }
 
         [Test]
         public void Search_Error_Arguments_Return_The_Error()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SEARCH(#N/A, ""a"")");
-            Assert.AreEqual(XLError.NoValueAvailable, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NoValueAvailable));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH("""", #N/A)");
-            Assert.AreEqual(XLError.NoValueAvailable, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NoValueAvailable));
 
             actual = XLWorkbook.EvaluateExpr(@"SEARCH(""a"", ""a"", #N/A)");
-            Assert.AreEqual(XLError.NoValueAvailable, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NoValueAvailable));
         }
 
         [Test]
         public void Substitute_replaces_n_th_occurence()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday."", ""Tuesday"", ""Monday"")");
-            Assert.AreEqual("This is a Monday.", actual);
+            Assert.That(actual, Is.EqualTo("This is a Monday."));
 
             actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", ""Monday"", 1)");
-            Assert.AreEqual("This is a Monday. Next week also has a Tuesday.", actual);
+            Assert.That(actual, Is.EqualTo("This is a Monday. Next week also has a Tuesday."));
 
             actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", ""Monday"", 2)");
-            Assert.AreEqual("This is a Tuesday. Next week also has a Monday.", actual);
+            Assert.That(actual, Is.EqualTo("This is a Tuesday. Next week also has a Monday."));
 
             actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", """", ""Monday"")");
-            Assert.AreEqual("This is a Tuesday. Next week also has a Tuesday.", actual);
+            Assert.That(actual, Is.EqualTo("This is a Tuesday. Next week also has a Tuesday."));
 
             actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""This is a Tuesday. Next week also has a Tuesday."", ""Tuesday"", """")");
-            Assert.AreEqual("This is a . Next week also has a .", actual);
+            Assert.That(actual, Is.EqualTo("This is a . Next week also has a ."));
         }
 
         [Test]
         public void Substitute_on_empty_string_returns_empty_string()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE("""","""",""Monday"")");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [Test]
         public void Substitute_is_case_sensitive()
         {
             var actual = XLWorkbook.EvaluateExpr("""SUBSTITUTE("A","a","Z")""");
-            Assert.AreEqual("A", actual);
+            Assert.That(actual, Is.EqualTo("A"));
         }
 
         [Test]
         public void Substitute_returns_original_string_when_occurrence_is_not_found()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABCABC"",""A"",""Z"",3)");
-            Assert.AreEqual(@"ABCABC", actual);
+            Assert.That(actual, Is.EqualTo(@"ABCABC"));
         }
 
         [Test]
@@ -955,67 +994,70 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // AA is matches at every character, it doesn't skip
             var actual = XLWorkbook.EvaluateExpr("""SUBSTITUTE("AAAAAAAA","AA","ZZ",3)""");
-            Assert.AreEqual(@"AAZZAAAA", actual);
+            Assert.That(actual, Is.EqualTo(@"AAZZAAAA"));
         }
 
         [Test]
         public void Substitute_occurence_must_be_between_one_and_max_int()
         {
             var actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABC"",""B"",""ZZ"",0.9)");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
 
             actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABC"",""B"",""ZZ"", 2147483646.9)");
-            Assert.AreEqual("ABC", actual);
+            Assert.That(actual, Is.EqualTo("ABC"));
 
             actual = XLWorkbook.EvaluateExpr(@"SUBSTITUTE(""ABC"",""B"",""ZZ"", 2147483647)");
-            Assert.AreEqual(XLError.IncompatibleValue, actual);
+            Assert.That(actual, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void T_returns_empty_string_on_non_text()
         {
             var actual = XLWorkbook.EvaluateExpr("T(TODAY())");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
 
             actual = XLWorkbook.EvaluateExpr("T(IF(TRUE,,))");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
 
             actual = XLWorkbook.EvaluateExpr("T(TRUE)");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
 
             actual = XLWorkbook.EvaluateExpr("T(123)");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [Test]
         public void T_propagates_error()
         {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("T(#DIV/0!)"));
+            Assert.That(XLWorkbook.EvaluateExpr("T(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
         }
 
         [Test]
         public void T_returns_text_when_value_is_text()
         {
             var actual = XLWorkbook.EvaluateExpr("""T("asdf")""");
-            Assert.AreEqual("asdf", actual);
+            Assert.That(actual, Is.EqualTo("asdf"));
 
             actual = XLWorkbook.EvaluateExpr("""T("")""");
-            Assert.AreEqual("", actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [Test]
         public void T_returns_array_of_results_when_argument_is_array()
         {
             const string formula = """T({"A",5,"B"})""";
-            Assert.AreEqual(3, XLWorkbook.EvaluateExpr($"""COLUMNS({formula})"""));
-            Assert.AreEqual(1, XLWorkbook.EvaluateExpr($"""ROWS({formula})"""));
-            Assert.AreEqual("A", XLWorkbook.EvaluateExpr($"""INDEX({formula},1,1)"""));
-            Assert.AreEqual("", XLWorkbook.EvaluateExpr($"""INDEX({formula},1,2)"""));
-            Assert.AreEqual("B", XLWorkbook.EvaluateExpr($"""INDEX({formula},1,3)"""));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr($"""COLUMNS({formula})"""), Is.EqualTo(3));
+                Assert.That(XLWorkbook.EvaluateExpr($"""ROWS({formula})"""), Is.EqualTo(1));
+                Assert.That(XLWorkbook.EvaluateExpr($"""INDEX({formula},1,1)"""), Is.EqualTo("A"));
+                Assert.That(XLWorkbook.EvaluateExpr($"""INDEX({formula},1,2)"""), Is.EqualTo(""));
+                Assert.That(XLWorkbook.EvaluateExpr($"""INDEX({formula},1,3)"""), Is.EqualTo("B"));
 
-            // Array doesn't propagate single error, but returns errors in the array
-            Assert.AreEqual("A", XLWorkbook.EvaluateExpr("""INDEX(T({"A",#REF!}),1,1)"""));
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("""INDEX(T({"A",#REF!}),1,2)"""));
+                // Array doesn't propagate single error, but returns errors in the array
+                Assert.That(XLWorkbook.EvaluateExpr("""INDEX(T({"A",#REF!}),1,1)"""), Is.EqualTo("A"));
+                Assert.That(XLWorkbook.EvaluateExpr("""INDEX(T({"A",#REF!}),1,2)"""), Is.EqualTo(XLError.CellReference));
+            });
         }
 
         [Test]
@@ -1027,19 +1069,22 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("B4").Value = 10;
             ws.Cell("B5").Value = XLError.NoValueAvailable;
 
-            Assert.AreEqual("ABC", ws.Evaluate("T(B3:B4)"));
-            Assert.AreEqual(2, ws.Evaluate("TYPE(T(B3:B4))")); // Is text, not array
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Evaluate("T(B3:B4)"), Is.EqualTo("ABC"));
+                Assert.That(ws.Evaluate("TYPE(T(B3:B4))"), Is.EqualTo(2)); // Is text, not array
 
-            Assert.AreEqual(string.Empty, ws.Evaluate("T(B4:C4)"));
+                Assert.That(ws.Evaluate("T(B4:C4)"), Is.EqualTo(""));
 
-            Assert.AreEqual(XLError.NoValueAvailable, ws.Evaluate("T(B5:C5)"));
+                Assert.That(ws.Evaluate("T(B5:C5)"), Is.EqualTo(XLError.NoValueAvailable));
+            });
         }
 
         [Test]
         public void Text_returns_empty_string_on_empty_string()
         {
             var actual = XLWorkbook.EvaluateExpr(@"TEXT(1913415.93,"""")");
-            Assert.AreEqual(string.Empty, actual);
+            Assert.That(actual, Is.EqualTo(""));
         }
 
         [TestCase("DATE(2010, 1, 1)", "yyyy-MM-dd", ExpectedResult = "2010-01-01")]
@@ -1074,13 +1119,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(2018, 12, 10, 11, 22, 42, "m/d/yyyy h:mm:ss", "12/10/2018 11:22:42")]
         public void Text_formats_serial_dates(int year, int months, int days, int hour, int minutes, int seconds, string format, string expected)
         {
-            Assert.AreEqual(expected, XLWorkbook.EvaluateExpr($@"TEXT(DATE({year},{months},{days}) + TIME({hour},{minutes},{seconds}),""{format}"")"));
+            Assert.That(XLWorkbook.EvaluateExpr($@"TEXT(DATE({year},{months},{days}) + TIME({hour},{minutes},{seconds}),""{format}"")"), Is.EqualTo(expected));
         }
 
         [Test]
         public void Text_propagates_errors()
         {
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr(@"TEXT(#REF!,""#00"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"TEXT(#REF!,""#00"")"), Is.EqualTo(XLError.CellReference));
         }
 
         [TestCase("TEXTJOIN(\",\",TRUE,A1:B2)", "A,B,D")]
@@ -1110,7 +1155,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("C1").FormulaA1 = formula;
             var a = ws.Cell("C1").Value;
 
-            Assert.AreEqual(expectedOutput, a);
+            Assert.That(a, Is.EqualTo(expectedOutput));
         }
 
         [TestCase("TEXTJOIN(\",\", FALSE, D1:D32769)")]
@@ -1123,13 +1168,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Excel actually returns #CALC!, but we don't have that error, mostly
             // because parser doesn't recognize it.
-            Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("C1").Value);
+            Assert.That(ws.Cell("C1").Value, Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("TEXTJOIN(\",\", \"Invalid\", \"Hello\", \"World\")")]
         public void TextJoin_coercion(string formula)
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(formula));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [TestCase("", ExpectedResult = "")]
@@ -1148,14 +1193,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void Upper_empty_string_returns_empty_string()
         {
-            Assert.AreEqual("", XLWorkbook.EvaluateExpr("""UPPER("")"""));
+            Assert.That(XLWorkbook.EvaluateExpr("""UPPER("")"""), Is.EqualTo(""));
         }
 
         [Test]
         public void Upper_converts_text_to_upper_case()
         {
             var actual = XLWorkbook.EvaluateExpr("""UPPER("AbCdEfG")""");
-            Assert.AreEqual(@"ABCDEFG", actual);
+            Assert.That(actual, Is.EqualTo(@"ABCDEFG"));
         }
 
         [SetCulture("tr-TR")]
@@ -1164,13 +1209,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             // Türkiye converts i to İ, not I.
             using var wb = new XLWorkbook();
-            Assert.AreEqual("İNTELLİGENCE 2.0!", wb.Evaluate("""UPPER("intelligence 2.0!")"""));
+            Assert.That(wb.Evaluate("""UPPER("intelligence 2.0!")"""), Is.EqualTo("İNTELLİGENCE 2.0!"));
         }
 
         [Test]
         public void Value_Input_String_Is_Not_A_Number()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"VALUE(""asdf"")"));
+            Assert.That(XLWorkbook.EvaluateExpr(@"VALUE(""asdf"")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
@@ -1178,22 +1223,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.AreEqual(0d, ws.Evaluate("VALUE(A1)"));
+            Assert.That(ws.Evaluate("VALUE(A1)"), Is.EqualTo(0d));
         }
 
         [Test]
         public void Value_FromEmptyStringIsError()
         {
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("VALUE(\"\")"));
+            Assert.That(XLWorkbook.EvaluateExpr("VALUE(\"\")"), Is.EqualTo(XLError.IncompatibleValue));
         }
 
         [Test]
         public void Value_PassingUnexpectedTypes()
         {
-            Assert.AreEqual(14d, XLWorkbook.EvaluateExpr(@"VALUE(14)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"VALUE(TRUE)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr(@"VALUE(FALSE)"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr(@"VALUE(#DIV/0!)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr(@"VALUE(14)"), Is.EqualTo(14d));
+                Assert.That(XLWorkbook.EvaluateExpr(@"VALUE(TRUE)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr(@"VALUE(FALSE)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr(@"VALUE(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
+            });
         }
 
         [Test]
@@ -1201,11 +1249,14 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
 
-            // Examples from spec
-            Assert.AreEqual(123.456d, wb.Evaluate("VALUE(\"123.456\")"));
-            Assert.AreEqual(1000d, wb.Evaluate("VALUE(\"$1,000\")"));
-            Assert.AreEqual(new DateTime(2002, 3, 23).ToSerialDateTime(), wb.Evaluate("VALUE(\"23-Mar-2002\")"));
-            Assert.AreEqual(0.188056d, (double)wb.Evaluate("VALUE(\"16:48:00\")-VALUE(\"12:17:12\")"), 0.000001d);
+            Assert.Multiple(() =>
+            {
+                // Examples from spec
+                Assert.That(wb.Evaluate("VALUE(\"123.456\")"), Is.EqualTo(123.456d));
+                Assert.That(wb.Evaluate("VALUE(\"$1,000\")"), Is.EqualTo(1000d));
+                Assert.That(wb.Evaluate("VALUE(\"23-Mar-2002\")"), Is.EqualTo(new DateTime(2002, 3, 23).ToSerialDateTime()));
+                Assert.That((double)wb.Evaluate("VALUE(\"16:48:00\")-VALUE(\"12:17:12\")"), Is.EqualTo(0.188056d).Within(0.000001d));
+            });
         }
 
         [Test]
@@ -1214,24 +1265,33 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             using var wb = new XLWorkbook();
 
-            // Examples from spec
-            Assert.AreEqual(123.456d, wb.Evaluate("VALUE(\"123,456\")"));
-            Assert.AreEqual(1000d, wb.Evaluate("VALUE(\"1 000 Kč\")"));
-            Assert.AreEqual(37338d, wb.Evaluate("VALUE(\"23-bře-2002\")"));
-            Assert.AreEqual(0.188056d, (double)wb.Evaluate("VALUE(\"16:48:00\")-VALUE(\"12:17:12\")"), 0.000001d);
+            Assert.Multiple(() =>
+            {
+                // Examples from spec
+                Assert.That(wb.Evaluate("VALUE(\"123,456\")"), Is.EqualTo(123.456d));
+                Assert.That(wb.Evaluate("VALUE(\"1 000 Kč\")"), Is.EqualTo(1000d));
+                Assert.That(wb.Evaluate("VALUE(\"23-bře-2002\")"), Is.EqualTo(37338d));
+                Assert.That((double)wb.Evaluate("VALUE(\"16:48:00\")-VALUE(\"12:17:12\")"), Is.EqualTo(0.188056d).Within(0.000001d));
 
-            // Various number/currency formats
-            Assert.AreEqual(-1d, wb.Evaluate("VALUE(\"(1)\")"));
-            Assert.AreEqual(-1d, wb.Evaluate("VALUE(\"(100%)\")"));
-            Assert.AreEqual(-1d, wb.Evaluate("VALUE(\"(100%)\")"));
-            Assert.AreEqual(-15d, wb.Evaluate("VALUE(\"(1,5e1 Kč)\")"));
-            Assert.AreEqual(-15d, wb.Evaluate("VALUE(\"(1,5e3%)\")"));
-            Assert.AreEqual(-15d, wb.Evaluate("VALUE(\"(1,5e3)%\")"));
+                // Various number/currency formats
+                Assert.That(wb.Evaluate("VALUE(\"(1)\")"), Is.EqualTo(-1d));
+                Assert.That(wb.Evaluate("VALUE(\"(100%)\")"), Is.EqualTo(-1d));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Evaluate("VALUE(\"(100%)\")"), Is.EqualTo(-1d));
+                Assert.That(wb.Evaluate("VALUE(\"(1,5e1 Kč)\")"), Is.EqualTo(-15d));
+                Assert.That(wb.Evaluate("VALUE(\"(1,5e3%)\")"), Is.EqualTo(-15d));
+                Assert.That(wb.Evaluate("VALUE(\"(1,5e3)%\")"), Is.EqualTo(-15d));
+            });
 
             var expectedSerialDate = new DateTime(2022, 3, 5).ToSerialDateTime();
-            Assert.AreEqual(expectedSerialDate, wb.Evaluate("VALUE(\"5-březen-22\")"));
-            Assert.AreEqual(expectedSerialDate, wb.Evaluate("VALUE(\"05.03.2022\")"));
-            Assert.AreEqual(new DateTime(DateTime.Now.Year, 3, 5).ToSerialDateTime(), wb.Evaluate("VALUE(\"5-březen\")"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Evaluate("VALUE(\"5-březen-22\")"), Is.EqualTo(expectedSerialDate));
+                Assert.That(wb.Evaluate("VALUE(\"05.03.2022\")"), Is.EqualTo(expectedSerialDate));
+                Assert.That(wb.Evaluate("VALUE(\"5-březen\")"), Is.EqualTo(new DateTime(DateTime.Now.Year, 3, 5).ToSerialDateTime()));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/TextToNumberCoercionTests.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var firstValue = (double)XLWorkbook.EvaluateExpr("\"0:0:0.0015\" * 1");
             var secondValue = (double)XLWorkbook.EvaluateExpr("\"0:0:0.0024\" * 1");
-            Assert.AreEqual(firstValue, secondValue);
+            Assert.That(secondValue, Is.EqualTo(firstValue));
         }
 
         [TestCase("100%", 1)]
@@ -314,9 +314,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             using var wb = new XLWorkbook();
             var parsedValue = wb.Evaluate($"\"{text}\"*1");
             if (expectedValue is null)
-                Assert.AreEqual(XLError.IncompatibleValue, parsedValue);
+                Assert.That(parsedValue, Is.EqualTo(XLError.IncompatibleValue));
             else
-                Assert.AreEqual(expectedValue.Value, (double)parsedValue, tolerance);
+                Assert.That((double)parsedValue, Is.EqualTo(expectedValue.Value).Within(tolerance));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/WildcardTests.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("abc")]
         public void Empty_Pattern_Matches_Any_String(string text)
         {
-            Assert.AreEqual(0, SearchWildcard(text, string.Empty));
+            Assert.That(SearchWildcard(text, string.Empty), Is.EqualTo(0));
         }
 
         [TestCase("", "abc", 0)]
@@ -22,25 +22,25 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("c", "abc", 2)]
         public void Substring_Of_Text_Matches_Text(string substringPattern, string text, int expectedIndex)
         {
-            Assert.AreEqual(expectedIndex, SearchWildcard(text, substringPattern));
+            Assert.That(SearchWildcard(text, substringPattern), Is.EqualTo(expectedIndex));
         }
 
         [TestCase("abcd", "abc")]
         public void Pattern_Not_In_Text_Returns_Negative_One(string pattern, string text)
         {
-            Assert.AreEqual(-1, SearchWildcard(text, pattern));
+            Assert.That(SearchWildcard(text, pattern), Is.EqualTo(-1));
         }
 
         [Test]
         public void Pattern_Comparison_Is_Case_Insensitive()
         {
-            Assert.AreEqual(1, SearchWildcard("zabcd", "AbCd"));
+            Assert.That(SearchWildcard("zabcd", "AbCd"), Is.EqualTo(1));
         }
 
         [Test]
         public void Tilde_Is_Escape_Char()
         {
-            Assert.AreEqual(1, SearchWildcard("_abc_", "~a~B~c"));
+            Assert.That(SearchWildcard("_abc_", "~a~B~c"), Is.EqualTo(1));
         }
 
         [TestCase("~*", "*", 0)]
@@ -50,13 +50,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("~a~b~", "ab", 0)]
         public void Escaped_Wildcards_Are_Matched_As_Chars(string pattern, string text, int expectedPosition)
         {
-            Assert.AreEqual(expectedPosition, SearchWildcard(text, pattern));
+            Assert.That(SearchWildcard(text, pattern), Is.EqualTo(expectedPosition));
         }
 
         [Test]
         public void Question_Mark_Wildcard_Matches_Any_Char()
         {
-            Assert.AreEqual(0, SearchWildcard("abc", "a?c"));
+            Assert.That(SearchWildcard("abc", "a?c"), Is.EqualTo(0));
         }
 
         [TestCase("abcd", "ab*cd", 0)]
@@ -65,27 +65,30 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
         public void Star_Wildcard_Matches_Any_Number_Of_Chars(string text, string pattern, int index)
         {
-            Assert.AreEqual(index, SearchWildcard(text, pattern));
+            Assert.That(SearchWildcard(text, pattern), Is.EqualTo(index));
         }
 
         [Test]
         public void Unpaired_Escape_Char_At_The_End_Of_Pattern_Is_Not_Char()
         {
-            Assert.AreEqual(0, SearchWildcard("a", "a~"));
+            Assert.That(SearchWildcard("a", "a~"), Is.EqualTo(0));
         }
 
         [Test]
         public void Star_Wildcard_At_The_Beginning_Matches_First_Char()
         {
-            Assert.AreEqual(0, SearchWildcard("abcccd", "*ccd"));
+            Assert.That(SearchWildcard("abcccd", "*ccd"), Is.EqualTo(0));
         }
 
         [Test]
         public void Pattern_Size_Is_Limited_To_255_Chars()
         {
-            Assert.AreEqual(0, SearchWildcard(new string('a', 1000), new string('a', 255)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(SearchWildcard(new string('a', 1000), new string('a', 255)), Is.EqualTo(0));
 
-            Assert.AreEqual(-1, SearchWildcard(new string('a', 1000), new string('a', 256)));
+                Assert.That(SearchWildcard(new string('a', 1000), new string('a', 256)), Is.EqualTo(-1));
+            });
         }
 
         [TestCase("?", "a", true)]
@@ -103,7 +106,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("a*", @"zaba", false)]
         public void Matches(string pattern, string text, bool matches)
         {
-            Assert.AreEqual(matches, new Wildcard(pattern).Matches(text.AsSpan()));
+            Assert.That(new Wildcard(pattern).Matches(text.AsSpan()), Is.EqualTo(matches));
         }
 
         private static int SearchWildcard(string text, string pattern)

--- a/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
@@ -251,23 +251,35 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.False(chain.IsCurrentInCycle);
 
             chain.MoveToCurrent(b1);
-            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, b1, a1 }).AsCollection);
-            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, b1, a1 }).AsCollection);
+                Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
+            });
             Assert.False(chain.IsCurrentInCycle);
 
             chain.MoveToCurrent(a1);
-            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
-            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 2, 2 }).AsCollection);
-            Assert.That(chain.IsCurrentInCycle, Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+                Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 2, 2 }).AsCollection);
+                Assert.That(chain.IsCurrentInCycle, Is.True);
+            });
 
             chain.MoveAhead();
-            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
-            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+                Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
+            });
             Assert.False(chain.IsCurrentInCycle);
 
             chain.MoveAhead();
-            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
-            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 0 }).AsCollection);
+            Assert.Multiple(() =>
+            {
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+                Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 0 }).AsCollection);
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
@@ -195,7 +195,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, d1, a1 }));
             });
 
-            Assert.False(chain.MoveAhead());
+            Assert.That(chain.MoveAhead(), Is.False);
             Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, d1, a1 }));
         }
 
@@ -248,7 +248,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // A1 is no longer in a current, because current position is 2, but last position
             // of A1 was 1 => there has been a processed node in the meantime.
-            Assert.False(chain.IsCurrentInCycle);
+            Assert.That(chain.IsCurrentInCycle, Is.False);
 
             chain.MoveToCurrent(b1);
             Assert.Multiple(() =>
@@ -256,7 +256,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, b1, a1 }).AsCollection);
                 Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
             });
-            Assert.False(chain.IsCurrentInCycle);
+            Assert.That(chain.IsCurrentInCycle, Is.False);
 
             chain.MoveToCurrent(a1);
             Assert.Multiple(() =>
@@ -272,7 +272,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
                 Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
             });
-            Assert.False(chain.IsCurrentInCycle);
+            Assert.That(chain.IsCurrentInCycle, Is.False);
 
             chain.MoveAhead();
             Assert.Multiple(() =>

--- a/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Enumerating_empty_chain()
         {
             var chain = new XLCalculationChain();
-            CollectionAssert.IsEmpty(GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.Empty);
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
                 expectedPoints.Add(point);
             }
 
-            CollectionAssert.AreEqual(expectedPoints, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(expectedPoints).AsCollection);
         }
 
         [Test]
@@ -61,19 +61,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             // Remove point in the middle
             chain.Remove(c1);
-            CollectionAssert.AreEqual(new[] { a1, b1, d1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, b1, d1 }).AsCollection);
 
             // Remove last point in the sequence
             chain.Remove(d1);
-            CollectionAssert.AreEqual(new[] { a1, b1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, b1 }).AsCollection);
 
             // Remove head
             chain.Remove(a1);
-            CollectionAssert.AreEqual(new[] { b1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1 }).AsCollection);
 
             // Remove the only remaining
             chain.Remove(b1);
-            CollectionAssert.IsEmpty(GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.Empty);
         }
 
         [Test]
@@ -86,17 +86,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             // Add as tail for single link chain
             var b1 = new XLBookPoint(1, new XLSheetPoint(1, 2));
             chain.AddAfter(a1, b1, 0);
-            CollectionAssert.AreEqual(new[] { a1, b1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, b1 }).AsCollection);
 
             // Add as tail for multi link chain
             var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
             chain.AddAfter(b1, c1, 0);
-            CollectionAssert.AreEqual(new[] { a1, b1, c1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, b1, c1 }).AsCollection);
 
             // Add somewhere in the middle
             var d1 = new XLBookPoint(1, new XLSheetPoint(1, 4));
             chain.AddAfter(b1, d1, 0);
-            CollectionAssert.AreEqual(new[] { a1, b1, d1, c1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, b1, d1, c1 }).AsCollection);
         }
 
         [Test]
@@ -112,58 +112,91 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var d1 = new XLBookPoint(1, new XLSheetPoint(1, 4));
             chain.AddLast(d1);
 
-            Assert.True(chain.MoveAhead());
-            Assert.AreEqual(a1, chain.Current);
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.MoveAhead(), Is.True);
+                Assert.That(chain.Current, Is.EqualTo(a1));
+            });
 
             // a,b,c,d -> d,a,b,c
             chain.MoveToCurrent(d1);
-            Assert.AreEqual(d1, chain.Current);
-            Assert.AreEqual(new[] { d1, a1, b1, c1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(d1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { d1, a1, b1, c1 }));
+            });
 
             // d,a,b,c -> b,d,a,c
             chain.MoveToCurrent(b1);
-            Assert.AreEqual(b1, chain.Current);
-            Assert.AreEqual(new[] { b1, d1, a1, c1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(b1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, d1, a1, c1 }));
+            });
 
-            Assert.True(chain.MoveAhead());
-            Assert.AreEqual(d1, chain.Current);
-            Assert.AreEqual(new[] { b1, d1, a1, c1 }, GetPoints(chain));
+            Assert.That(chain.MoveAhead(), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(d1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, d1, a1, c1 }));
+            });
 
             // d,a,c -> a,d,c
             chain.MoveToCurrent(a1);
-            Assert.AreEqual(a1, chain.Current);
-            Assert.AreEqual(new[] { b1, a1, d1, c1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(a1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, a1, d1, c1 }));
+            });
 
             // Move A1 to front when it's already at front
             chain.MoveToCurrent(a1);
-            Assert.AreEqual(a1, chain.Current);
-            Assert.AreEqual(new[] { b1, a1, d1, c1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(a1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, a1, d1, c1 }));
+            });
 
             // a,d,c -> c,a,d
             chain.MoveToCurrent(c1);
-            Assert.AreEqual(c1, chain.Current);
-            Assert.AreEqual(new[] { b1, c1, a1, d1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(c1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, a1, d1 }));
+            });
 
-            Assert.True(chain.MoveAhead());
-            Assert.AreEqual(a1, chain.Current);
-            Assert.AreEqual(new[] { b1, c1, a1, d1 }, GetPoints(chain));
+            Assert.That(chain.MoveAhead(), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(a1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, a1, d1 }));
+            });
 
             // a,d -> d,a
             chain.MoveToCurrent(d1);
-            Assert.AreEqual(d1, chain.Current);
-            Assert.AreEqual(new[] { b1, c1, d1, a1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(d1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, d1, a1 }));
+            });
 
-            Assert.True(chain.MoveAhead());
-            Assert.AreEqual(a1, chain.Current);
-            Assert.AreEqual(new[] { b1, c1, d1, a1 }, GetPoints(chain));
+            Assert.That(chain.MoveAhead(), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(a1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, d1, a1 }));
+            });
 
             // a -> a
             chain.MoveToCurrent(a1);
-            Assert.AreEqual(a1, chain.Current);
-            Assert.AreEqual(new[] { b1, c1, d1, a1 }, GetPoints(chain));
+            Assert.Multiple(() =>
+            {
+                Assert.That(chain.Current, Is.EqualTo(a1));
+                Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, d1, a1 }));
+            });
 
             Assert.False(chain.MoveAhead());
-            Assert.AreEqual(new[] { b1, c1, d1, a1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { b1, c1, d1, a1 }));
         }
 
         [Test]
@@ -181,60 +214,60 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             chain.AddLast(c1);
 
             // Move to the first link.
-            Assert.True(chain.MoveAhead());
+            Assert.That(chain.MoveAhead(), Is.True);
 
             // Cycle a1, c1, when we first encounter c1, we don't know yet that it's a cycle
             chain.MoveToCurrent(c1);
-            CollectionAssert.AreEqual(new[] { c1, a1, b1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
 
             // A1 is marked with a position, because they have been at the current
             // C1 hasn't ben pushed back yet, so it keeps 0.
-            CollectionAssert.AreEqual(new[] { 0, 1, 0 }, GetPositions(chain));
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 1, 0 }).AsCollection);
 
             // But then we get A1 again, without any other point being marked
             // as done, therefore we are at cycle.
             chain.MoveToCurrent(a1);
-            CollectionAssert.AreEqual(new[] { a1, c1, b1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 1, 1, 0 }, GetPositions(chain));
-            Assert.True(chain.IsCurrentInCycle);
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, c1, b1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 1, 1, 0 }).AsCollection);
+            Assert.That(chain.IsCurrentInCycle, Is.True);
 
             // When we encounter C1 again, it's obviously a cycle.
             chain.MoveToCurrent(c1);
-            CollectionAssert.AreEqual(new[] { c1, a1, b1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 1, 1, 0 }, GetPositions(chain));
-            Assert.True(chain.IsCurrentInCycle);
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 1, 1, 0 }).AsCollection);
+            Assert.That(chain.IsCurrentInCycle, Is.True);
 
             // Let's move on and get A1 to the current. Because the C1 has been
             // marked as done, A1 is no longer in cycle.
             chain.MoveAhead();
-            CollectionAssert.AreEqual(new[] { c1, a1, b1 }, GetPoints(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
 
             // C1 position has been cleared, because it has moved beyond
             // current and A1 is now current.
-            CollectionAssert.AreEqual(new[] { 0, 1, 0 }, GetPositions(chain));
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 1, 0 }).AsCollection);
 
             // A1 is no longer in a current, because current position is 2, but last position
             // of A1 was 1 => there has been a processed node in the meantime.
             Assert.False(chain.IsCurrentInCycle);
 
             chain.MoveToCurrent(b1);
-            CollectionAssert.AreEqual(new[] { c1, b1, a1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 0, 0, 2 }, GetPositions(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, b1, a1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
             Assert.False(chain.IsCurrentInCycle);
 
             chain.MoveToCurrent(a1);
-            CollectionAssert.AreEqual(new[] { c1, a1, b1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 0, 2, 2 }, GetPositions(chain));
-            Assert.True(chain.IsCurrentInCycle);
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 2, 2 }).AsCollection);
+            Assert.That(chain.IsCurrentInCycle, Is.True);
 
             chain.MoveAhead();
-            CollectionAssert.AreEqual(new[] { c1, a1, b1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 0, 0, 2 }, GetPositions(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 2 }).AsCollection);
             Assert.False(chain.IsCurrentInCycle);
 
             chain.MoveAhead();
-            CollectionAssert.AreEqual(new[] { c1, a1, b1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 0, 0, 0 }, GetPositions(chain));
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { c1, a1, b1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 0 }).AsCollection);
         }
 
         [Test]
@@ -248,17 +281,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
             chain.AddLast(c1);
 
-            Assert.True(chain.MoveAhead());
+            Assert.That(chain.MoveAhead(), Is.True);
 
             chain.MoveToCurrent(b1);
             chain.MoveToCurrent(a1);
-            Assert.True(chain.IsCurrentInCycle);
-            CollectionAssert.AreEqual(new[] { a1, b1, c1 }, GetPoints(chain));
-            CollectionAssert.AreEqual(new[] { 1, 1, 0 }, GetPositions(chain));
+            Assert.That(chain.IsCurrentInCycle, Is.True);
+            Assert.That(GetPoints(chain), Is.EqualTo(new[] { a1, b1, c1 }).AsCollection);
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 1, 1, 0 }).AsCollection);
 
             chain.Reset();
 
-            CollectionAssert.AreEqual(new[] { 0, 0, 0 }, GetPositions(chain));
+            Assert.That(GetPositions(chain), Is.EqualTo(new[] { 0, 0, 0 }).AsCollection);
         }
 
         private static IEnumerable<XLBookPoint> GetPoints(XLCalculationChain chain)

--- a/ClosedXML.Tests/Excel/CalcEngine/XLMathTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/XLMathTests.cs
@@ -9,15 +9,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [Test]
         public void IsEven()
         {
-            Assert.IsTrue(XLMath.IsEven(2));
-            Assert.IsFalse(XLMath.IsEven(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLMath.IsEven(2), Is.True);
+                Assert.That(XLMath.IsEven(3), Is.False);
+            });
         }
 
         [Test]
         public void IsOdd()
         {
-            Assert.IsTrue(XLMath.IsOdd(3));
-            Assert.IsFalse(XLMath.IsOdd(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLMath.IsOdd(3), Is.True);
+                Assert.That(XLMath.IsOdd(2), Is.False);
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Cells/SharedStringTableTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/SharedStringTableTests.cs
@@ -16,12 +16,12 @@ namespace ClosedXML.Tests.Excel.Cells
             var ws2 = wb.AddWorksheet();
             var txt1 = "Hello";
             var txt2 = new StringBuilder("Hel").Append("lo").ToString();
-            Assert.AreNotSame(txt1, txt2);
+            Assert.That(txt2, Is.Not.SameAs(txt1));
 
             ws1.Cell(1, 1).Value = txt1;
             ws2.Cell(1, 1).Value = txt2;
 
-            Assert.AreSame(ws1.Cell(1, 1).Value.GetText(), ws2.Cell(1, 1).Value.GetText());
+            Assert.That(ws2.Cell(1, 1).Value.GetText(), Is.SameAs(ws1.Cell(1, 1).Value.GetText()));
         }
 
         [Test]
@@ -29,8 +29,11 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             var sst = new SharedStringTable();
             var id = sst.IncreaseRef("test", false);
-            Assert.AreEqual("test", sst[id]);
-            Assert.AreEqual(1, sst.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[id], Is.EqualTo("test"));
+                Assert.That(sst.Count, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -40,7 +43,7 @@ namespace ClosedXML.Tests.Excel.Cells
             var id = sst.IncreaseRef("test", false);
             sst.DecreaseRef(id);
 
-            Assert.AreEqual(0, sst.Count);
+            Assert.That(sst.Count, Is.EqualTo(0));
             Assert.That(() => _ = sst[id], Throws.ArgumentException.With.Message.EqualTo("Id 0 has no text."));
         }
 
@@ -52,20 +55,26 @@ namespace ClosedXML.Tests.Excel.Cells
             var id = sst.IncreaseRef(text, false);
 
             sst.IncreaseRef(text, false);
-            Assert.AreEqual(text, sst[id]);
-            Assert.AreEqual(1, sst.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[id], Is.EqualTo(text));
+                Assert.That(sst.Count, Is.EqualTo(1));
+            });
 
             sst.DecreaseRef(id);
-            Assert.AreEqual(text, sst[id]);
-            Assert.AreEqual(1, sst.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[id], Is.EqualTo(text));
+                Assert.That(sst.Count, Is.EqualTo(1));
+            });
 
             sst.IncreaseRef(text, false);
-            Assert.AreEqual(text, sst[id]);
-            Assert.AreEqual(1, sst.Count);
+            Assert.That(sst[id], Is.EqualTo(text));
+            Assert.That(sst.Count, Is.EqualTo(1));
 
             sst.DecreaseRef(id);
-            Assert.AreEqual(text, sst[id]);
-            Assert.AreEqual(1, sst.Count);
+            Assert.That(sst[id], Is.EqualTo(text));
+            Assert.That(sst.Count, Is.EqualTo(1));
 
             sst.DecreaseRef(id);
             Assert.Throws<ArgumentException>(() => _ = sst[id]);
@@ -85,8 +94,11 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.Throws<ArgumentException>(() => _ = sst[originalId]);
 
             var replacementId = sst.IncreaseRef("replacement", false);
-            Assert.AreEqual(originalId, replacementId);
-            Assert.AreEqual("replacement", sst[replacementId]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(replacementId, Is.EqualTo(originalId));
+                Assert.That(sst[replacementId], Is.EqualTo("replacement"));
+            });
         }
 
         [Test]
@@ -107,7 +119,7 @@ namespace ClosedXML.Tests.Excel.Cells
             TestHelper.LoadAndAssert((_, ws) =>
             {
                 // Check that type is a empty string, just like in Excel.
-                Assert.AreEqual(2, ws.Evaluate("TYPE(B2)"));
+                Assert.That(ws.Evaluate("TYPE(B2)"), Is.EqualTo(2));
                 Assert.IsEmpty(ws.Cell("B2").GetText());
             }, @"Other\Cells\EmptySi.xlsx");
         }
@@ -126,8 +138,11 @@ namespace ClosedXML.Tests.Excel.Cells
                 },
                 (_, ws) =>
                 {
-                    Assert.AreEqual("", ws.Cell("B1").CachedValue);
-                    Assert.AreEqual("", ws.Cell("B2").GetRichText().Text);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(ws.Cell("B1").CachedValue, Is.EqualTo(""));
+                        Assert.That(ws.Cell("B2").GetRichText().Text, Is.EqualTo(""));
+                    });
                 },
                 @"Other\Cells\EmptyText.xlsx");
         }

--- a/ClosedXML.Tests/Excel/Cells/SharedStringTableTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/SharedStringTableTests.cs
@@ -120,7 +120,7 @@ namespace ClosedXML.Tests.Excel.Cells
             {
                 // Check that type is a empty string, just like in Excel.
                 Assert.That(ws.Evaluate("TYPE(B2)"), Is.EqualTo(2));
-                Assert.IsEmpty(ws.Cell("B2").GetText());
+                Assert.That(ws.Cell("B2").GetText(), Is.Empty);
             }, @"Other\Cells\EmptySi.xlsx");
         }
 

--- a/ClosedXML.Tests/Excel/Cells/SliceTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/SliceTests.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Tests.Excel.Cells
             var slice = new Slice<int>();
             var point = new XLSheetPoint(574, 241);
             slice.Set(point, 1);
-            Assert.AreEqual(1, slice[point]);
+            Assert.That(slice[point], Is.EqualTo(1));
         }
 
         [Test]
@@ -21,13 +21,19 @@ namespace ClosedXML.Tests.Excel.Cells
             var slice = new Slice<int>();
             var point = new XLSheetPoint(574, 241);
             slice.Set(point, 1);
-            Assert.AreEqual(574, slice.MaxRow);
-            Assert.AreEqual(241, slice.MaxColumn);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice.MaxRow, Is.EqualTo(574));
+                Assert.That(slice.MaxColumn, Is.EqualTo(241));
+            });
 
             slice.Set(point, 0);
 
-            Assert.AreEqual(0, slice.MaxRow);
-            Assert.AreEqual(0, slice.MaxColumn);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice.MaxRow, Is.EqualTo(0));
+                Assert.That(slice.MaxColumn, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -38,23 +44,35 @@ namespace ClosedXML.Tests.Excel.Cells
             slice.Set(140, 32, 1);
             slice.Set(140, 72, 1);
 
-            Assert.AreEqual(140, slice.MaxRow);
-            Assert.AreEqual(72, slice.MaxColumn);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice.MaxRow, Is.EqualTo(140));
+                Assert.That(slice.MaxColumn, Is.EqualTo(72));
+            });
 
             slice.Set(140, 72, 0);
 
-            Assert.AreEqual(140, slice.MaxRow);
-            Assert.AreEqual(32, slice.MaxColumn);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice.MaxRow, Is.EqualTo(140));
+                Assert.That(slice.MaxColumn, Is.EqualTo(32));
+            });
 
             slice.Set(140, 32, 0);
 
-            Assert.AreEqual(54, slice.MaxRow);
-            Assert.AreEqual(32, slice.MaxColumn);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice.MaxRow, Is.EqualTo(54));
+                Assert.That(slice.MaxColumn, Is.EqualTo(32));
+            });
 
             slice.Set(54, 32, 0);
 
-            Assert.AreEqual(0, slice.MaxRow);
-            Assert.AreEqual(0, slice.MaxColumn);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice.MaxRow, Is.EqualTo(0));
+                Assert.That(slice.MaxColumn, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -64,25 +82,25 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.IsEmpty(slice.UsedRows);
 
             slice.Set(new XLSheetPoint(1, 1), 1);
-            CollectionAssert.AreEquivalent(new[] { 1 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1 }));
 
             slice.Set(new XLSheetPoint(70, 1), 1);
-            CollectionAssert.AreEquivalent(new[] { 1, 70 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1, 70 }));
 
             slice.Set(new XLSheetPoint(35, 1), 1);
-            CollectionAssert.AreEquivalent(new[] { 1, 35, 70 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1, 35, 70 }));
 
             slice.Set(new XLSheetPoint(35, 2), 1);
-            CollectionAssert.AreEquivalent(new[] { 1, 35, 70 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1, 35, 70 }));
 
             slice.Set(new XLSheetPoint(35, 1), 0);
-            CollectionAssert.AreEquivalent(new[] { 1, 35, 70 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1, 35, 70 }));
 
             slice.Set(new XLSheetPoint(35, 2), 0);
-            CollectionAssert.AreEquivalent(new[] { 1, 70 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1, 70 }));
 
             slice.Set(new XLSheetPoint(1, 1), 0);
-            CollectionAssert.AreEquivalent(new[] { 70 }, slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 70 }));
 
             slice.Set(new XLSheetPoint(70, 1), 0);
             Assert.IsEmpty(slice.UsedRows);
@@ -95,25 +113,25 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.IsEmpty(slice.UsedColumns);
 
             slice.Set(new XLSheetPoint(1, 5), 1);
-            CollectionAssert.AreEquivalent(new[] { 5 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 5 }));
 
             slice.Set(new XLSheetPoint(1, 750), 1);
-            CollectionAssert.AreEquivalent(new[] { 5, 750 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 5, 750 }));
 
             slice.Set(new XLSheetPoint(1, 90), 1);
-            CollectionAssert.AreEquivalent(new[] { 5, 90, 750 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 5, 90, 750 }));
 
             slice.Set(new XLSheetPoint(2, 5), 1);
-            CollectionAssert.AreEquivalent(new[] { 5, 90, 750 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 5, 90, 750 }));
 
             slice.Set(new XLSheetPoint(1, 5), 0);
-            CollectionAssert.AreEquivalent(new[] { 5, 90, 750 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 5, 90, 750 }));
 
             slice.Set(new XLSheetPoint(2, 5), 0);
-            CollectionAssert.AreEquivalent(new[] { 90, 750 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 90, 750 }));
 
             slice.Set(new XLSheetPoint(1, 750), 0);
-            CollectionAssert.AreEquivalent(new[] { 90 }, slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 90 }));
 
             slice.Set(new XLSheetPoint(1, 90), 0);
             Assert.IsEmpty(slice.UsedColumns);
@@ -133,10 +151,13 @@ namespace ClosedXML.Tests.Excel.Cells
             slice.Set(lastCorner, 1);
 
             slice.Clear(new XLSheetRange(firstCorner, lastCorner));
-            Assert.AreEqual(1, slice[outsideAddress]);
-            Assert.AreEqual(0, slice[firstCorner]);
-            Assert.AreEqual(0, slice[insideAddress]);
-            Assert.AreEqual(0, slice[lastCorner]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice[outsideAddress], Is.EqualTo(1));
+                Assert.That(slice[firstCorner], Is.EqualTo(0));
+                Assert.That(slice[insideAddress], Is.EqualTo(0));
+                Assert.That(slice[lastCorner], Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -153,10 +174,13 @@ namespace ClosedXML.Tests.Excel.Cells
 
             slice.InsertAreaAndShiftDown(new XLSheetRange(new XLSheetPoint(1, 1), new XLSheetPoint(2, 2)));
 
-            Assert.AreEqual(1, slice[3, 1]);
-            Assert.AreEqual(2, slice[5, 1]);
-            Assert.AreEqual(0, slice[XLHelper.MaxRowNumber, 2]);
-            Assert.AreEqual(4, slice[outsideAddress]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice[3, 1], Is.EqualTo(1));
+                Assert.That(slice[5, 1], Is.EqualTo(2));
+                Assert.That(slice[XLHelper.MaxRowNumber, 2], Is.EqualTo(0));
+                Assert.That(slice[outsideAddress], Is.EqualTo(4));
+            });
         }
 
         [Test]
@@ -173,10 +197,13 @@ namespace ClosedXML.Tests.Excel.Cells
 
             slice.InsertAreaAndShiftRight(new XLSheetRange(new XLSheetPoint(1, 1), new XLSheetPoint(2, 2)));
 
-            Assert.AreEqual(1, slice[1, 3]);
-            Assert.AreEqual(2, slice[1, 5]);
-            Assert.AreEqual(0, slice[purgedAddress]);
-            Assert.AreEqual(4, slice[outsideAddress]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice[1, 3], Is.EqualTo(1));
+                Assert.That(slice[1, 5], Is.EqualTo(2));
+                Assert.That(slice[purgedAddress], Is.EqualTo(0));
+                Assert.That(slice[outsideAddress], Is.EqualTo(4));
+            });
         }
 
         [Test]
@@ -198,12 +225,15 @@ namespace ClosedXML.Tests.Excel.Cells
 
             var deleteArea = new XLSheetRange(firstCorner, secondCorner);
             slice.DeleteAreaAndShiftUp(deleteArea);
-            Assert.AreEqual(0, slice[firstCorner]);
-            Assert.AreEqual(0, slice[secondCorner]);
-            Assert.AreEqual(5, slice[belowAddress.Row - deleteArea.Height, belowAddress.Column]);
-            Assert.AreEqual(1, slice[aboveAddress]);
-            Assert.AreEqual(4, slice[rightAddress]);
-            Assert.AreEqual(6, slice[leftAddress]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice[firstCorner], Is.EqualTo(0));
+                Assert.That(slice[secondCorner], Is.EqualTo(0));
+                Assert.That(slice[belowAddress.Row - deleteArea.Height, belowAddress.Column], Is.EqualTo(5));
+                Assert.That(slice[aboveAddress], Is.EqualTo(1));
+                Assert.That(slice[rightAddress], Is.EqualTo(4));
+                Assert.That(slice[leftAddress], Is.EqualTo(6));
+            });
         }
 
         [Test]
@@ -225,12 +255,15 @@ namespace ClosedXML.Tests.Excel.Cells
 
             var deleteArea = new XLSheetRange(firstCorner, secondCorner);
             slice.DeleteAreaAndShiftLeft(deleteArea);
-            Assert.AreEqual(0, slice[firstCorner]);
-            Assert.AreEqual(0, slice[secondCorner]);
-            Assert.AreEqual(5, slice[rightAddress.Row, rightAddress.Column - deleteArea.Width]);
-            Assert.AreEqual(1, slice[leftAddress]);
-            Assert.AreEqual(4, slice[belowAddress]);
-            Assert.AreEqual(6, slice[aboveAddress]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(slice[firstCorner], Is.EqualTo(0));
+                Assert.That(slice[secondCorner], Is.EqualTo(0));
+                Assert.That(slice[rightAddress.Row, rightAddress.Column - deleteArea.Width], Is.EqualTo(5));
+                Assert.That(slice[leftAddress], Is.EqualTo(1));
+                Assert.That(slice[belowAddress], Is.EqualTo(4));
+                Assert.That(slice[aboveAddress], Is.EqualTo(6));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Cells/SliceTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/SliceTests.cs
@@ -79,7 +79,7 @@ namespace ClosedXML.Tests.Excel.Cells
         public void Keeps_Track_Of_Used_Rows()
         {
             var slice = new Slice<int>();
-            Assert.IsEmpty(slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.Empty);
 
             slice.Set(new XLSheetPoint(1, 1), 1);
             Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 1 }));
@@ -103,14 +103,14 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.That(slice.UsedRows, Is.EquivalentTo(new[] { 70 }));
 
             slice.Set(new XLSheetPoint(70, 1), 0);
-            Assert.IsEmpty(slice.UsedRows);
+            Assert.That(slice.UsedRows, Is.Empty);
         }
 
         [Test]
         public void Keeps_Track_Of_Used_Columns()
         {
             var slice = new Slice<int>();
-            Assert.IsEmpty(slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.Empty);
 
             slice.Set(new XLSheetPoint(1, 5), 1);
             Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 5 }));
@@ -134,7 +134,7 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.That(slice.UsedColumns, Is.EquivalentTo(new[] { 90 }));
 
             slice.Set(new XLSheetPoint(1, 90), 0);
-            Assert.IsEmpty(slice.UsedColumns);
+            Assert.That(slice.UsedColumns, Is.Empty);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Cells/ValueSliceTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/ValueSliceTests.cs
@@ -17,12 +17,15 @@ namespace ClosedXML.Tests.Excel.Cells
             removedWs.Cell("A1").Value = "Double referenced text";
             removedWs.Cell("B1").Value = "Single referenced text";
 
-            Assert.AreEqual(2, sst.Count);
+            Assert.That(sst.Count, Is.EqualTo(2));
 
             wb.Worksheets.Delete(removedWs.Name);
 
-            Assert.AreEqual(1, sst.Count);
-            Assert.AreEqual("Double referenced text", keptWs.Cell(1, 1).Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst.Count, Is.EqualTo(1));
+                Assert.That(keptWs.Cell(1, 1).Value, Is.EqualTo("Double referenced text"));
+            });
         }
 
         [Test]
@@ -35,10 +38,13 @@ namespace ClosedXML.Tests.Excel.Cells
             ws.Cell("B2").Value = "Double referenced text";
             ws.Cell("C2").Value = "Single referenced text";
 
-            Assert.AreEqual(2, sst.Count);
+            Assert.That(sst.Count, Is.EqualTo(2));
             ((XLWorksheet)ws).Internals.CellsCollection.ValueSlice.Clear(new XLSheetRange(2, 2, 2, 3));
-            Assert.AreEqual(1, sst.Count);
-            Assert.AreEqual("Double referenced text", ws.Cell("A1").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst.Count, Is.EqualTo(1));
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo("Double referenced text"));
+            });
         }
 
         [Test]
@@ -54,9 +60,12 @@ namespace ClosedXML.Tests.Excel.Cells
 
             ((XLWorksheet)ws).Internals.CellsCollection.ValueSlice.DeleteAreaAndShiftLeft(new XLSheetRange(2, 2, 3, 3));
 
-            Assert.AreEqual(2, sst.Count);
-            Assert.AreEqual("Kept Single Reference", sst[1]);
-            Assert.AreEqual("Kept Double Reference", sst[2]);
+            Assert.That(sst.Count, Is.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[1], Is.EqualTo("Kept Single Reference"));
+                Assert.That(sst[2], Is.EqualTo("Kept Double Reference"));
+            });
         }
 
         [Test]
@@ -72,9 +81,12 @@ namespace ClosedXML.Tests.Excel.Cells
 
             ((XLWorksheet)ws).Internals.CellsCollection.ValueSlice.DeleteAreaAndShiftLeft(new XLSheetRange(2, 2, 3, 3));
 
-            Assert.AreEqual(2, sst.Count);
-            Assert.AreEqual("Kept Single Reference", sst[1]);
-            Assert.AreEqual("Kept Double Reference", sst[2]);
+            Assert.That(sst.Count, Is.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[1], Is.EqualTo("Kept Single Reference"));
+                Assert.That(sst[2], Is.EqualTo("Kept Double Reference"));
+            });
         }
 
         [Test]
@@ -90,9 +102,12 @@ namespace ClosedXML.Tests.Excel.Cells
             ws.Cell("B1048576").Value = "Kept Double Reference"; // id 2
             ((XLWorksheet)ws).Internals.CellsCollection.ValueSlice.InsertAreaAndShiftDown(new XLSheetRange(3, 2, 4, 3));
 
-            Assert.AreEqual(2, sst.Count);
-            Assert.AreEqual("Kept Single Reference", sst[0]);
-            Assert.AreEqual("Kept Double Reference", sst[2]);
+            Assert.That(sst.Count, Is.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[0], Is.EqualTo("Kept Single Reference"));
+                Assert.That(sst[2], Is.EqualTo("Kept Double Reference"));
+            });
         }
 
         [Test]
@@ -108,9 +123,12 @@ namespace ClosedXML.Tests.Excel.Cells
             ws.Cell("XFB3").Value = "Kept Double Reference"; // id 2
             ((XLWorksheet)ws).Internals.CellsCollection.ValueSlice.InsertAreaAndShiftRight(new XLSheetRange(2, 3, 3, 4));
 
-            Assert.AreEqual(2, sst.Count);
-            Assert.AreEqual("Kept Single Reference", sst[0]);
-            Assert.AreEqual("Kept Double Reference", sst[2]);
+            Assert.That(sst.Count, Is.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(sst[0], Is.EqualTo("Kept Single Reference"));
+                Assert.That(sst[2], Is.EqualTo("Kept Double Reference"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Cells/XLCellFormulaTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellFormulaTests.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Tests.Excel.Cells
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell(1, 1).FormulaA1 = "=B1";
-            Assert.AreEqual("B1", ws.Cell(1, 1).FormulaA1);
+            Assert.That(ws.Cell(1, 1).FormulaA1, Is.EqualTo("B1"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -1094,14 +1094,14 @@ namespace ClosedXML.Tests
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             Assert.That(ws.ActiveCell, Is.Null);
-            Assert.False(ws.Cell(1, 1).Active);
+            Assert.That(ws.Cell(1, 1).Active, Is.False);
 
             ws.ActiveCell = ws.Cell("C4");
             Assert.That(ws.Cell("C4").Active, Is.True);
-            Assert.False(ws.Cell("C5").Active);
+            Assert.That(ws.Cell("C5").Active, Is.False);
 
             ws.ActiveCell = null;
-            Assert.False(ws.Cell("C4").Active);
+            Assert.That(ws.Cell("C4").Active, Is.False);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -37,7 +37,7 @@ namespace ClosedXML.Tests
             ws.Cell(1, 1);
             ws.Cell(2, 2);
             int count = ws.Range("A1:B2").CellsUsed().Count();
-            Assert.AreEqual(0, count);
+            Assert.That(count, Is.EqualTo(0));
         }
 
         [Test]
@@ -48,7 +48,7 @@ namespace ClosedXML.Tests
             ws.Column(3).Style.Fill.BackgroundColor = XLColor.Red;
             ws.Cell(2, 2).Value = "ASDF";
             var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
-            Assert.AreEqual("B2:C3", range);
+            Assert.That(range, Is.EqualTo("B2:C3"));
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace ClosedXML.Tests
             ws.Column(2).Style.Fill.BackgroundColor = XLColor.Red;
             ws.Cell(3, 3).Value = "ASDF";
             var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
-            Assert.AreEqual("B2:C3", range);
+            Assert.That(range, Is.EqualTo("B2:C3"));
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             var range = ws.RangeUsed(XLCellsUsedOptions.All);
-            Assert.AreEqual(null, range);
+            Assert.That(range, Is.Null);
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace ClosedXML.Tests
             ws.SparklineGroups.Add("F5", "C4:E4");
 
             var range = ws.RangeUsed(XLCellsUsedOptions.All).RangeAddress.ToString();
-            Assert.AreEqual("B2:F5", range);
+            Assert.That(range, Is.EqualTo("B2:F5"));
         }
 
         [Test]
@@ -87,10 +87,13 @@ namespace ClosedXML.Tests
         {
             var cell = new XLWorkbook().AddWorksheet().FirstCell();
 
-            Assert.IsNull(cell.Clear().GetValue<double?>());
-            Assert.AreEqual(1.5, cell.SetValue(1.5).GetValue<double?>());
-            Assert.AreEqual(2, cell.SetValue(2).GetValue<int?>());
-            Assert.IsNull(cell.SetValue(Blank.Value).GetValue<double?>());
+            Assert.That(cell.Clear().GetValue<double?>(), Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.SetValue(1.5).GetValue<double?>(), Is.EqualTo(1.5));
+                Assert.That(cell.SetValue(2).GetValue<int?>(), Is.EqualTo(2));
+            });
+            Assert.That(cell.SetValue(Blank.Value).GetValue<double?>(), Is.Null);
             Assert.Throws<InvalidCastException>(() => cell.SetValue("text").GetValue<double?>());
         }
 
@@ -99,7 +102,7 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" });
-            Assert.AreEqual("Sheet1!B2:B4", range.ToString());
+            Assert.That(range.ToString(), Is.EqualTo("Sheet1!B2:B4"));
         }
 
         [Test]
@@ -107,7 +110,7 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" }, false);
-            Assert.AreEqual("Sheet1!B2:B4", range.ToString());
+            Assert.That(range.ToString(), Is.EqualTo("Sheet1!B2:B4"));
         }
 
         [Test]
@@ -115,7 +118,7 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLRange range = ws.Cell(2, 2).InsertData(new[] { "a", "b", "c" }, true);
-            Assert.AreEqual("Sheet1!B2:D2", range.ToString());
+            Assert.That(range.ToString(), Is.EqualTo("Sheet1!B2:D2"));
         }
 
         [Test]
@@ -127,12 +130,15 @@ namespace ClosedXML.Tests
 
             ws.FirstCell().InsertData(values);
 
-            Assert.AreEqual("Text", ws.FirstCell().GetString());
-            Assert.AreEqual(45, ws.Cell("A2").GetDouble());
-            Assert.AreEqual(DateTime.Today, ws.Cell("A3").GetDateTime());
-            Assert.AreEqual(true, ws.Cell("A4").GetBoolean());
-            Assert.AreEqual("More text", ws.Cell("A5").GetString());
-            Assert.IsTrue(ws.Cell("A6").IsEmpty());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.FirstCell().GetString(), Is.EqualTo("Text"));
+                Assert.That(ws.Cell("A2").GetDouble(), Is.EqualTo(45));
+                Assert.That(ws.Cell("A3").GetDateTime(), Is.EqualTo(DateTime.Today));
+                Assert.That(ws.Cell("A4").GetBoolean(), Is.True);
+                Assert.That(ws.Cell("A5").GetString(), Is.EqualTo("More text"));
+                Assert.That(ws.Cell("A6").IsEmpty(), Is.True);
+            });
         }
 
         [Test]
@@ -141,8 +147,11 @@ namespace ClosedXML.Tests
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.FirstCell().InsertData(Enumerable.Range(1, 20).Select(i => new { Guid = Guid.NewGuid() }));
 
-            Assert.AreEqual(XLDataType.Text, ws.FirstCell().DataType);
-            Assert.AreEqual(Guid.NewGuid().ToString().Length, ws.FirstCell().GetText().Length);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.FirstCell().DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.FirstCell().GetText().Length, Is.EqualTo(Guid.NewGuid().ToString().Length));
+            });
         }
 
         [Test]
@@ -165,9 +174,12 @@ namespace ClosedXML.Tests
 
             ws.FirstCell().InsertData(table);
 
-            Assert.AreEqual(25, ws.Cell("A1").Value);
-            Assert.AreEqual("", ws.Cell("C4").Value);
-            Assert.AreEqual("", ws.Cell("D5").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(25));
+                Assert.That(ws.Cell("C4").Value, Is.EqualTo(""));
+                Assert.That(ws.Cell("D5").Value, Is.EqualTo(""));
+            });
         }
 
         [Test]
@@ -186,8 +198,11 @@ namespace ClosedXML.Tests
 
             ws.FirstCell().InsertData(dateTimeList);
 
-            Assert.AreEqual(new DateTime(2000, 1, 1), ws.Cell("A1").GetDateTime());
-            Assert.AreEqual(Blank.Value, ws.Cell("A5").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").GetDateTime(), Is.EqualTo(new DateTime(2000, 1, 1)));
+                Assert.That(ws.Cell("A5").Value, Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
@@ -201,7 +216,7 @@ namespace ClosedXML.Tests
             {
                 var expectedValue = Convert.ChangeType(AllNumberTypes[row - 1], typeof(double));
                 var actualValue = ws.Cell(row, 1).Value;
-                Assert.AreEqual(expectedValue, actualValue);
+                Assert.That(actualValue, Is.EqualTo(expectedValue));
             }
         }
 
@@ -225,7 +240,7 @@ namespace ClosedXML.Tests
             {
                 var expectedValue = Convert.ChangeType(AllNumberTypes[column - 1], typeof(double));
                 var actualValue = ws.Cell(2, column).Value;
-                Assert.AreEqual(expectedValue, actualValue);
+                Assert.That(actualValue, Is.EqualTo(expectedValue));
             }
         }
 
@@ -236,7 +251,7 @@ namespace ClosedXML.Tests
             IXLCell cell = ws.Cell(1, 1);
             bool actual = cell.IsEmpty();
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -246,7 +261,7 @@ namespace ClosedXML.Tests
             IXLCell cell = ws.Cell(1, 1);
             bool actual = cell.IsEmpty(XLCellsUsedOptions.All);
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -257,7 +272,7 @@ namespace ClosedXML.Tests
             cell.Style.Fill.BackgroundColor = XLColor.Red;
             bool actual = cell.IsEmpty();
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -268,7 +283,7 @@ namespace ClosedXML.Tests
             cell.Style.Fill.BackgroundColor = XLColor.Red;
             bool actual = cell.IsEmpty(XLCellsUsedOptions.AllContents);
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -279,7 +294,7 @@ namespace ClosedXML.Tests
             cell.Style.Fill.BackgroundColor = XLColor.Red;
             bool actual = cell.IsEmpty(XLCellsUsedOptions.All);
             bool expected = false;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -290,7 +305,7 @@ namespace ClosedXML.Tests
             cell.Value = "X";
             bool actual = cell.IsEmpty();
             bool expected = false;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -300,7 +315,7 @@ namespace ClosedXML.Tests
             IXLCell cell = ws.Cell("A1");
             cell.Value = "NaN";
 
-            Assert.AreNotEqual(XLDataType.Number, cell.DataType);
+            Assert.That(cell.DataType, Is.Not.EqualTo(XLDataType.Number));
         }
 
         [Test]
@@ -310,7 +325,7 @@ namespace ClosedXML.Tests
             IXLCell cell = ws.Cell("A1");
             cell.Value = "Nan";
 
-            Assert.AreNotEqual(XLDataType.Number, cell.DataType);
+            Assert.That(cell.DataType, Is.Not.EqualTo(XLDataType.Number));
         }
 
         [Test]
@@ -319,7 +334,7 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue("ABC");
             bool success = cell.TryGetValue(out bool outValue);
-            Assert.IsFalse(success);
+            Assert.That(success, Is.False);
         }
 
         [Test]
@@ -328,8 +343,11 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue(false);
             bool success = cell.TryGetValue(out bool outValue);
-            Assert.IsTrue(success);
-            Assert.IsFalse(outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.False);
+            });
         }
 
         [Test]
@@ -337,9 +355,12 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue("False");
-            var success = cell.TryGetValue(out Boolean outValue);
-            Assert.IsTrue(success);
-            Assert.IsFalse(outValue);
+            var success = cell.TryGetValue(out bool outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.False);
+            });
         }
 
         [Test]
@@ -348,8 +369,11 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue(true);
             bool success = cell.TryGetValue(out bool outValue);
-            Assert.IsTrue(success);
-            Assert.IsTrue(outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.True);
+            });
         }
 
         [Test]
@@ -358,8 +382,11 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue("True");
             var success = cell.TryGetValue(out bool outValue);
-            Assert.IsTrue(success);
-            Assert.IsTrue(outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.True);
+            });
         }
 
         [Test]
@@ -367,8 +394,11 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             bool success = ws.Cell("A1").SetFormulaA1("=TODAY() + 10").TryGetValue(out DateTime outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(DateTime.Today.AddDays(10), outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(DateTime.Today.AddDays(10)));
+            });
         }
 
         [Test]
@@ -376,13 +406,16 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             bool success = ws.Cell("A1").SetFormulaA1("=\"44\"&\"020\"").TryGetValue(out DateTime outValue);
-            Assert.IsFalse(success);
+            Assert.That(success, Is.False);
 
             ws.Cell("B1").SetFormulaA1("=A1+1");
 
             success = ws.Cell("B1").TryGetValue(out outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(new DateTime(2020, 07, 09), outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(new DateTime(2020, 07, 09)));
+            });
         }
 
         [Test]
@@ -391,7 +424,7 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             var date = "ABC";
             bool success = ws.Cell("A1").SetValue(date).TryGetValue(out DateTime outValue);
-            Assert.IsFalse(success);
+            Assert.That(success, Is.False);
         }
 
         [Test]
@@ -401,27 +434,33 @@ namespace ClosedXML.Tests
             var serialDateTimeOutsideRange = 5545454;
             ws.FirstCell().SetValue(serialDateTimeOutsideRange);
             bool success = ws.FirstCell().TryGetValue(out DateTime _);
-            Assert.IsFalse(success);
+            Assert.That(success, Is.False);
         }
 
         [Test]
         public void TryGetValue_Enum_Good()
         {
             var ws = new XLWorkbook().AddWorksheet();
-            Assert.IsTrue(ws.FirstCell().SetValue(nameof(NumberStyles.AllowCurrencySymbol)).TryGetValue(out NumberStyles value));
-            Assert.AreEqual(NumberStyles.AllowCurrencySymbol, value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.FirstCell().SetValue(nameof(NumberStyles.AllowCurrencySymbol)).TryGetValue(out NumberStyles value), Is.True);
+                Assert.That(value, Is.EqualTo(NumberStyles.AllowCurrencySymbol));
 
-            // Nullable alternative
-            Assert.IsTrue(ws.FirstCell().SetValue(nameof(NumberStyles.AllowCurrencySymbol)).TryGetValue(out NumberStyles? value2));
-            Assert.AreEqual(NumberStyles.AllowCurrencySymbol, value2);
+                // Nullable alternative
+                Assert.That(ws.FirstCell().SetValue(nameof(NumberStyles.AllowCurrencySymbol)).TryGetValue(out NumberStyles? value2), Is.True);
+                Assert.That(value2, Is.EqualTo(NumberStyles.AllowCurrencySymbol));
+            });
         }
 
         [Test]
         public void TryGetValue_Enum_BadString()
         {
             var ws = new XLWorkbook().AddWorksheet();
-            Assert.IsFalse(ws.FirstCell().SetValue("ABC").TryGetValue(out NumberStyles value));
-            Assert.IsFalse(ws.FirstCell().SetValue("ABC").TryGetValue(out NumberStyles? value2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.FirstCell().SetValue("ABC").TryGetValue(out NumberStyles value), Is.False);
+                Assert.That(ws.FirstCell().SetValue("ABC").TryGetValue(out NumberStyles? value2), Is.False);
+            });
         }
 
         [Test]
@@ -430,7 +469,7 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             string timeSpan = "ABC";
             bool success = ws.Cell("A1").SetValue(timeSpan).TryGetValue(out TimeSpan outValue);
-            Assert.IsFalse(success);
+            Assert.That(success, Is.False);
         }
 
         [Test]
@@ -439,8 +478,11 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             var timeSpan = new TimeSpan(1, 1, 1);
             bool success = ws.Cell("A1").SetValue(timeSpan).TryGetValue(out TimeSpan outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(timeSpan, outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(timeSpan));
+            });
         }
 
         [Test]
@@ -448,8 +490,11 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             bool success = ws.Cell("A1").SetValue(0.0034722222222222199).TryGetValue(out TimeSpan outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(TimeSpan.FromMinutes(5), outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(TimeSpan.FromMinutes(5)));
+            });
         }
 
         [Test]
@@ -458,8 +503,11 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             var timeSpan = TimeSpan.FromMilliseconds((double)int.MaxValue + 1);
             bool success = ws.Cell("A1").SetValue(timeSpan).TryGetValue(out TimeSpan outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(timeSpan, outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(timeSpan));
+            });
         }
 
         [Test]
@@ -468,8 +516,11 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             bool success = ws.Cell("A1").SetValue("300:14:50.453").TryGetValue(out TimeSpan outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(new TimeSpan(12, 12, 14, 50, 453), outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(new TimeSpan(12, 12, 14, 50, 453)));
+            });
         }
 
         [Test]
@@ -478,7 +529,7 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue("255");
             bool success = cell.TryGetValue(out sbyte outValue);
-            Assert.IsFalse(success);
+            Assert.That(success, Is.False);
         }
 
         [Test]
@@ -487,8 +538,11 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell("A1").SetValue(5);
             bool success = cell.TryGetValue(out sbyte outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual(5, outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo(5));
+            });
         }
 
         [Test]
@@ -496,21 +550,27 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
 
-            Boolean success;
-            String outValue;
+            bool success;
+            string outValue;
 
             success = ws.Cell("A1")
                 .SetValue("Site_x0020_Column_x0020_Test")
                 .TryGetValue(out outValue);
-            Assert.IsTrue(success);
-            Assert.AreEqual("Site Column Test", outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo("Site Column Test"));
+            });
 
             success = ws.Cell("A1")
                 .SetValue("Site_x005F_x0020_Column_x005F_x0020_Test")
                 .TryGetValue(out outValue);
 
-            Assert.IsTrue(success);
-            Assert.AreEqual("Site_x005F_x0020_Column_x005F_x0020_Test", outValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(outValue, Is.EqualTo("Site_x005F_x0020_Column_x005F_x0020_Test"));
+            });
         }
 
         [Test]
@@ -524,10 +584,13 @@ namespace ClosedXML.Tests
             ws.Cell("A3").SetValue(2.5.ToString(CultureInfo.CurrentCulture));
             ws.Cell("A4").SetValue("text");
 
-            Assert.IsTrue(ws.Cell("A1").TryGetValue(out double? _));
-            Assert.IsTrue(ws.Cell("A2").TryGetValue(out double? _));
-            Assert.IsTrue(ws.Cell("A3").TryGetValue(out double? _));
-            Assert.IsFalse(ws.Cell("A4").TryGetValue(out double? _));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").TryGetValue(out double? _), Is.True);
+                Assert.That(ws.Cell("A2").TryGetValue(out double? _), Is.True);
+                Assert.That(ws.Cell("A3").TryGetValue(out double? _), Is.True);
+                Assert.That(ws.Cell("A4").TryGetValue(out double? _), Is.False);
+            });
         }
 
         [Test]
@@ -544,28 +607,37 @@ namespace ClosedXML.Tests
 
             ws.Cell("B2").CopyFrom(range);
 
-            Assert.AreEqual(2, ws.Cell("B2").Value);
-            Assert.AreEqual(3, ws.Cell("C2").Value);
-            Assert.AreEqual(5, ws.Cell("D2").Value);
-            Assert.AreEqual(7, ws.Cell("E2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("C2").Value, Is.EqualTo(3));
+                Assert.That(ws.Cell("D2").Value, Is.EqualTo(5));
+                Assert.That(ws.Cell("E2").Value, Is.EqualTo(7));
+            });
         }
 
         [Test]
         public void ValueSetToEmptyString()
         {
-            string expected = String.Empty;
+            string expected = string.Empty;
 
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
             cell.Value = new DateTime(2000, 1, 2);
-            cell.Value = String.Empty;
-            Assert.AreEqual(expected, cell.GetText());
-            Assert.AreEqual(expected, cell.Value);
+            cell.Value = string.Empty;
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetText(), Is.EqualTo(expected));
+                Assert.That(cell.Value, Is.EqualTo(expected));
+            });
 
             cell.Value = new DateTime(2000, 1, 2);
             cell.SetValue(string.Empty);
-            Assert.AreEqual(expected, cell.GetText());
-            Assert.AreEqual(expected, cell.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetText(), Is.EqualTo(expected));
+                Assert.That(cell.Value, Is.EqualTo(expected));
+            });
         }
 
         [Test]
@@ -581,63 +653,57 @@ namespace ClosedXML.Tests
             var expected = DateTime.Today.AddYears(20);
             cell.Value = expected;
             var actual = (DateTime)cell.Value;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
         public void SetStringValueTooLong()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                ws.FirstCell().Value = new DateTime(2018, 5, 15);
+            ws.FirstCell().Value = new DateTime(2018, 5, 15);
 
-                ws.FirstCell().SetValue(new String('A', 32767));
+            ws.FirstCell().SetValue(new string('A', 32767));
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.FirstCell().Value = new String('A', 32768));
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.FirstCell().SetValue(new String('A', 32768)));
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.FirstCell().Value = new string('A', 32768));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.FirstCell().SetValue(new string('A', 32768)));
         }
 
         [Test]
         public void SetCellValueWipesFormulas()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                ws.FirstCell().FormulaA1 = "=TODAY()";
-                ws.FirstCell().Value = "hello world";
-                Assert.IsFalse(ws.FirstCell().HasFormula);
+            ws.FirstCell().FormulaA1 = "=TODAY()";
+            ws.FirstCell().Value = "hello world";
+            Assert.That(ws.FirstCell().HasFormula, Is.False);
 
-                ws.FirstCell().FormulaA1 = "=TODAY()";
-                ws.FirstCell().SetValue("hello world");
-                Assert.IsFalse(ws.FirstCell().HasFormula);
-            }
+            ws.FirstCell().FormulaA1 = "=TODAY()";
+            ws.FirstCell().SetValue("hello world");
+            Assert.That(ws.FirstCell().HasFormula, Is.False);
         }
 
         [Test]
         public void CellValueLineWrapping()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                ws.FirstCell().Value = "hello world";
-                Assert.IsFalse(ws.FirstCell().Style.Alignment.WrapText);
+            ws.FirstCell().Value = "hello world";
+            Assert.That(ws.FirstCell().Style.Alignment.WrapText, Is.False);
 
-                ws.FirstCell().Value = "hello\r\nworld";
-                Assert.IsTrue(ws.FirstCell().Style.Alignment.WrapText);
+            ws.FirstCell().Value = "hello\r\nworld";
+            Assert.That(ws.FirstCell().Style.Alignment.WrapText, Is.True);
 
-                ws.FirstCell().Style.Alignment.WrapText = false;
+            ws.FirstCell().Style.Alignment.WrapText = false;
 
-                ws.FirstCell().SetValue("hello world");
-                Assert.IsFalse(ws.FirstCell().Style.Alignment.WrapText);
+            ws.FirstCell().SetValue("hello world");
+            Assert.That(ws.FirstCell().Style.Alignment.WrapText, Is.False);
 
-                ws.FirstCell().SetValue("hello\r\nworld");
-                Assert.IsTrue(ws.FirstCell().Style.Alignment.WrapText);
-            }
+            ws.FirstCell().SetValue("hello\r\nworld");
+            Assert.That(ws.FirstCell().Style.Alignment.WrapText, Is.True);
         }
 
         [Test]
@@ -656,44 +722,51 @@ namespace ClosedXML.Tests
             using (var stream = new MemoryStream(data))
             {
                 var wb = new XLWorkbook(stream);
-                Assert.AreEqual("\u0018", wb.Worksheets.First().FirstCell().Value);
+                Assert.That(wb.Worksheets.First().FirstCell().Value, Is.EqualTo("\u0018"));
             }
         }
 
         [Test]
         public void CanClearDateTimeCellValue()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet("Sheet1");
+                var c = ws.FirstCell();
+                c.SetValue(new DateTime(2017, 10, 08));
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    var c = ws.FirstCell();
-                    c.SetValue(new DateTime(2017, 10, 08));
-                    Assert.AreEqual(XLDataType.DateTime, c.DataType);
-                    Assert.AreEqual(new DateTime(2017, 10, 08), c.Value);
+                    Assert.That(c.DataType, Is.EqualTo(XLDataType.DateTime));
+                    Assert.That(c.Value, Is.EqualTo(new DateTime(2017, 10, 08)));
+                });
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                var c = ws.FirstCell();
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var c = ws.FirstCell();
-                    Assert.AreEqual(XLDataType.DateTime, c.DataType);
-                    Assert.AreEqual(new DateTime(2017, 10, 08), c.Value);
+                    Assert.That(c.DataType, Is.EqualTo(XLDataType.DateTime));
+                    Assert.That(c.Value, Is.EqualTo(new DateTime(2017, 10, 08)));
+                });
 
-                    c.Clear();
-                    wb.Save();
-                }
+                c.Clear();
+                wb.Save();
+            }
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                var c = ws.FirstCell();
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var c = ws.FirstCell();
-                    Assert.AreEqual(XLDataType.Blank, c.DataType);
-                    Assert.True(c.IsEmpty());
-                }
+                    Assert.That(c.DataType, Is.EqualTo(XLDataType.Blank));
+                    Assert.That(c.IsEmpty(), Is.True);
+                });
             }
         }
 
@@ -706,169 +779,170 @@ namespace ClosedXML.Tests
             ws.Cell("B1").Clear(XLClearOptions.All);
             ws.Cell("B2").Clear(XLClearOptions.Sparklines);
 
-            Assert.AreEqual(1, ws.SparklineGroups.Single().Count());
-            Assert.IsFalse(ws.Cell("B1").HasSparkline);
-            Assert.IsFalse(ws.Cell("B2").HasSparkline);
-            Assert.IsTrue(ws.Cell("B3").HasSparkline);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(1));
+                Assert.That(ws.Cell("B1").HasSparkline, Is.False);
+                Assert.That(ws.Cell("B2").HasSparkline, Is.False);
+                Assert.That(ws.Cell("B3").HasSparkline, Is.True);
+            });
         }
 
         [Test]
         public void CurrentRegion()
         {
             // Partially based on sample in https://github.com/ClosedXML/ClosedXML/issues/120
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            ws.Cell("B1").SetValue("x")
+                .CellBelow().SetValue("x")
+                .CellBelow().SetValue("x");
+
+            ws.Cell("C1").SetValue("x")
+                .CellBelow().SetValue("x")
+                .CellBelow().SetValue("x");
+
+            //Deliberately D2
+            ws.Cell("D2").SetValue("x")
+                .CellBelow().SetValue("x");
+
+            ws.Cell("G1").SetValue("x")
+                .CellBelow() // skip a cell
+                .CellBelow().SetValue("x")
+                .CellBelow().SetValue("x");
+
+            // Deliberately H2
+            ws.Cell("H2").SetValue("x")
+                .CellBelow().SetValue("x")
+                .CellBelow().SetValue("x");
+
+            // A diagonal
+            ws.Cell("E8").SetValue("x")
+                .CellBelow().CellRight().SetValue("x")
+                .CellBelow().CellRight().SetValue("x")
+                .CellBelow().CellRight().SetValue("x")
+                .CellBelow().CellRight().SetValue("x");
+
+            Assert.That(ws.Cell("A10").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("A10:A10"));
+            Assert.That(ws.Cell("B5").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B5:B5"));
+            Assert.AreEqual("P1:P1", ws.Cell("P1").CurrentRegion.RangeAddress.ToString());
+
+            Assert.AreEqual("B1:D3", ws.Cell("D3").CurrentRegion.RangeAddress.ToString());
+            Assert.AreEqual("B1:D4", ws.Cell("D4").CurrentRegion.RangeAddress.ToString());
+            Assert.AreEqual("B1:E4", ws.Cell("E4").CurrentRegion.RangeAddress.ToString());
+
+            foreach (var c in ws.Range("B1:D3").Cells())
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                ws.Cell("B1").SetValue("x")
-                    .CellBelow().SetValue("x")
-                    .CellBelow().SetValue("x");
-
-                ws.Cell("C1").SetValue("x")
-                    .CellBelow().SetValue("x")
-                    .CellBelow().SetValue("x");
-
-                //Deliberately D2
-                ws.Cell("D2").SetValue("x")
-                    .CellBelow().SetValue("x");
-
-                ws.Cell("G1").SetValue("x")
-                    .CellBelow() // skip a cell
-                    .CellBelow().SetValue("x")
-                    .CellBelow().SetValue("x");
-
-                // Deliberately H2
-                ws.Cell("H2").SetValue("x")
-                    .CellBelow().SetValue("x")
-                    .CellBelow().SetValue("x");
-
-                // A diagonal
-                ws.Cell("E8").SetValue("x")
-                    .CellBelow().CellRight().SetValue("x")
-                    .CellBelow().CellRight().SetValue("x")
-                    .CellBelow().CellRight().SetValue("x")
-                    .CellBelow().CellRight().SetValue("x");
-
-                Assert.AreEqual("A10:A10", ws.Cell("A10").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("B5:B5", ws.Cell("B5").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("P1:P1", ws.Cell("P1").CurrentRegion.RangeAddress.ToString());
-
-                Assert.AreEqual("B1:D3", ws.Cell("D3").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("B1:D4", ws.Cell("D4").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("B1:E4", ws.Cell("E4").CurrentRegion.RangeAddress.ToString());
-
-                foreach (var c in ws.Range("B1:D3").Cells())
-                {
-                    Assert.AreEqual("B1:D3", c.CurrentRegion.RangeAddress.ToString());
-                }
-
-                foreach (var c in ws.Range("A1:A3").Cells())
-                {
-                    Assert.AreEqual("A1:D3", c.CurrentRegion.RangeAddress.ToString());
-                }
-
-                Assert.AreEqual("A1:D4", ws.Cell("A4").CurrentRegion.RangeAddress.ToString());
-
-                foreach (var c in ws.Range("E1:E3").Cells())
-                {
-                    Assert.AreEqual("B1:E3", c.CurrentRegion.RangeAddress.ToString());
-                }
-
-                Assert.AreEqual("B1:E4", ws.Cell("E4").CurrentRegion.RangeAddress.ToString());
-
-                //// SECOND REGION
-                foreach (var c in ws.Range("F1:F4").Cells())
-                {
-                    Assert.AreEqual("F1:H4", c.CurrentRegion.RangeAddress.ToString());
-                }
-
-                Assert.AreEqual("F1:H5", ws.Cell("F5").CurrentRegion.RangeAddress.ToString());
-
-                //// DIAGONAL
-                Assert.AreEqual("E8:I12", ws.Cell("E8").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("E8:I12", ws.Cell("F9").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("E8:I12", ws.Cell("G10").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("E8:I12", ws.Cell("H11").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("E8:I12", ws.Cell("I12").CurrentRegion.RangeAddress.ToString());
-
-                Assert.AreEqual("E8:I12", ws.Cell("G9").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("E8:I12", ws.Cell("F10").CurrentRegion.RangeAddress.ToString());
-
-                Assert.AreEqual("D7:I12", ws.Cell("D7").CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("E8:J13", ws.Cell("J13").CurrentRegion.RangeAddress.ToString());
-
-                // Four corners of a sheet
-                Assert.AreEqual("A1:D3", ws.Cell(1, 1).CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("XFD1:XFD1", ws.Cell(1, XLHelper.MaxColumnNumber).CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("XFD1048576:XFD1048576", ws.Cell(XLHelper.MaxRowNumber, XLHelper.MaxColumnNumber).CurrentRegion.RangeAddress.ToString());
-                Assert.AreEqual("A1048576:A1048576", ws.Cell(XLHelper.MaxRowNumber, 1).CurrentRegion.RangeAddress.ToString());
+                Assert.That(c.CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B1:D3"));
             }
+
+            foreach (var c in ws.Range("A1:A3").Cells())
+            {
+                Assert.That(c.CurrentRegion.RangeAddress.ToString(), Is.EqualTo("A1:D3"));
+            }
+
+            Assert.That(ws.Cell("A4").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("A1:D4"));
+
+            foreach (var c in ws.Range("E1:E3").Cells())
+            {
+                Assert.That(c.CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B1:E3"));
+            }
+
+            Assert.That(ws.Cell("E4").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B1:E4"));
+
+            //// SECOND REGION
+            foreach (var c in ws.Range("F1:F4").Cells())
+            {
+                Assert.That(c.CurrentRegion.RangeAddress.ToString(), Is.EqualTo("F1:H4"));
+            }
+
+            Assert.That(ws.Cell("F5").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("F1:H5"));
+
+            //// DIAGONAL
+            Assert.That(ws.Cell("E8").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+            Assert.That(ws.Cell("F9").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+            Assert.That(ws.Cell("G10").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+            Assert.That(ws.Cell("H11").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+            Assert.That(ws.Cell("I12").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+
+            Assert.That(ws.Cell("G9").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+            Assert.That(ws.Cell("F10").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:I12"));
+
+            Assert.That(ws.Cell("D7").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("D7:I12"));
+            Assert.That(ws.Cell("J13").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("E8:J13"));
+
+            // Four corners of a sheet
+            Assert.That(ws.Cell(1, 1).CurrentRegion.RangeAddress.ToString(), Is.EqualTo("A1:D3"));
+            Assert.That(ws.Cell(1, XLHelper.MaxColumnNumber).CurrentRegion.RangeAddress.ToString(), Is.EqualTo("XFD1:XFD1"));
+            Assert.That(ws.Cell(XLHelper.MaxRowNumber, XLHelper.MaxColumnNumber).CurrentRegion.RangeAddress.ToString(), Is.EqualTo("XFD1048576:XFD1048576"));
+            Assert.That(ws.Cell(XLHelper.MaxRowNumber, 1).CurrentRegion.RangeAddress.ToString(), Is.EqualTo("A1048576:A1048576"));
         }
 
         // https://github.com/ClosedXML/ClosedXML/issues/630
         [Test]
         public void ConsiderEmptyValueAsNumericInSumFormula()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            ws.Cell("A1").SetValue("Empty");
+            ws.Cell("A2").SetValue("Numeric");
+            ws.Cell("A3").SetValue("Copy of numeric");
+
+            ws.Cell("B2").SetFormulaA1("=B1");
+            ws.Cell("B3").SetFormulaA1("=B2");
+
+            ws.Cell("C2").SetFormulaA1("=SUM(C1)");
+            ws.Cell("C3").SetFormulaA1("=C2");
+
+            var b1 = ws.Cell("B1").Value;
+            var b2 = ws.Cell("B2").Value;
+            var b3 = ws.Cell("B3").Value;
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(b1, Is.EqualTo(Blank.Value));
+                Assert.That(b2, Is.EqualTo(0));
+                Assert.That(b3, Is.EqualTo(0));
+            });
 
-                ws.Cell("A1").SetValue("Empty");
-                ws.Cell("A2").SetValue("Numeric");
-                ws.Cell("A3").SetValue("Copy of numeric");
+            var c1 = ws.Cell("C1").Value;
+            var c2 = ws.Cell("C2").Value;
+            var c3 = ws.Cell("C3").Value;
 
-                ws.Cell("B2").SetFormulaA1("=B1");
-                ws.Cell("B3").SetFormulaA1("=B2");
-
-                ws.Cell("C2").SetFormulaA1("=SUM(C1)");
-                ws.Cell("C3").SetFormulaA1("=C2");
-
-                var b1 = ws.Cell("B1").Value;
-                var b2 = ws.Cell("B2").Value;
-                var b3 = ws.Cell("B3").Value;
-
-                Assert.AreEqual(Blank.Value, b1);
-                Assert.AreEqual(0, b2);
-                Assert.AreEqual(0, b3);
-
-                var c1 = ws.Cell("C1").Value;
-                var c2 = ws.Cell("C2").Value;
-                var c3 = ws.Cell("C3").Value;
-
-                Assert.AreEqual(Blank.Value, c1);
-                Assert.AreEqual(0, c2);
-                Assert.AreEqual(0, c3);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(c1, Is.EqualTo(Blank.Value));
+                Assert.That(c2, Is.EqualTo(0));
+                Assert.That(c3, Is.EqualTo(0));
+            });
         }
 
         [Test]
         public void SetFormulaA1AffectsR1C1()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                var cell = ws.Cell(1, 1);
-                cell.FormulaR1C1 = "R[1]C";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var cell = ws.Cell(1, 1);
+            cell.FormulaR1C1 = "R[1]C";
 
-                cell.FormulaA1 = "B2";
+            cell.FormulaA1 = "B2";
 
-                Assert.AreEqual("R[1]C[1]", cell.FormulaR1C1);
-            }
+            Assert.That(cell.FormulaR1C1, Is.EqualTo("R[1]C[1]"));
         }
 
         [Test]
         public void SetFormulaR1C1AffectsA1()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                var cell = ws.Cell(1, 1);
-                cell.FormulaA1 = "A2";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var cell = ws.Cell(1, 1);
+            cell.FormulaA1 = "A2";
 
-                cell.FormulaR1C1 = "R[1]C[1]";
+            cell.FormulaR1C1 = "R[1]C[1]";
 
-                Assert.AreEqual("B2", cell.FormulaA1);
-            }
+            Assert.That(cell.FormulaA1, Is.EqualTo("B2"));
         }
 
         [TestCase(" = 1 + SUM({ 1; 7})  - A8  ", "1 + SUM({ 1; 7})  - A8")]
@@ -877,7 +951,7 @@ namespace ClosedXML.Tests
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").FormulaA1 = formula;
-            Assert.AreEqual(expectedResult, ws.Cell("A1").FormulaA1);
+            Assert.That(ws.Cell("A1").FormulaA1, Is.EqualTo(expectedResult));
         }
 
         [TestCase(" =  1 +   R[1]C[7]  ", "1 +   R[1]C[7]")]
@@ -886,56 +960,52 @@ namespace ClosedXML.Tests
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
             ws.Cell("A1").FormulaR1C1 = formula;
-            Assert.AreEqual(expectedResult, ws.Cell("A1").FormulaR1C1);
+            Assert.That(ws.Cell("A1").FormulaR1C1, Is.EqualTo(expectedResult));
         }
 
         [Test]
         public void FormulaWithCircularReferenceFails()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                var A1 = ws.Cell("A1");
-                var A2 = ws.Cell("A2");
-                A1.FormulaA1 = "A2 + 1";
-                A2.FormulaA1 = "A1 + 1";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var A1 = ws.Cell("A1");
+            var A2 = ws.Cell("A2");
+            A1.FormulaA1 = "A2 + 1";
+            A2.FormulaA1 = "A1 + 1";
 
-                Assert.Throws(
-                    Is.TypeOf<InvalidOperationException>().And.Message.Contains("cycle"),
-                    () => _ = A1.Value);
-                Assert.Throws(
-                    Is.TypeOf<InvalidOperationException>().And.Message.Contains("cycle"),
-                    () => _ = A2.Value);
-            }
+            Assert.Throws(
+                Is.TypeOf<InvalidOperationException>().And.Message.Contains("cycle"),
+                () => _ = A1.Value);
+            Assert.Throws(
+                Is.TypeOf<InvalidOperationException>().And.Message.Contains("cycle"),
+                () => _ = A2.Value);
         }
 
         [Test]
         public void InvalidFormulaShiftProducesREF()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.Worksheets.Add("Sheet1");
-                    ws.Cell("A1").Value = 1;
-                    ws.Cell("B1").Value = 2;
-                    ws.Cell("B2").FormulaA1 = "=A1+B1";
+                var ws = wb.Worksheets.Add("Sheet1");
+                ws.Cell("A1").Value = 1;
+                ws.Cell("B1").Value = 2;
+                ws.Cell("B2").FormulaA1 = "=A1+B1";
 
-                    Assert.AreEqual(3, ws.Cell("B2").Value);
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(3));
 
-                    ws.Range("B2").CopyTo(ws.Range("A2"));
-                    var fA2 = ws.Cell("A2").FormulaA1;
+                ws.Range("B2").CopyTo(ws.Range("A2"));
+                var fA2 = ws.Cell("A2").FormulaA1;
 
-                    wb.SaveAs(ms);
+                wb.SaveAs(ms);
 
-                    Assert.AreEqual("#REF!+A1", fA2);
-                }
+                Assert.That(fA2, Is.EqualTo("#REF!+A1"));
+            }
 
-                using (var wb2 = new XLWorkbook(ms))
-                {
-                    var fA2 = wb2.Worksheets.First().Cell("A2").FormulaA1;
-                    Assert.AreEqual("#REF!+A1", fA2);
-                }
+            using (var wb2 = new XLWorkbook(ms))
+            {
+                var fA2 = wb2.Worksheets.First().Cell("A2").FormulaA1;
+                Assert.That(fA2, Is.EqualTo("#REF!+A1"));
             }
         }
 
@@ -953,19 +1023,20 @@ namespace ClosedXML.Tests
         [Test]
         public void TryGetValueFormula_EvaluationFail_ReturnFalse()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                var A1 = ws.Cell("A1");
-                var A2 = ws.Cell("A2");
-                var A3 = ws.Cell("A3");
-                A1.FormulaA1 = "A2 + 1";
-                A2.FormulaA1 = "A1 + 1";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var A1 = ws.Cell("A1");
+            var A2 = ws.Cell("A2");
+            var A3 = ws.Cell("A3");
+            A1.FormulaA1 = "A2 + 1";
+            A2.FormulaA1 = "A1 + 1";
 
-                Assert.IsFalse(A1.TryGetValue(out String _));
-                Assert.IsFalse(A2.TryGetValue(out String _));
-                Assert.IsTrue(A3.TryGetValue(out String _));
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(A1.TryGetValue(out string _), Is.False);
+                Assert.That(A2.TryGetValue(out string _), Is.False);
+                Assert.That(A3.TryGetValue(out string _), Is.True);
+            });
         }
 
         [Test]
@@ -975,7 +1046,7 @@ namespace ClosedXML.Tests
             var ws = wb.AddWorksheet("Sheet1");
             var c = ws.FirstCell().CellBelow(2).CellRight(3);
 
-            Assert.AreEqual("D3", c.ToString());
+            Assert.That(c.ToString(), Is.EqualTo("D3"));
         }
 
         [Test]
@@ -1002,7 +1073,7 @@ namespace ClosedXML.Tests
             c.Style.Font.FontColor = XLColor.Red;
             c.Style.Fill.BackgroundColor = XLColor.FromTheme(XLThemeColor.Accent5);
 
-            Assert.AreEqual(expected, c.ToString(format));
+            Assert.That(c.ToString(format), Is.EqualTo(expected));
 
             Assert.Throws<FormatException>(() => c.ToString("dummy"));
         }
@@ -1022,11 +1093,11 @@ namespace ClosedXML.Tests
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.IsNull(ws.ActiveCell);
+            Assert.That(ws.ActiveCell, Is.Null);
             Assert.False(ws.Cell(1, 1).Active);
 
             ws.ActiveCell = ws.Cell("C4");
-            Assert.True(ws.Cell("C4").Active);
+            Assert.That(ws.Cell("C4").Active, Is.True);
             Assert.False(ws.Cell("C5").Active);
 
             ws.ActiveCell = null;
@@ -1041,10 +1112,10 @@ namespace ClosedXML.Tests
             ws.ActiveCell = ws.Cell("A2");
 
             ws.Cell("B2").Active = false;
-            Assert.AreEqual(ws.Cell("A2"), ws.ActiveCell);
+            Assert.That(ws.ActiveCell, Is.EqualTo(ws.Cell("A2")));
 
             ws.Cell("A2").Active = false;
-            Assert.IsNull(ws.ActiveCell);
+            Assert.That(ws.ActiveCell, Is.Null);
         }
 
         [Test]
@@ -1052,10 +1123,10 @@ namespace ClosedXML.Tests
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
-            Assert.IsNull(ws.ActiveCell);
+            Assert.That(ws.ActiveCell, Is.Null);
 
             ws.Cell("B2").Active = true;
-            Assert.AreEqual(ws.Cell("B2"), ws.ActiveCell);
+            Assert.That(ws.ActiveCell, Is.EqualTo(ws.Cell("B2")));
         }
 
         [TestCase("PY(4)", "_xlfn._xlws.PY(4)")]
@@ -1069,7 +1140,7 @@ namespace ClosedXML.Tests
             var cell = ws.Cell("A1");
             cell.FormulaA1 = formula;
 
-            Assert.AreEqual(expected, cell.FormulaA1);
+            Assert.That(cell.FormulaA1, Is.EqualTo(expected));
         }
 
         [TestCase("PY(4)", "_xlfn._xlws.PY(4)")]
@@ -1083,7 +1154,7 @@ namespace ClosedXML.Tests
             var cell = ws.Cell("A1");
             cell.FormulaR1C1 = formula;
 
-            Assert.AreEqual(expected, cell.FormulaR1C1);
+            Assert.That(cell.FormulaR1C1, Is.EqualTo(expected));
         }
 
         [Test]
@@ -1095,7 +1166,7 @@ namespace ClosedXML.Tests
             foreach (var (simpleName, prefixedName) in XLConstants.FutureFunctionMap.Value)
             {
                 cell.FormulaA1 = simpleName + "()";
-                Assert.AreEqual(prefixedName + "()", cell.FormulaA1);
+                Assert.That(cell.FormulaA1, Is.EqualTo(prefixedName + "()"));
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -150,7 +150,7 @@ namespace ClosedXML.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(ws.FirstCell().DataType, Is.EqualTo(XLDataType.Text));
-                Assert.That(ws.FirstCell().GetText().Length, Is.EqualTo(Guid.NewGuid().ToString().Length));
+                Assert.That(ws.FirstCell().GetText(), Has.Length.EqualTo(Guid.NewGuid().ToString().Length));
             });
         }
 
@@ -826,11 +826,11 @@ namespace ClosedXML.Tests
 
             Assert.That(ws.Cell("A10").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("A10:A10"));
             Assert.That(ws.Cell("B5").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B5:B5"));
-            Assert.AreEqual("P1:P1", ws.Cell("P1").CurrentRegion.RangeAddress.ToString());
+            Assert.That(ws.Cell("P1").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("P1:P1"));
 
-            Assert.AreEqual("B1:D3", ws.Cell("D3").CurrentRegion.RangeAddress.ToString());
-            Assert.AreEqual("B1:D4", ws.Cell("D4").CurrentRegion.RangeAddress.ToString());
-            Assert.AreEqual("B1:E4", ws.Cell("E4").CurrentRegion.RangeAddress.ToString());
+            Assert.That(ws.Cell("D3").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B1:D3"));
+            Assert.That(ws.Cell("D4").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B1:D4"));
+            Assert.That(ws.Cell("E4").CurrentRegion.RangeAddress.ToString(), Is.EqualTo("B1:E4"));
 
             foreach (var c in ws.Range("B1:D3").Cells())
             {

--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -738,7 +738,7 @@ namespace ClosedXML.Tests
                 Assert.Multiple(() =>
                 {
                     Assert.That(c.DataType, Is.EqualTo(XLDataType.DateTime));
-                    Assert.That(c.Value, Is.EqualTo(new DateTime(2017, 10, 08)));
+                    Assert.That(c.Value.GetDateTime(), Is.EqualTo(new DateTime(2017, 10, 08)));
                 });
 
                 wb.SaveAs(ms);
@@ -751,7 +751,7 @@ namespace ClosedXML.Tests
                 Assert.Multiple(() =>
                 {
                     Assert.That(c.DataType, Is.EqualTo(XLDataType.DateTime));
-                    Assert.That(c.Value, Is.EqualTo(new DateTime(2017, 10, 08)));
+                    Assert.That(c.Value.GetDateTime(), Is.EqualTo(new DateTime(2017, 10, 08)));
                 });
 
                 c.Clear();

--- a/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
@@ -530,10 +530,10 @@ namespace ClosedXML.Tests.Excel.Cells
         public void UnifiedNumber_IsFormOf_Number_DateTime_And_TimeSpan()
         {
             XLCellValue value = Blank.Value;
-            Assert.False(value.IsUnifiedNumber);
+            Assert.That(value.IsUnifiedNumber, Is.False);
 
             value = true;
-            Assert.False(value.IsUnifiedNumber);
+            Assert.That(value.IsUnifiedNumber, Is.False);
 
             value = 14;
             Assert.Multiple(() =>
@@ -557,10 +557,10 @@ namespace ClosedXML.Tests.Excel.Cells
             });
 
             value = "Text";
-            Assert.False(value.IsUnifiedNumber);
+            Assert.That(value.IsUnifiedNumber, Is.False);
 
             value = XLError.CellReference;
-            Assert.False(value.IsUnifiedNumber);
+            Assert.That(value.IsUnifiedNumber, Is.False);
         }
 
         [TestCase("1900-01-01", 1)]
@@ -629,11 +629,11 @@ namespace ClosedXML.Tests.Excel.Cells
 
             value = "False";
             Assert.That(value.TryConvert(out boolean), Is.True);
-            Assert.False(boolean);
+            Assert.That(boolean, Is.False);
 
             value = 0;
             Assert.That(value.TryConvert(out boolean), Is.True);
-            Assert.False(boolean);
+            Assert.That(boolean, Is.False);
 
             value = 0.001;
             Assert.That(value.TryConvert(out boolean), Is.True);
@@ -711,7 +711,7 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.That(dt, Is.EqualTo(new DateTime(9999, 12, 31)));
 
             v = lastSerialDate + 1;
-            Assert.False(v.TryConvert(out dt));
+            Assert.That(v.TryConvert(out dt), Is.False);
 
             v = new TimeSpan(14, 0, 0, 0);
             Assert.That(v.TryConvert(out dt), Is.True);

--- a/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
@@ -647,33 +647,55 @@ namespace ClosedXML.Tests.Excel.Cells
             XLCellValue value = 5;
             Assert.That(value.TryConvert(out double number, c), Is.True);
             Assert.That(number, Is.EqualTo(5.0));
+            
             value = "1,5";
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(1.5));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(1.5));
+            });
 
             value = "1 1/4";
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(1.25));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(1.25));
+            });
 
             value = "3.1.1900";
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(3));
+            });
 
             value = true;
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(1.0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(1.0));
+            });
 
             value = false;
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(0.0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(0.0));
+            });
 
             value = new DateTime(2020, 4, 5, 10, 14, 5);
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(43926.42644675926));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(43926.42644675926));
+            });
 
             value = new TimeSpan(18, 0, 0);
-            Assert.That(value.TryConvert(out number, c), Is.True);
-            Assert.That(number, Is.EqualTo(0.75));
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.TryConvert(out number, c), Is.True);
+                Assert.That(number, Is.EqualTo(0.75));
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellValueTests.cs
@@ -13,32 +13,41 @@ namespace ClosedXML.Tests.Excel.Cells
         public void Creation_Blank()
         {
             XLCellValue blank = Blank.Value;
-            Assert.AreEqual(XLDataType.Blank, blank.Type);
-            Assert.True(blank.IsBlank);
+            Assert.Multiple(() =>
+            {
+                Assert.That(blank.Type, Is.EqualTo(XLDataType.Blank));
+                Assert.That(blank.IsBlank, Is.True);
+            });
         }
 
         [Test]
         public void Creation_Boolean()
         {
             XLCellValue logical = true;
-            Assert.AreEqual(XLDataType.Boolean, logical.Type);
-            Assert.True(logical.GetBoolean());
-            Assert.True(logical.IsBoolean);
+            Assert.Multiple(() =>
+            {
+                Assert.That(logical.Type, Is.EqualTo(XLDataType.Boolean));
+                Assert.That(logical.GetBoolean(), Is.True);
+                Assert.That(logical.IsBoolean, Is.True);
+            });
         }
 
         [Test]
         public void Creation_Number()
         {
             XLCellValue number = 14.0;
-            Assert.AreEqual(XLDataType.Number, number.Type);
-            Assert.True(number.IsNumber);
-            Assert.AreEqual(14.0, number.GetNumber());
+            Assert.Multiple(() =>
+            {
+                Assert.That(number.Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(number.IsNumber, Is.True);
+                Assert.That(number.GetNumber(), Is.EqualTo(14.0));
+            });
         }
 
-        [TestCase(Double.NaN)]
-        [TestCase(Double.PositiveInfinity)]
-        [TestCase(Double.NegativeInfinity)]
-        public void Creation_Number_CantBeNonNumber(Double nonNumber)
+        [TestCase(double.NaN)]
+        [TestCase(double.PositiveInfinity)]
+        [TestCase(double.NegativeInfinity)]
+        public void Creation_Number_CantBeNonNumber(double nonNumber)
         {
             Assert.Throws<ArgumentException>(() => _ = (XLCellValue)nonNumber);
         }
@@ -47,32 +56,41 @@ namespace ClosedXML.Tests.Excel.Cells
         private static readonly object[] DecimalTestCases =
         {
             new object[] { 5.875m, 5.875d },
-            new object[] { Decimal.MaxValue, 7.922816251426434E+28 },
+            new object[] { decimal.MaxValue, 7.922816251426434E+28 },
             new object[] { 1.0E-28m, 1.0000000000000001E-28d }
         };
 
         [TestCaseSource(nameof(DecimalTestCases))]
-        public void Creation_Decimal(Decimal decimalNumber, Double expectedNumber)
+        public void Creation_Decimal(decimal decimalNumber, double expectedNumber)
         {
             XLCellValue cellValue = decimalNumber;
-            Assert.True(cellValue.IsNumber);
-            Assert.AreEqual(expectedNumber, cellValue.GetNumber());
+            Assert.Multiple(() =>
+            {
+                Assert.That(cellValue.IsNumber, Is.True);
+                Assert.That(cellValue.GetNumber(), Is.EqualTo(expectedNumber));
+            });
         }
 
         [Test]
         public void Creation_Text()
         {
             XLCellValue text = "Hello World";
-            Assert.AreEqual(XLDataType.Text, text.Type);
-            Assert.AreEqual("Hello World", text.GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(text.Type, Is.EqualTo(XLDataType.Text));
+                Assert.That(text.GetText(), Is.EqualTo("Hello World"));
+            });
         }
 
         [Test]
         public void NullString_IsConvertedToBlank()
         {
             XLCellValue value = (string)null;
-            Assert.IsTrue(value.IsBlank);
-            Assert.IsFalse(value.IsText);
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.IsBlank, Is.True);
+                Assert.That(value.IsText, Is.False);
+            });
         }
 
         [Test]
@@ -86,51 +104,63 @@ namespace ClosedXML.Tests.Excel.Cells
         public void Creation_Error()
         {
             XLCellValue error = XLError.NumberInvalid;
-            Assert.AreEqual(XLDataType.Error, error.Type);
-            Assert.True(error.IsError);
-            Assert.AreEqual(XLError.NumberInvalid, error.GetError());
+            Assert.Multiple(() =>
+            {
+                Assert.That(error.Type, Is.EqualTo(XLDataType.Error));
+                Assert.That(error.IsError, Is.True);
+                Assert.That(error.GetError(), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
         public void Creation_DateTime()
         {
             XLCellValue dateTime = new DateTime(2021, 1, 1);
-            Assert.AreEqual(XLDataType.DateTime, dateTime.Type);
-            Assert.True(dateTime.IsDateTime);
-            Assert.AreEqual(new DateTime(2021, 1, 1), dateTime.GetDateTime());
+            Assert.Multiple(() =>
+            {
+                Assert.That(dateTime.Type, Is.EqualTo(XLDataType.DateTime));
+                Assert.That(dateTime.IsDateTime, Is.True);
+                Assert.That(dateTime.GetDateTime(), Is.EqualTo(new DateTime(2021, 1, 1)));
+            });
         }
 
         [Test]
         public void Creation_TimeSpan()
         {
             XLCellValue dateTime = new TimeSpan(10, 1, 2, 3, 456);
-            Assert.AreEqual(XLDataType.TimeSpan, dateTime.Type);
-            Assert.True(dateTime.IsTimeSpan);
-            Assert.AreEqual(new TimeSpan(10, 1, 2, 3, 456), dateTime.GetTimeSpan());
+            Assert.Multiple(() =>
+            {
+                Assert.That(dateTime.Type, Is.EqualTo(XLDataType.TimeSpan));
+                Assert.That(dateTime.IsTimeSpan, Is.True);
+                Assert.That(dateTime.GetTimeSpan(), Is.EqualTo(new TimeSpan(10, 1, 2, 3, 456)));
+            });
         }
 
         [Test]
         public void Creation_FromObject()
         {
-            Assert.AreEqual(XLDataType.Blank, XLCellValue.FromObject(null).Type);
-            Assert.AreEqual(XLDataType.Blank, XLCellValue.FromObject(Blank.Value).Type);
-            Assert.AreEqual(XLDataType.Boolean, XLCellValue.FromObject(true).Type);
-            Assert.AreEqual(XLDataType.Text, XLCellValue.FromObject("Hello World").Type);
-            Assert.AreEqual(XLDataType.Error, XLCellValue.FromObject(XLError.NumberInvalid).Type);
-            Assert.AreEqual(XLDataType.DateTime, XLCellValue.FromObject(new DateTime(2021, 1, 1)).Type);
-            Assert.AreEqual(XLDataType.TimeSpan, XLCellValue.FromObject(new TimeSpan(10, 1, 2, 3, 456)).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((sbyte)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((byte)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((short)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((ushort)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((int)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((uint)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((long)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((ulong)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((float)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((double)42).Type);
-            Assert.AreEqual(XLDataType.Number, XLCellValue.FromObject((decimal)42).Type);
-            Assert.AreEqual(XLDataType.Text, XLCellValue.FromObject(DayOfWeek.Sunday).Type);
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLCellValue.FromObject(null).Type, Is.EqualTo(XLDataType.Blank));
+                Assert.That(XLCellValue.FromObject(Blank.Value).Type, Is.EqualTo(XLDataType.Blank));
+                Assert.That(XLCellValue.FromObject(true).Type, Is.EqualTo(XLDataType.Boolean));
+                Assert.That(XLCellValue.FromObject("Hello World").Type, Is.EqualTo(XLDataType.Text));
+                Assert.That(XLCellValue.FromObject(XLError.NumberInvalid).Type, Is.EqualTo(XLDataType.Error));
+                Assert.That(XLCellValue.FromObject(new DateTime(2021, 1, 1)).Type, Is.EqualTo(XLDataType.DateTime));
+                Assert.That(XLCellValue.FromObject(new TimeSpan(10, 1, 2, 3, 456)).Type, Is.EqualTo(XLDataType.TimeSpan));
+                Assert.That(XLCellValue.FromObject((sbyte)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((byte)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((short)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((ushort)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((int)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((uint)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((long)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((ulong)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((float)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((double)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject((decimal)42).Type, Is.EqualTo(XLDataType.Number));
+                Assert.That(XLCellValue.FromObject(DayOfWeek.Sunday).Type, Is.EqualTo(XLDataType.Text));
+            });
         }
 
         [Test]
@@ -139,68 +169,101 @@ namespace ClosedXML.Tests.Excel.Cells
             {
                 sbyte sbyteNumber = 5;
                 XLCellValue sbyteCellValue = sbyteNumber;
-                Assert.IsTrue(sbyteCellValue.IsNumber);
-                Assert.AreEqual(5d, sbyteCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sbyteCellValue.IsNumber, Is.True);
+                    Assert.That(sbyteCellValue.GetNumber(), Is.EqualTo(5d));
+                });
             }
             {
                 byte byteNumber = 6;
                 XLCellValue byteCellValue = byteNumber;
-                Assert.IsTrue(byteCellValue.IsNumber);
-                Assert.AreEqual(6d, byteCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(byteCellValue.IsNumber, Is.True);
+                    Assert.That(byteCellValue.GetNumber(), Is.EqualTo(6d));
+                });
             }
             {
                 short shortNumber = 7;
                 XLCellValue shortCellValue = shortNumber;
-                Assert.IsTrue(shortCellValue.IsNumber);
-                Assert.AreEqual(7d, shortCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(shortCellValue.IsNumber, Is.True);
+                    Assert.That(shortCellValue.GetNumber(), Is.EqualTo(7d));
+                });
             }
             {
                 ushort ushortNumber = 8;
                 XLCellValue ushortCellValue = ushortNumber;
-                Assert.IsTrue(ushortCellValue.IsNumber);
-                Assert.AreEqual(8d, ushortCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ushortCellValue.IsNumber, Is.True);
+                    Assert.That(ushortCellValue.GetNumber(), Is.EqualTo(8d));
+                });
             }
             {
                 int intNumber = 9;
                 XLCellValue intCellValue = intNumber;
-                Assert.IsTrue(intCellValue.IsNumber);
-                Assert.AreEqual(9d, intCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(intCellValue.IsNumber, Is.True);
+                    Assert.That(intCellValue.GetNumber(), Is.EqualTo(9d));
+                });
             }
             {
                 uint uintNumber = 10;
                 XLCellValue uintCellValue = uintNumber;
-                Assert.IsTrue(uintCellValue.IsNumber);
-                Assert.AreEqual(10d, uintCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(uintCellValue.IsNumber, Is.True);
+                    Assert.That(uintCellValue.GetNumber(), Is.EqualTo(10d));
+                });
             }
             {
                 long longNumber = 11;
                 XLCellValue longCellValue = longNumber;
-                Assert.IsTrue(longCellValue.IsNumber);
-                Assert.AreEqual(11d, longCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(longCellValue.IsNumber, Is.True);
+                    Assert.That(longCellValue.GetNumber(), Is.EqualTo(11d));
+                });
             }
             {
                 ulong ulongNumber = 12;
                 XLCellValue ulongCellValue = ulongNumber;
-                Assert.IsTrue(ulongCellValue.IsNumber);
-                Assert.AreEqual(12d, ulongCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ulongCellValue.IsNumber, Is.True);
+                    Assert.That(ulongCellValue.GetNumber(), Is.EqualTo(12d));
+                });
             }
             {
                 float floatNumber = 13.5f;
                 XLCellValue floatCellValue = floatNumber;
-                Assert.IsTrue(floatCellValue.IsNumber);
-                Assert.AreEqual(13.5d, floatCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(floatCellValue.IsNumber, Is.True);
+                    Assert.That(floatCellValue.GetNumber(), Is.EqualTo(13.5d));
+                });
             }
             {
                 double doubleNumber = 14.5;
                 XLCellValue doubleCellValue = doubleNumber;
-                Assert.IsTrue(doubleCellValue.IsNumber);
-                Assert.AreEqual(14.5d, doubleCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(doubleCellValue.IsNumber, Is.True);
+                    Assert.That(doubleCellValue.GetNumber(), Is.EqualTo(14.5d));
+                });
             }
             {
                 decimal decimalNumber = 15.75m;
                 XLCellValue decimalCellValue = decimalNumber;
-                Assert.IsTrue(decimalCellValue.IsNumber);
-                Assert.AreEqual(15.75d, decimalCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(decimalCellValue.IsNumber, Is.True);
+                    Assert.That(decimalCellValue.GetNumber(), Is.EqualTo(15.75d));
+                });
             }
         }
 
@@ -211,68 +274,101 @@ namespace ClosedXML.Tests.Excel.Cells
             {
                 sbyte? sbyteNull = null;
                 XLCellValue sbyteCellValue = sbyteNull;
-                Assert.IsFalse(sbyteCellValue.IsNumber);
-                Assert.IsTrue(sbyteCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sbyteCellValue.IsNumber, Is.False);
+                    Assert.That(sbyteCellValue.IsBlank, Is.True);
+                });
             }
             {
                 byte? byteNull = null;
                 XLCellValue byteCellValue = byteNull;
-                Assert.IsFalse(byteCellValue.IsNumber);
-                Assert.IsTrue(byteCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(byteCellValue.IsNumber, Is.False);
+                    Assert.That(byteCellValue.IsBlank, Is.True);
+                });
             }
             {
                 short? shortNull = null;
                 XLCellValue shortCellValue = shortNull;
-                Assert.IsFalse(shortCellValue.IsNumber);
-                Assert.IsTrue(shortCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(shortCellValue.IsNumber, Is.False);
+                    Assert.That(shortCellValue.IsBlank, Is.True);
+                });
             }
             {
                 ushort? ushortNull = null;
                 XLCellValue ushortCellValue = ushortNull;
-                Assert.IsFalse(ushortCellValue.IsNumber);
-                Assert.IsTrue(ushortCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ushortCellValue.IsNumber, Is.False);
+                    Assert.That(ushortCellValue.IsBlank, Is.True);
+                });
             }
             {
                 int? intNull = null;
                 XLCellValue intCellValue = intNull;
-                Assert.IsFalse(intCellValue.IsNumber);
-                Assert.IsTrue(intCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(intCellValue.IsNumber, Is.False);
+                    Assert.That(intCellValue.IsBlank, Is.True);
+                });
             }
             {
                 uint? uintNull = null;
                 XLCellValue uintCellValue = uintNull;
-                Assert.IsFalse(uintCellValue.IsNumber);
-                Assert.IsTrue(uintCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(uintCellValue.IsNumber, Is.False);
+                    Assert.That(uintCellValue.IsBlank, Is.True);
+                });
             }
             {
                 long? longNull = null;
                 XLCellValue longCellValue = longNull;
-                Assert.IsFalse(longCellValue.IsNumber);
-                Assert.IsTrue(longCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(longCellValue.IsNumber, Is.False);
+                    Assert.That(longCellValue.IsBlank, Is.True);
+                });
             }
             {
                 ulong? ulongNull = null;
                 XLCellValue ulongCellValue = ulongNull;
-                Assert.IsFalse(ulongCellValue.IsNumber);
-                Assert.IsTrue(ulongCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ulongCellValue.IsNumber, Is.False);
+                    Assert.That(ulongCellValue.IsBlank, Is.True);
+                });
             }
             {
                 float? floatValue = null;
                 XLCellValue floatCellValue = floatValue;
-                Assert.IsFalse(floatCellValue.IsNumber);
-                Assert.IsTrue(floatCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(floatCellValue.IsNumber, Is.False);
+                    Assert.That(floatCellValue.IsBlank, Is.True);
+                });
             }
             {
                 double? doubleValue = null;
                 XLCellValue doubleCellValue = doubleValue;
-                Assert.IsFalse(doubleCellValue.IsNumber);
-                Assert.IsTrue(doubleCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(doubleCellValue.IsNumber, Is.False);
+                    Assert.That(doubleCellValue.IsBlank, Is.True);
+                });
             }
             {
                 decimal? decimalValue = null;
                 XLCellValue decimalCellValue = decimalValue;
-                Assert.IsFalse(decimalCellValue.IsNumber);
-                Assert.IsTrue(decimalCellValue.IsBlank);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(decimalCellValue.IsNumber, Is.False);
+                    Assert.That(decimalCellValue.IsBlank, Is.True);
+                });
             }
         }
 
@@ -282,68 +378,101 @@ namespace ClosedXML.Tests.Excel.Cells
             {
                 sbyte? sbyteNumber = 5;
                 XLCellValue sbyteCellValue = sbyteNumber;
-                Assert.IsTrue(sbyteCellValue.IsNumber);
-                Assert.AreEqual(5d, sbyteCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(sbyteCellValue.IsNumber, Is.True);
+                    Assert.That(sbyteCellValue.GetNumber(), Is.EqualTo(5d));
+                });
             }
             {
                 byte? byteNumber = 6;
                 XLCellValue byteCellValue = byteNumber;
-                Assert.IsTrue(byteCellValue.IsNumber);
-                Assert.AreEqual(6d, byteCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(byteCellValue.IsNumber, Is.True);
+                    Assert.That(byteCellValue.GetNumber(), Is.EqualTo(6d));
+                });
             }
             {
                 short? shortNumber = 7;
                 XLCellValue shortCellValue = shortNumber;
-                Assert.IsTrue(shortCellValue.IsNumber);
-                Assert.AreEqual(7d, shortCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(shortCellValue.IsNumber, Is.True);
+                    Assert.That(shortCellValue.GetNumber(), Is.EqualTo(7d));
+                });
             }
             {
                 ushort? ushortNumber = 8;
                 XLCellValue ushortCellValue = ushortNumber;
-                Assert.IsTrue(ushortCellValue.IsNumber);
-                Assert.AreEqual(8d, ushortCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ushortCellValue.IsNumber, Is.True);
+                    Assert.That(ushortCellValue.GetNumber(), Is.EqualTo(8d));
+                });
             }
             {
                 int? intNumber = 9;
                 XLCellValue intCellValue = intNumber;
-                Assert.IsTrue(intCellValue.IsNumber);
-                Assert.AreEqual(9d, intCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(intCellValue.IsNumber, Is.True);
+                    Assert.That(intCellValue.GetNumber(), Is.EqualTo(9d));
+                });
             }
             {
                 uint? uintNumber = 9;
                 XLCellValue uintCellValue = uintNumber;
-                Assert.IsTrue(uintCellValue.IsNumber);
-                Assert.AreEqual(9d, uintCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(uintCellValue.IsNumber, Is.True);
+                    Assert.That(uintCellValue.GetNumber(), Is.EqualTo(9d));
+                });
             }
             {
                 long? longNumber = 10;
                 XLCellValue longCellValue = longNumber;
-                Assert.IsTrue(longCellValue.IsNumber);
-                Assert.AreEqual(10d, longCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(longCellValue.IsNumber, Is.True);
+                    Assert.That(longCellValue.GetNumber(), Is.EqualTo(10d));
+                });
             }
             {
                 ulong? ulongNumber = 11;
                 XLCellValue ulongCellValue = ulongNumber;
-                Assert.IsTrue(ulongCellValue.IsNumber);
-                Assert.AreEqual(11d, ulongCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ulongCellValue.IsNumber, Is.True);
+                    Assert.That(ulongCellValue.GetNumber(), Is.EqualTo(11d));
+                });
             }
             {
                 float? floatNumber = 12.875f;
                 XLCellValue floatCellValue = floatNumber;
-                Assert.IsTrue(floatCellValue.IsNumber);
-                Assert.AreEqual(12.875d, floatCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(floatCellValue.IsNumber, Is.True);
+                    Assert.That(floatCellValue.GetNumber(), Is.EqualTo(12.875d));
+                });
             }
             {
                 double? doubleNumber = 13.875d;
                 XLCellValue doubleCellValue = doubleNumber;
-                Assert.IsTrue(doubleCellValue.IsNumber);
-                Assert.AreEqual(13.875d, doubleCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(doubleCellValue.IsNumber, Is.True);
+                    Assert.That(doubleCellValue.GetNumber(), Is.EqualTo(13.875d));
+                });
             }
             {
                 decimal? decimalNumber = 14.875m;
                 XLCellValue decimalCellValue = decimalNumber;
-                Assert.IsTrue(decimalCellValue.IsNumber);
-                Assert.AreEqual(14.875d, decimalCellValue.GetNumber());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(decimalCellValue.IsNumber, Is.True);
+                    Assert.That(decimalCellValue.GetNumber(), Is.EqualTo(14.875d));
+                });
             }
         }
 
@@ -353,8 +482,11 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             DateTime? dateTimeNull = null;
             XLCellValue dateTimeCellValue = dateTimeNull;
-            Assert.IsFalse(dateTimeCellValue.IsDateTime);
-            Assert.IsTrue(dateTimeCellValue.IsBlank);
+            Assert.Multiple(() =>
+            {
+                Assert.That(dateTimeCellValue.IsDateTime, Is.False);
+                Assert.That(dateTimeCellValue.IsBlank, Is.True);
+            });
         }
 
         [Test]
@@ -362,8 +494,11 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             DateTime? dateTime = new DateTime(2020, 5, 14, 8, 14, 30);
             XLCellValue dateTimeCellValue = dateTime;
-            Assert.IsTrue(dateTimeCellValue.IsDateTime);
-            Assert.AreEqual(dateTime.Value, dateTimeCellValue.GetDateTime());
+            Assert.Multiple(() =>
+            {
+                Assert.That(dateTimeCellValue.IsDateTime, Is.True);
+                Assert.That(dateTimeCellValue.GetDateTime(), Is.EqualTo(dateTime.Value));
+            });
         }
 
         [Test]
@@ -372,8 +507,11 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             TimeSpan? timeSpanNull = null;
             XLCellValue timeSpanCellValue = timeSpanNull;
-            Assert.IsFalse(timeSpanCellValue.IsTimeSpan);
-            Assert.IsTrue(timeSpanCellValue.IsBlank);
+            Assert.Multiple(() =>
+            {
+                Assert.That(timeSpanCellValue.IsTimeSpan, Is.False);
+                Assert.That(timeSpanCellValue.IsBlank, Is.True);
+            });
         }
 
         [Test]
@@ -381,8 +519,11 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             TimeSpan? timeSpan = new TimeSpan(48, 12, 45, 30);
             XLCellValue timeSpanCellValue = timeSpan;
-            Assert.IsTrue(timeSpanCellValue.IsTimeSpan);
-            Assert.AreEqual(timeSpan.Value, timeSpanCellValue.GetTimeSpan());
+            Assert.Multiple(() =>
+            {
+                Assert.That(timeSpanCellValue.IsTimeSpan, Is.True);
+                Assert.That(timeSpanCellValue.GetTimeSpan(), Is.EqualTo(timeSpan.Value));
+            });
         }
 
         [Test]
@@ -395,16 +536,25 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.False(value.IsUnifiedNumber);
 
             value = 14;
-            Assert.True(value.IsUnifiedNumber);
-            Assert.AreEqual(14.0, value.GetUnifiedNumber());
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.IsUnifiedNumber, Is.True);
+                Assert.That(value.GetUnifiedNumber(), Is.EqualTo(14.0));
+            });
 
             value = new DateTime(1900, 1, 1);
-            Assert.True(value.IsUnifiedNumber);
-            Assert.AreEqual(1.0, value.GetUnifiedNumber());
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.IsUnifiedNumber, Is.True);
+                Assert.That(value.GetUnifiedNumber(), Is.EqualTo(1.0));
+            });
 
             value = new TimeSpan(2, 12, 0, 0);
-            Assert.True(value.IsUnifiedNumber);
-            Assert.AreEqual(2.5, value.GetUnifiedNumber());
+            Assert.Multiple(() =>
+            {
+                Assert.That(value.IsUnifiedNumber, Is.True);
+                Assert.That(value.GetUnifiedNumber(), Is.EqualTo(2.5));
+            });
 
             value = "Text";
             Assert.False(value.IsUnifiedNumber);
@@ -422,7 +572,7 @@ namespace ClosedXML.Tests.Excel.Cells
         public void SerialDateTime(string dateString, double expectedSerial)
         {
             XLCellValue date = DateTime.Parse(dateString);
-            Assert.AreEqual(expectedSerial, date.GetUnifiedNumber());
+            Assert.That(date.GetUnifiedNumber(), Is.EqualTo(expectedSerial));
         }
 
         [Test]
@@ -430,64 +580,64 @@ namespace ClosedXML.Tests.Excel.Cells
         public void ToString_RespectsCulture()
         {
             XLCellValue v = Blank.Value;
-            Assert.AreEqual(String.Empty, v.ToString());
+            Assert.That(v.ToString(), Is.Empty);
 
             v = true;
-            Assert.AreEqual("TRUE", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("TRUE"));
 
             v = 25.4;
-            Assert.AreEqual("25,4", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("25,4"));
 
             v = "Hello";
-            Assert.AreEqual("Hello", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("Hello"));
 
             v = XLError.IncompatibleValue;
-            Assert.AreEqual("#VALUE!", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("#VALUE!"));
 
             v = new DateTime(1900, 1, 2);
-            Assert.AreEqual("02.01.1900 0:00:00", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("02.01.1900 0:00:00"));
 
             v = new DateTime(1900, 3, 1, 4, 10, 5);
-            Assert.AreEqual("01.03.1900 4:10:05", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("01.03.1900 4:10:05"));
 
             v = new TimeSpan(4, 5, 6, 7, 82);
-            Assert.AreEqual("101:06:07,082", v.ToString());
+            Assert.That(v.ToString(), Is.EqualTo("101:06:07,082"));
         }
 
         [Test]
         public void TryConvert_Blank()
         {
             XLCellValue value = Blank.Value;
-            Assert.True(value.TryConvert(out Blank blank));
-            Assert.AreEqual(Blank.Value, blank);
+            Assert.That(value.TryConvert(out Blank blank), Is.True);
+            Assert.That(blank, Is.EqualTo(Blank.Value));
 
-            value = String.Empty;
-            Assert.True(value.TryConvert(out blank));
-            Assert.AreEqual(Blank.Value, blank);
+            value = string.Empty;
+            Assert.That(value.TryConvert(out blank), Is.True);
+            Assert.That(blank, Is.EqualTo(Blank.Value));
         }
 
         [Test]
         public void TryConvert_Boolean()
         {
             XLCellValue value = true;
-            Assert.True(value.TryConvert(out Boolean boolean));
-            Assert.True(boolean);
+            Assert.That(value.TryConvert(out bool boolean), Is.True);
+            Assert.That(boolean, Is.True);
 
             value = "True";
-            Assert.True(value.TryConvert(out boolean));
-            Assert.True(boolean);
+            Assert.That(value.TryConvert(out boolean), Is.True);
+            Assert.That(boolean, Is.True);
 
             value = "False";
-            Assert.True(value.TryConvert(out boolean));
+            Assert.That(value.TryConvert(out boolean), Is.True);
             Assert.False(boolean);
 
             value = 0;
-            Assert.True(value.TryConvert(out boolean));
+            Assert.That(value.TryConvert(out boolean), Is.True);
             Assert.False(boolean);
 
             value = 0.001;
-            Assert.True(value.TryConvert(out boolean));
-            Assert.True(boolean);
+            Assert.That(value.TryConvert(out boolean), Is.True);
+            Assert.That(boolean, Is.True);
         }
 
         [Test]
@@ -495,56 +645,55 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             var c = CultureInfo.GetCultureInfo("cs-CZ");
             XLCellValue value = 5;
-            Assert.True(value.TryConvert(out Double number, c));
-            Assert.AreEqual(5.0, number);
-
+            Assert.That(value.TryConvert(out double number, c), Is.True);
+            Assert.That(number, Is.EqualTo(5.0));
             value = "1,5";
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(1.5, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(1.5));
 
             value = "1 1/4";
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(1.25, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(1.25));
 
             value = "3.1.1900";
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(3, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(3));
 
             value = true;
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(1.0, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(1.0));
 
             value = false;
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(0.0, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(0.0));
 
             value = new DateTime(2020, 4, 5, 10, 14, 5);
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(43926.42644675926, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(43926.42644675926));
 
             value = new TimeSpan(18, 0, 0);
-            Assert.True(value.TryConvert(out number, c));
-            Assert.AreEqual(0.75, number);
+            Assert.That(value.TryConvert(out number, c), Is.True);
+            Assert.That(number, Is.EqualTo(0.75));
         }
 
         [Test]
         public void TryConvert_DateTime()
         {
             XLCellValue v = new DateTime(2020, 1, 1);
-            Assert.True(v.TryConvert(out DateTime dt));
-            Assert.AreEqual(new DateTime(2020, 1, 1), dt);
+            Assert.That(v.TryConvert(out DateTime dt), Is.True);
+            Assert.That(dt, Is.EqualTo(new DateTime(2020, 1, 1)));
 
             var lastSerialDate = 2958465;
             v = lastSerialDate;
-            Assert.True(v.TryConvert(out dt));
-            Assert.AreEqual(new DateTime(9999, 12, 31), dt);
+            Assert.That(v.TryConvert(out dt), Is.True);
+            Assert.That(dt, Is.EqualTo(new DateTime(9999, 12, 31)));
 
             v = lastSerialDate + 1;
             Assert.False(v.TryConvert(out dt));
 
             v = new TimeSpan(14, 0, 0, 0);
-            Assert.True(v.TryConvert(out dt));
-            Assert.AreEqual(new DateTime(1900, 1, 14), dt);
+            Assert.That(v.TryConvert(out dt), Is.True);
+            Assert.That(dt, Is.EqualTo(new DateTime(1900, 1, 14)));
         }
 
         [Test]
@@ -552,16 +701,16 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             var c = CultureInfo.GetCultureInfo("cs-CZ");
             XLCellValue v = new TimeSpan(10, 15, 30);
-            Assert.True(v.TryConvert(out TimeSpan ts, c));
-            Assert.AreEqual(new TimeSpan(10, 15, 30), ts);
+            Assert.That(v.TryConvert(out TimeSpan ts, c), Is.True);
+            Assert.That(ts, Is.EqualTo(new TimeSpan(10, 15, 30)));
 
             v = "26:15:30,5";
-            Assert.True(v.TryConvert(out ts, c));
-            Assert.AreEqual(new TimeSpan(1, 2, 15, 30, 500), ts);
+            Assert.That(v.TryConvert(out ts, c), Is.True);
+            Assert.That(ts, Is.EqualTo(new TimeSpan(1, 2, 15, 30, 500)));
 
             v = 0.75;
-            Assert.True(v.TryConvert(out ts, c));
-            Assert.AreEqual(new TimeSpan(18, 0, 0), ts);
+            Assert.That(v.TryConvert(out ts, c), Is.True);
+            Assert.That(ts, Is.EqualTo(new TimeSpan(18, 0, 0)));
         }
 
         [TestCase(1)]
@@ -571,7 +720,7 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             var subMsTimeSpan = TimeSpan.FromTicks(ticks);
             XLCellValue value = subMsTimeSpan;
-            Assert.AreEqual(subMsTimeSpan, value.GetTimeSpan());
+            Assert.That(value.GetTimeSpan(), Is.EqualTo(subMsTimeSpan));
         }
 
         [TestCase(1)]
@@ -582,14 +731,11 @@ namespace ClosedXML.Tests.Excel.Cells
             // NetFx converts double to string using G15. Core changed it to G17, but ClosedXML still use G15.
             var subMsTimeSpan = TimeSpan.FromTicks(ticks);
             TestHelper.CreateSaveLoadAssert(
-                (_, ws) =>
-                {
-                    ws.Cell("A1").Value = subMsTimeSpan;
-                },
+                (_, ws) => { ws.Cell("A1").Value = subMsTimeSpan; },
                 (_, ws) =>
                 {
                     var cellValue = ws.Cell("A1").CachedValue;
-                    Assert.AreEqual(subMsTimeSpan, cellValue.GetTimeSpan());
+                    Assert.That(cellValue.GetTimeSpan(), Is.EqualTo(subMsTimeSpan));
                 });
         }
 
@@ -599,7 +745,7 @@ namespace ClosedXML.Tests.Excel.Cells
         {
             var value = XLCellValue.FromSerialTimeSpan(serialDateTime);
             var ex = Assert.Throws<OverflowException>(() => value.GetTimeSpan())!;
-            Assert.AreEqual("The serial date time value is too large to be represented in a TimeSpan.", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("The serial date time value is too large to be represented in a TimeSpan."));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Clearing/ClearingTests.cs
+++ b/ClosedXML.Tests/Excel/Clearing/ClearingTests.cs
@@ -55,23 +55,29 @@ namespace ClosedXML.Tests
                 .Border.SetOutsideBorderColor(XLColor.Blue)
                 .Font.SetBold();
 
-            Assert.AreEqual(XLDataType.Text, ws.Cell("A1").Value.Type);
-            Assert.AreEqual(XLDataType.Text, ws.Cell("A2").Value.Type);
-            Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").Value.Type);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value.Type, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A2").Value.Type, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A3").Value.Type, Is.EqualTo(XLDataType.DateTime));
 
-            Assert.AreEqual(false, ws.Cell("A1").HasFormula);
-            Assert.AreEqual(true, ws.Cell("A2").HasFormula);
-            Assert.AreEqual(false, ws.Cell("A1").HasFormula);
+                Assert.That(ws.Cell("A1").HasFormula, Is.False);
+                Assert.That(ws.Cell("A2").HasFormula, Is.EqualTo(true));
+            });
+            Assert.That(ws.Cell("A1").HasFormula, Is.EqualTo(false));
 
             foreach (var cell in ws.Range("A1:A3").Cells())
             {
-                Assert.AreEqual(backgroundColor, cell.Style.Fill.BackgroundColor);
-                Assert.AreEqual(foregroundColor, cell.Style.Font.FontColor);
-                Assert.IsTrue(ws.ConditionalFormats.Any());
-                Assert.IsTrue(cell.HasComment);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(cell.Style.Fill.BackgroundColor, Is.EqualTo(backgroundColor));
+                    Assert.That(cell.Style.Font.FontColor, Is.EqualTo(foregroundColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.True);
+                    Assert.That(cell.HasComment, Is.True);
+                });
             }
 
-            Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
+            Assert.That(ws.Cell("A1").GetDataValidation().Value, Is.EqualTo("B1"));
 
             return wb;
         }
@@ -79,183 +85,202 @@ namespace ClosedXML.Tests
         [Test]
         public void WorksheetClearAll()
         {
-            using (var wb = SetupWorkbook())
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+
+            ws.Clear(XLClearOptions.All);
+
+            foreach (var c in ws.Range("A1:A10").Cells())
             {
-                var ws = wb.Worksheets.First();
-
-                ws.Clear(XLClearOptions.All);
-
-                foreach (var c in ws.Range("A1:A10").Cells())
+                Assert.Multiple(() =>
                 {
-                    Assert.IsTrue(c.IsEmpty());
-                    Assert.AreEqual(XLDataType.Blank, c.DataType);
-                    Assert.AreEqual(ws.Style.Fill.BackgroundColor, c.Style.Fill.BackgroundColor);
-                    Assert.AreEqual(ws.Style.Font.FontColor, c.Style.Font.FontColor);
-                    Assert.IsFalse(ws.ConditionalFormats.Any());
-                    Assert.IsFalse(c.HasComment);
-                    Assert.AreEqual(String.Empty, c.GetDataValidation().Value);
-                }
+                    Assert.That(c.IsEmpty(), Is.True);
+                    Assert.That(c.DataType, Is.EqualTo(XLDataType.Blank));
+                    Assert.That(c.Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+                    Assert.That(c.Style.Font.FontColor, Is.EqualTo(ws.Style.Font.FontColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.False);
+                    Assert.That(c.HasComment, Is.False);
+                    Assert.That(c.GetDataValidation().Value, Is.Empty);
+                });
             }
         }
 
         [Test]
         public void WorksheetClearContents()
         {
-            using (var wb = SetupWorkbook())
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+
+            ws.Clear(XLClearOptions.Contents);
+
+            foreach (var c in ws.Range("A1:A3").Cells())
             {
-                var ws = wb.Worksheets.First();
-
-                ws.Clear(XLClearOptions.Contents);
-
-                foreach (var c in ws.Range("A1:A3").Cells())
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(XLDataType.Blank, ws.Cell("A1").DataType);
-                    Assert.IsTrue(c.IsEmpty(XLCellsUsedOptions.Contents));
+                    Assert.That(ws.Cell("A1").DataType, Is.EqualTo(XLDataType.Blank));
+                    Assert.That(c.IsEmpty(XLCellsUsedOptions.Contents), Is.True);
 
-                    Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
-                    Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
-                    Assert.IsTrue(ws.ConditionalFormats.Any());
-                    Assert.IsTrue(c.HasComment);
-                }
-
-                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
+                    Assert.That(c.Style.Fill.BackgroundColor, Is.EqualTo(backgroundColor));
+                    Assert.That(c.Style.Font.FontColor, Is.EqualTo(foregroundColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.True);
+                    Assert.That(c.HasComment, Is.True);
+                });
             }
+
+            Assert.That(ws.Cell("A1").GetDataValidation().Value, Is.EqualTo("B1"));
         }
 
         [Test]
         public void WorksheetClearNormalFormats()
         {
-            using (var wb = SetupWorkbook())
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+
+            ws.Clear(XLClearOptions.NormalFormats);
+
+            foreach (var c in ws.Range("A1:A3").Cells())
             {
-                var ws = wb.Worksheets.First();
-
-                ws.Clear(XLClearOptions.NormalFormats);
-
-                foreach (var c in ws.Range("A1:A3").Cells())
+                Assert.Multiple(() =>
                 {
-                    Assert.IsFalse(c.IsEmpty());
-                    Assert.AreEqual(ws.Style.Fill.BackgroundColor, c.Style.Fill.BackgroundColor);
-                    Assert.AreEqual(ws.Style.Font.FontColor, c.Style.Font.FontColor);
-                    Assert.IsTrue(ws.ConditionalFormats.Any());
-                    Assert.IsTrue(c.HasComment);
-                }
-
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
-                Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
-
-                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
+                    Assert.That(c.IsEmpty(), Is.False);
+                    Assert.That(c.Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+                    Assert.That(c.Style.Font.FontColor, Is.EqualTo(ws.Style.Font.FontColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.True);
+                    Assert.That(c.HasComment, Is.True);
+                });
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A2").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A3").DataType, Is.EqualTo(XLDataType.DateTime));
+
+                Assert.That(ws.Cell("A1").GetDataValidation().Value, Is.EqualTo("B1"));
+            });
         }
 
         [Test]
         public void WorksheetClearConditionalFormats()
         {
-            using (var wb = SetupWorkbook())
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+
+            ws.Clear(XLClearOptions.ConditionalFormats);
+
+            foreach (var c in ws.Range("A1:A3").Cells())
             {
-                var ws = wb.Worksheets.First();
-
-                ws.Clear(XLClearOptions.ConditionalFormats);
-
-                foreach (var c in ws.Range("A1:A3").Cells())
+                Assert.Multiple(() =>
                 {
-                    Assert.IsFalse(c.IsEmpty());
-                    Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
-                    Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
-                    Assert.IsFalse(ws.ConditionalFormats.Any());
-                    Assert.IsTrue(c.HasComment);
-                }
-
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
-                Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
-
-                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
+                    Assert.That(c.IsEmpty(), Is.False);
+                    Assert.That(c.Style.Fill.BackgroundColor, Is.EqualTo(backgroundColor));
+                    Assert.That(c.Style.Font.FontColor, Is.EqualTo(foregroundColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.False);
+                    Assert.That(c.HasComment, Is.True);
+                });
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A2").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A3").DataType, Is.EqualTo(XLDataType.DateTime));
+
+                Assert.That(ws.Cell("A1").GetDataValidation().Value, Is.EqualTo("B1"));
+            });
         }
 
         [Test]
         public void WorksheetClearComments()
         {
-            using (var wb = SetupWorkbook())
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+
+            ws.Clear(XLClearOptions.Comments);
+
+            foreach (var c in ws.Range("A1:A3").Cells())
             {
-                var ws = wb.Worksheets.First();
-
-                ws.Clear(XLClearOptions.Comments);
-
-                foreach (var c in ws.Range("A1:A3").Cells())
+                Assert.Multiple(() =>
                 {
-                    Assert.IsFalse(c.IsEmpty());
-                    Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
-                    Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
-                    Assert.IsTrue(ws.ConditionalFormats.Any());
-                    Assert.IsFalse(c.HasComment);
-                }
-
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
-                Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
-
-                Assert.AreEqual("B1", ws.Cell("A1").GetDataValidation().Value);
+                    Assert.That(c.IsEmpty(), Is.False);
+                    Assert.That(c.Style.Fill.BackgroundColor, Is.EqualTo(backgroundColor));
+                    Assert.That(c.Style.Font.FontColor, Is.EqualTo(foregroundColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.True);
+                    Assert.That(c.HasComment, Is.False);
+                });
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A2").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A3").DataType, Is.EqualTo(XLDataType.DateTime));
+
+                Assert.That(ws.Cell("A1").GetDataValidation().Value, Is.EqualTo("B1"));
+            });
         }
 
         [Test]
         public void WorksheetClearDataValidation()
         {
-            using (var wb = SetupWorkbook())
+            using var wb = SetupWorkbook();
+            var ws = wb.Worksheets.First();
+
+            ws.Clear(XLClearOptions.DataValidation);
+
+            foreach (var c in ws.Range("A1:A3").Cells())
             {
-                var ws = wb.Worksheets.First();
-
-                ws.Clear(XLClearOptions.DataValidation);
-
-                foreach (var c in ws.Range("A1:A3").Cells())
+                Assert.Multiple(() =>
                 {
-                    Assert.IsFalse(c.IsEmpty());
-                    Assert.AreEqual(backgroundColor, c.Style.Fill.BackgroundColor);
-                    Assert.AreEqual(foregroundColor, c.Style.Font.FontColor);
-                    Assert.IsTrue(ws.ConditionalFormats.Any());
-                    Assert.IsTrue(c.HasComment);
-                }
-
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A1").DataType);
-                Assert.AreEqual(XLDataType.Text, ws.Cell("A2").DataType);
-                Assert.AreEqual(XLDataType.DateTime, ws.Cell("A3").DataType);
-
-                Assert.AreEqual(string.Empty, ws.Cell("A1").GetDataValidation().Value);
+                    Assert.That(c.IsEmpty(), Is.False);
+                    Assert.That(c.Style.Fill.BackgroundColor, Is.EqualTo(backgroundColor));
+                    Assert.That(c.Style.Font.FontColor, Is.EqualTo(foregroundColor));
+                    Assert.That(ws.ConditionalFormats.Any(), Is.True);
+                    Assert.That(c.HasComment, Is.True);
+                });
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A2").DataType, Is.EqualTo(XLDataType.Text));
+                Assert.That(ws.Cell("A3").DataType, Is.EqualTo(XLDataType.DateTime));
+
+                Assert.That(ws.Cell("A1").GetDataValidation().Value, Is.Empty);
+            });
         }
 
         [Test]
         public void DeleteClearedCellValue()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = SetupWorkbook())
             {
-                using (var wb = SetupWorkbook())
+                var ws = wb.Worksheets.First();
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    Assert.AreEqual("Hello world!", ws.Cell("A1").GetText());
-                    Assert.AreEqual(new DateTime(2018, 1, 15), ws.Cell("A3").GetDateTime());
+                    Assert.That(ws.Cell("A1").GetText(), Is.EqualTo("Hello world!"));
+                    Assert.That(ws.Cell("A3").GetDateTime(), Is.EqualTo(new DateTime(2018, 1, 15)));
+                });
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    ws.Clear(XLClearOptions.Contents);
-                    Assert.AreEqual(Blank.Value, ws.Cell("A1").Value);
-                    Assert.Throws<InvalidCastException>(() => ws.Cell("A3").GetDateTime());
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                ws.Clear(XLClearOptions.Contents);
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(Blank.Value));
+                Assert.Throws<InvalidCastException>(() => ws.Cell("A3").GetDateTime());
 
-                    wb.Save();
-                }
+                wb.Save();
+            }
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    Assert.AreEqual(Blank.Value, ws.Cell("A1").Value);
-                    Assert.Throws<InvalidCastException>(() => ws.Cell("A3").GetDateTime());
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(Blank.Value));
+                Assert.Throws<InvalidCastException>(() => ws.Cell("A3").GetDateTime());
             }
         }
 
@@ -266,19 +291,17 @@ namespace ClosedXML.Tests
         [TestCase(XLClearOptions.MergedRanges, 2)]
         public void CanClearMergedRanges(XLClearOptions options, int expectedCount)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Test");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Test");
 
-                ws.Range("A1:C3").Merge();
-                ws.Range("A4:B6").Merge();
-                ws.Range("D1:F3").Merge();
-                ws.Range("E4:F6").Merge();
+            ws.Range("A1:C3").Merge();
+            ws.Range("A4:B6").Merge();
+            ws.Range("D1:F3").Merge();
+            ws.Range("E4:F6").Merge();
 
-                ws.Range("C1:D6").Clear(options);
+            ws.Range("C1:D6").Clear(options);
 
-                Assert.AreEqual(expectedCount, ws.MergedRanges.Count);
-            }
+            Assert.That(ws.MergedRanges, Has.Count.EqualTo(expectedCount));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
+++ b/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
@@ -17,10 +17,10 @@ namespace ClosedXML.Tests.Excel
             ws.Cell(3, 1).SetValue("Test");
 
             IXLRangeColumn fromColumn = ws.Column(1).ColumnUsed();
-            Assert.AreEqual("A2:A3", fromColumn.RangeAddress.ToStringRelative());
+            Assert.That(fromColumn.RangeAddress.ToStringRelative(), Is.EqualTo("A2:A3"));
 
             IXLRangeColumn fromRange = ws.Range("A1:A5").FirstColumn().ColumnUsed();
-            Assert.AreEqual("A2:A3", fromRange.RangeAddress.ToStringRelative());
+            Assert.That(fromRange.RangeAddress.ToStringRelative(), Is.EqualTo("A2:A3"));
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet();
             ws.FirstCell().SetValue("Hello world!");
             var columnsUsed = ws.Row(1).AsRange().ColumnsUsed();
-            Assert.AreEqual(1, columnsUsed.Count());
+            Assert.That(columnsUsed.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -41,7 +41,7 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue("Test").Style.Font.SetBold();
             ws.FirstColumn().CopyTo(ws.Column(2));
 
-            Assert.IsTrue(ws.Cell("B1").Style.Font.Bold);
+            Assert.That(ws.Cell("B1").Style.Font.Bold, Is.True);
         }
 
         [Test]
@@ -60,41 +60,47 @@ namespace ClosedXML.Tests.Excel
 
             IXLColumn columnIns = ws.Column(1).InsertColumnsBefore(1).First();
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Column(1).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Column(1).Cell(2).Style.Fill.BackgroundColor);
+            Assert.That(ws.Column(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(ws.Column(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
             Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Column(1).Cell(3).Style.Fill.BackgroundColor);
 
-            Assert.AreEqual(XLColor.Red, ws.Column(2).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(2).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(2).Cell(3).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column(2).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(2).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(2).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Column(3).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Column(3).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Column(3).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(3).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Column(3).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Column(3).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(4).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(4).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(4).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", ws.Column(3).Cell(2).GetText());
+                Assert.That(ws.Column(3).Cell(2).GetText(), Is.EqualTo("X"));
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, columnIns.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, columnIns.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, columnIns.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(columnIns.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            });
+            Assert.That(columnIns.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(columnIns.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
 
-            Assert.AreEqual(XLColor.Red, column1.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column1.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column1.Cell(3).Style.Fill.BackgroundColor);
+            Assert.That(column1.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+            Assert.Multiple(() =>
+            {
+                Assert.That(column1.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column1.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, column2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, column2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, column2.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(column2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(column2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, column3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column3.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", column2.Cell(2).GetText());
+                Assert.That(column2.Cell(2).GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
@@ -113,41 +119,44 @@ namespace ClosedXML.Tests.Excel
 
             IXLColumn columnIns = ws.Column(2).InsertColumnsBefore(1).First();
 
-            Assert.AreEqual(XLColor.Red, ws.Column(1).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(1).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(1).Cell(3).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(1).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Red, ws.Column(2).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(2).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(2).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(2).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(2).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(2).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Column(3).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Column(3).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Column(3).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(3).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Column(3).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Column(3).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(4).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(4).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(4).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", ws.Column(3).Cell(2).GetText());
+                Assert.That(ws.Column(3).Cell(2).GetText(), Is.EqualTo("X"));
 
-            Assert.AreEqual(XLColor.Red, columnIns.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, columnIns.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, columnIns.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(columnIns.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(columnIns.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(columnIns.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Red, column1.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column1.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column1.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column1.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column1.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column1.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, column2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, column2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, column2.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(column2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(column2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, column3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column3.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", column2.Cell(2).GetText());
+                Assert.That(column2.Cell(2).GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
@@ -166,41 +175,44 @@ namespace ClosedXML.Tests.Excel
 
             IXLColumn columnIns = ws.Column(3).InsertColumnsBefore(1).First();
 
-            Assert.AreEqual(XLColor.Red, ws.Column(1).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(1).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(1).Cell(3).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(1).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Column(2).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Column(2).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Column(2).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(2).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Column(2).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Column(2).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Column(3).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Column(3).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Column(3).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(3).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Column(3).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Column(3).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Column(4).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Column(4).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(4).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Column(4).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", ws.Column(2).Cell(2).GetText());
+                Assert.That(ws.Column(2).Cell(2).GetText(), Is.EqualTo("X"));
 
-            Assert.AreEqual(XLColor.Yellow, columnIns.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, columnIns.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, columnIns.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(columnIns.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(columnIns.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(columnIns.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, column1.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column1.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column1.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column1.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column1.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column1.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, column2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, column2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, column2.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(column2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(column2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, column3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, column3.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(column3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", column2.Cell(2).GetText());
+                Assert.That(column2.Cell(2).GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
@@ -216,7 +228,7 @@ namespace ClosedXML.Tests.Excel
             foreach (IXLRangeColumn row in ws.Range("A1:C3").ColumnsUsed())
                 count++;
 
-            Assert.AreEqual(0, count);
+            Assert.That(count, Is.EqualTo(0));
         }
 
         [Test]
@@ -235,7 +247,7 @@ namespace ClosedXML.Tests.Excel
             ws.Cell("B1").Value = "B1";
             ws.Cell("A2").Value = "A2";
             var lastCoUsed = ws.LastColumnUsed().ColumnNumber();
-            Assert.AreEqual(2, lastCoUsed);
+            Assert.That(lastCoUsed, Is.EqualTo(2));
         }
 
         [Test]
@@ -245,7 +257,7 @@ namespace ClosedXML.Tests.Excel
 
             var column = new XLColumn(ws, -1);
 
-            Assert.IsFalse(column.RangeAddress.IsValid);
+            Assert.That(column.RangeAddress.IsValid, Is.False);
         }
 
         [Test]
@@ -256,8 +268,11 @@ namespace ClosedXML.Tests.Excel
 
             columns.Width = 100;
 
-            Assert.AreEqual(100, ws.Column("G").Width, XLHelper.Epsilon);
-            Assert.AreEqual(100, ws.ColumnWidth, XLHelper.Epsilon);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column("G").Width, Is.EqualTo(100).Within(XLHelper.Epsilon));
+                Assert.That(ws.ColumnWidth, Is.EqualTo(100).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -269,8 +284,11 @@ namespace ClosedXML.Tests.Excel
 
             columns.Width = 100;
 
-            Assert.AreEqual(100, ws.Column("G").Width, XLHelper.Epsilon);
-            Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column("G").Width, Is.EqualTo(100).Within(XLHelper.Epsilon));
+                Assert.That(ws.ColumnWidth, Is.EqualTo(defaultColumnWidth).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -283,9 +301,12 @@ namespace ClosedXML.Tests.Excel
 
             columns.Width = 100;
 
-            Assert.AreEqual(100, ws.Column("C").Width, XLHelper.Epsilon);
-            Assert.AreEqual(defaultColumnWidth, ws.Column("G").Width, XLHelper.Epsilon);
-            Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column("C").Width, Is.EqualTo(100).Within(XLHelper.Epsilon));
+                Assert.That(ws.Column("G").Width, Is.EqualTo(defaultColumnWidth).Within(XLHelper.Epsilon));
+                Assert.That(ws.ColumnWidth, Is.EqualTo(defaultColumnWidth).Within(XLHelper.Epsilon));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
+++ b/ClosedXML.Tests/Excel/Columns/ColumnTests.cs
@@ -62,7 +62,7 @@ namespace ClosedXML.Tests.Excel
 
             Assert.That(ws.Column(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
             Assert.That(ws.Column(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Column(1).Cell(3).Style.Fill.BackgroundColor);
+            Assert.That(ws.Column(1).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
 
             Assert.Multiple(() =>
             {

--- a/ClosedXML.Tests/Excel/Comments/CommentsTests.cs
+++ b/ClosedXML.Tests/Excel/Comments/CommentsTests.cs
@@ -198,8 +198,8 @@ namespace ClosedXML.Tests.Excel.Comments
                     Assert.That(margins.Left, Is.EqualTo(0.5));
                     Assert.That(margins.Top, Is.EqualTo(0.75));
 
-                    Assert.AreEqual(0, margins.Right);
-                    Assert.AreEqual(0, margins.Bottom);
+                    Assert.That(margins.Right, Is.EqualTo(0));
+                    Assert.That(margins.Bottom, Is.EqualTo(0));
                 }
             }, @"Other\Comments\InsetsUnitConversion.xlsx", new LoadOptions { Dpi = new Point(120, 120) });
         }

--- a/ClosedXML.Tests/Excel/Comments/CommentsTests.cs
+++ b/ClosedXML.Tests/Excel/Comments/CommentsTests.cs
@@ -174,7 +174,7 @@ namespace ClosedXML.Tests.Excel.Comments
             var ws = workbook.Worksheets.First();
 
             Assert.That(ws.Cell("A1").GetComment().Visible, Is.True);
-            Assert.False(ws.Cell("A4").GetComment().Visible);
+            Assert.That(ws.Cell("A4").GetComment().Visible, Is.False);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Comments/CommentsTests.cs
+++ b/ClosedXML.Tests/Excel/Comments/CommentsTests.cs
@@ -13,163 +13,168 @@ namespace ClosedXML.Tests.Excel.Comments
         [Test]
         public void CanConvertVmlPaletteEntriesToColors()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CommentsWithColorNamesAndIndexes.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CommentsWithColorNamesAndIndexes.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            var c = ws.FirstCellUsed();
+
+            // None indicates an absence of a color
+            var lineColor = c.GetComment().Style.ColorsAndLines.LineColor;
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.First();
-                var c = ws.FirstCellUsed();
+                Assert.That(lineColor.ColorType, Is.EqualTo(XLColorType.Color));
+                Assert.That(lineColor.Color.ToHex(), Is.EqualTo("00000000"));
+            });
 
-                // None indicates an absence of a color
-                var lineColor = c.GetComment().Style.ColorsAndLines.LineColor;
-                Assert.AreEqual(XLColorType.Color, lineColor.ColorType);
-                Assert.AreEqual("00000000", lineColor.Color.ToHex());
-
-                var bgColor = c.GetComment().Style.ColorsAndLines.FillColor;
-                Assert.AreEqual(XLColorType.Color, bgColor.ColorType);
-                Assert.AreEqual("FFFFFFE1", bgColor.Color.ToHex());
-            }
+            var bgColor = c.GetComment().Style.ColorsAndLines.FillColor;
+            Assert.Multiple(() =>
+            {
+                Assert.That(bgColor.ColorType, Is.EqualTo(XLColorType.Color));
+                Assert.That(bgColor.Color.ToHex(), Is.EqualTo("FFFFFFE1"));
+            });
         }
 
         [Test]
         public void CopyCommentStyle()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            string strExcelComment = "1) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "1) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "2) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "3) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "4) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "5) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "6) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "7) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "8) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+            strExcelComment = strExcelComment + "9) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
+
+            var cell = ws.Cell(2, 2).SetValue("Comment 1");
+
+            cell.GetComment()
+                .SetVisible(false)
+                .AddText(strExcelComment);
+
+            cell.GetComment()
+                .Style
+                .Alignment
+                .SetAutomaticSize();
+
+            cell.GetComment()
+                .Style
+                .ColorsAndLines
+                .SetFillColor(XLColor.Red);
+
+            ws.Row(1).InsertRowsAbove(1);
+
+            Action<IXLCell> validate = c =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                string strExcelComment = "1) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "1) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "2) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "3) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "4) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "5) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "6) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "7) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "8) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-                strExcelComment = strExcelComment + "9) ABCDEFGHIJKLMNOPQRSTUVWXYZ ABC ABC ABC ABC ABC" + Environment.NewLine;
-
-                var cell = ws.Cell(2, 2).SetValue("Comment 1");
-
-                cell.GetComment()
-                    .SetVisible(false)
-                    .AddText(strExcelComment);
-
-                cell.GetComment()
-                    .Style
-                    .Alignment
-                    .SetAutomaticSize();
-
-                cell.GetComment()
-                    .Style
-                    .ColorsAndLines
-                    .SetFillColor(XLColor.Red);
-
-                ws.Row(1).InsertRowsAbove(1);
-
-                Action<IXLCell> validate = c =>
+                Assert.Multiple(() =>
                 {
-                    Assert.IsTrue(c.GetComment().Style.Alignment.AutomaticSize);
-                    Assert.AreEqual(XLColor.Red, c.GetComment().Style.ColorsAndLines.FillColor);
-                };
+                    Assert.That(c.GetComment().Style.Alignment.AutomaticSize, Is.True);
+                    Assert.That(c.GetComment().Style.ColorsAndLines.FillColor, Is.EqualTo(XLColor.Red));
+                });
+            };
 
-                validate(ws.Cell("B3"));
+            validate(ws.Cell("B3"));
 
-                ws.Column(1).InsertColumnsBefore(2);
+            ws.Column(1).InsertColumnsBefore(2);
 
-                validate(ws.Cell("D3"));
+            validate(ws.Cell("D3"));
 
-                ws.Column(1).Delete();
+            ws.Column(1).Delete();
 
-                validate(ws.Cell("C3"));
+            validate(ws.Cell("C3"));
 
-                ws.Row(1).Delete();
+            ws.Row(1).Delete();
 
-                validate(ws.Cell("C2"));
-            }
+            validate(ws.Cell("C2"));
         }
 
         [Test]
         public void EnsureUnaffectedCommentAndVmlPartIdsAndUris()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CommentAndButton.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CommentAndButton.xlsx"));
+            using var ms = new MemoryStream();
+            string commentPartId;
+            string commentPartUri;
+
+            string vmlPartId;
+            string vmlPartUri;
+
+            using (var ssd = SpreadsheetDocument.Open(stream, isEditable: false))
             {
-                string commentPartId;
-                string commentPartUri;
+                var wbp = ssd.GetPartsOfType<WorkbookPart>().Single();
+                var wsp = wbp.GetPartsOfType<WorksheetPart>().Last();
 
-                string vmlPartId;
-                string vmlPartUri;
+                var wscp = wsp.GetPartsOfType<WorksheetCommentsPart>().Single();
+                commentPartId = wsp.GetIdOfPart(wscp);
+                commentPartUri = wscp.Uri.ToString();
 
-                using (var ssd = SpreadsheetDocument.Open(stream, isEditable: false))
+                var vmlp = wsp.GetPartsOfType<VmlDrawingPart>().Single();
+                vmlPartId = wsp.GetIdOfPart(vmlp);
+                vmlPartUri = vmlp.Uri.ToString();
+            }
+
+            stream.Position = 0;
+            stream.CopyTo(ms);
+            ms.Position = 0;
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                Assert.That(ws.FirstCell().HasComment, Is.True);
+
+                wb.SaveAs(ms);
+            }
+
+            ms.Position = 0;
+
+            using (var ssd = SpreadsheetDocument.Open(ms, isEditable: false))
+            {
+                var wbp = ssd.GetPartsOfType<WorkbookPart>().Single();
+                var wsp = wbp.GetPartsOfType<WorksheetPart>().Last();
+
+                var wscp = wsp.GetPartsOfType<WorksheetCommentsPart>().Single();
+                Assert.Multiple(() =>
                 {
-                    var wbp = ssd.GetPartsOfType<WorkbookPart>().Single();
-                    var wsp = wbp.GetPartsOfType<WorksheetPart>().Last();
+                    Assert.That(wscp.Uri.ToString(), Is.EqualTo(commentPartUri));
+                    Assert.That(wsp.GetIdOfPart(wscp), Is.EqualTo(commentPartId));
+                });
 
-                    var wscp = wsp.GetPartsOfType<WorksheetCommentsPart>().Single();
-                    commentPartId = wsp.GetIdOfPart(wscp);
-                    commentPartUri = wscp.Uri.ToString();
-
-                    var vmlp = wsp.GetPartsOfType<VmlDrawingPart>().Single();
-                    vmlPartId = wsp.GetIdOfPart(vmlp);
-                    vmlPartUri = vmlp.Uri.ToString();
-                }
-
-                stream.Position = 0;
-                stream.CopyTo(ms);
-                ms.Position = 0;
-
-                using (var wb = new XLWorkbook(ms))
+                var vmlp = wsp.GetPartsOfType<VmlDrawingPart>().Single();
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    Assert.IsTrue(ws.FirstCell().HasComment);
-
-                    wb.SaveAs(ms);
-                }
-
-                ms.Position = 0;
-
-                using (var ssd = SpreadsheetDocument.Open(ms, isEditable: false))
-                {
-                    var wbp = ssd.GetPartsOfType<WorkbookPart>().Single();
-                    var wsp = wbp.GetPartsOfType<WorksheetPart>().Last();
-
-                    var wscp = wsp.GetPartsOfType<WorksheetCommentsPart>().Single();
-                    Assert.AreEqual(commentPartUri, wscp.Uri.ToString());
-                    Assert.AreEqual(commentPartId, wsp.GetIdOfPart(wscp));
-
-                    var vmlp = wsp.GetPartsOfType<VmlDrawingPart>().Single();
-                    Assert.AreEqual(vmlPartUri, vmlp.Uri.ToString());
-                    Assert.AreEqual(vmlPartId, wsp.GetIdOfPart(vmlp));
-                }
+                    Assert.That(vmlp.Uri.ToString(), Is.EqualTo(vmlPartUri));
+                    Assert.That(wsp.GetIdOfPart(vmlp), Is.EqualTo(vmlPartId));
+                });
             }
         }
 
         [Test]
         public void SavingDoesNotCauseTwoRootElements() // See #1157
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CommentAndButton.xlsx")))
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CommentAndButton.xlsx")))
-                using (var wb = new XLWorkbook(stream))
-                {
-                    wb.SaveAs(ms);
-                }
-
-                Assert.DoesNotThrow(() => new XLWorkbook(ms));
+                wb.SaveAs(ms);
             }
+
+            Assert.DoesNotThrow(() => new XLWorkbook(ms));
         }
 
         [Test]
         public void CanLoadCommentVisibility()
         {
-            using (var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Drawings\Comments\inputfile.xlsx")))
-            using (var workbook = new XLWorkbook(inputStream))
-            {
-                var ws = workbook.Worksheets.First();
+            using var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Drawings\Comments\inputfile.xlsx"));
+            using var workbook = new XLWorkbook(inputStream);
+            var ws = workbook.Worksheets.First();
 
-                Assert.True(ws.Cell("A1").GetComment().Visible);
-                Assert.False(ws.Cell("A4").GetComment().Visible);
-            }
+            Assert.That(ws.Cell("A1").GetComment().Visible, Is.True);
+            Assert.False(ws.Cell("A4").GetComment().Visible);
         }
 
         [Test]
@@ -187,11 +192,11 @@ namespace ClosedXML.Tests.Excel.Comments
                 foreach (var commentCell in commentCells)
                 {
                     var cell = ws.Cell(commentCell);
-                    Assert.True(cell.HasComment);
+                    Assert.That(cell.HasComment, Is.True);
                     var margins = cell.GetComment().Style.Margins;
 
-                    Assert.AreEqual(0.5, margins.Left);
-                    Assert.AreEqual(0.75, margins.Top);
+                    Assert.That(margins.Left, Is.EqualTo(0.5));
+                    Assert.That(margins.Top, Is.EqualTo(0.75));
 
                     Assert.AreEqual(0, margins.Right);
                     Assert.AreEqual(0, margins.Bottom);

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
@@ -34,10 +34,13 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ws.Cell("A1").CopyTo("B2");
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual(2, ws.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("A1:A1", ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
-            Assert.AreEqual("B2:B2", ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.First().Ranges, Has.Count.EqualTo(2));
+            });
+            Assert.That(ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            Assert.That(ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToString(), Is.EqualTo("B2:B2"));
         }
 
         [Test]
@@ -51,9 +54,12 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ws.Cell("A1").CopyTo("B2");
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("A1:C3", ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.First().Ranges, Has.Count.EqualTo(1));
+            });
+            Assert.That(ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo("A1:C3"));
         }
 
         [Test]
@@ -69,14 +75,20 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ws1.Cell("A1").CopyTo(otherCell);
 
-            Assert.AreEqual(1, ws1.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws2.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws1.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual(1, ws2.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("Sheet1", ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("Sheet2", ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("A1:A1", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
-            Assert.AreEqual("B2:B2", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws2.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws1.ConditionalFormats.First().Ranges, Has.Count.EqualTo(1));
+                Assert.That(ws2.ConditionalFormats.First().Ranges, Has.Count.EqualTo(1));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name, Is.EqualTo("Sheet1"));
+                Assert.That(ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name, Is.EqualTo("Sheet2"));
+                Assert.That(ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            });
+            Assert.That(ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo("B2:B2"));
         }
 
         [Test]
@@ -105,12 +117,15 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             format.CopyTo(ws2);
 
-            Assert.AreEqual(1, ws1.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws2.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws1.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual(1, ws2.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("Sheet1!A1:C3", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet2!A1:C3", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws2.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws1.ConditionalFormats.First().Ranges, Has.Count.EqualTo(1));
+                Assert.That(ws2.ConditionalFormats.First().Ranges, Has.Count.EqualTo(1));
+            });
+            Assert.That(ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet1!A1:C3"));
+            Assert.That(ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!A1:C3"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
@@ -22,7 +22,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Column(2).InsertColumnsAfter(2);
             var cf = ws.ConditionalFormats.ToArray();
 
-            Assert.That(cf.Length, Is.EqualTo(5));
+            Assert.That(cf, Has.Length.EqualTo(5));
             Assert.Multiple(() =>
             {
                 Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
@@ -48,7 +48,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Row(2).InsertRowsBelow(2);
             var cf = ws.ConditionalFormats.ToArray();
 
-            Assert.That(cf.Length, Is.EqualTo(5));
+            Assert.That(cf, Has.Length.EqualTo(5));
             Assert.Multiple(() =>
             {
                 Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
@@ -74,7 +74,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Column(2).Delete();
             var cf = ws.ConditionalFormats.ToArray();
 
-            Assert.That(cf.Length, Is.EqualTo(4));
+            Assert.That(cf, Has.Length.EqualTo(4));
             Assert.Multiple(() =>
             {
                 Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
@@ -99,7 +99,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Row(2).Delete();
             var cf = ws.ConditionalFormats.ToArray();
 
-            Assert.That(cf.Length, Is.EqualTo(4));
+            Assert.That(cf, Has.Length.EqualTo(4));
             Assert.Multiple(() =>
             {
                 Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
@@ -10,118 +10,126 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
         [Test]
         public void CFShiftedOnColumnInsert()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("CFShift");
+            ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+            ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+            ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+            ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+            ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+            ws.Cells("A1:D7").Value = 1;
+
+            ws.Column(2).InsertColumnsAfter(2);
+            var cf = ws.ConditionalFormats.ToArray();
+
+            Assert.That(cf.Length, Is.EqualTo(5));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:D7").Value = 1;
-
-                ws.Column(2).InsertColumnsAfter(2);
-                var cf = ws.ConditionalFormats.ToArray();
-
-                Assert.AreEqual(5, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("A2:D2", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("A3:E3", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("B4:D6", cf[3].Range.RangeAddress.ToString());
-                Assert.AreEqual("E7:F7", cf[4].Range.RangeAddress.ToString());
-            }
+                Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+                Assert.That(cf[1].Range.RangeAddress.ToString(), Is.EqualTo("A2:D2"));
+                Assert.That(cf[2].Range.RangeAddress.ToString(), Is.EqualTo("A3:E3"));
+                Assert.That(cf[3].Range.RangeAddress.ToString(), Is.EqualTo("B4:D6"));
+                Assert.That(cf[4].Range.RangeAddress.ToString(), Is.EqualTo("E7:F7"));
+            });
         }
 
         [Test]
         public void CFShiftedOnRowInsert()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("CFShift");
+            ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+            ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+            ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+            ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+            ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+            ws.Cells("A1:G5").Value = 1;
+
+            ws.Row(2).InsertRowsBelow(2);
+            var cf = ws.ConditionalFormats.ToArray();
+
+            Assert.That(cf.Length, Is.EqualTo(5));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:G5").Value = 1;
-
-                ws.Row(2).InsertRowsBelow(2);
-                var cf = ws.ConditionalFormats.ToArray();
-
-                Assert.AreEqual(5, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("B1:B4", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("C1:C5", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("D2:F4", cf[3].Range.RangeAddress.ToString());
-                Assert.AreEqual("G6:G7", cf[4].Range.RangeAddress.ToString());
-            }
+                Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+                Assert.That(cf[1].Range.RangeAddress.ToString(), Is.EqualTo("B1:B4"));
+                Assert.That(cf[2].Range.RangeAddress.ToString(), Is.EqualTo("C1:C5"));
+                Assert.That(cf[3].Range.RangeAddress.ToString(), Is.EqualTo("D2:F4"));
+                Assert.That(cf[4].Range.RangeAddress.ToString(), Is.EqualTo("G6:G7"));
+            });
         }
 
         [Test]
         public void CFShiftedOnColumnDelete()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("CFShift");
+            ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+            ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+            ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+            ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+            ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+            ws.Cells("A1:D7").Value = 1;
+
+            ws.Column(2).Delete();
+            var cf = ws.ConditionalFormats.ToArray();
+
+            Assert.That(cf.Length, Is.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:D7").Value = 1;
-
-                ws.Column(2).Delete();
-                var cf = ws.ConditionalFormats.ToArray();
-
-                Assert.AreEqual(4, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("A2:A2", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("A3:B3", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("B7:C7", cf[3].Range.RangeAddress.ToString());
-            }
+                Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+                Assert.That(cf[1].Range.RangeAddress.ToString(), Is.EqualTo("A2:A2"));
+                Assert.That(cf[2].Range.RangeAddress.ToString(), Is.EqualTo("A3:B3"));
+                Assert.That(cf[3].Range.RangeAddress.ToString(), Is.EqualTo("B7:C7"));
+            });
         }
 
         [Test]
         public void CFShiftedOnRowDelete()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("CFShift");
+            ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+            ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+            ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+            ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+            ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+            ws.Cells("A1:G5").Value = 1;
+
+            ws.Row(2).Delete();
+            var cf = ws.ConditionalFormats.ToArray();
+
+            Assert.That(cf.Length, Is.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:G5").Value = 1;
-
-                ws.Row(2).Delete();
-                var cf = ws.ConditionalFormats.ToArray();
-
-                Assert.AreEqual(4, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("B1:B1", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("C1:C2", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("G3:G4", cf[3].Range.RangeAddress.ToString());
-            }
+                Assert.That(cf[0].Range.RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+                Assert.That(cf[1].Range.RangeAddress.ToString(), Is.EqualTo("B1:B1"));
+                Assert.That(cf[2].Range.RangeAddress.ToString(), Is.EqualTo("C1:C2"));
+                Assert.That(cf[3].Range.RangeAddress.ToString(), Is.EqualTo("G3:G4"));
+            });
         }
 
         [Test]
         public void CFShiftedTruncateRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("CFShift");
+            ws.AsRange().AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Red);
+            var cf = ws.ConditionalFormats.Single();
+
+            ws.Row(2).InsertRowsAbove(1);
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.AsRange().AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Red);
-                var cf = ws.ConditionalFormats.Single();
+                Assert.That(cf.Range.RangeAddress.IsValid, Is.True);
+                Assert.That(cf.Range.RangeAddress.ToString(), Is.EqualTo($"1:{XLHelper.MaxRowNumber}"));
+            });
 
-                ws.Row(2).InsertRowsAbove(1);
-                Assert.IsTrue(cf.Range.RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Range.RangeAddress.ToString());
-
-                ws.Column(2).InsertColumnsAfter(1);
-                Assert.IsTrue(cf.Range.RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Range.RangeAddress.ToString());
-            }
+            ws.Column(2).InsertColumnsAfter(1);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cf.Range.RangeAddress.IsValid, Is.True);
+                Assert.That(cf.Range.RangeAddress.ToString(), Is.EqualTo($"1:{XLHelper.MaxRowNumber}"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
@@ -151,7 +151,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             {
                 var cf = ws.ConditionalFormats.Single(cf => cf.ConditionalFormatType == XLConditionalFormatType.Expression && cf.Range.RangeAddress.ToString() == range);
                 Assert.That(cf.Values, Has.Count.EqualTo(1));
-                Assert.That(cf.Values[1].Value, Is.EqualTo(expectedFormula).AsCollection);
+                Assert.That(cf.Values[1].Value, Is.EqualTo(expectedFormula));
             }
         }
     }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
@@ -13,16 +13,14 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
         [Test]
         public void MaintainConditionalFormattingOrder()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\ConditionalFormattingOrder\inputfile.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\ConditionalFormattingOrder\inputfile.xlsx"));
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
-                {
-                    var wb = new XLWorkbook(stream);
-                    wb.SaveAs(ms);
-                    return wb;
-                }, @"Other\StyleReferenceFiles\ConditionalFormattingOrder\ConditionalFormattingOrder.xlsx");
-            }
+                var wb = new XLWorkbook(stream);
+                wb.SaveAs(ms);
+                return wb;
+            }, @"Other\StyleReferenceFiles\ConditionalFormattingOrder\ConditionalFormattingOrder.xlsx");
         }
 
         [TestCase(true, 7)]
@@ -45,12 +43,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Range("H2:H7").AddConditionalFormat().WhenIsUnique().Fill.SetBackgroundColor(XLColor.Blue);
             ws.Range("I2:I6").AddConditionalFormat().WhenContains("test");
             ws.Range("J2:J6").AddConditionalFormat().WhenContains("test");
-            using (var ms = new MemoryStream())
-            {
-                wb.SaveAs(ms, options);
-                var wb_saved = new XLWorkbook(ms);
-                Assert.AreEqual(expectedCount, wb_saved.Worksheet("Sheet").ConditionalFormats.Count());
-            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, options);
+            var wb_saved = new XLWorkbook(ms);
+            Assert.That(wb_saved.Worksheet("Sheet").ConditionalFormats.Count(), Is.EqualTo(expectedCount));
         }
 
         [TestCase(true, 1)]
@@ -67,12 +63,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Range("C2:C5").CreateDataValidation().Decimal.Between(1, 5);
             ws.Range("D2:D5").CreateDataValidation().Decimal.Between(1, 5);
 
-            using (var ms = new MemoryStream())
-            {
-                wb.SaveAs(ms, options);
-                var wb_saved = new XLWorkbook(ms);
-                Assert.AreEqual(expectedCount, wb_saved.Worksheet("Sheet").DataValidations.Count());
-            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, options);
+            var wb_saved = new XLWorkbook(ms);
+            Assert.That(wb_saved.Worksheet("Sheet").DataValidations.Count(), Is.EqualTo(expectedCount));
         }
 
         [TestCase("en-US")]
@@ -80,38 +74,39 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
         [TestCase("ru-RU")]
         public void SaveConditionalFormat_CultureIndependent(string culture)
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            var expectedValue = 1.5;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            using (var wb = new XLWorkbook())
             {
-                var expectedValue = 1.5;
-                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(culture);
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet();
+                var i = 1;
+                ws.Cell(i++, 1).AddConditionalFormat().WhenEquals(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenNotEquals(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenGreaterThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenLessThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenEqualOrGreaterThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenEqualOrLessThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenBetween(expectedValue, expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+                ws.Cell(i++, 1).AddConditionalFormat().WhenNotBetween(expectedValue, expectedValue).Fill.SetBackgroundColor(XLColor.Red);
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+
+                var conditionalFormatValues = ws.ConditionalFormats
+                    .SelectMany(cf => cf.Values.Values)
+                    .Select(v => v.Value)
+                    .Distinct();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.AddWorksheet();
-                    var i = 1;
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenEquals(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenNotEquals(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenGreaterThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenLessThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenEqualOrGreaterThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenEqualOrLessThan(expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenBetween(expectedValue, expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-                    ws.Cell(i++, 1).AddConditionalFormat().WhenNotBetween(expectedValue, expectedValue).Fill.SetBackgroundColor(XLColor.Red);
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-
-                    var conditionalFormatValues = ws.ConditionalFormats
-                        .SelectMany(cf => cf.Values.Values)
-                        .Select(v => v.Value)
-                        .Distinct();
-
-                    Assert.AreEqual(1, conditionalFormatValues.Count());
-                    Assert.AreEqual("1.5", conditionalFormatValues.Single());
-                }
+                    Assert.That(conditionalFormatValues.Count(), Is.EqualTo(1));
+                    Assert.That(conditionalFormatValues.Single(), Is.EqualTo("1.5"));
+                });
             }
         }
 
@@ -134,8 +129,8 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             static void AssertFormulaArgs(IXLWorksheet ws, XLCFOperator cfOperator, params string[] expectedFormulas)
             {
                 var cf = ws.ConditionalFormats.Single(cf => cf.ConditionalFormatType == XLConditionalFormatType.CellIs && cf.Operator == cfOperator);
-                Assert.AreEqual(expectedFormulas.Length, cf.Values.Count);
-                CollectionAssert.AreEqual(expectedFormulas, cf.Values.Select(v => v.Value.Value));
+                Assert.That(cf.Values, Has.Count.EqualTo(expectedFormulas.Length));
+                Assert.That(cf.Values.Select(v => v.Value.Value), Is.EqualTo(expectedFormulas).AsCollection);
             }
         }
 
@@ -155,8 +150,8 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             static void AssertFormulaArgs(IXLWorksheet ws, string range, string expectedFormula)
             {
                 var cf = ws.ConditionalFormats.Single(cf => cf.ConditionalFormatType == XLConditionalFormatType.Expression && cf.Range.RangeAddress.ToString() == range);
-                Assert.AreEqual(1, cf.Values.Count);
-                CollectionAssert.AreEqual(expectedFormula, cf.Values[1].Value);
+                Assert.That(cf.Values, Has.Count.EqualTo(1));
+                Assert.That(cf.Values[1].Value, Is.EqualTo(expectedFormula).AsCollection);
             }
         }
     }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
@@ -19,10 +19,13 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
             var format = ws.ConditionalFormats.First();
-            Assert.AreEqual("B2:C4", format.Range.RangeAddress.ToStringRelative());
-            Assert.AreEqual("F2", format.Values.Values.First().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(format.Range.RangeAddress.ToStringRelative(), Is.EqualTo("B2:C4"));
+                Assert.That(format.Values.Values.First().Value, Is.EqualTo("F2"));
+            });
         }
 
         [Test]
@@ -37,10 +40,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
             var format = ws.ConditionalFormats.First();
-            Assert.AreEqual("B2:D3", format.Ranges.First().RangeAddress.ToStringRelative());
-            Assert.AreEqual("F2", format.Values.Values.First().Value);
+            Assert.That(format.Ranges.First().RangeAddress.ToStringRelative(), Is.EqualTo("B2:D3"));
+            Assert.That(format.Values.Values.First().Value, Is.EqualTo("F2"));
         }
 
         [Test]
@@ -54,10 +57,13 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
             var format = ws.ConditionalFormats.First();
-            Assert.AreEqual("B11:D12", format.Range.RangeAddress.ToStringRelative());
-            Assert.AreEqual("F11", format.Values.Values.First().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(format.Range.RangeAddress.ToStringRelative(), Is.EqualTo("B11:D12"));
+                Assert.That(format.Values.Values.First().Value, Is.EqualTo("F11"));
+            });
         }
 
         [Test]
@@ -71,10 +77,13 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
             var format = ws.ConditionalFormats.First();
-            Assert.AreEqual("B14:C14", format.Range.RangeAddress.ToStringRelative());
-            Assert.AreEqual("F14", format.Values.Values.First().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(format.Range.RangeAddress.ToStringRelative(), Is.EqualTo("B14:C14"));
+                Assert.That(format.Values.Values.First().Value, Is.EqualTo("F14"));
+            });
         }
 
         [Test]
@@ -88,10 +97,13 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
             var format = ws.ConditionalFormats.First();
-            Assert.AreEqual("B16:D19", format.Range.RangeAddress.ToStringRelative());
-            Assert.AreEqual("F16", format.Values.Values.First().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(format.Range.RangeAddress.ToStringRelative(), Is.EqualTo("B16:D19"));
+                Assert.That(format.Values.Values.First().Value, Is.EqualTo("F16"));
+            });
         }
 
         [Test]
@@ -105,7 +117,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(2, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -121,9 +133,12 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(3, ws.ConditionalFormats.Count());
-            Assert.AreEqual((ws.ConditionalFormats.First().Style as XLStyle).Value, (ws.ConditionalFormats.Last().Style as XLStyle).Value);
-            Assert.AreNotEqual((ws.ConditionalFormats.First().Style as XLStyle).Value, (ws.ConditionalFormats.ElementAt(1).Style as XLStyle).Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(3));
+                Assert.That((ws.ConditionalFormats.Last().Style as XLStyle).Value, Is.EqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value));
+            });
+            Assert.That((ws.ConditionalFormats.ElementAt(1).Style as XLStyle).Value, Is.Not.EqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value));
         }
 
         [Test]
@@ -139,12 +154,18 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(3, ws.ConditionalFormats.Count());
-            Assert.AreEqual((ws.ConditionalFormats.First().Style as XLStyle).Value, (ws.ConditionalFormats.Last().Style as XLStyle).Value);
-            Assert.AreNotEqual((ws.ConditionalFormats.First().Style as XLStyle).Value, (ws.ConditionalFormats.ElementAt(1).Style as XLStyle).Value);
-            Assert.IsTrue(ws.ConditionalFormats.All(cf => cf.Ranges.Count == 1), "Number of ranges in consolidated conditional formats is expected to be 1");
-            Assert.AreEqual("A1:A1", ws.ConditionalFormats.ElementAt(0).Ranges.Single().RangeAddress.ToString());
-            Assert.AreEqual("A2:A3", ws.ConditionalFormats.ElementAt(1).Ranges.Single().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(3));
+                Assert.That((ws.ConditionalFormats.Last().Style as XLStyle).Value, Is.EqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value));
+            });
+            Assert.That((ws.ConditionalFormats.ElementAt(1).Style as XLStyle).Value, Is.Not.EqualTo((ws.ConditionalFormats.First().Style as XLStyle).Value));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.All(cf => cf.Ranges.Count == 1), Is.True, "Number of ranges in consolidated conditional formats is expected to be 1");
+                Assert.That(ws.ConditionalFormats.ElementAt(0).Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            });
+            Assert.That(ws.ConditionalFormats.ElementAt(1).Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:A3"));
             Assert.AreEqual("A2:A8", ws.ConditionalFormats.ElementAt(2).Ranges.Single().RangeAddress.ToString());
         }
 
@@ -162,32 +183,33 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             ((XLConditionalFormats)ws.ConditionalFormats).Consolidate();
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual((ws.ConditionalFormats.Single().Style as XLStyle).Value, (cf.Style as XLStyle).Value);
-            Assert.AreEqual("A3:C8", ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToString());
-            Assert.IsTrue(ws.ConditionalFormats.Single().Values.Single().Value.IsFormula);
-            Assert.AreEqual("A3=$D3", ws.ConditionalFormats.Single().Values.Single().Value.Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That((cf.Style as XLStyle).Value, Is.EqualTo((ws.ConditionalFormats.Single().Style as XLStyle).Value));
+                Assert.That(ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A3:C8"));
+                Assert.That(ws.ConditionalFormats.Single().Values.Single().Value.IsFormula, Is.True);
+            });
+            Assert.That(ws.ConditionalFormats.Single().Values.Single().Value.Value, Is.EqualTo("A3=$D3"));
         }
 
         [Test]
         public void ColorScaleComparing()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet");
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet");
 
-                var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>();
-                var cf1 = new XLConditionalFormat(ranges);
-                cf1.ColorScale()
-                    .LowestValue(XLColor.Red)
-                    .HighestValue(XLColor.Green);
+            var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>();
+            var cf1 = new XLConditionalFormat(ranges);
+            cf1.ColorScale()
+                .LowestValue(XLColor.Red)
+                .HighestValue(XLColor.Green);
 
-                var cf2 = new XLConditionalFormat(ranges);
-                cf2.ColorScale()
-                    .LowestValue(XLColor.Red)
-                    .HighestValue(XLColor.Green);
-                Assert.True(XLConditionalFormat.NoRangeComparer.Equals(cf1, cf2));
-            }
+            var cf2 = new XLConditionalFormat(ranges);
+            cf2.ColorScale()
+                .LowestValue(XLColor.Red)
+                .HighestValue(XLColor.Green);
+            Assert.That(XLConditionalFormat.NoRangeComparer.Equals(cf1, cf2), Is.True);
         }
 
         private static void SetFormat1(IXLConditionalFormat format)

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
@@ -166,7 +166,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
                 Assert.That(ws.ConditionalFormats.ElementAt(0).Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
             });
             Assert.That(ws.ConditionalFormats.ElementAt(1).Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:A3"));
-            Assert.AreEqual("A2:A8", ws.ConditionalFormats.ElementAt(2).Ranges.Single().RangeAddress.ToString());
+            Assert.That(ws.ConditionalFormats.ElementAt(2).Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:A8"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Coordinates/EmuTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/EmuTests.cs
@@ -15,7 +15,7 @@ internal class EmuTests
     [TestCase(2348.52, AbsLengthUnit.Inch, null)]
     public void From_converts_value_to_emu(double value, AbsLengthUnit unit, int? emu)
     {
-        Assert.AreEqual(emu, Emu.From(value, unit)?.Value);
+        Assert.That(Emu.From(value, unit)?.Value, Is.EqualTo(emu));
     }
 
     [TestCase(AbsLengthUnit.Inch, 5.9912904636920388)]
@@ -26,13 +26,13 @@ internal class EmuTests
     [TestCase(AbsLengthUnit.Emu, 5_478_436)]
     public void To_converts_to_specified_unit(AbsLengthUnit unit, double value)
     {
-        Assert.AreEqual(value, Emu.From(5_478_436, AbsLengthUnit.Emu)?.To(unit));
+        Assert.That(Emu.From(5_478_436, AbsLengthUnit.Emu)?.To(unit), Is.EqualTo(value));
     }
 
     [Test]
     [SetCulture("cs-CZ")]
     public void ToString_uses_culture_invariant_format()
     {
-        Assert.AreEqual("1.4mm", Emu.From(1.4, AbsLengthUnit.Millimeter).ToString());
+        Assert.That(Emu.From(1.4, AbsLengthUnit.Millimeter).ToString(), Is.EqualTo("1.4mm"));
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLAddressTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLAddressTests.cs
@@ -12,22 +12,25 @@ namespace ClosedXML.Tests
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLAddress address = ws.Cell(1, 1).Address;
 
-            Assert.AreEqual("A1", address.ToString());
-            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("Sheet1!A1", address.ToString(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("R1C1"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!A1"));
 
-            Assert.AreEqual("A1", address.ToStringRelative());
-            Assert.AreEqual("Sheet1!A1", address.ToStringRelative(true));
+                Assert.That(address.ToStringRelative(), Is.EqualTo("A1"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("Sheet1!A1"));
 
-            Assert.AreEqual("$A$1", address.ToStringFixed());
-            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("Sheet1!$A$1", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet1!R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("Sheet1!$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
+                Assert.That(address.ToStringFixed(), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("Sheet1!$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("Sheet1!R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$A$1"));
+            });
         }
 
         [Test]
@@ -36,22 +39,25 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
             IXLAddress address = ws.Cell(1, 1).Address;
 
-            Assert.AreEqual("A1", address.ToString());
-            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("'Sheet 1'!A1", address.ToString(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("R1C1"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!A1"));
 
-            Assert.AreEqual("A1", address.ToStringRelative());
-            Assert.AreEqual("'Sheet 1'!A1", address.ToStringRelative(true));
+                Assert.That(address.ToStringRelative(), Is.EqualTo("A1"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("'Sheet 1'!A1"));
 
-            Assert.AreEqual("$A$1", address.ToStringFixed());
-            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("'Sheet 1'!$A$1", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("'Sheet 1'!R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("'Sheet 1'!$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
+                Assert.That(address.ToStringFixed(), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("'Sheet 1'!R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!$A$1"));
+            });
         }
 
         [Test]
@@ -59,11 +65,14 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddress();
 
-            Assert.AreEqual("#REF!", address.ToString());
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!#REF!"));
+            });
         }
 
         [Test]
@@ -71,13 +80,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddress();
 
-            Assert.AreEqual("#REF!", address.ToStringFixed());
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringFixed(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!#REF!"));
+            });
         }
 
         [Test]
@@ -85,8 +97,11 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddress();
 
-            Assert.AreEqual("#REF!", address.ToStringRelative());
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringRelative(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringRelative(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("'Sheet 1'!#REF!"));
+            });
         }
 
         [Test]
@@ -94,11 +109,14 @@ namespace ClosedXML.Tests
         {
             var address = ProduceAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("A1", address.ToString());
-            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("A1", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!A1", address.ToString(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("R1C1"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("A1"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("#REF!A1"));
+            });
         }
 
         [Test]
@@ -106,13 +124,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("$A$1", address.ToStringFixed());
-            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("$A$1", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!$A$1", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("#REF!R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("#REF!$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringFixed(), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("#REF!$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("#REF!R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("#REF!$A$1"));
+            });
         }
 
         [Test]
@@ -120,8 +141,11 @@ namespace ClosedXML.Tests
         {
             var address = ProduceAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("A1", address.ToStringRelative());
-            Assert.AreEqual("#REF!A1", address.ToStringRelative(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringRelative(), Is.EqualTo("A1"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("#REF!A1"));
+            });
         }
 
         [Test]
@@ -129,11 +153,14 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!", address.ToString());
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("#REF!#REF!"));
+            });
         }
 
         [Test]
@@ -141,13 +168,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!", address.ToStringFixed());
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringFixed(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("#REF!#REF!"));
+            });
         }
 
         [Test]
@@ -155,8 +185,11 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!", address.ToStringRelative());
-            Assert.AreEqual("#REF!#REF!", address.ToStringRelative(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringRelative(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("#REF!#REF!"));
+            });
         }
 
         #region Private Methods

--- a/ClosedXML.Tests/Excel/Coordinates/XLNameTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLNameTests.cs
@@ -11,11 +11,13 @@ namespace ClosedXML.Tests.Excel.Coordinates
         {
             var lowerCase = new XLName("name");
             var upperCase = new XLName("NAME");
-
-            Assert.AreEqual(lowerCase, upperCase);
-            Assert.AreEqual(lowerCase.GetHashCode(), upperCase.GetHashCode());
-
-            Assert.AreNotEqual(lowerCase, new XLName("different_name"));
+            
+            Assert.Multiple(() =>
+            {
+                Assert.That(upperCase, Is.EqualTo(lowerCase));
+                Assert.That(upperCase.GetHashCode(), Is.EqualTo(lowerCase.GetHashCode()));
+                Assert.That(new XLName("different_name"), Is.Not.EqualTo(lowerCase));
+            });
         }
 
         [Test]
@@ -24,11 +26,14 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var lowerCase = new XLName("sheet", "name");
             var upperCase = new XLName("SHEET", "NAME");
 
-            Assert.AreEqual(lowerCase, upperCase);
-            Assert.AreEqual(lowerCase.GetHashCode(), upperCase.GetHashCode());
-
-            Assert.AreNotEqual(lowerCase, new XLName("Different sheet", "name"));
-            Assert.AreNotEqual(lowerCase, new XLName("sheet", "different_name"));
+            
+            Assert.Multiple(() =>
+            {
+                Assert.That(upperCase, Is.EqualTo(lowerCase));
+                Assert.That(upperCase.GetHashCode(), Is.EqualTo(lowerCase.GetHashCode()));
+                Assert.That(new XLName("Different sheet", "name"), Is.Not.EqualTo(lowerCase));
+                Assert.That(new XLName("sheet", "different_name"), Is.Not.EqualTo(lowerCase));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
@@ -29,7 +29,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             Assert.That(sameSheetIntersection, Is.EqualTo(new XLBookArea("sheet", XLSheetRange.Parse("B2:C3"))));
 
             var differentSheetIntersection = sheetArea1.Intersect(otherSheetArea);
-            Assert.Null(differentSheetIntersection);
+            Assert.That(differentSheetIntersection, Is.Null);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetAreaTests.cs
@@ -11,8 +11,11 @@ namespace ClosedXML.Tests.Excel.Coordinates
         {
             var upperCase = new XLBookArea("NAME", new XLSheetRange(1, 2, 3, 4));
             var lowerCase = new XLBookArea("name", new XLSheetRange(1, 2, 3, 4));
-            Assert.AreEqual(upperCase.GetHashCode(), lowerCase.GetHashCode());
-            Assert.AreEqual(upperCase, lowerCase);
+            Assert.Multiple(() =>
+            {
+                Assert.That(lowerCase.GetHashCode(), Is.EqualTo(upperCase.GetHashCode()));
+                Assert.That(lowerCase, Is.EqualTo(upperCase));
+            });
         }
 
         [Test]
@@ -23,7 +26,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var otherSheetArea = new XLBookArea("Other", XLSheetRange.Parse("B2:D4"));
 
             var sameSheetIntersection = sheetArea1.Intersect(sheetArea2);
-            Assert.AreEqual(new XLBookArea("sheet", XLSheetRange.Parse("B2:C3")), sameSheetIntersection);
+            Assert.That(sameSheetIntersection, Is.EqualTo(new XLBookArea("sheet", XLSheetRange.Parse("B2:C3"))));
 
             var differentSheetIntersection = sheetArea1.Intersect(otherSheetArea);
             Assert.Null(differentSheetIntersection);

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetPointTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetPointTests.cs
@@ -19,8 +19,11 @@ namespace ClosedXML.Tests.Excel.Coordinates
         public void ParseCellRefsAccordingToGrammar(string cellRef, int columnNumber, int rowNumber)
         {
             var sheetPoint = XLSheetPoint.Parse(cellRef.AsSpan());
-            Assert.AreEqual(columnNumber, sheetPoint.Column);
-            Assert.AreEqual(rowNumber, sheetPoint.Row);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sheetPoint.Column, Is.EqualTo(columnNumber));
+                Assert.That(sheetPoint.Row, Is.EqualTo(rowNumber));
+            });
         }
 
         [TestCase("")]
@@ -58,7 +61,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
         public void CanFormatToString(string cellRef)
         {
             var r = XLSheetPoint.Parse(cellRef);
-            Assert.AreEqual(cellRef, r.ToString());
+            Assert.That(r.ToString(), Is.EqualTo(cellRef));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -16,10 +16,13 @@ namespace ClosedXML.Tests.Excel.Coordinates
         public void ParseCellRefsAccordingToGrammar(string refText, int firstRow, int firstCol, int lastRow, int lastCol)
         {
             var reference = XLSheetRange.Parse(refText);
-            Assert.AreEqual(firstRow, reference.FirstPoint.Row);
-            Assert.AreEqual(firstCol, reference.FirstPoint.Column);
-            Assert.AreEqual(lastRow, reference.LastPoint.Row);
-            Assert.AreEqual(lastCol, reference.LastPoint.Column);
+            Assert.Multiple(() =>
+            {
+                Assert.That(reference.FirstPoint.Row, Is.EqualTo(firstRow));
+                Assert.That(reference.FirstPoint.Column, Is.EqualTo(firstCol));
+                Assert.That(reference.LastPoint.Row, Is.EqualTo(lastRow));
+                Assert.That(reference.LastPoint.Column, Is.EqualTo(lastCol));
+            });
         }
 
         [TestCase("")]
@@ -42,7 +45,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
         public void CanFormatToString(string cellRef, string expected)
         {
             var r = XLSheetRange.Parse(cellRef);
-            Assert.AreEqual(expected, r.ToString());
+            Assert.That(r.ToString(), Is.EqualTo(expected));
         }
 
         [TestCase("A1", "A1", "A1")]
@@ -57,7 +60,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var right = XLSheetRange.Parse(rightOperand);
             var expected = XLSheetRange.Parse(expectedRange);
 
-            Assert.AreEqual(expected, left.Range(right));
+            Assert.That(left.Range(right), Is.EqualTo(expected));
         }
 
         [TestCase("A1", "A1", "A1")]
@@ -72,7 +75,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var right = XLSheetRange.Parse(rightOperand);
             var expected = expectedRange is null ? (XLSheetRange?)null : XLSheetRange.Parse(expectedRange);
 
-            Assert.AreEqual(expected, left.Intersect(right));
+            Assert.That(left.Intersect(right), Is.EqualTo(expected));
         }
 
         [TestCase("A1", "A1", true)]
@@ -86,7 +89,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var left = XLSheetRange.Parse(leftOperand);
             var right = XLSheetRange.Parse(rightOperand);
 
-            Assert.AreEqual(expected, left.Intersects(right));
+            Assert.That(left.Intersects(right), Is.EqualTo(expected));
         }
 
         [TestCase("A1", "A1", true)]
@@ -99,7 +102,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var left = XLSheetRange.Parse(leftOperand);
             var right = XLSheetRange.Parse(rightOperand);
 
-            Assert.AreEqual(expected, left.Overlaps(right));
+            Assert.That(left.Overlaps(right), Is.EqualTo(expected));
         }
 
         [TestCase("C4:F8", "C1:F3", "C4:F8")] // Inserted area is fully above
@@ -121,8 +124,11 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             var success = originalArea.TryInsertAreaAndShiftRight(insertedArea, out var result);
 
-            Assert.True(success);
-            Assert.AreEqual(repositionedArea, result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(repositionedArea));
+            });
         }
 
         [TestCase("C4:F8", "B3:B4")] // Partially above
@@ -155,8 +161,11 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             var success = originalArea.TryInsertAreaAndShiftDown(insertedArea, out var result);
 
-            Assert.True(success);
-            Assert.AreEqual(repositionedArea, result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(repositionedArea));
+            });
         }
 
         [TestCase("D6:G10", "A6:E6")] // Left
@@ -188,8 +197,11 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             var success = originalArea.TryDeleteAreaAndShiftLeft(deletedArea, out var result);
 
-            Assert.True(success);
-            Assert.AreEqual(repositionedArea, result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(repositionedArea));
+            });
         }
 
         [TestCase("D4:E8", "A1:B5")] // Partial left
@@ -223,8 +235,11 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             var success = originalArea.TryDeleteAreaAndShiftUp(deletedArea, out var result);
 
-            Assert.True(success);
-            Assert.AreEqual(expectedResult, result);
+            Assert.Multiple(() =>
+            {
+                Assert.That(success, Is.True);
+                Assert.That(result, Is.EqualTo(expectedResult));
+            });
         }
 
         [TestCase("B5:D8", "A1:B3")] // Partial above

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -214,7 +214,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var success = originalArea.TryDeleteAreaAndShiftLeft(deletedArea, out var result);
 
             Assert.False(success);
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
 
         [TestCase("B5:B8", "A1:C3", "B2:B5")] // Deleted area fully above (with a row space) with overlapping width
@@ -252,7 +252,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var success = originalArea.TryDeleteAreaAndShiftUp(deletedArea, out var result);
 
             Assert.False(success);
-            Assert.Null(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -139,7 +139,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var originalArea = XLSheetRange.Parse(original);
             var insertedArea = XLSheetRange.Parse(inserted);
 
-            Assert.False(originalArea.TryInsertAreaAndShiftRight(insertedArea, out var result));
+            Assert.That(originalArea.TryInsertAreaAndShiftRight(insertedArea, out var result), Is.False);
         }
 
         [TestCase("D6:G10", "A1:C15", "D6:G10")] // Inserted are is fully to the left
@@ -176,7 +176,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var originalArea = XLSheetRange.Parse(original);
             var insertedArea = XLSheetRange.Parse(inserted);
 
-            Assert.False(originalArea.TryInsertAreaAndShiftDown(insertedArea, out var result));
+            Assert.That(originalArea.TryInsertAreaAndShiftDown(insertedArea, out var result), Is.False);
         }
 
         [TestCase("E4:G4", "B3:C5", "C4:E4")] // Deleted area fully to the left with overlapping width
@@ -213,7 +213,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var deletedArea = XLSheetRange.Parse(deleted);
             var success = originalArea.TryDeleteAreaAndShiftLeft(deletedArea, out var result);
 
-            Assert.False(success);
+            Assert.That(success, Is.False);
             Assert.That(result, Is.Null);
         }
 
@@ -251,7 +251,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var deletedArea = XLSheetRange.Parse(deleted);
             var success = originalArea.TryDeleteAreaAndShiftUp(deletedArea, out var result);
 
-            Assert.False(success);
+            Assert.That(success, Is.False);
             Assert.That(result, Is.Null);
         }
     }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -22,7 +22,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Column(2).InsertColumnsAfter(2);
             var dv = ws.DataValidations.ToArray();
 
-            Assert.That(dv.Length, Is.EqualTo(5));
+            Assert.That(dv, Has.Length.EqualTo(5));
             Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
             Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:D2"));
             Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A3:E3"));
@@ -45,7 +45,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Row(2).InsertRowsBelow(2);
             var dv = ws.DataValidations.ToArray();
 
-            Assert.That(dv.Length, Is.EqualTo(5));
+            Assert.That(dv, Has.Length.EqualTo(5));
             Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
             Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B1:B4"));
             Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("C1:C5"));
@@ -68,7 +68,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Column(2).Delete();
             var dv = ws.DataValidations.ToArray();
 
-            Assert.That(dv.Length, Is.EqualTo(4));
+            Assert.That(dv, Has.Length.EqualTo(4));
             Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
             Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:A2"));
             Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A3:B3"));
@@ -90,7 +90,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Row(2).Delete();
             var dv = ws.DataValidations.ToArray();
 
-            Assert.That(dv.Length, Is.EqualTo(4));
+            Assert.That(dv, Has.Length.EqualTo(4));
             Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
             Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B1:B1"));
             Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("C1:C2"));

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -10,118 +10,114 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void DataValidationShiftedOnColumnInsert()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:D7").Value = 1;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("DataValidationShift");
+            ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Cells("A1:D7").Value = 1;
 
-                ws.Column(2).InsertColumnsAfter(2);
-                var dv = ws.DataValidations.ToArray();
+            ws.Column(2).InsertColumnsAfter(2);
+            var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(5, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A2:D2", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A3:E3", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B4:D6", dv[3].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("E7:F7", dv[4].Ranges.Single().RangeAddress.ToString());
-            }
+            Assert.That(dv.Length, Is.EqualTo(5));
+            Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:D2"));
+            Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A3:E3"));
+            Assert.That(dv[3].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B4:D6"));
+            Assert.That(dv[4].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("E7:F7"));
         }
 
         [Test]
         public void DataValidationShiftedOnRowInsert()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:G5").Value = 1;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("DataValidationShift");
+            ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Cells("A1:G5").Value = 1;
 
-                ws.Row(2).InsertRowsBelow(2);
-                var dv = ws.DataValidations.ToArray();
+            ws.Row(2).InsertRowsBelow(2);
+            var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(5, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B1:B4", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("C1:C5", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("D2:F4", dv[3].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("G6:G7", dv[4].Ranges.Single().RangeAddress.ToString());
-            }
+            Assert.That(dv.Length, Is.EqualTo(5));
+            Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B1:B4"));
+            Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("C1:C5"));
+            Assert.That(dv[3].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("D2:F4"));
+            Assert.That(dv[4].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("G6:G7"));
         }
 
         [Test]
         public void DataValidationShiftedOnColumnDelete()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:D7").Value = 1;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("DataValidationShift");
+            ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Cells("A1:D7").Value = 1;
 
-                ws.Column(2).Delete();
-                var dv = ws.DataValidations.ToArray();
+            ws.Column(2).Delete();
+            var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(4, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A2:A2", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A3:B3", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B7:C7", dv[3].Ranges.Single().RangeAddress.ToString());
-            }
+            Assert.That(dv.Length, Is.EqualTo(4));
+            Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A2:A2"));
+            Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A3:B3"));
+            Assert.That(dv[3].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B7:C7"));
         }
 
         [Test]
         public void DataValidationShiftedOnRowDelete()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:G5").Value = 1;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("DataValidationShift");
+            ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
+            ws.Cells("A1:G5").Value = 1;
 
-                ws.Row(2).Delete();
-                var dv = ws.DataValidations.ToArray();
+            ws.Row(2).Delete();
+            var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(4, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B1:B1", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("C1:C2", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("G3:G4", dv[3].Ranges.Single().RangeAddress.ToString());
-            }
+            Assert.That(dv.Length, Is.EqualTo(4));
+            Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            Assert.That(dv[1].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B1:B1"));
+            Assert.That(dv[2].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("C1:C2"));
+            Assert.That(dv[3].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("G3:G4"));
         }
 
         [Test]
         public void DataValidationShiftedTruncateRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("DataValidationShift");
+            ws.AsRange().CreateDataValidation().WholeNumber.Between(0, 1);
+            var dv = ws.DataValidations.Single();
+
+            ws.Row(2).InsertRowsAbove(1);
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.AsRange().CreateDataValidation().WholeNumber.Between(0, 1);
-                var dv = ws.DataValidations.Single();
+                Assert.That(dv.Ranges.Single().RangeAddress.IsValid, Is.True);
+                Assert.That(dv.Ranges.Single().RangeAddress.ToString(), Is.EqualTo($"1:{XLHelper.MaxRowNumber}"));
+            });
 
-                ws.Row(2).InsertRowsAbove(1);
-                Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
-
-                ws.Column(2).InsertColumnsAfter(1);
-                Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
-            }
+            ws.Column(2).InsertColumnsAfter(1);
+            Assert.Multiple(() =>
+            {
+                Assert.That(dv.Ranges.Single().RangeAddress.IsValid, Is.True);
+                Assert.That(dv.Ranges.Single().RangeAddress.ToString(), Is.EqualTo($"1:{XLHelper.MaxRowNumber}"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -29,8 +29,11 @@ namespace ClosedXML.Tests.Excel.DataValidations
             cell = uiSheet.Cell("A2");
             cell.GetDataValidation().List(valuesSheet.Range("ValuesSheet!$E$1:$E$4"));
 
-            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
-            Assert.AreEqual("ValuesSheet!$E$1:$E$4", cell.GetDataValidation().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                Assert.That(cell.GetDataValidation().Value, Is.EqualTo("ValuesSheet!$E$1:$E$4"));
+            });
         }
 
         [Test]
@@ -56,18 +59,24 @@ namespace ClosedXML.Tests.Excel.DataValidations
             cell.GetDataValidation().List(ws.Range("$E$1:$E$4"));
             cell.GetDataValidation().InputTitle = "Title for B2";
 
-            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
-            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.GetDataValidation().Value);
-            Assert.AreEqual("Title for B2", cell.GetDataValidation().InputTitle);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                Assert.That(cell.GetDataValidation().Value, Is.EqualTo("'Data Validation Issue'!$E$1:$E$4"));
+                Assert.That(cell.GetDataValidation().InputTitle, Is.EqualTo("Title for B2"));
+            });
 
             ws.Cell("C1").SetValue("Cell below has Validation with a message.");
             cell = ws.Cell("C2");
             cell.GetDataValidation().List(ws.Range("$E$1:$E$4"));
             cell.GetDataValidation().InputMessage = "Message for C2";
 
-            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
-            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.GetDataValidation().Value);
-            Assert.AreEqual("Message for C2", cell.GetDataValidation().InputMessage);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                Assert.That(cell.GetDataValidation().Value, Is.EqualTo("'Data Validation Issue'!$E$1:$E$4"));
+                Assert.That(cell.GetDataValidation().InputMessage, Is.EqualTo("Message for C2"));
+            });
 
             ws.Cell("D1").SetValue("Cell below has Validation with title and message.");
             cell = ws.Cell("D2");
@@ -75,10 +84,13 @@ namespace ClosedXML.Tests.Excel.DataValidations
             cell.GetDataValidation().InputTitle = "Title for D2";
             cell.GetDataValidation().InputMessage = "Message for D2";
 
-            Assert.AreEqual(XLAllowedValues.List, cell.GetDataValidation().AllowedValues);
-            Assert.AreEqual("'Data Validation Issue'!$E$1:$E$4", cell.GetDataValidation().Value);
-            Assert.AreEqual("Title for D2", cell.GetDataValidation().InputTitle);
-            Assert.AreEqual("Message for D2", cell.GetDataValidation().InputMessage);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                Assert.That(cell.GetDataValidation().Value, Is.EqualTo("'Data Validation Issue'!$E$1:$E$4"));
+                Assert.That(cell.GetDataValidation().InputTitle, Is.EqualTo("Title for D2"));
+                Assert.That(cell.GetDataValidation().InputMessage, Is.EqualTo("Message for D2"));
+            });
         }
 
         [Test]
@@ -93,7 +105,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws2.Cell("A1").SetValue("B");
             ws.Cell("B1").CopyTo(ws2.Cell("B1"));
 
-            Assert.AreEqual("Sheet1!A1", ws2.Cell("B1").GetDataValidation().Value);
+            Assert.That(ws2.Cell("B1").GetDataValidation().Value, Is.EqualTo("Sheet1!A1"));
         }
 
         [Test, Ignore("Wait for proper formula shifting (#686)")]
@@ -105,7 +117,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.FirstRow().InsertRowsAbove(1);
 
-            Assert.AreEqual("A2", ws.Cell("B2").GetDataValidation().Value);
+            Assert.That(ws.Cell("B2").GetDataValidation().Value, Is.EqualTo("A2"));
         }
 
         [Test]
@@ -116,7 +128,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Cell("A1").SetValue("A");
             ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.Cell("B1").CopyTo(ws.Cell("B2"));
-            Assert.AreEqual("A2", ws.Cell("B2").GetDataValidation().Value);
+            Assert.That(ws.Cell("B2").GetDataValidation().Value, Is.EqualTo("A2"));
         }
 
         [Test, Ignore("Wait for proper formula shifting (#686)")]
@@ -128,7 +140,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.FirstColumn().InsertColumnsBefore(1);
 
-            Assert.AreEqual("B1", ws.Cell("C1").GetDataValidation().Value);
+            Assert.That(ws.Cell("C1").GetDataValidation().Value, Is.EqualTo("B1"));
         }
 
         [Test]
@@ -139,7 +151,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             ws.Cell("A1").SetValue("A");
             ws.Cell("B1").CreateDataValidation().Custom("A1");
             ws.Cell("B1").CopyTo(ws.Cell("C1"));
-            Assert.AreEqual("B1", ws.Cell("C1").GetDataValidation().Value);
+            Assert.That(ws.Cell("C1").GetDataValidation().Value, Is.EqualTo("B1"));
         }
 
         [Test]
@@ -157,7 +169,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             IXLDataValidation dv = table.DataRange.CreateDataValidation();
             dv.ErrorTitle = "Error";
 
-            Assert.AreEqual("Error", table.DataRange.FirstCell().GetDataValidation().ErrorTitle);
+            Assert.That(table.DataRange.FirstCell().GetDataValidation().ErrorTitle, Is.EqualTo("Error"));
         }
 
         [Test]
@@ -174,7 +186,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             IXLDataValidation dv = table.DataRange.CreateDataValidation();
             dv.ErrorTitle = "Error";
 
-            Assert.AreEqual("Error", ws.DataValidations.Single().ErrorTitle);
+            Assert.That(ws.DataValidations.Single().ErrorTitle, Is.EqualTo("Error"));
         }
 
         [Test]
@@ -197,10 +209,13 @@ namespace ClosedXML.Tests.Excel.DataValidations
             //Act
             ws.Row(rowNum).InsertRowsAbove(1);
 
-            //Assert
-            Assert.AreEqual(1, ws.DataValidations.Count());
-            Assert.AreEqual(1, ws.DataValidations.First().Ranges.Count());
-            Assert.AreEqual(expectedAddress, ws.DataValidations.First().Ranges.First().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                //Assert
+                Assert.That(ws.DataValidations.Count(), Is.EqualTo(1));
+                Assert.That(ws.DataValidations.First().Ranges.Count(), Is.EqualTo(1));
+            });
+            Assert.That(ws.DataValidations.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo(expectedAddress));
         }
 
         [Test]
@@ -223,48 +238,53 @@ namespace ClosedXML.Tests.Excel.DataValidations
             //Act
             ws.Column(columnNum).InsertColumnsBefore(1);
 
-            //Assert
-            Assert.AreEqual(1, ws.DataValidations.Count());
-            Assert.AreEqual(1, ws.DataValidations.First().Ranges.Count());
-            Assert.AreEqual(expectedAddress, ws.DataValidations.First().Ranges.First().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                //Assert
+                Assert.That(ws.DataValidations.Count(), Is.EqualTo(1));
+                Assert.That(ws.DataValidations.First().Ranges.Count(), Is.EqualTo(1));
+            });
+            Assert.That(ws.DataValidations.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo(expectedAddress));
         }
 
         [Test]
         public void DataValidationClearSplitsRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("DataValidation");
+            var validation = ws.Range("A1:C3").CreateDataValidation();
+            validation.WholeNumber.Between(0, 100);
+
+            //Act
+            ws.Cell("B2").Clear(XLClearOptions.DataValidation);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("DataValidation");
-                var validation = ws.Range("A1:C3").CreateDataValidation();
-                validation.WholeNumber.Between(0, 100);
-
-                //Act
-                ws.Cell("B2").Clear(XLClearOptions.DataValidation);
-
                 //Assert
-                Assert.IsFalse(ws.Cell("B2").HasDataValidation);
-                Assert.IsTrue(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2").All(c => c.HasDataValidation));
-            }
+                Assert.That(ws.Cell("B2").HasDataValidation, Is.False);
+                Assert.That(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2").All(c => c.HasDataValidation), Is.True);
+            });
         }
 
         [Test]
         public void NewDataValidationSplitsRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("DataValidation");
+            var validation = ws.Range("A1:C3").CreateDataValidation();
+            validation.WholeNumber.Between(10, 100);
+
+            //Act
+            ws.Cell("B2").CreateDataValidation().WholeNumber.Between(-100, -0);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("DataValidation");
-                var validation = ws.Range("A1:C3").CreateDataValidation();
-                validation.WholeNumber.Between(10, 100);
-
-                //Act
-                ws.Cell("B2").CreateDataValidation().WholeNumber.Between(-100, -0);
-
                 //Assert
-                Assert.AreEqual("-100", ws.Cell("B2").GetDataValidation().MinValue);
-                Assert.IsTrue(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2").All(c => c.HasDataValidation));
-                Assert.IsTrue(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2")
-                                .All(c => c.GetDataValidation().MinValue == "10"));
-            }
+                Assert.That(ws.Cell("B2").GetDataValidation().MinValue, Is.EqualTo("-100"));
+                Assert.That(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2").All(c => c.HasDataValidation), Is.True);
+                Assert.That(ws.Range("A1:C3").Cells().Where(c => c.Address.ToString() != "B2")
+                    .All(c => c.GetDataValidation().MinValue == "10"), Is.True);
+            });
         }
 
         [Test]
@@ -273,25 +293,23 @@ namespace ClosedXML.Tests.Excel.DataValidations
             var values = string.Join(",", Enumerable.Range(1, 20)
                 .Select(i => Guid.NewGuid().ToString("N")));
 
-            Assert.True(values.Length > 255);
+            Assert.That(values.Length, Is.GreaterThan(255));
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var dv = wb.AddWorksheet("Sheet 1").Cell(1, 1).GetDataValidation();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => dv.List(values));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
-                var dv = wb.AddWorksheet("Sheet 1").Cell(1, 1).GetDataValidation();
+                dv.TextLength.Between(0, 5);
+                dv.MinValue = values;
+            });
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => dv.List(values));
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                {
-                    dv.TextLength.Between(0, 5);
-                    dv.MinValue = values;
-                });
-
-                Assert.Throws<ArgumentOutOfRangeException>(() =>
-                {
-                    dv.TextLength.Between(0, 5);
-                    dv.MaxValue = values;
-                });
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                dv.TextLength.Between(0, 5);
+                dv.MaxValue = values;
+            });
         }
 
         [Test]
@@ -303,205 +321,189 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void DataValidationHasWorksheetAndRangesWhenCreated()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range = ws.Range("A1:A3");
+
+            var dv = new XLDataValidation(range);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet();
-                var range = ws.Range("A1:A3");
-
-                var dv = new XLDataValidation(range);
-
-                Assert.AreSame(ws, dv.Worksheet);
-                Assert.AreSame(range, dv.Ranges.Single());
-            }
+                Assert.That(dv.Worksheet, Is.SameAs(ws));
+                Assert.That(dv.Ranges.Single(), Is.SameAs(range));
+            });
         }
 
         [Test]
         public void CanAddRangeFromSameWorksheet()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
+            var ranges3 = ws.Ranges("D1:D3,F1:F3");
+            var dv = new XLDataValidation(range1);
+
+            dv.AddRange(range2);
+            dv.AddRanges(ranges3);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var ranges3 = ws.Ranges("D1:D3,F1:F3");
-                var dv = new XLDataValidation(range1);
-
-                dv.AddRange(range2);
-                dv.AddRanges(ranges3);
-
-                Assert.IsTrue(dv.Ranges.Any(r => r == range1));
-                Assert.IsTrue(dv.Ranges.Any(r => r == range2));
-                Assert.IsTrue(dv.Ranges.Any(r => r == ranges3.First()));
-                Assert.IsTrue(dv.Ranges.Any(r => r == ranges3.Last()));
-            }
+                Assert.That(dv.Ranges.Any(r => r == range1), Is.True);
+                Assert.That(dv.Ranges.Any(r => r == range2), Is.True);
+                Assert.That(dv.Ranges.Any(r => r == ranges3.First()), Is.True);
+                Assert.That(dv.Ranges.Any(r => r == ranges3.Last()), Is.True);
+            });
         }
 
         [Test]
         public void CanAddRangeFromAnotherWorksheet()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws1 = wb.AddWorksheet();
-                var ws2 = wb.AddWorksheet();
-                var range1 = ws1.Range("A1:A3");
-                var range2 = ws2.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            var ws2 = wb.AddWorksheet();
+            var range1 = ws1.Range("A1:A3");
+            var range2 = ws2.Range("C1:C3");
+            var dv = new XLDataValidation(range1);
 
-                dv.AddRange(range2);
+            dv.AddRange(range2);
 
-                Assert.IsTrue(dv.Ranges.Any(r => r != range2 && r.RangeAddress.ToString() == range2.RangeAddress.ToString()));
-            }
+            Assert.That(dv.Ranges.Any(r => r != range2 && r.RangeAddress.ToString() == range2.RangeAddress.ToString()), Is.True);
         }
 
         [Test]
         public void CanClearRanges()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var ranges3 = ws.Ranges("D1:D3,F1:F3");
-                var dv = new XLDataValidation(range1);
-                dv.AddRange(range2);
-                dv.AddRanges(ranges3);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
+            var ranges3 = ws.Ranges("D1:D3,F1:F3");
+            var dv = new XLDataValidation(range1);
+            dv.AddRange(range2);
+            dv.AddRanges(ranges3);
 
-                dv.ClearRanges();
+            dv.ClearRanges();
 
-                Assert.IsEmpty(dv.Ranges);
-            }
+            Assert.IsEmpty(dv.Ranges);
         }
 
         [Test]
         public void CanRemoveExistingRange()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
 
-                var dv = new XLDataValidation(range1);
-                dv.AddRange(range2);
+            var dv = new XLDataValidation(range1);
+            dv.AddRange(range2);
 
-                dv.RemoveRange(range1);
+            dv.RemoveRange(range1);
 
-                Assert.AreSame(range2, dv.Ranges.Single());
-            }
+            Assert.That(dv.Ranges.Single(), Is.SameAs(range2));
         }
 
         [Test]
         public void RemovingExistingRangeDoesNoFail()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
 
-                var dv = new XLDataValidation(range1);
+            var dv = new XLDataValidation(range1);
 
-                dv.RemoveRange(range2);
-                dv.RemoveRange(null);
+            dv.RemoveRange(range2);
+            dv.RemoveRange(null);
 
-                Assert.AreSame(range1, dv.Ranges.Single());
-            }
+            Assert.That(dv.Ranges.Single(), Is.SameAs(range1));
         }
 
         [Test]
         public void AddRangeFiresEvent()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
+            var dv = new XLDataValidation(range1);
 
-                IXLRange addedRange = null;
+            IXLRange addedRange = null;
 
-                dv.RangeAdded += (s, e) => addedRange = e.Range;
+            dv.RangeAdded += (s, e) => addedRange = e.Range;
 
-                dv.AddRange(range2);
+            dv.AddRange(range2);
 
-                Assert.AreSame(range2, addedRange);
-            }
+            Assert.That(addedRange, Is.SameAs(range2));
         }
 
         [Test]
         public void AddRangesFiresMultipleEvents()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var ranges = ws.Ranges("D1:D3,F1:F3");
-                var dv = new XLDataValidation(range1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var ranges = ws.Ranges("D1:D3,F1:F3");
+            var dv = new XLDataValidation(range1);
 
-                var addedRanges = new List<IXLRange>();
+            var addedRanges = new List<IXLRange>();
 
-                dv.RangeAdded += (s, e) => addedRanges.Add(e.Range);
+            dv.RangeAdded += (s, e) => addedRanges.Add(e.Range);
 
-                dv.AddRanges(ranges);
+            dv.AddRanges(ranges);
 
-                Assert.AreEqual(2, addedRanges.Count);
-            }
+            Assert.That(addedRanges, Has.Count.EqualTo(2));
         }
 
         [Test]
         public void RemoveRangeFiresEvent()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
-                dv.AddRange(range2);
-                IXLRange removedRange = null;
-                dv.RangeRemoved += (s, e) => removedRange = e.Range;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
+            var dv = new XLDataValidation(range1);
+            dv.AddRange(range2);
+            IXLRange removedRange = null;
+            dv.RangeRemoved += (s, e) => removedRange = e.Range;
 
-                dv.RemoveRange(range2);
+            dv.RemoveRange(range2);
 
-                Assert.AreSame(range2, removedRange);
-            }
+            Assert.That(removedRange, Is.SameAs(range2));
         }
 
         [Test]
         public void RemoveNonExistingRangeDoesNotFireEvent()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
+            var dv = new XLDataValidation(range1);
 
-                dv.RangeRemoved += (s, e) => Assert.Fail("Expected not to fire event");
+            dv.RangeRemoved += (s, e) => Assert.Fail("Expected not to fire event");
 
-                dv.RemoveRange(range2);
-            }
+            dv.RemoveRange(range2);
         }
 
         [Test]
         public void ClearRangesFiresMultipleEvents()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
-                dv.AddRange(range2);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var range1 = ws.Range("A1:A3");
+            var range2 = ws.Range("C1:C3");
+            var dv = new XLDataValidation(range1);
+            dv.AddRange(range2);
 
-                var removedRanges = new List<IXLRange>();
+            var removedRanges = new List<IXLRange>();
 
-                dv.RangeRemoved += (s, e) => removedRanges.Add(e.Range);
+            dv.RangeRemoved += (s, e) => removedRanges.Add(e.Range);
 
-                dv.ClearRanges();
+            dv.ClearRanges();
 
-                Assert.AreEqual(2, removedRanges.Count);
-            }
+            Assert.That(removedRanges, Has.Count.EqualTo(2));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -293,7 +293,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
             var values = string.Join(",", Enumerable.Range(1, 20)
                 .Select(i => Guid.NewGuid().ToString("N")));
 
-            Assert.That(values.Length, Is.GreaterThan(255));
+            Assert.That(values, Has.Length.GreaterThan(255));
 
             using var wb = new XLWorkbook();
             var dv = wb.AddWorksheet("Sheet 1").Cell(1, 1).GetDataValidation();
@@ -385,7 +385,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
 
             dv.ClearRanges();
 
-            Assert.IsEmpty(dv.Ranges);
+            Assert.That(dv.Ranges, Is.Empty);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -145,7 +145,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 Assert.That(consolidatedDv, Is.SameAs(dv1));
                 Assert.That(ws.Cell("C1").HasDataValidation, Is.True);
             });
-            Assert.False(ws.Cell("D1").HasDataValidation);
+            Assert.That(ws.Cell("D1").HasDataValidation, Is.False);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -16,24 +16,28 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [Test]
         public void AddedRangesAreTransferredToTargetSheet()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            var ws2 = wb.AddWorksheet();
+
+            var dv1 = ws1.Range("A1:A3").CreateDataValidation();
+            dv1.MinValue = "100";
+
+            var dv2 = ws2.DataValidations.Add(dv1);
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb.AddWorksheet();
-                var ws2 = wb.AddWorksheet();
+                Assert.That(ws1.DataValidations.Count(), Is.EqualTo(1));
+                Assert.That(ws2.DataValidations.Count(), Is.EqualTo(1));
+            });
 
-                var dv1 = ws1.Range("A1:A3").CreateDataValidation();
-                dv1.MinValue = "100";
+            Assert.Multiple(() =>
+            {
+                Assert.That(dv2, Is.Not.SameAs(dv1));
 
-                var dv2 = ws2.DataValidations.Add(dv1);
-
-                Assert.AreEqual(1, ws1.DataValidations.Count());
-                Assert.AreEqual(1, ws2.DataValidations.Count());
-
-                Assert.AreNotSame(dv1, dv2);
-
-                Assert.AreSame(ws1, dv1.Ranges.Single().Worksheet);
-                Assert.AreSame(ws2, dv2.Ranges.Single().Worksheet);
-            }
+                Assert.That(dv1.Ranges.Single().Worksheet, Is.SameAs(ws1));
+            });
+            Assert.That(dv2.Ranges.Single().Worksheet, Is.SameAs(ws2));
         }
 
         [TestCase("A1:A1", true)]
@@ -44,22 +48,20 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [TestCase("A1:C3", false)]
         public void CanFindDataValidationForRange(string searchAddress, bool expectedResult)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var dv = ws.Range("A1:A3").CreateDataValidation();
-                dv.MinValue = "100";
-                dv.AddRange(ws.Range("C1:C3"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv = ws.Range("A1:A3").CreateDataValidation();
+            dv.MinValue = "100";
+            dv.AddRange(ws.Range("C1:C3"));
 
-                var address = new XLRangeAddress(ws as XLWorksheet, searchAddress);
+            var address = new XLRangeAddress(ws as XLWorksheet, searchAddress);
 
-                var actualResult = ws.DataValidations.TryGet(address, out var foundDv);
-                Assert.AreEqual(expectedResult, actualResult);
-                if (expectedResult)
-                    Assert.AreSame(dv, foundDv);
-                else
-                    Assert.IsNull(foundDv);
-            }
+            var actualResult = ws.DataValidations.TryGet(address, out var foundDv);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
+            if (expectedResult)
+                Assert.That(foundDv, Is.SameAs(dv));
+            else
+                Assert.That(foundDv, Is.Null);
         }
 
         [TestCase("A1:A1", 1)]
@@ -71,81 +73,79 @@ namespace ClosedXML.Tests.Excel.DataValidations
         [TestCase("E2:E3", 0)]
         public void CanGetAllDataValidationsForRange(string searchAddress, int expectedCount)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var dv1 = ws.Range("A1:A3").CreateDataValidation();
-                dv1.MinValue = "100";
-                dv1.AddRange(ws.Range("C1:C3"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv1 = ws.Range("A1:A3").CreateDataValidation();
+            dv1.MinValue = "100";
+            dv1.AddRange(ws.Range("C1:C3"));
 
-                var dv2 = ws.Range("E4:G6").CreateDataValidation();
-                dv2.MinValue = "200";
+            var dv2 = ws.Range("E4:G6").CreateDataValidation();
+            dv2.MinValue = "200";
 
-                var address = new XLRangeAddress(ws as XLWorksheet, searchAddress);
+            var address = new XLRangeAddress(ws as XLWorksheet, searchAddress);
 
-                var actualResult = ws.DataValidations.GetAllInRange(address);
+            var actualResult = ws.DataValidations.GetAllInRange(address);
 
-                Assert.AreEqual(expectedCount, actualResult.Count());
-            }
+            Assert.That(actualResult.Count(), Is.EqualTo(expectedCount));
         }
 
         [Test]
         public void AddDataValidationSplitsExistingRanges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv1 = ws.Ranges("B2:G7,C11:C13").CreateDataValidation();
+            dv1.MinValue = "100";
+
+            var dv2 = ws.Range("E4:G6").CreateDataValidation();
+            dv2.MinValue = "100";
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet();
-                var dv1 = ws.Ranges("B2:G7,C11:C13").CreateDataValidation();
-                dv1.MinValue = "100";
-
-                var dv2 = ws.Range("E4:G6").CreateDataValidation();
-                dv2.MinValue = "100";
-
-                Assert.AreEqual(4, dv1.Ranges.Count());
-                Assert.AreEqual("B2:G3,B4:D6,B7:G7,C11:C13",
-                    string.Join(",", dv1.Ranges.Select(r => r.RangeAddress.ToString())));
-            }
+                Assert.That(dv1.Ranges.Count(), Is.EqualTo(4));
+                Assert.That(string.Join(",", dv1.Ranges.Select(r => r.RangeAddress.ToString())),
+                    Is.EqualTo("B2:G3,B4:D6,B7:G7,C11:C13"));
+            });
         }
 
         [Test]
         public void RemovedRangeExcludedFromIndex()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var dv = ws.Range("A1:A3").CreateDataValidation();
-                dv.MinValue = "100";
-                var range = ws.Range("C1:C3");
-                dv.AddRange(range);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv = ws.Range("A1:A3").CreateDataValidation();
+            dv.MinValue = "100";
+            var range = ws.Range("C1:C3");
+            dv.AddRange(range);
 
-                dv.RemoveRange(range);
+            dv.RemoveRange(range);
 
-                var actualResult = ws.DataValidations.TryGet(range.RangeAddress, out var foundDv);
-                Assert.IsFalse(actualResult);
-                Assert.IsNull(foundDv);
-            }
+            var actualResult = ws.DataValidations.TryGet(range.RangeAddress, out var foundDv);
+            Assert.That(actualResult, Is.False);
+            Assert.That(foundDv, Is.Null);
         }
 
         [Test]
         public void ConsolidatedDataValidationsAreUnsubscribed()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv1 = ws.Range("A1:A3").CreateDataValidation();
+            dv1.MinValue = "100";
+            var dv2 = ws.Range("B1:B3").CreateDataValidation();
+            dv2.MinValue = "100";
+
+            (ws.DataValidations as XLDataValidations).Consolidate();
+            dv1.AddRange(ws.Range("C1:C3"));
+            dv2.AddRange(ws.Range("D1:D3"));
+
+            var consolidatedDv = ws.DataValidations.Single();
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet();
-                var dv1 = ws.Range("A1:A3").CreateDataValidation();
-                dv1.MinValue = "100";
-                var dv2 = ws.Range("B1:B3").CreateDataValidation();
-                dv2.MinValue = "100";
-
-                (ws.DataValidations as XLDataValidations).Consolidate();
-                dv1.AddRange(ws.Range("C1:C3"));
-                dv2.AddRange(ws.Range("D1:D3"));
-
-                var consolidatedDv = ws.DataValidations.Single();
-                Assert.AreSame(dv1, consolidatedDv);
-                Assert.True(ws.Cell("C1").HasDataValidation);
-                Assert.False(ws.Cell("D1").HasDataValidation);
-            }
+                Assert.That(consolidatedDv, Is.SameAs(dv1));
+                Assert.That(ws.Cell("C1").HasDataValidation, Is.True);
+            });
+            Assert.False(ws.Cell("D1").HasDataValidation);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Globalization/GlobalizationTests.cs
+++ b/ClosedXML.Tests/Excel/Globalization/GlobalizationTests.cs
@@ -20,26 +20,27 @@ namespace ClosedXML.Tests.Excel.Globalization
         {
             Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("ru-RU");
 
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (XLWorkbook book1 = new XLWorkbook())
             {
-                using (XLWorkbook book1 = new XLWorkbook())
-                {
-                    var sheet = book1.AddWorksheet("sheet1");
-                    sheet.Cell("A1").Value = 123;
-                    sheet.Cell("A2").FormulaA1 = formula;
-                    var options = new SaveOptions { EvaluateFormulasBeforeSaving = true };
+                var sheet = book1.AddWorksheet("sheet1");
+                sheet.Cell("A1").Value = 123;
+                sheet.Cell("A2").FormulaA1 = formula;
+                var options = new SaveOptions { EvaluateFormulasBeforeSaving = true };
 
-                    book1.SaveAs(ms, options);
-                }
-                ms.Position = 0;
+                book1.SaveAs(ms, options);
+            }
+            ms.Position = 0;
 
-                using (XLWorkbook book2 = new XLWorkbook(ms))
+            using (XLWorkbook book2 = new XLWorkbook(ms))
+            {
+                var ws = book2.Worksheet(1);
+                var storedValueA2 = ws.Cell("A2").CachedValue;
+                Assert.Multiple(() =>
                 {
-                    var ws = book2.Worksheet(1);
-                    var storedValueA2 = ws.Cell("A2").CachedValue;
-                    Assert.IsFalse(ws.Cell("A2").NeedsRecalculation);
-                    Assert.AreEqual(expectedValue, storedValueA2);
-                }
+                    Assert.That(ws.Cell("A2").NeedsRecalculation, Is.False);
+                    Assert.That(storedValueA2, Is.EqualTo(expectedValue));
+                });
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
+++ b/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
@@ -19,7 +19,7 @@ public class XLHyperlinksTests
 
         structuralChange(ws);
 
-        Assert.False(ws.Cell(hyperlinkPosition).HasHyperlink);
+        Assert.That(ws.Cell(hyperlinkPosition).HasHyperlink, Is.False);
         Assert.That(hyperlink, Is.SameAs(ws.Cell(expectedPosition).GetHyperlink()));
     }
 

--- a/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
+++ b/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
@@ -20,7 +20,7 @@ public class XLHyperlinksTests
         structuralChange(ws);
 
         Assert.False(ws.Cell(hyperlinkPosition).HasHyperlink);
-        Assert.AreSame(ws.Cell(expectedPosition).GetHyperlink(), hyperlink);
+        Assert.That(hyperlink, Is.SameAs(ws.Cell(expectedPosition).GetHyperlink()));
     }
 
     public static IEnumerable<object[]> StructuralChangeCases

--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Tests
                     fileStream.Close();
                 }
 
-                Parallel.Invoke(() => verifyAddImageFromFile(path), () => verifyAddImageFromFile(path));
+                Parallel.Invoke(() => VerifyAddImageFromFile(path), () => VerifyAddImageFromFile(path));
             }
             finally
             {
@@ -95,7 +95,7 @@ namespace ClosedXML.Tests
             }
         }
 
-        private void verifyAddImageFromFile(string filePath)
+        private static void VerifyAddImageFromFile(string filePath)
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet1");
@@ -104,12 +104,12 @@ namespace ClosedXML.Tests
                 .WithPlacement(XLPicturePlacement.FreeFloating)
                 .MoveTo(50, 50);
 
-            Assert.Multiple(() =>
-            {
-                Assert.That(picture.Format, Is.EqualTo(XLPictureFormat.Jpeg));
-                Assert.That(picture.Width, Is.EqualTo(400));
-                Assert.That(picture.Top, Is.EqualTo(50));
-            });
+            // Do not Wrap inside an Assert.Multiple, will create an error due to parallel invoke.
+#pragma warning disable NUnit2045
+            Assert.That(picture.Format, Is.EqualTo(XLPictureFormat.Jpeg));
+            Assert.That(picture.Width, Is.EqualTo(400));
+            Assert.That(picture.Top, Is.EqualTo(50));
+#pragma warning restore NUnit2045
         }
 
         [Test]
@@ -404,6 +404,7 @@ namespace ClosedXML.Tests
                     .WithPlacement(XLPicturePlacement.FreeFloating)
                     .MoveTo(220, 155) as XLPicture;
             }
+
             var ws2 = wb.Worksheets.Add("Sheet2");
 
             var copy = original.CopyTo(ws2);

--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -16,56 +16,56 @@ namespace ClosedXML.Tests
         [Test]
         public void CanAddPictureFromStream()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            using var resourceStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg");
+            var picture = ws.AddPicture(resourceStream, "MyPicture")
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(50, 50)
+                .WithSize(200, 200);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                using (var resourceStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
-                {
-                    var picture = ws.AddPicture(resourceStream, "MyPicture")
-                        .WithPlacement(XLPicturePlacement.FreeFloating)
-                        .MoveTo(50, 50)
-                        .WithSize(200, 200);
-
-                    Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
-                    Assert.AreEqual(200, picture.Width);
-                    Assert.AreEqual(200, picture.Height);
-                }
-            }
+                Assert.That(picture.Format, Is.EqualTo(XLPictureFormat.Jpeg));
+                Assert.That(picture.Width, Is.EqualTo(200));
+                Assert.That(picture.Height, Is.EqualTo(200));
+            });
         }
 
         [Test]
         public void CanAddPictureFromFile()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            var path = Path.ChangeExtension(Path.GetTempFileName(), "jpg");
+
+            try
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                var path = Path.ChangeExtension(Path.GetTempFileName(), "jpg");
-
-                try
+                using (var resourceStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
+                using (var fileStream = File.Create(path))
                 {
-                    using (var resourceStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
-                    using (var fileStream = File.Create(path))
-                    {
-                        resourceStream.Seek(0, SeekOrigin.Begin);
-                        resourceStream.CopyTo(fileStream);
-                        fileStream.Close();
-                    }
-
-                    var picture = ws.AddPicture(path)
-                        .WithPlacement(XLPicturePlacement.FreeFloating)
-                        .MoveTo(50, 50);
-
-                    Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
-                    Assert.AreEqual(400, picture.Width);
-                    Assert.AreEqual(400, picture.Height);
+                    resourceStream.Seek(0, SeekOrigin.Begin);
+                    resourceStream.CopyTo(fileStream);
+                    fileStream.Close();
                 }
-                finally
+
+                var picture = ws.AddPicture(path)
+                    .WithPlacement(XLPicturePlacement.FreeFloating)
+                    .MoveTo(50, 50);
+
+                Assert.Multiple(() =>
                 {
-                    if (File.Exists(path))
-                        File.Delete(path);
-                }
+                    Assert.That(picture.Format, Is.EqualTo(XLPictureFormat.Jpeg));
+                    Assert.That(picture.Width, Is.EqualTo(400));
+                    Assert.That(picture.Height, Is.EqualTo(400));
+                });
+            }
+            finally
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
             }
         }
 
@@ -97,121 +97,132 @@ namespace ClosedXML.Tests
 
         private void verifyAddImageFromFile(string filePath)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            var picture = ws.AddPicture(filePath)
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(50, 50);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                var picture = ws.AddPicture(filePath)
-                           .WithPlacement(XLPicturePlacement.FreeFloating)
-                           .MoveTo(50, 50);
-
-                Assert.AreEqual(XLPictureFormat.Jpeg, picture.Format);
-                Assert.AreEqual(400, picture.Width);
-                Assert.AreEqual(50, picture.Top);
-            }
+                Assert.That(picture.Format, Is.EqualTo(XLPictureFormat.Jpeg));
+                Assert.That(picture.Width, Is.EqualTo(400));
+                Assert.That(picture.Top, Is.EqualTo(50));
+            });
         }
 
         [Test]
         public void CanScaleImage()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            using var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png");
+            var pic = ws.AddPicture(resourceStream, "MyPicture")
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(50, 50);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(pic.OriginalWidth, Is.EqualTo(252));
+                Assert.That(pic.OriginalHeight, Is.EqualTo(152));
+                Assert.That(pic.Width, Is.EqualTo(252));
+                Assert.That(pic.Height, Is.EqualTo(152));
+            });
 
-                using (var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
-                {
-                    var pic = ws.AddPicture(resourceStream, "MyPicture")
-                        .WithPlacement(XLPicturePlacement.FreeFloating)
-                        .MoveTo(50, 50);
+            pic.ScaleHeight(0.7);
+            pic.ScaleWidth(1.2);
 
-                    Assert.AreEqual(252, pic.OriginalWidth);
-                    Assert.AreEqual(152, pic.OriginalHeight);
-                    Assert.AreEqual(252, pic.Width);
-                    Assert.AreEqual(152, pic.Height);
+            Assert.Multiple(() =>
+            {
+                Assert.That(pic.OriginalWidth, Is.EqualTo(252));
+                Assert.That(pic.OriginalHeight, Is.EqualTo(152));
+                Assert.That(pic.Width, Is.EqualTo(302));
+                Assert.That(pic.Height, Is.EqualTo(106));
+            });
 
-                    pic.ScaleHeight(0.7);
-                    pic.ScaleWidth(1.2);
+            pic.ScaleHeight(0.7);
+            pic.ScaleWidth(1.2);
 
-                    Assert.AreEqual(252, pic.OriginalWidth);
-                    Assert.AreEqual(152, pic.OriginalHeight);
-                    Assert.AreEqual(302, pic.Width);
-                    Assert.AreEqual(106, pic.Height);
+            Assert.Multiple(() =>
+            {
+                Assert.That(pic.OriginalWidth, Is.EqualTo(252));
+                Assert.That(pic.OriginalHeight, Is.EqualTo(152));
+                Assert.That(pic.Width, Is.EqualTo(362));
+                Assert.That(pic.Height, Is.EqualTo(74));
+            });
 
-                    pic.ScaleHeight(0.7);
-                    pic.ScaleWidth(1.2);
+            pic.ScaleHeight(0.8, true);
+            pic.ScaleWidth(1.1, true);
 
-                    Assert.AreEqual(252, pic.OriginalWidth);
-                    Assert.AreEqual(152, pic.OriginalHeight);
-                    Assert.AreEqual(362, pic.Width);
-                    Assert.AreEqual(74, pic.Height);
-
-                    pic.ScaleHeight(0.8, true);
-                    pic.ScaleWidth(1.1, true);
-
-                    Assert.AreEqual(252, pic.OriginalWidth);
-                    Assert.AreEqual(152, pic.OriginalHeight);
-                    Assert.AreEqual(277, pic.Width);
-                    Assert.AreEqual(122, pic.Height);
-                }
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(pic.OriginalWidth, Is.EqualTo(252));
+                Assert.That(pic.OriginalHeight, Is.EqualTo(152));
+                Assert.That(pic.Width, Is.EqualTo(277));
+                Assert.That(pic.Height, Is.EqualTo(122));
+            });
         }
 
         [Test]
         public void TestDefaultPictureNames()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                ws.AddPicture(stream, XLPictureFormat.Png);
+                stream.Position = 0;
 
-                using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
-                {
-                    ws.AddPicture(stream, XLPictureFormat.Png);
-                    stream.Position = 0;
+                ws.AddPicture(stream, XLPictureFormat.Png);
+                stream.Position = 0;
 
-                    ws.AddPicture(stream, XLPictureFormat.Png);
-                    stream.Position = 0;
+                ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
+                stream.Position = 0;
 
-                    ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
-                    stream.Position = 0;
-
-                    ws.AddPicture(stream, XLPictureFormat.Png);
-                    stream.Position = 0;
-                }
-
-                Assert.AreEqual("Picture 1", ws.Pictures.Skip(0).First().Name);
-                Assert.AreEqual("Picture 2", ws.Pictures.Skip(1).First().Name);
-                Assert.AreEqual("Picture 4", ws.Pictures.Skip(2).First().Name);
-                Assert.AreEqual("Picture 5", ws.Pictures.Skip(3).First().Name);
+                ws.AddPicture(stream, XLPictureFormat.Png);
+                stream.Position = 0;
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Pictures.Skip(0).First().Name, Is.EqualTo("Picture 1"));
+                Assert.That(ws.Pictures.Skip(1).First().Name, Is.EqualTo("Picture 2"));
+                Assert.That(ws.Pictures.Skip(2).First().Name, Is.EqualTo("Picture 4"));
+                Assert.That(ws.Pictures.Skip(3).First().Name, Is.EqualTo("Picture 5"));
+            });
         }
 
         [Test]
         public void TestDefaultIds()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                ws.AddPicture(stream, XLPictureFormat.Png);
+                stream.Position = 0;
 
-                using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
-                {
-                    ws.AddPicture(stream, XLPictureFormat.Png);
-                    stream.Position = 0;
+                ws.AddPicture(stream, XLPictureFormat.Png);
+                stream.Position = 0;
 
-                    ws.AddPicture(stream, XLPictureFormat.Png);
-                    stream.Position = 0;
+                ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
+                stream.Position = 0;
 
-                    ws.AddPicture(stream, XLPictureFormat.Png).Name = "Picture 4";
-                    stream.Position = 0;
-
-                    ws.AddPicture(stream, XLPictureFormat.Png);
-                    stream.Position = 0;
-                }
-
-                Assert.AreEqual(1, ws.Pictures.Skip(0).First().Id);
-                Assert.AreEqual(2, ws.Pictures.Skip(1).First().Id);
-                Assert.AreEqual(3, ws.Pictures.Skip(2).First().Id);
-                Assert.AreEqual(4, ws.Pictures.Skip(3).First().Id);
+                ws.AddPicture(stream, XLPictureFormat.Png);
+                stream.Position = 0;
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Pictures.Skip(0).First().Id, Is.EqualTo(1));
+                Assert.That(ws.Pictures.Skip(1).First().Id, Is.EqualTo(2));
+                Assert.That(ws.Pictures.Skip(2).First().Id, Is.EqualTo(3));
+                Assert.That(ws.Pictures.Skip(3).First().Id, Is.EqualTo(4));
+            });
         }
 
         [Test]
@@ -220,135 +231,127 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             XLMarker firstMarker = new XLMarker(ws.Cell(1, 10), new Point(100, 0));
 
-            Assert.AreEqual(10, firstMarker.ColumnNumber);
-            Assert.AreEqual(1, firstMarker.RowNumber);
-            Assert.AreEqual(100, firstMarker.Offset.X);
-            Assert.AreEqual(0, firstMarker.Offset.Y);
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstMarker.ColumnNumber, Is.EqualTo(10));
+                Assert.That(firstMarker.RowNumber, Is.EqualTo(1));
+                Assert.That(firstMarker.Offset.X, Is.EqualTo(100));
+                Assert.That(firstMarker.Offset.Y, Is.EqualTo(0));
+            });
         }
 
         [Test]
         public void XLPictureTests()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png");
+            var pic = ws.AddPicture(stream, XLPictureFormat.Png, "Image1")
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(220, 155);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-
-                using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
-                {
-                    var pic = ws.AddPicture(stream, XLPictureFormat.Png, "Image1")
-                        .WithPlacement(XLPicturePlacement.FreeFloating)
-                        .MoveTo(220, 155);
-
-                    Assert.AreEqual(XLPicturePlacement.FreeFloating, pic.Placement);
-                    Assert.AreEqual("Image1", pic.Name);
-                    Assert.AreEqual(XLPictureFormat.Png, pic.Format);
-                    Assert.AreEqual(252, pic.OriginalWidth);
-                    Assert.AreEqual(152, pic.OriginalHeight);
-                    Assert.AreEqual(252, pic.Width);
-                    Assert.AreEqual(152, pic.Height);
-                    Assert.AreEqual(220, pic.Left);
-                    Assert.AreEqual(155, pic.Top);
-                }
-            }
+                Assert.That(pic.Placement, Is.EqualTo(XLPicturePlacement.FreeFloating));
+                Assert.That(pic.Name, Is.EqualTo("Image1"));
+                Assert.That(pic.Format, Is.EqualTo(XLPictureFormat.Png));
+                Assert.That(pic.OriginalWidth, Is.EqualTo(252));
+                Assert.That(pic.OriginalHeight, Is.EqualTo(152));
+                Assert.That(pic.Width, Is.EqualTo(252));
+                Assert.That(pic.Height, Is.EqualTo(152));
+                Assert.That(pic.Left, Is.EqualTo(220));
+                Assert.That(pic.Top, Is.EqualTo(155));
+            });
         }
 
         [Test]
         public void CanLoadFileWithImagesAndCopyImagesToNewSheet()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                Assert.AreEqual(2, ws.Pictures.Count);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            Assert.That(ws.Pictures, Has.Count.EqualTo(2));
 
-                var copy = ws.CopyTo("NewSheet");
-                Assert.AreEqual(2, copy.Pictures.Count);
-            }
+            var copy = ws.CopyTo("NewSheet");
+            Assert.That(copy.Pictures, Has.Count.EqualTo(2));
         }
 
         [Test]
         public void CanDeletePictures()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            int originalCount;
+
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
+            using (var wb = new XLWorkbook(stream))
             {
-                int originalCount;
+                var ws = wb.Worksheets.First();
+                originalCount = ws.Pictures.Count;
+                ws.Pictures.Delete(ws.Pictures.First());
 
-                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-                using (var wb = new XLWorkbook(stream))
-                {
-                    var ws = wb.Worksheets.First();
-                    originalCount = ws.Pictures.Count;
-                    ws.Pictures.Delete(ws.Pictures.First());
+                var pictureName = ws.Pictures.First().Name;
+                ws.Pictures.Delete(pictureName);
 
-                    var pictureName = ws.Pictures.First().Name;
-                    ws.Pictures.Delete(pictureName);
+                wb.SaveAs(ms);
+            }
 
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    Assert.AreEqual(originalCount - 2, ws.Pictures.Count);
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                Assert.That(ws.Pictures, Has.Count.EqualTo(originalCount - 2));
             }
         }
 
         [Test]
         public void PictureRenameTests()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet("Images3");
-                var picture = ws.Pictures.First();
-                Assert.AreEqual("Picture 1", picture.Name);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("Images3");
+            var picture = ws.Pictures.First();
+            Assert.That(picture.Name, Is.EqualTo("Picture 1"));
 
-                picture.Name = "picture 1";
-                picture.Name = "pICture 1";
-                picture.Name = "Picture 1";
+            picture.Name = "picture 1";
+            picture.Name = "pICture 1";
+            picture.Name = "Picture 1";
 
-                picture = ws.Pictures.Last();
-                picture.Name = "new name";
+            picture = ws.Pictures.Last();
+            picture.Name = "new name";
 
-                Assert.Throws<ArgumentException>(() => picture.Name = "Picture 1");
-                Assert.Throws<ArgumentException>(() => picture.Name = "picTURE 1");
-            }
+            Assert.Throws<ArgumentException>(() => picture.Name = "Picture 1");
+            Assert.Throws<ArgumentException>(() => picture.Name = "picTURE 1");
         }
 
         [Test]
         public void HandleDuplicatePictureIdsAcrossWorksheets()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws1 = wb.AddWorksheet("Sheet1");
-                var ws2 = wb.AddWorksheet("Sheet2");
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet("Sheet1");
+            var ws2 = wb.AddWorksheet("Sheet2");
 
-                using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
-                {
-                    (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2);
-                    (ws1 as XLWorksheet).AddPicture(stream, "Picture 2", 3);
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png");
+            (ws1 as XLWorksheet).AddPicture(stream, "Picture 1", 2);
+            (ws1 as XLWorksheet).AddPicture(stream, "Picture 2", 3);
 
-                    //Internal method - used for loading files
-                    var pic = (ws2 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
-                        .WithPlacement(XLPicturePlacement.FreeFloating)
-                        .MoveTo(220, 155) as XLPicture;
+            //Internal method - used for loading files
+            var pic = (ws2 as XLWorksheet).AddPicture(stream, "Picture 1", 2)
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(220, 155) as XLPicture;
 
-                    var id = pic.Id;
+            var id = pic.Id;
 
-                    pic.Id = id;
-                    Assert.AreEqual(id, pic.Id);
+            pic.Id = id;
+            Assert.That(pic.Id, Is.EqualTo(id));
 
-                    pic.Id = 3;
-                    Assert.AreEqual(3, pic.Id);
+            pic.Id = 3;
+            Assert.That(pic.Id, Is.EqualTo(3));
 
-                    pic.Id = id;
+            pic.Id = id;
 
-                    var pic2 = (ws2 as XLWorksheet).AddPicture(stream, "Picture 2", 3)
-                        .WithPlacement(XLPicturePlacement.FreeFloating)
-                        .MoveTo(440, 300) as XLPicture;
-                }
-            }
+            var pic2 = (ws2 as XLWorksheet).AddPicture(stream, "Picture 2", 3)
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(440, 300) as XLPicture;
         }
 
         [Test]
@@ -368,19 +371,25 @@ namespace ClosedXML.Tests
             var copy = original.Duplicate()
                 .MoveTo(300, 200) as XLPicture;
 
-            Assert.AreEqual(2, ws1.Pictures.Count());
-            Assert.AreEqual(ws1, copy.Worksheet);
-            Assert.AreEqual(original.Format, copy.Format);
-            Assert.AreEqual(original.Height, copy.Height);
-            Assert.AreEqual(original.Placement, copy.Placement);
-            Assert.AreEqual(original.TopLeftCell.ToString(), copy.TopLeftCell.ToString());
-            Assert.AreEqual(original.Width, copy.Width);
-            Assert.AreEqual(original.ImageStream.ToArray(), copy.ImageStream.ToArray(), "Image streams differ");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.Pictures, Has.Count.EqualTo(2));
+                Assert.That(copy.Worksheet, Is.EqualTo(ws1));
+                Assert.That(copy.Format, Is.EqualTo(original.Format));
+                Assert.That(copy.Height, Is.EqualTo(original.Height));
+                Assert.That(copy.Placement, Is.EqualTo(original.Placement));
+                Assert.That(copy.TopLeftCell.ToString(), Is.EqualTo(original.TopLeftCell.ToString()));
+                Assert.That(copy.Width, Is.EqualTo(original.Width));
+                Assert.That(copy.ImageStream.ToArray(), Is.EqualTo(original.ImageStream.ToArray()), "Image streams differ");
 
-            Assert.AreEqual(200, copy.Top);
-            Assert.AreEqual(300, copy.Left);
-            Assert.AreNotEqual(original.Id, copy.Id);
-            Assert.AreNotEqual(original.Name, copy.Name);
+                Assert.That(copy.Top, Is.EqualTo(200));
+                Assert.That(copy.Left, Is.EqualTo(300));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.Id, Is.Not.EqualTo(original.Id));
+                Assert.That(copy.Name, Is.Not.EqualTo(original.Name));
+            });
         }
 
         [Test]
@@ -399,50 +408,49 @@ namespace ClosedXML.Tests
 
             var copy = original.CopyTo(ws2);
 
-            Assert.AreEqual(1, ws1.Pictures.Count());
-            Assert.AreEqual(1, ws2.Pictures.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.Pictures, Has.Count.EqualTo(1));
+                Assert.That(ws2.Pictures, Has.Count.EqualTo(1));
 
-            Assert.AreEqual(ws2, copy.Worksheet);
+                Assert.That(copy.Worksheet, Is.EqualTo(ws2));
 
-            Assert.AreEqual(original.Format, copy.Format);
-            Assert.AreEqual(original.Height, copy.Height);
-            Assert.AreEqual(original.Left, copy.Left);
-            Assert.AreEqual(original.Name, copy.Name);
-            Assert.AreEqual(original.Placement, copy.Placement);
-            Assert.AreEqual(original.Top, copy.Top);
-            Assert.AreEqual(original.TopLeftCell.ToString(), copy.TopLeftCell.ToString());
-            Assert.AreEqual(original.Width, copy.Width);
-            Assert.AreEqual(original.ImageStream.ToArray(), copy.ImageStream.ToArray(), "Image streams differ");
+                Assert.That(copy.Format, Is.EqualTo(original.Format));
+                Assert.That(copy.Height, Is.EqualTo(original.Height));
+                Assert.That(copy.Left, Is.EqualTo(original.Left));
+                Assert.That(copy.Name, Is.EqualTo(original.Name));
+                Assert.That(copy.Placement, Is.EqualTo(original.Placement));
+                Assert.That(copy.Top, Is.EqualTo(original.Top));
+                Assert.That(copy.TopLeftCell.ToString(), Is.EqualTo(original.TopLeftCell.ToString()));
+                Assert.That(copy.Width, Is.EqualTo(original.Width));
+                Assert.That(copy.ImageStream.ToArray(), Is.EqualTo(original.ImageStream.ToArray()), "Image streams differ");
+            });
 
-            Assert.AreNotEqual(original.Id, copy.Id);
+            Assert.That(copy.Id, Is.Not.EqualTo(original.Id));
         }
 
         [Test]
         public void PictureShiftsWhenInsertingRows()
         {
-            using (var wb = new XLWorkbook())
-            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png"))
-            {
-                var ws = wb.Worksheets.Add("ImageShift");
-                var picture = ws.AddPicture(stream, XLPictureFormat.Png, "PngImage")
-                    .MoveTo(ws.Cell(5, 2))
-                    .WithPlacement(XLPicturePlacement.Move);
+            using var wb = new XLWorkbook();
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png");
+            var ws = wb.Worksheets.Add("ImageShift");
+            var picture = ws.AddPicture(stream, XLPictureFormat.Png, "PngImage")
+                .MoveTo(ws.Cell(5, 2))
+                .WithPlacement(XLPicturePlacement.Move);
 
-                ws.Row(2).InsertRowsBelow(20);
+            ws.Row(2).InsertRowsBelow(20);
 
-                Assert.AreEqual(25, picture.TopLeftCell.Address.RowNumber);
-            }
+            Assert.That(picture.TopLeftCell.Address.RowNumber, Is.EqualTo(25));
         }
 
         [Test]
         public void PictureNotFound()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Picture("dummy"));
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Pictures.Delete("dummy"));
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Picture("dummy"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Pictures.Delete("dummy"));
         }
 
         [Test]
@@ -458,7 +466,7 @@ namespace ClosedXML.Tests
 
             var img2 = img1.CopyTo(ws2);
 
-            Assert.AreEqual(XLPictureFormat.Emf, img2.Format);
+            Assert.That(img2.Format, Is.EqualTo(XLPictureFormat.Emf));
 
             using var ms = new MemoryStream();
             wb.SaveAs(ms);
@@ -468,7 +476,7 @@ namespace ClosedXML.Tests
             using var wb2 = new XLWorkbook(ms);
             ws2 = wb2.Worksheet("Sheet2");
             img2 = ws2.Pictures.First();
-            Assert.AreEqual(XLPictureFormat.Emf, img2.Format);
+            Assert.That(img2.Format, Is.EqualTo(XLPictureFormat.Emf));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/ArrayTypeReaderTests.cs
@@ -16,21 +16,21 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void GetPropertyNameReturnsNull()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.IsNull(reader.GetPropertyName(0));
+            Assert.That(reader.GetPropertyName(0), Is.Null);
         }
 
         [Test]
         public void CanGetPropertiesCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetPropertiesCount());
+            Assert.That(reader.GetPropertiesCount(), Is.EqualTo(3));
         }
 
         [Test]
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(2, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -39,10 +39,13 @@ namespace ClosedXML.Tests.Excel.InsertData
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
             var result = reader.GetRecords();
 
-            Assert.AreEqual(1, result.First().First());
-            Assert.AreEqual(3, result.First().Last());
-            Assert.AreEqual(4, result.Last().First());
-            Assert.AreEqual(6, result.Last().Last());
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.First().First(), Is.EqualTo(1));
+                Assert.That(result.First().Last(), Is.EqualTo(3));
+                Assert.That(result.Last().First(), Is.EqualTo(4));
+                Assert.That(result.Last().Last(), Is.EqualTo(6));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/InsertData/DataRecordReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/DataRecordReaderTests.cs
@@ -20,25 +20,21 @@ namespace ClosedXML.Tests.Excel.InsertData
             union all
             select 'Value 3', 300";
 
-            using (var connection = new SqlConnection(_connectionString))
-            using (var command = new SqlCommand(queryString, connection))
+            using var connection = new SqlConnection(_connectionString);
+            using var command = new SqlCommand(queryString, connection);
+            try
             {
-                try
-                {
-                    connection.Open();
-                }
-                catch
-                {
-                    Assert.Ignore("Could not connect to localdb");
-                }
+                connection.Open();
+            }
+            catch
+            {
+                Assert.Ignore("Could not connect to localdb");
+            }
 
-                using (var reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        yield return reader;
-                    }
-                }
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return reader;
             }
         }
 
@@ -46,22 +42,25 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetPropertyName()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
-            Assert.AreEqual("StringValue", reader.GetPropertyName(0));
-            Assert.AreEqual("NumericValue", reader.GetPropertyName(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetPropertyName(0), Is.EqualTo("StringValue"));
+                Assert.That(reader.GetPropertyName(1), Is.EqualTo("NumericValue"));
+            });
         }
 
         [Test]
         public void CanGetPropertiesCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
-            Assert.AreEqual(2, reader.GetPropertiesCount());
+            Assert.That(reader.GetPropertiesCount(), Is.EqualTo(2));
         }
 
         [Test]
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
-            Assert.AreEqual(3, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(3));
         }
 
         [Test]
@@ -70,10 +69,13 @@ namespace ClosedXML.Tests.Excel.InsertData
             var reader = InsertDataReaderFactory.Instance.CreateReader(GetData());
             var result = reader.GetRecords().ToArray();
 
-            Assert.AreEqual("Value 1", result.First().First());
-            Assert.AreEqual(100, result.First().Last());
-            Assert.AreEqual("Value 3", result.Last().First());
-            Assert.AreEqual(300, result.Last().Last());
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.First().First(), Is.EqualTo("Value 1"));
+                Assert.That(result.First().Last(), Is.EqualTo(100));
+                Assert.That(result.Last().First(), Is.EqualTo("Value 3"));
+                Assert.That(result.Last().Last(), Is.EqualTo(300));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/InsertData/DataRowReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/DataRowReaderTests.cs
@@ -24,23 +24,26 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetPropertyName()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual("Last name", reader.GetPropertyName(0));
-            Assert.AreEqual("First name", reader.GetPropertyName(1));
-            Assert.AreEqual("Age", reader.GetPropertyName(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetPropertyName(0), Is.EqualTo("Last name"));
+                Assert.That(reader.GetPropertyName(1), Is.EqualTo("First name"));
+                Assert.That(reader.GetPropertyName(2), Is.EqualTo("Age"));
+            });
         }
 
         [Test]
         public void CanGetPropertiesCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetPropertiesCount());
+            Assert.That(reader.GetPropertiesCount(), Is.EqualTo(3));
         }
 
         [Test]
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(2, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -49,10 +52,19 @@ namespace ClosedXML.Tests.Excel.InsertData
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
             var result = reader.GetRecords();
 
-            Assert.AreEqual("Smith", result.First().First());
-            Assert.AreEqual(33, result.First().Last());
-            Assert.AreEqual("Ivanova", result.Last().First());
-            Assert.AreEqual(25, result.Last().Last());
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.First().First(), Is.EqualTo("Smith"));
+                Assert.That(result.First().Last(), Is.EqualTo(33));
+                Assert.That(result.Last().First(), Is.EqualTo("Ivanova"));
+                Assert.That(result.Last().Last(), Is.EqualTo(25));
+            });
+        }
+        
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            _data.Dispose();
         }
     }
 }

--- a/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
@@ -15,8 +15,11 @@ namespace ClosedXML.Tests.Excel.InsertData
         {
             var factory = InsertDataReaderFactory.Instance;
 
-            Assert.IsNotNull(factory);
-            Assert.That(InsertDataReaderFactory.Instance, Is.SameAs(factory));
+            Assert.Multiple(() =>
+            {
+                Assert.That(factory, Is.Not.Null);
+                Assert.That(InsertDataReaderFactory.Instance, Is.SameAs(factory));
+            });
         }
 
         [TestCaseSource(nameof(SimpleSources))]
@@ -24,7 +27,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 
-            Assert.IsInstanceOf<SimpleTypeReader>(reader);
+            Assert.That(reader, Is.InstanceOf<SimpleTypeReader>());
         }
 
         private static IEnumerable<object> SimpleSources
@@ -44,7 +47,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 
-            Assert.IsInstanceOf<SimpleNullableTypeReader>(reader);
+            Assert.That(reader, Is.InstanceOf<SimpleNullableTypeReader>());
         }
 
         private static IEnumerable<object> SimpleNullableSources
@@ -63,7 +66,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 
-            Assert.IsInstanceOf<ArrayReader>(reader);
+            Assert.That(reader, Is.InstanceOf<ArrayReader>());
         }
 
         private static IEnumerable<object> ArraySources
@@ -99,7 +102,7 @@ namespace ClosedXML.Tests.Excel.InsertData
             };
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 
-            Assert.IsInstanceOf<ArrayReader>(reader);
+            Assert.That(reader, Is.InstanceOf<ArrayReader>());
         }
 
         [Test]
@@ -112,7 +115,7 @@ namespace ClosedXML.Tests.Excel.InsertData
             };
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 
-            Assert.IsInstanceOf<SimpleTypeReader>(reader);
+            Assert.That(reader, Is.InstanceOf<SimpleTypeReader>());
         }
 
         [Test]
@@ -121,31 +124,31 @@ namespace ClosedXML.Tests.Excel.InsertData
             var dt = new DataTable();
             var reader = InsertDataReaderFactory.Instance.CreateReader(dt);
 
-            Assert.IsInstanceOf<ClosedXML.Excel.InsertData.DataTableReader>(reader);
+            Assert.That(reader, Is.InstanceOf<ClosedXML.Excel.InsertData.DataTableReader>());
         }
 
         [Test]
         public void CanCreateDataRecordReader()
         {
-            var dataRecords = new IDataRecord[0];
+            var dataRecords = Array.Empty<IDataRecord>();
             var reader = InsertDataReaderFactory.Instance.CreateReader(dataRecords);
-            Assert.IsInstanceOf<DataRecordReader>(reader);
+            Assert.That(reader, Is.InstanceOf<DataRecordReader>());
         }
 
         [Test]
         public void CanCreateObjectReader()
         {
-            var entities = new TestEntity[0];
+            var entities = Array.Empty<TestEntity>();
             var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
-            Assert.IsInstanceOf<ObjectReader>(reader);
+            Assert.That(reader, Is.InstanceOf<ObjectReader>());
         }
 
         [Test]
         public void CanCreateObjectReaderForStruct()
         {
-            var entities = new TestStruct[0];
+            var entities = Array.Empty<TestStruct>();
             var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
-            Assert.IsInstanceOf<ObjectReader>(reader);
+            Assert.That(reader, Is.InstanceOf<ObjectReader>());
         }
 
         [Test]
@@ -157,7 +160,7 @@ namespace ClosedXML.Tests.Excel.InsertData
                 "123",
             });
             var reader = InsertDataReaderFactory.Instance.CreateReader(entities);
-            Assert.IsInstanceOf<UntypedObjectReader>(reader);
+            Assert.That(reader, Is.InstanceOf<UntypedObjectReader>());
         }
 
         private class TestEntity { }

--- a/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Tests.Excel.InsertData
             var factory = InsertDataReaderFactory.Instance;
 
             Assert.IsNotNull(factory);
-            Assert.AreSame(factory, InsertDataReaderFactory.Instance);
+            Assert.That(InsertDataReaderFactory.Instance, Is.SameAs(factory));
         }
 
         [TestCaseSource(nameof(SimpleSources))]

--- a/ClosedXML.Tests/Excel/InsertData/ObjectReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/ObjectReaderTests.cs
@@ -126,7 +126,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(ObjectWithAttributes);
-            Assert.AreEqual(2, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -138,15 +138,18 @@ namespace ClosedXML.Tests.Excel.InsertData
             var firstRecord = result.First().ToArray();
             var lastRecord = result.Last().ToArray();
 
-            Assert.AreEqual("Value 2", firstRecord[0]);
-            Assert.AreEqual("Value 1", firstRecord[1]);
-            Assert.AreEqual(4, firstRecord[2]);
-            Assert.AreEqual(3, firstRecord[3]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstRecord[0], Is.EqualTo("Value 2"));
+                Assert.That(firstRecord[1], Is.EqualTo("Value 1"));
+                Assert.That(firstRecord[2], Is.EqualTo(4));
+                Assert.That(firstRecord[3], Is.EqualTo(3));
 
-            Assert.AreEqual("Value 6", lastRecord[0]);
-            Assert.AreEqual("Value 5", lastRecord[1]);
-            Assert.AreEqual(8, lastRecord[2]);
-            Assert.AreEqual(7, lastRecord[3]);
+                Assert.That(lastRecord[0], Is.EqualTo("Value 6"));
+                Assert.That(lastRecord[1], Is.EqualTo("Value 5"));
+                Assert.That(lastRecord[2], Is.EqualTo(8));
+                Assert.That(lastRecord[3], Is.EqualTo(7));
+            });
         }
 
         [Test]
@@ -158,13 +161,16 @@ namespace ClosedXML.Tests.Excel.InsertData
             var firstRecord = result.First().ToArray();
             var lastRecord = result.Last().ToArray();
 
-            Assert.AreEqual(1, firstRecord[0]);
-            Assert.AreEqual(2, firstRecord[1]);
-            Assert.AreEqual(3, firstRecord[2]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstRecord[0], Is.EqualTo(1));
+                Assert.That(firstRecord[1], Is.EqualTo(2));
+                Assert.That(firstRecord[2], Is.EqualTo(3));
 
-            Assert.AreEqual(0, lastRecord[0]);
-            Assert.AreEqual(0, lastRecord[1]);
-            Assert.AreEqual(Blank.Value, lastRecord[2]);
+                Assert.That(lastRecord[0], Is.EqualTo(0));
+                Assert.That(lastRecord[1], Is.EqualTo(0));
+                Assert.That(lastRecord[2], Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
@@ -176,13 +182,16 @@ namespace ClosedXML.Tests.Excel.InsertData
             var firstRecord = result.First().ToArray();
             var lastRecord = result.Last().ToArray();
 
-            Assert.AreEqual(1, firstRecord[0]);
-            Assert.AreEqual(2, firstRecord[1]);
-            Assert.AreEqual(3, firstRecord[2]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstRecord[0], Is.EqualTo(1));
+                Assert.That(firstRecord[1], Is.EqualTo(2));
+                Assert.That(firstRecord[2], Is.EqualTo(3));
 
-            Assert.AreEqual(Blank.Value, lastRecord[0]);
-            Assert.AreEqual(Blank.Value, lastRecord[1]);
-            Assert.AreEqual(Blank.Value, lastRecord[2]);
+                Assert.That(lastRecord[0], Is.EqualTo(Blank.Value));
+                Assert.That(lastRecord[1], Is.EqualTo(Blank.Value));
+                Assert.That(lastRecord[2], Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
@@ -191,8 +200,11 @@ namespace ClosedXML.Tests.Excel.InsertData
             var data = new[] { new TestClassWithIndexer() };
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 
-            Assert.AreEqual(1, reader.GetPropertiesCount());
-            Assert.AreEqual(nameof(TestClassWithIndexer.Value), reader.GetPropertyName(0));
+            Assert.Multiple(() =>
+            {
+                Assert.That(reader.GetPropertiesCount(), Is.EqualTo(1));
+                Assert.That(reader.GetPropertyName(0), Is.EqualTo(nameof(TestClassWithIndexer.Value)));
+            });
         }
 
         private record TestClassWithIndexer

--- a/ClosedXML.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/SimpleNullableTypeReaderTests.cs
@@ -34,14 +34,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetPropertiesCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(1, reader.GetPropertiesCount());
+            Assert.That(reader.GetPropertiesCount(), Is.EqualTo(1));
         }
 
         [Test]
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(3));
         }
 
         [Test]
@@ -50,8 +50,11 @@ namespace ClosedXML.Tests.Excel.InsertData
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
             var result = reader.GetRecords();
 
-            Assert.AreEqual(1, result.First().Single());
-            Assert.AreEqual(Blank.Value, result.Last().Single());
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.First().Single(), Is.EqualTo(1));
+                Assert.That(result.Last().Single(), Is.EqualTo(Blank.Value));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/SimpleTypeReaderTests.cs
@@ -34,14 +34,14 @@ namespace ClosedXML.Tests.Excel.InsertData
         public void CanGetPropertiesCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(1, reader.GetPropertiesCount());
+            Assert.That(reader.GetPropertiesCount(), Is.EqualTo(1));
         }
 
         [Test]
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(3, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(3));
         }
 
         [Test]
@@ -50,8 +50,11 @@ namespace ClosedXML.Tests.Excel.InsertData
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
             var result = reader.GetRecords();
 
-            Assert.AreEqual(1, result.First().Single());
-            Assert.AreEqual(3, result.Last().Single());
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.First().Single(), Is.EqualTo(1));
+                Assert.That(result.Last().Single(), Is.EqualTo(3));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/UntypedObjectReaderTests.cs
@@ -40,21 +40,21 @@ namespace ClosedXML.Tests.Excel.InsertData
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
             var actualPropertyName = reader.GetPropertyName(propertyIndex);
-            Assert.AreEqual(expectedPropertyName, actualPropertyName);
+            Assert.That(actualPropertyName, Is.EqualTo(expectedPropertyName));
         }
 
         [Test]
         public void CanGetPropertiesCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(4, reader.GetPropertiesCount());
+            Assert.That(reader.GetPropertiesCount(), Is.EqualTo(4));
         }
 
         [Test]
         public void CanGetRecordsCount()
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(_data);
-            Assert.AreEqual(9, reader.GetRecords().Count());
+            Assert.That(reader.GetRecords().Count(), Is.EqualTo(9));
         }
 
         [Test]
@@ -64,15 +64,18 @@ namespace ClosedXML.Tests.Excel.InsertData
 
             var result = reader.GetRecords().ToArray();
 
-            Assert.AreEqual(new XLCellValue[] { Blank.Value }, result[0]);
-            Assert.AreEqual(new XLCellValue[] { "Value 2", "Value 1", 4, 3 }, result[1]);
-            Assert.AreEqual(new XLCellValue[] { Blank.Value }, result[2]);
-            Assert.AreEqual(new XLCellValue[] { Blank.Value }, result[3]);
-            Assert.AreEqual(new XLCellValue[] { Blank.Value }, result[4]);
-            Assert.AreEqual(new XLCellValue[] { 1, 2, 3 }, result[5]);
-            Assert.AreEqual(new XLCellValue[] { 4, 5, 6, 7 }, result[6]);
-            Assert.AreEqual(new XLCellValue[] { "Separator" }, result[7]);
-            Assert.AreEqual(new XLCellValue[] { "Value 9", "Value 10" }, result[8]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0], Is.EqualTo(new XLCellValue[] { Blank.Value }));
+                Assert.That(result[1], Is.EqualTo(new XLCellValue[] { "Value 2", "Value 1", 4, 3 }));
+                Assert.That(result[2], Is.EqualTo(new XLCellValue[] { Blank.Value }));
+                Assert.That(result[3], Is.EqualTo(new XLCellValue[] { Blank.Value }));
+                Assert.That(result[4], Is.EqualTo(new XLCellValue[] { Blank.Value }));
+                Assert.That(result[5], Is.EqualTo(new XLCellValue[] { 1, 2, 3 }));
+                Assert.That(result[6], Is.EqualTo(new XLCellValue[] { 4, 5, 6, 7 }));
+                Assert.That(result[7], Is.EqualTo(new XLCellValue[] { "Separator" }));
+                Assert.That(result[8], Is.EqualTo(new XLCellValue[] { "Value 9", "Value 10" }));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
@@ -744,7 +744,7 @@ namespace ClosedXML.Tests.Excel
                 // Third sheet doesn't have r:id and it contains pivot table that is not loaded.
                 var ptSheet = wb.Worksheet("Pivot Sheet without relId");
                 Assert.That(ptSheet.Cell("A1").Value, Is.EqualTo(Blank.Value));
-                Assert.False(ptSheet.PivotTables.Any());
+                Assert.That(ptSheet.PivotTables.Any(), Is.False);
             }, @"TryToLoad\SheetsWithoutRelId.xlsx");
         }
 

--- a/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
@@ -80,50 +80,55 @@ namespace ClosedXML.Tests.Excel
             // Assert
             var ws = wb.Worksheet("UI Sheet");
             var B2 = ws.Cell("B2");
-            Assert.AreEqual(XLAllowedValues.List, B2.GetDataValidation().AllowedValues);
-            Assert.AreEqual("$E$1:$E$4", B2.GetDataValidation().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(B2.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                Assert.That(B2.GetDataValidation().Value, Is.EqualTo("$E$1:$E$4"));
+            });
             var A2 = ws.Cell("A2");
-            Assert.AreEqual(XLAllowedValues.List, A2.GetDataValidation().AllowedValues);
-            Assert.AreEqual("ValuesSheet!$A$1:$A$4", A2.GetDataValidation().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(A2.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                Assert.That(A2.GetDataValidation().Value, Is.EqualTo("ValuesSheet!$A$1:$A$4"));
+            });
         }
 
         [Test]
         public void CanLoadAndManipulateFileWithEmptyTable()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyTable.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                var table = ws.Tables.First();
-                table.DataRange.InsertRowsBelow(5);
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyTable.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            var table = ws.Tables.First();
+            table.DataRange.InsertRowsBelow(5);
         }
 
         [Test]
         public void CanLoadDate1904SystemCorrectly()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\Date1904System.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\Date1904System.xlsx"));
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var wb = new XLWorkbook(stream))
+                var ws = wb.Worksheets.First();
+                var c = ws.Cell("A2");
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var c = ws.Cell("A2");
-                    Assert.AreEqual(XLDataType.DateTime, c.DataType);
-                    Assert.AreEqual(new DateTime(2017, 10, 27, 21, 0, 0), c.GetDateTime());
-                    wb.SaveAs(ms);
-                }
+                    Assert.That(c.DataType, Is.EqualTo(XLDataType.DateTime));
+                    Assert.That(c.GetDateTime(), Is.EqualTo(new DateTime(2017, 10, 27, 21, 0, 0)));
+                });
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    var c = ws.Cell("A2");
-                    Assert.AreEqual(XLDataType.DateTime, c.DataType);
-                    Assert.AreEqual(new DateTime(2017, 10, 27, 21, 0, 0), c.GetDateTime());
-                    wb.SaveAs(ms);
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                var c = ws.Cell("A2");
+                Assert.That(c.DataType, Is.EqualTo(XLDataType.DateTime));
+                Assert.That(c.GetDateTime(), Is.EqualTo(new DateTime(2017, 10, 27, 21, 0, 0)));
+                wb.SaveAs(ms);
             }
         }
 
@@ -133,87 +138,75 @@ namespace ClosedXML.Tests.Excel
             // This file's workbook.xml contains:
             // <x:sheet name="Data" sheetId="13" r:id="rId1" />
             // and the mismatch between the sheetId and r:id can create problems.
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FileWithMismatchSheetIdAndRelId.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                using (var ms = new MemoryStream())
-                {
-                    wb.SaveAs(ms, true);
-                }
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FileWithMismatchSheetIdAndRelId.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
         }
 
         [Test]
         public void CanLoadBasicPivotTable()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LoadPivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet("PivotTable1");
-                var pt = ws.PivotTable("PivotTable1");
-                Assert.AreEqual("PivotTable1", pt.Name);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LoadPivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("PivotTable1");
+            var pt = ws.PivotTable("PivotTable1");
+            Assert.That(pt.Name, Is.EqualTo("PivotTable1"));
 
-                Assert.AreEqual(1, pt.RowLabels.Count());
-                Assert.AreEqual("Name", pt.RowLabels.Single().SourceName);
+            Assert.That(pt.RowLabels.Count(), Is.EqualTo(1));
+            Assert.That(pt.RowLabels.Single().SourceName, Is.EqualTo("Name"));
 
-                Assert.AreEqual(1, pt.ColumnLabels.Count());
-                Assert.AreEqual("Month", pt.ColumnLabels.Single().SourceName);
+            Assert.That(pt.ColumnLabels.Count(), Is.EqualTo(1));
+            Assert.That(pt.ColumnLabels.Single().SourceName, Is.EqualTo("Month"));
 
-                var pv = pt.Values.Single();
-                Assert.AreEqual("Sum of NumberOfOrders", pv.CustomName);
-                Assert.AreEqual("NumberOfOrders", pv.SourceName);
-            }
+            var pv = pt.Values.Single();
+            Assert.That(pv.CustomName, Is.EqualTo("Sum of NumberOfOrders"));
+            Assert.That(pv.SourceName, Is.EqualTo("NumberOfOrders"));
         }
 
         [Test]
         public void CanLoadOrderedPivotTable()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LoadPivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet("OrderedPivotTable");
-                var pt = ws.PivotTable("OrderedPivotTable");
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LoadPivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("OrderedPivotTable");
+            var pt = ws.PivotTable("OrderedPivotTable");
 
-                Assert.AreEqual(XLPivotSortType.Ascending, pt.RowLabels.Single().SortType);
-                Assert.AreEqual(XLPivotSortType.Descending, pt.ColumnLabels.Single().SortType);
-            }
+            Assert.That(pt.RowLabels.Single().SortType, Is.EqualTo(XLPivotSortType.Ascending));
+            Assert.That(pt.ColumnLabels.Single().SortType, Is.EqualTo(XLPivotSortType.Descending));
         }
 
         [Test]
         public void CanLoadPivotTableSubtotals()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LoadPivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LoadPivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("PivotTableSubtotals");
+            var pt = ws.PivotTable("PivotTableSubtotals");
+
+            var subtotals = pt.RowLabels.Get("Group").Subtotals.ToArray();
+
+            Assert.That(subtotals, Is.EquivalentTo(new[]
             {
-                var ws = wb.Worksheet("PivotTableSubtotals");
-                var pt = ws.PivotTable("PivotTableSubtotals");
-
-                var subtotals = pt.RowLabels.Get("Group").Subtotals.ToArray();
-
-                CollectionAssert.AreEquivalent(new[]
-                {
-                    XLSubtotalFunction.Average,
-                    XLSubtotalFunction.Count,
-                    XLSubtotalFunction.Sum,
-                }, subtotals);
-            }
+                XLSubtotalFunction.Average,
+                XLSubtotalFunction.Count,
+                XLSubtotalFunction.Sum,
+            }));
         }
 
         [Test]
         [Ignore("PT styles will be fixed in a different PR")]
         public void CanLoadPivotTableWithBorder()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\PivotTableWithBorder.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var pt = wb.Worksheet(1).PivotTables.PivotTable("PivotTable1");
-                var border = pt.RowLabels.Single().StyleFormats.DataValuesFormat.Style.Border;
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\PivotTableWithBorder.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var pt = wb.Worksheet(1).PivotTables.PivotTable("PivotTable1");
+            var border = pt.RowLabels.Single().StyleFormats.DataValuesFormat.Style.Border;
 
-                Assert.AreEqual(XLBorderStyleValues.Thin, border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, border.BottomBorder);
-            }
+            Assert.That(border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+            Assert.That(border.TopBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+            Assert.That(border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+            Assert.That(border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Thin));
         }
 
         /// <summary>
@@ -225,14 +218,10 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void CanSaveFileWithDefaultStyleNameNotInEnglish()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FileWithDefaultStyleNameNotInEnglish.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                using (var ms = new MemoryStream())
-                {
-                    wb.SaveAs(ms, true);
-                }
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FileWithDefaultStyleNameNotInEnglish.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
         }
 
         /// <summary>
@@ -244,48 +233,42 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void CanLoadLibreOfficeFileWithDates()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LibreOfficeFileWithDates.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LibreOfficeFileWithDates.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            foreach (var cell in ws.CellsUsed())
             {
-                var ws = wb.Worksheets.First();
-                foreach (var cell in ws.CellsUsed())
-                {
-                    Assert.AreEqual(XLDataType.DateTime, cell.DataType);
-                }
+                Assert.That(cell.DataType, Is.EqualTo(XLDataType.DateTime));
             }
         }
 
         [Test]
         public void CanLoadFileWithImagesWithCorrectAnchorTypes()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                Assert.AreEqual(2, ws.Pictures.Count);
-                Assert.AreEqual(XLPicturePlacement.FreeFloating, ws.Pictures.First().Placement);
-                Assert.AreEqual(XLPicturePlacement.Move, ws.Pictures.Skip(1).First().Placement);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            Assert.That(ws.Pictures, Has.Count.EqualTo(2));
+            Assert.That(ws.Pictures.First().Placement, Is.EqualTo(XLPicturePlacement.FreeFloating));
+            Assert.That(ws.Pictures.Skip(1).First().Placement, Is.EqualTo(XLPicturePlacement.Move));
 
-                var ws2 = wb.Worksheets.Skip(1).First();
-                Assert.AreEqual(1, ws2.Pictures.Count);
-                Assert.AreEqual(XLPicturePlacement.MoveAndSize, ws2.Pictures.First().Placement);
-            }
+            var ws2 = wb.Worksheets.Skip(1).First();
+            Assert.That(ws2.Pictures, Has.Count.EqualTo(1));
+            Assert.That(ws2.Pictures.First().Placement, Is.EqualTo(XLPicturePlacement.MoveAndSize));
         }
 
         [Test]
         public void CanLoadFileWithImagesWithCorrectImageType()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageFormats.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                Assert.AreEqual(1, ws.Pictures.Count);
-                Assert.AreEqual(XLPictureFormat.Jpeg, ws.Pictures.First().Format);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageFormats.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            Assert.That(ws.Pictures, Has.Count.EqualTo(1));
+            Assert.That(ws.Pictures.First().Format, Is.EqualTo(XLPictureFormat.Jpeg));
 
-                var ws2 = wb.Worksheets.Skip(1).First();
-                Assert.AreEqual(1, ws2.Pictures.Count);
-                Assert.AreEqual(XLPictureFormat.Png, ws2.Pictures.First().Format);
-            }
+            var ws2 = wb.Worksheets.Skip(1).First();
+            Assert.That(ws2.Pictures, Has.Count.EqualTo(1));
+            Assert.That(ws2.Pictures.First().Format, Is.EqualTo(XLPictureFormat.Png));
         }
 
         [Test]
@@ -294,40 +277,36 @@ namespace ClosedXML.Tests.Excel
             // This file was produced by Excel. It contains 3 images, but the latter 2 were copied from the first.
             // There is actually only 1 embedded image if you inspect the file's internals.
             // Additionally, Excel saves all image anchors as TwoCellAnchor, but uses the EditAs attribute to distinguish the types
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\ExcelProducedWorkbookWithImages.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                Assert.AreEqual(3, ws.Pictures.Count);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\ExcelProducedWorkbookWithImages.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            Assert.That(ws.Pictures, Has.Count.EqualTo(3));
 
-                Assert.AreEqual(XLPicturePlacement.MoveAndSize, ws.Picture("Picture 1").Placement);
-                Assert.AreEqual(XLPicturePlacement.Move, ws.Picture("Picture 2").Placement);
-                Assert.AreEqual(XLPicturePlacement.FreeFloating, ws.Picture("Picture 3").Placement);
+            Assert.That(ws.Picture("Picture 1").Placement, Is.EqualTo(XLPicturePlacement.MoveAndSize));
+            Assert.That(ws.Picture("Picture 2").Placement, Is.EqualTo(XLPicturePlacement.Move));
+            Assert.That(ws.Picture("Picture 3").Placement, Is.EqualTo(XLPicturePlacement.FreeFloating));
 
-                using (var ms = new MemoryStream())
-                    wb.SaveAs(ms, true);
-            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
         }
 
         [Test]
         public void CanLoadFromTemplate()
         {
-            using (var tf1 = new TemporaryFile())
-            using (var tf2 = new TemporaryFile())
+            using var tf1 = new TemporaryFile();
+            using var tf2 = new TemporaryFile();
+            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\AllShapes.xlsx")))
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\AllShapes.xlsx")))
-                using (var wb = new XLWorkbook(stream))
-                {
-                    // Save as temporary file
-                    wb.SaveAs(tf1.Path);
-                }
-
-                var workbook = XLWorkbook.OpenFromTemplate(tf1.Path);
-                Assert.True(workbook.Worksheets.Any());
-                Assert.Throws<InvalidOperationException>(() => workbook.Save());
-
-                workbook.SaveAs(tf2.Path);
+                // Save as temporary file
+                wb.SaveAs(tf1.Path);
             }
+
+            var workbook = XLWorkbook.OpenFromTemplate(tf1.Path);
+            Assert.That(workbook.Worksheets.Any(), Is.True);
+            Assert.Throws<InvalidOperationException>(() => workbook.Save());
+
+            workbook.SaveAs(tf2.Path);
         }
 
         /// <summary>
@@ -339,41 +318,33 @@ namespace ClosedXML.Tests.Excel
             string title = "";
             TestDelegate openWorkbook = () =>
             {
-                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EscapedApostrophe.xlsx")))
-                using (var wb = new XLWorkbook(stream))
-                {
-                    var ws = wb.Worksheets.First();
-                    title = ws.Name;
-                }
+                using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EscapedApostrophe.xlsx"));
+                using var wb = new XLWorkbook(stream);
+                var ws = wb.Worksheets.First();
+                title = ws.Name;
             };
 
             Assert.DoesNotThrow(openWorkbook);
-            Assert.AreEqual("L'E", title);
+            Assert.That(title, Is.EqualTo("L'E"));
         }
 
         [Test]
         public void CanRoundTripSheetProtectionForObjects()
         {
-            using (var book = new XLWorkbook())
-            {
-                var sheet = book.AddWorksheet("TestSheet");
-                sheet.Protect()
-                    .AllowElement(XLSheetProtectionElements.EditObjects | XLSheetProtectionElements.EditScenarios);
+            using var book = new XLWorkbook();
+            var sheet = book.AddWorksheet("TestSheet");
+            sheet.Protect()
+                .AllowElement(XLSheetProtectionElements.EditObjects | XLSheetProtectionElements.EditScenarios);
 
-                Assert.AreEqual(XLSheetProtectionElements.SelectEverything | XLSheetProtectionElements.EditObjects | XLSheetProtectionElements.EditScenarios, sheet.Protection.AllowedElements);
+            Assert.That(sheet.Protection.AllowedElements, Is.EqualTo(XLSheetProtectionElements.SelectEverything | XLSheetProtectionElements.EditObjects | XLSheetProtectionElements.EditScenarios));
 
-                using (var xlStream = new MemoryStream())
-                {
-                    book.SaveAs(xlStream);
+            using var xlStream = new MemoryStream();
+            book.SaveAs(xlStream);
 
-                    using (var persistedBook = new XLWorkbook(xlStream))
-                    {
-                        var persistedSheet = persistedBook.Worksheets.Worksheet(1);
+            using var persistedBook = new XLWorkbook(xlStream);
+            var persistedSheet = persistedBook.Worksheets.Worksheet(1);
 
-                        Assert.AreEqual(sheet.Protection.AllowedElements, persistedSheet.Protection.AllowedElements);
-                    }
-                }
-            }
+            Assert.That(persistedSheet.Protection.AllowedElements, Is.EqualTo(sheet.Protection.AllowedElements));
         }
 
         [Test]
@@ -386,77 +357,69 @@ namespace ClosedXML.Tests.Excel
         [TestCase("DATE(2018,1,28)", 43128)]
         public void LoadFormulaCachedValue(string formula, object expectedCachedValue)
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (XLWorkbook book1 = new XLWorkbook())
             {
-                using (XLWorkbook book1 = new XLWorkbook())
-                {
-                    var sheet = book1.AddWorksheet("sheet1");
-                    sheet.Cell("A1").Value = 123;
-                    sheet.Cell("A2").FormulaA1 = formula;
-                    var options = new SaveOptions { EvaluateFormulasBeforeSaving = true };
+                var sheet = book1.AddWorksheet("sheet1");
+                sheet.Cell("A1").Value = 123;
+                sheet.Cell("A2").FormulaA1 = formula;
+                var options = new SaveOptions { EvaluateFormulasBeforeSaving = true };
 
-                    book1.SaveAs(ms, options);
-                }
-                ms.Position = 0;
+                book1.SaveAs(ms, options);
+            }
+            ms.Position = 0;
 
-                using (XLWorkbook book2 = new XLWorkbook(ms))
-                {
-                    var ws = book2.Worksheet(1);
-                    Assert.IsFalse(ws.Cell("A2").NeedsRecalculation);
-                    Assert.AreEqual(expectedCachedValue, ws.Cell("A2").CachedValue);
-                }
+            using (XLWorkbook book2 = new XLWorkbook(ms))
+            {
+                var ws = book2.Worksheet(1);
+                Assert.That(ws.Cell("A2").NeedsRecalculation, Is.False);
+                Assert.That(ws.Cell("A2").CachedValue, Is.EqualTo(expectedCachedValue));
             }
         }
 
         [Test]
         public void LoadingOptions()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\Formulas.xlsx")))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\Formulas.xlsx"));
+            Assert.DoesNotThrow(() =>
             {
-                Assert.DoesNotThrow(() =>
-                {
-                    // The value in the file is blank and kept.
-                    using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = false });
-                    Assert.AreEqual(Blank.Value, wb.Worksheets.Single().Cell("C2").CachedValue);
-                });
+                // The value in the file is blank and kept.
+                using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = false });
+                Assert.That(wb.Worksheets.Single().Cell("C2").CachedValue, Is.EqualTo(Blank.Value));
+            });
 
-                Assert.DoesNotThrow(() =>
-                {
-                    // The value in the file is blank, but recalculation sets it to correct 3.
-                    using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = true });
-                    Assert.AreEqual(3, wb.Worksheets.Single().Cell("C2").CachedValue);
-                });
+            Assert.DoesNotThrow(() =>
+            {
+                // The value in the file is blank, but recalculation sets it to correct 3.
+                using var wb = new XLWorkbook(stream, new LoadOptions { RecalculateAllFormulas = true });
+                Assert.That(wb.Worksheets.Single().Cell("C2").CachedValue, Is.EqualTo(3));
+            });
 
-                Assert.AreEqual(30, new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiX);
-                Assert.AreEqual(14, new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiY);
-            }
+            Assert.That(new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiX, Is.EqualTo(30));
+            Assert.That(new XLWorkbook(stream, new LoadOptions { Dpi = new Point(30, 14) }).DpiY, Is.EqualTo(14));
         }
 
         [Test]
         public void CanLoadWorksheetStyle()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\BaseColumnWidth.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\BaseColumnWidth.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
 
-                Assert.AreEqual(8, ws.Style.Font.FontSize);
-                Assert.AreEqual("Arial", ws.Style.Font.FontName);
-                Assert.AreEqual(8, ws.Cell("A1").Style.Font.FontSize);
-                Assert.AreEqual("Arial", ws.Cell("A1").Style.Font.FontName);
-            }
+            Assert.That(ws.Style.Font.FontSize, Is.EqualTo(8));
+            Assert.That(ws.Style.Font.FontName, Is.EqualTo("Arial"));
+            Assert.That(ws.Cell("A1").Style.Font.FontSize, Is.EqualTo(8));
+            Assert.That(ws.Cell("A1").Style.Font.FontName, Is.EqualTo("Arial"));
         }
 
         [Test]
         public void CanCorrectLoadWorkbookCellWithStringDataType()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CellWithStringDataType.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var cellToCheck = wb.Worksheet(1).Cell("B2");
-                Assert.AreEqual(XLDataType.Text, cellToCheck.DataType);
-                Assert.AreEqual("String with String Data type", cellToCheck.Value);
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\CellWithStringDataType.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var cellToCheck = wb.Worksheet(1).Cell("B2");
+            Assert.That(cellToCheck.DataType, Is.EqualTo(XLDataType.Text));
+            Assert.That(cellToCheck.Value, Is.EqualTo("String with String Data type"));
         }
 
         [Test]
@@ -468,8 +431,8 @@ namespace ClosedXML.Tests.Excel
                 for (int row = 2; row < 18; row++)
                 {
                     var cellToCheck = wb.Worksheet(1).Cell(row, 2);
-                    Assert.AreEqual(XLDataType.DateTime, cellToCheck.DataType, $"Cell B{row} has incorrect DataType");
-                    Assert.AreEqual(expected, cellToCheck.Value.ToString(CultureInfo.InvariantCulture), $"Cell B{row} value differs");
+                    Assert.That(cellToCheck.DataType, Is.EqualTo(XLDataType.DateTime), $"Cell B{row} has incorrect DataType");
+                    Assert.That(cellToCheck.Value.ToString(CultureInfo.InvariantCulture), Is.EqualTo(expected), $"Cell B{row} value differs");
                 }
             }, @"TryToLoad\CellsWithDateTimeDataTypeOrFormatting.xlsx");
         }
@@ -483,8 +446,8 @@ namespace ClosedXML.Tests.Excel
                 for (int i = 0, row = 2; i < expected.Length; i++, row++)
                 {
                     var cellToCheck = wb.Worksheet(1).Cell(row, 2);
-                    Assert.AreEqual(XLDataType.TimeSpan, cellToCheck.DataType, $"Cell B{row} has incorrect DataType");
-                    Assert.AreEqual(expected[i], cellToCheck.Value.ToString(CultureInfo.InvariantCulture), $"Cell B{row} value differs");
+                    Assert.That(cellToCheck.DataType, Is.EqualTo(XLDataType.TimeSpan), $"Cell B{row} has incorrect DataType");
+                    Assert.That(cellToCheck.Value.ToString(CultureInfo.InvariantCulture), Is.EqualTo(expected[i]), $"Cell B{row} value differs");
                 }
             }, @"TryToLoad\CellsWithTimeSpanDataTypeOrFormatting.xlsx");
         }
@@ -496,9 +459,9 @@ namespace ClosedXML.Tests.Excel
             {
                 var ws = wb.Worksheet(1);
 
-                Assert.AreEqual("21 January 2019", ws.Cell(1, 1).GetFormattedString());
-                Assert.AreEqual("21-Jan-19", ws.Cell(2, 1).GetFormattedString());
-                Assert.AreEqual("Monday, 21 January 2019", ws.Cell(3, 1).GetFormattedString());
+                Assert.That(ws.Cell(1, 1).GetFormattedString(), Is.EqualTo("21 January 2019"));
+                Assert.That(ws.Cell(2, 1).GetFormattedString(), Is.EqualTo("21-Jan-19"));
+                Assert.That(ws.Cell(3, 1).GetFormattedString(), Is.EqualTo("Monday, 21 January 2019"));
                 Assert.AreEqual("21 Jan 2019", ws.Cell(4, 1).GetFormattedString());
             }, @"TryToLoad\CellsWithDateTimeWithLocalePrefix.xlsx");
         }
@@ -511,8 +474,8 @@ namespace ClosedXML.Tests.Excel
             {
                 var defaultColumnWidth = wb.ColumnWidth;
                 var pixelWidth = XLHelper.NoCToPixels(defaultColumnWidth, wb.Style.Font, wb);
-                Assert.AreEqual(8.43, defaultColumnWidth, XLHelper.Epsilon);
-                Assert.AreEqual(64, pixelWidth);
+                Assert.That(defaultColumnWidth, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
+                Assert.That(pixelWidth, Is.EqualTo(64));
             }
 
             using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\DefaultColumnWidth.xlsx")))
@@ -520,8 +483,8 @@ namespace ClosedXML.Tests.Excel
             {
                 var defaultColumnWidth = wb.ColumnWidth;
                 var pixelWidth = XLHelper.NoCToPixels(defaultColumnWidth, wb.Style.Font, wb);
-                Assert.AreEqual(8.5, defaultColumnWidth, XLHelper.Epsilon);
-                Assert.AreEqual(56, pixelWidth);
+                Assert.That(defaultColumnWidth, Is.EqualTo(8.5).Within(XLHelper.Epsilon));
+                Assert.That(pixelWidth, Is.EqualTo(56));
             }
         }
 
@@ -533,8 +496,8 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook(stream))
             {
                 var ws = wb.Worksheet(1);
-                Assert.AreEqual(8.43, ws.ColumnWidth, XLHelper.Epsilon);
-                Assert.AreEqual(8.43, ws.Column(1).Width, XLHelper.Epsilon);
+                Assert.That(ws.ColumnWidth, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
+                Assert.That(ws.Column(1).Width, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
             }
 
             // worksheet has base column width.
@@ -542,8 +505,8 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook(stream))
             {
                 var ws = wb.Worksheet(1);
-                Assert.AreEqual(11.17, ws.ColumnWidth, XLHelper.Epsilon);
-                Assert.AreEqual(11.17, ws.Column(1).Width, XLHelper.Epsilon);
+                Assert.That(ws.ColumnWidth, Is.EqualTo(11.17).Within(XLHelper.Epsilon));
+                Assert.That(ws.Column(1).Width, Is.EqualTo(11.17).Within(XLHelper.Epsilon));
             }
         }
 
@@ -551,119 +514,105 @@ namespace ClosedXML.Tests.Excel
         public void CanCorrectLoadWorksheetDefaultColumnWidth()
         {
             // worksheet has default column width.
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SheetDefaultColumnWidth.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
-                double pixelWidth = XLHelper.NoCToPixels(ws.Column(1).Width, ws.Style.Font, wb);
-                Assert.AreEqual(19.75, ws.ColumnWidth, XLHelper.Epsilon);
-                Assert.AreEqual(163, pixelWidth, XLHelper.Epsilon);
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SheetDefaultColumnWidth.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
+            double pixelWidth = XLHelper.NoCToPixels(ws.Column(1).Width, ws.Style.Font, wb);
+            Assert.That(ws.ColumnWidth, Is.EqualTo(19.75).Within(XLHelper.Epsilon));
+            Assert.That(pixelWidth, Is.EqualTo(163).Within(XLHelper.Epsilon));
         }
 
         [Test]
         public void CanLoadFileWithInvalidSelectedRanges()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\SelectedRanges\InvalidSelectedRange.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\SelectedRanges\InvalidSelectedRange.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
 
-                Assert.AreEqual(2, ws.SelectedRanges.Count);
-                Assert.AreEqual("B2:B2", ws.SelectedRanges.First().RangeAddress.ToString());
-                Assert.AreEqual("B2:C2", ws.SelectedRanges.Last().RangeAddress.ToString());
-            }
+            Assert.That(ws.SelectedRanges, Has.Count.EqualTo(2));
+            Assert.That(ws.SelectedRanges.First().RangeAddress.ToString(), Is.EqualTo("B2:B2"));
+            Assert.AreEqual("B2:C2", ws.SelectedRanges.Last().RangeAddress.ToString());
         }
 
         [Test]
         public void CanLoadCellsWithoutReferencesCorrectly()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LO\xlsx\row-index-1-based.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\LO\xlsx\row-index-1-based.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
+
+            Assert.That(ws.Name, Is.EqualTo("Page 1"));
+
+            var expected = new Dictionary<string, XLCellValue>
             {
-                var ws = wb.Worksheet(1);
+                ["A1"] = "Action Plan.Name",
+                ["B1"] = "Action Plan.Description",
+                ["A2"] = "Jerry",
+                ["B2"] = "This is a longer Text.\nSecond line.\nThird line.",
+                ["A3"] = Blank.Value,
+                ["B3"] = Blank.Value
+            };
 
-                Assert.AreEqual("Page 1", ws.Name);
-
-                var expected = new Dictionary<string, XLCellValue>
-                {
-                    ["A1"] = "Action Plan.Name",
-                    ["B1"] = "Action Plan.Description",
-                    ["A2"] = "Jerry",
-                    ["B2"] = "This is a longer Text.\nSecond line.\nThird line.",
-                    ["A3"] = Blank.Value,
-                    ["B3"] = Blank.Value
-                };
-
-                foreach (var pair in expected)
-                    Assert.AreEqual(pair.Value, ws.Cell(pair.Key).Value, pair.Key);
-            }
+            foreach (var pair in expected)
+                Assert.That(ws.Cell(pair.Key).Value, Is.EqualTo(pair.Value), pair.Key);
         }
 
         [Test]
         public void CorrectlyLoadThemeColors()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\ThemeColors\inputfile.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\ThemeColors\inputfile.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
 
-                var c = ws.Cell("A1");
-                var themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
-                Assert.AreEqual(XLThemeColor.Accent2, themeColor);
-                Assert.AreEqual("FFED7D31", wb.Theme.ResolveThemeColor(themeColor).Color.ToHex());
+            var c = ws.Cell("A1");
+            var themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
+            Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent2));
+            Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FFED7D31"));
 
-                c = ws.Cell("A2");
-                themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
-                Assert.AreEqual(XLThemeColor.Accent4, themeColor);
-                Assert.AreEqual("FFFFC000", wb.Theme.ResolveThemeColor(themeColor).Color.ToHex());
+            c = ws.Cell("A2");
+            themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
+            Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent4));
+            Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FFFFC000"));
 
-                c = ws.Cell("A3");
-                themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
-                Assert.AreEqual(XLThemeColor.Accent6, themeColor);
-                Assert.AreEqual("FF70AD47", wb.Theme.ResolveThemeColor(themeColor).Color.ToHex());
-            }
+            c = ws.Cell("A3");
+            themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
+            Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent6));
+            Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FF70AD47"));
         }
 
         [Test]
         public void CorrectlyLoadMergedCellsBorder()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\MergedCellsBorder\inputfile.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\MergedCellsBorder\inputfile.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
 
-                var c = ws.Cell("B2");
-                Assert.AreEqual(XLColorType.Theme, c.Style.Border.TopBorderColor.ColorType);
-                Assert.AreEqual(XLThemeColor.Accent1, c.Style.Border.TopBorderColor.ThemeColor);
-                Assert.AreEqual(0.39994506668294322d, c.Style.Border.TopBorderColor.ThemeTint, XLHelper.Epsilon);
-            }
+            var c = ws.Cell("B2");
+            Assert.That(c.Style.Border.TopBorderColor.ColorType, Is.EqualTo(XLColorType.Theme));
+            Assert.That(c.Style.Border.TopBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+            Assert.That(c.Style.Border.TopBorderColor.ThemeTint, Is.EqualTo(0.39994506668294322d).Within(XLHelper.Epsilon));
         }
 
         [Test]
         public void CorrectlyLoadDefaultRowAndColumnStyles()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\RowAndColumnStyles\inputfile.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\RowAndColumnStyles\inputfile.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
 
-                Assert.AreEqual(8, ws.Row(1).Style.Font.FontSize);
-                Assert.AreEqual(8, ws.Row(2).Style.Font.FontSize);
-                Assert.AreEqual(8, ws.Column("A").Style.Font.FontSize);
-            }
+            Assert.That(ws.Row(1).Style.Font.FontSize, Is.EqualTo(8));
+            Assert.That(ws.Row(2).Style.Font.FontSize, Is.EqualTo(8));
+            Assert.That(ws.Column("A").Style.Font.FontSize, Is.EqualTo(8));
         }
 
         [Test]
         public void EmptyNumberFormatIdTreatedAsGeneral()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyNumberFormatId.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet(1);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyNumberFormatId.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet(1);
 
-                Assert.AreEqual(XLPredefinedFormat.General, ws.Cell("A2").Style.NumberFormat.NumberFormatId);
-            }
+            Assert.That(ws.Cell("A2").Style.NumberFormat.NumberFormatId, Is.EqualTo(XLPredefinedFormat.General));
         }
 
         [Test]
@@ -682,45 +631,43 @@ namespace ClosedXML.Tests.Excel
             const string company = "TestCompany";
             const string manager = "TestManager";
 
-            using (var stream = new MemoryStream())
+            using var stream = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var sheet = wb.AddWorksheet("sheet1");
+                var sheet = wb.AddWorksheet("sheet1");
 
-                    wb.Properties.Author = author;
-                    wb.Properties.Title = title;
-                    wb.Properties.Subject = subject;
-                    wb.Properties.Category = category;
-                    wb.Properties.Keywords = keywords;
-                    wb.Properties.Comments = comments;
-                    wb.Properties.Status = status;
-                    wb.Properties.Created = created;
-                    wb.Properties.Modified = modified;
-                    wb.Properties.LastModifiedBy = lastModifiedBy;
-                    wb.Properties.Company = company;
-                    wb.Properties.Manager = manager;
+                wb.Properties.Author = author;
+                wb.Properties.Title = title;
+                wb.Properties.Subject = subject;
+                wb.Properties.Category = category;
+                wb.Properties.Keywords = keywords;
+                wb.Properties.Comments = comments;
+                wb.Properties.Status = status;
+                wb.Properties.Created = created;
+                wb.Properties.Modified = modified;
+                wb.Properties.LastModifiedBy = lastModifiedBy;
+                wb.Properties.Company = company;
+                wb.Properties.Manager = manager;
 
-                    wb.SaveAs(stream, true);
-                }
+                wb.SaveAs(stream, true);
+            }
 
-                stream.Position = 0;
+            stream.Position = 0;
 
-                using (var wb = new XLWorkbook(stream))
-                {
-                    Assert.AreEqual(author, wb.Properties.Author);
-                    Assert.AreEqual(title, wb.Properties.Title);
-                    Assert.AreEqual(subject, wb.Properties.Subject);
-                    Assert.AreEqual(category, wb.Properties.Category);
-                    Assert.AreEqual(keywords, wb.Properties.Keywords);
-                    Assert.AreEqual(comments, wb.Properties.Comments);
-                    Assert.AreEqual(status, wb.Properties.Status);
-                    Assert.AreEqual(created, wb.Properties.Created);
-                    Assert.AreEqual(modified, wb.Properties.Modified);
-                    Assert.AreEqual(lastModifiedBy, wb.Properties.LastModifiedBy);
-                    Assert.AreEqual(company, wb.Properties.Company);
-                    Assert.AreEqual(manager, wb.Properties.Manager);
-                }
+            using (var wb = new XLWorkbook(stream))
+            {
+                Assert.That(wb.Properties.Author, Is.EqualTo(author));
+                Assert.That(wb.Properties.Title, Is.EqualTo(title));
+                Assert.That(wb.Properties.Subject, Is.EqualTo(subject));
+                Assert.That(wb.Properties.Category, Is.EqualTo(category));
+                Assert.That(wb.Properties.Keywords, Is.EqualTo(keywords));
+                Assert.That(wb.Properties.Comments, Is.EqualTo(comments));
+                Assert.That(wb.Properties.Status, Is.EqualTo(status));
+                Assert.That(wb.Properties.Created, Is.EqualTo(created));
+                Assert.That(wb.Properties.Modified, Is.EqualTo(modified));
+                Assert.That(wb.Properties.LastModifiedBy, Is.EqualTo(lastModifiedBy));
+                Assert.That(wb.Properties.Company, Is.EqualTo(company));
+                Assert.That(wb.Properties.Manager, Is.EqualTo(manager));
             }
         }
 
@@ -744,7 +691,7 @@ namespace ClosedXML.Tests.Excel
             TestHelper.LoadAndAssert(wb =>
             {
                 var ws = wb.Worksheets.Single();
-                Assert.AreEqual(XLColor.FromArgb(0xFF000000), ws.Cell("A1").Style.Font.FontColor);
+                Assert.That(ws.Cell("A1").Style.Font.FontColor, Is.EqualTo(XLColor.FromArgb(0xFF000000)));
                 Assert.AreEqual(XLColor.FromArgb(0xFF000FED), ws.Cell("A2").Style.Fill.BackgroundColor);
             }, @"TryToLoad\InvalidColors.xlsx");
         }
@@ -762,10 +709,10 @@ namespace ClosedXML.Tests.Excel
             // the specified name and so does ClosedXML.
             TestHelper.LoadAndAssert(wb =>
             {
-                Assert.AreEqual(3, wb.Worksheets.Count);
+                Assert.That(wb.Worksheets, Has.Count.EqualTo(3));
 
                 // First sheet has r:id, so it keeps content
-                Assert.AreEqual("Sheet1", wb.Worksheet("Sheet1").Cell("A1").Value);
+                Assert.That(wb.Worksheet("Sheet1").Cell("A1").Value, Is.EqualTo("Sheet1"));
 
                 // Second sheet doesn't have r:id, so it is empty after load.
                 Assert.AreEqual(Blank.Value, wb.Worksheet("Sheet without relId").Cell("A1").Value);
@@ -788,7 +735,7 @@ namespace ClosedXML.Tests.Excel
             TestHelper.LoadAndAssert(wb =>
             {
                 // Dialog sheet
-                Assert.AreEqual(1, wb.UnsupportedSheets.Count);
+                Assert.That(wb.UnsupportedSheets, Has.Count.EqualTo(1));
 
                 // Data and pivot sheets
                 Assert.AreEqual(2, wb.Worksheets.Count);

--- a/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
+++ b/ClosedXML.Tests/Excel/Loading/LoadingTests.cs
@@ -372,8 +372,11 @@ namespace ClosedXML.Tests.Excel
             using (XLWorkbook book2 = new XLWorkbook(ms))
             {
                 var ws = book2.Worksheet(1);
-                Assert.That(ws.Cell("A2").NeedsRecalculation, Is.False);
-                Assert.That(ws.Cell("A2").CachedValue, Is.EqualTo(expectedCachedValue));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.Cell("A2").NeedsRecalculation, Is.False);
+                    Assert.That(ws.Cell("A2").CachedValue, Is.EqualTo(expectedCachedValue));
+                });
             }
         }
 
@@ -462,7 +465,7 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(ws.Cell(1, 1).GetFormattedString(), Is.EqualTo("21 January 2019"));
                 Assert.That(ws.Cell(2, 1).GetFormattedString(), Is.EqualTo("21-Jan-19"));
                 Assert.That(ws.Cell(3, 1).GetFormattedString(), Is.EqualTo("Monday, 21 January 2019"));
-                Assert.AreEqual("21 Jan 2019", ws.Cell(4, 1).GetFormattedString());
+                Assert.That(ws.Cell(4, 1).GetFormattedString(), Is.EqualTo("21 Jan 2019"));
             }, @"TryToLoad\CellsWithDateTimeWithLocalePrefix.xlsx");
         }
 
@@ -496,17 +499,23 @@ namespace ClosedXML.Tests.Excel
             using (var wb = new XLWorkbook(stream))
             {
                 var ws = wb.Worksheet(1);
-                Assert.That(ws.ColumnWidth, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
-                Assert.That(ws.Column(1).Width, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.ColumnWidth, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
+                    Assert.That(ws.Column(1).Width, Is.EqualTo(8.43).Within(XLHelper.Epsilon));
+                });
             }
 
-            // worksheet has base column width.
+            // the worksheet has base column width.
             using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\BaseColumnWidth.xlsx")))
             using (var wb = new XLWorkbook(stream))
             {
                 var ws = wb.Worksheet(1);
-                Assert.That(ws.ColumnWidth, Is.EqualTo(11.17).Within(XLHelper.Epsilon));
-                Assert.That(ws.Column(1).Width, Is.EqualTo(11.17).Within(XLHelper.Epsilon));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.ColumnWidth, Is.EqualTo(11.17).Within(XLHelper.Epsilon));
+                    Assert.That(ws.Column(1).Width, Is.EqualTo(11.17).Within(XLHelper.Epsilon));
+                });
             }
         }
 
@@ -531,7 +540,7 @@ namespace ClosedXML.Tests.Excel
 
             Assert.That(ws.SelectedRanges, Has.Count.EqualTo(2));
             Assert.That(ws.SelectedRanges.First().RangeAddress.ToString(), Is.EqualTo("B2:B2"));
-            Assert.AreEqual("B2:C2", ws.SelectedRanges.Last().RangeAddress.ToString());
+            Assert.That(ws.SelectedRanges.Last().RangeAddress.ToString(), Is.EqualTo("B2:C2"));
         }
 
         [Test]
@@ -566,18 +575,27 @@ namespace ClosedXML.Tests.Excel
 
             var c = ws.Cell("A1");
             var themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
-            Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent2));
-            Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FFED7D31"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent2));
+                Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FFED7D31"));
+            });
 
             c = ws.Cell("A2");
             themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
-            Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent4));
-            Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FFFFC000"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent4));
+                Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FFFFC000"));
+            });
 
             c = ws.Cell("A3");
             themeColor = c.Style.Fill.BackgroundColor.ThemeColor;
-            Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent6));
-            Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FF70AD47"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(themeColor, Is.EqualTo(XLThemeColor.Accent6));
+                Assert.That(wb.Theme.ResolveThemeColor(themeColor).Color.ToHex(), Is.EqualTo("FF70AD47"));
+            });
         }
 
         [Test]
@@ -588,9 +606,12 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.Worksheet(1);
 
             var c = ws.Cell("B2");
-            Assert.That(c.Style.Border.TopBorderColor.ColorType, Is.EqualTo(XLColorType.Theme));
-            Assert.That(c.Style.Border.TopBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
-            Assert.That(c.Style.Border.TopBorderColor.ThemeTint, Is.EqualTo(0.39994506668294322d).Within(XLHelper.Epsilon));
+            Assert.Multiple(() =>
+            {
+                Assert.That(c.Style.Border.TopBorderColor.ColorType, Is.EqualTo(XLColorType.Theme));
+                Assert.That(c.Style.Border.TopBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(c.Style.Border.TopBorderColor.ThemeTint, Is.EqualTo(0.39994506668294322d).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -600,9 +621,12 @@ namespace ClosedXML.Tests.Excel
             using var wb = new XLWorkbook(stream);
             var ws = wb.Worksheet(1);
 
-            Assert.That(ws.Row(1).Style.Font.FontSize, Is.EqualTo(8));
-            Assert.That(ws.Row(2).Style.Font.FontSize, Is.EqualTo(8));
-            Assert.That(ws.Column("A").Style.Font.FontSize, Is.EqualTo(8));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(1).Style.Font.FontSize, Is.EqualTo(8));
+                Assert.That(ws.Row(2).Style.Font.FontSize, Is.EqualTo(8));
+                Assert.That(ws.Column("A").Style.Font.FontSize, Is.EqualTo(8));
+            });
         }
 
         [Test]
@@ -692,7 +716,7 @@ namespace ClosedXML.Tests.Excel
             {
                 var ws = wb.Worksheets.Single();
                 Assert.That(ws.Cell("A1").Style.Font.FontColor, Is.EqualTo(XLColor.FromArgb(0xFF000000)));
-                Assert.AreEqual(XLColor.FromArgb(0xFF000FED), ws.Cell("A2").Style.Fill.BackgroundColor);
+                Assert.That(ws.Cell("A2").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromArgb(0xFF000FED)));
             }, @"TryToLoad\InvalidColors.xlsx");
         }
 
@@ -715,11 +739,11 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(wb.Worksheet("Sheet1").Cell("A1").Value, Is.EqualTo("Sheet1"));
 
                 // Second sheet doesn't have r:id, so it is empty after load.
-                Assert.AreEqual(Blank.Value, wb.Worksheet("Sheet without relId").Cell("A1").Value);
+                Assert.That(wb.Worksheet("Sheet without relId").Cell("A1").Value, Is.EqualTo(Blank.Value));
 
                 // Third sheet doesn't have r:id and it contains pivot table that is not loaded.
                 var ptSheet = wb.Worksheet("Pivot Sheet without relId");
-                Assert.AreEqual(Blank.Value, ptSheet.Cell("A1").Value);
+                Assert.That(ptSheet.Cell("A1").Value, Is.EqualTo(Blank.Value));
                 Assert.False(ptSheet.PivotTables.Any());
             }, @"TryToLoad\SheetsWithoutRelId.xlsx");
         }
@@ -738,8 +762,8 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(wb.UnsupportedSheets, Has.Count.EqualTo(1));
 
                 // Data and pivot sheets
-                Assert.AreEqual(2, wb.Worksheets.Count);
-                Assert.NotNull(wb.Worksheet("Pivot").PivotTables.Contains("PivotTable1"));
+                Assert.That(wb.Worksheets.Count, Is.EqualTo(2));
+                Assert.That(wb.Worksheet("Pivot").PivotTables.Contains("PivotTable1"), Is.True);
             }, @"TryToLoad\DialogSheet.xlsx");
         }
     }

--- a/ClosedXML.Tests/Excel/Misc/CopyContentsTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/CopyContentsTests.cs
@@ -31,7 +31,7 @@ namespace ClosedXML.Tests.Excel.Misc
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().AddConditionalFormat().WhenContains("1").Fill.SetBackgroundColor(XLColor.Blue);
             ws.Cell("A2").CopyFrom(ws.FirstCell().AsRange());
-            Assert.AreEqual(2, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(2));
         }
 
         [Test]
@@ -43,8 +43,8 @@ namespace ClosedXML.Tests.Excel.Misc
             ws.Cell("B1").Value = "1";
             ws.Cell("A1").AddConditionalFormat().WhenEquals(1).Fill.SetBackgroundColor(XLColor.Blue);
             ws.Cell("A2").CopyFrom(ws.Cell("A1").AsRange());
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)));
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)));
+            Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)), Is.True);
+            Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)), Is.True);
         }
 
         [Test]
@@ -56,8 +56,8 @@ namespace ClosedXML.Tests.Excel.Misc
             ws.Cell("B1").Value = "B";
             ws.Cell("A1").AddConditionalFormat().WhenEquals("A").Fill.SetBackgroundColor(XLColor.Blue);
             ws.Cell("A2").CopyFrom(ws.Cell("A1").AsRange());
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "A" && !v.Value.IsFormula)));
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "A" && !v.Value.IsFormula)));
+            Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "A" && !v.Value.IsFormula)), Is.True);
+            Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "A" && !v.Value.IsFormula)), Is.True);
         }
 
         [Test]
@@ -69,8 +69,8 @@ namespace ClosedXML.Tests.Excel.Misc
             ws.Cell("B1").Value = "1";
             ws.Cell("A1").AddConditionalFormat().WhenEquals("1").Fill.SetBackgroundColor(XLColor.Blue);
             ws.Cell("A2").CopyFrom(ws.Cell("A1").AsRange());
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)));
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)));
+            Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)), Is.True);
+            Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "1" && !v.Value.IsFormula)), Is.True);
         }
 
         [Test]
@@ -82,8 +82,11 @@ namespace ClosedXML.Tests.Excel.Misc
             ws.Cell("B1").Value = "1";
             ws.Cell("A1").AddConditionalFormat().WhenEquals("=B1").Fill.SetBackgroundColor(XLColor.Blue);
             ws.Cell("A2").CopyFrom(ws.Cell("A1").AsRange());
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "B1" && v.Value.IsFormula)));
-            Assert.IsTrue(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "B2" && v.Value.IsFormula)));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "B1" && v.Value.IsFormula)), Is.True);
+                Assert.That(ws.ConditionalFormats.Any(cf => cf.Values.Any(v => v.Value.Value == "B2" && v.Value.IsFormula)), Is.True);
+            });
         }
 
         [Test]
@@ -117,16 +120,17 @@ namespace ClosedXML.Tests.Excel.Misc
         [Test]
         public void UpdateCellsWorksheetTest()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet1");
+            ws1.Cell(1, 1).Value = "hello, world.";
+
+            var ws2 = ws1.CopyTo("Sheet2");
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb.Worksheets.Add("Sheet1");
-                ws1.Cell(1, 1).Value = "hello, world.";
-
-                var ws2 = ws1.CopyTo("Sheet2");
-
-                Assert.AreEqual("Sheet1", ws1.FirstCell().Address.Worksheet.Name);
-                Assert.AreEqual("Sheet2", ws2.FirstCell().Address.Worksheet.Name);
-            }
+                Assert.That(ws1.FirstCell().Address.Worksheet.Name, Is.EqualTo("Sheet1"));
+                Assert.That(ws2.FirstCell().Address.Worksheet.Name, Is.EqualTo("Sheet2"));
+            });
         }
 
         [Test]
@@ -143,10 +147,16 @@ namespace ClosedXML.Tests.Excel.Misc
             source.Cell("A1").AsRange().CopyTo(target.Cell("B7"));
 
             var cell = target.Cell("B7");
-            Assert.True(cell.HasHyperlink);
-            Assert.True(cell.GetHyperlink().IsExternal);
-            Assert.AreEqual(new Uri("https://example.com"), cell.GetHyperlink().ExternalAddress);
-            Assert.AreEqual("Test tooltip", cell.GetHyperlink().Tooltip);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.HasHyperlink, Is.True);
+                Assert.That(cell.GetHyperlink().IsExternal, Is.True);
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.GetHyperlink().ExternalAddress, Is.EqualTo(new Uri("https://example.com")));
+                Assert.That(cell.GetHyperlink().Tooltip, Is.EqualTo("Test tooltip"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Misc/ExtensionsTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/ExtensionsTests.cs
@@ -11,24 +11,27 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void FixNewLines()
         {
-            Assert.AreEqual("\n".FixNewLines(), Environment.NewLine);
-            Assert.AreEqual("\r\n".FixNewLines(), Environment.NewLine);
-            Assert.AreEqual("\rS\n".FixNewLines(), "\rS" + Environment.NewLine);
-            Assert.AreEqual("\r\n\n".FixNewLines(), Environment.NewLine + Environment.NewLine);
+            Assert.That(Environment.NewLine, Is.EqualTo("\n".FixNewLines()));
+            Assert.Multiple(() =>
+            {
+                Assert.That(Environment.NewLine, Is.EqualTo("\r\n".FixNewLines()));
+                Assert.That("\rS" + Environment.NewLine, Is.EqualTo("\rS\n".FixNewLines()));
+            });
+            Assert.That(Environment.NewLine + Environment.NewLine, Is.EqualTo("\r\n\n".FixNewLines()));
         }
 
         [Test]
         public void DoubleSaveRound()
         {
             Double value = 1234.1234567;
-            Assert.AreEqual(value.SaveRound(), Math.Round(value, 6));
+            Assert.That(Math.Round(value, 6), Is.EqualTo(value.SaveRound()));
         }
 
         [Test]
         public void DoubleValueSaveRound()
         {
             Double value = 1234.1234567;
-            Assert.AreEqual(new DoubleValue(value).SaveRound().Value, Math.Round(value, 6));
+            Assert.That(Math.Round(value, 6), Is.EqualTo(new DoubleValue(value).SaveRound().Value));
         }
 
         [TestCase("NoEscaping", ExpectedResult = "NoEscaping")]

--- a/ClosedXML.Tests/Excel/Misc/FormulaTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/FormulaTests.cs
@@ -111,11 +111,11 @@ namespace ClosedXML.Tests.Excel
 
             ws.Cell("A2").FormulaA1 = @"=IF(A1 = """", ""A"", ""B"")";
             var actual = ws.Cell("A2").Value;
-            Assert.That("B", Is.EqualTo(actual));
+            Assert.That(actual, Is.EqualTo("B"));
 
             ws.Cell("A3").FormulaA1 = @"=IF("""" = A1, ""A"", ""B"")";
             actual = ws.Cell("A3").Value;
-            Assert.That("B", Is.EqualTo(actual));
+            Assert.That(actual, Is.EqualTo("B"));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Misc/FormulaTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/FormulaTests.cs
@@ -15,145 +15,137 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell("A1").FormulaA1 = "B1";
             ws.Cell("A1").CopyTo("A2");
-            Assert.AreEqual("B2", ws.Cell("A2").FormulaA1);
+            Assert.That(ws.Cell("A2").FormulaA1, Is.EqualTo("B2"));
         }
 
         [Test]
         public void CopyFormula2()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
+
+            ws.Cell("A1").FormulaA1 = "A2-1";
+            ws.Cell("A1").CopyTo("B1");
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
+                Assert.That(ws.Cell("A1").FormulaR1C1, Is.EqualTo("R[1]C-1"));
+                Assert.That(ws.Cell("B1").FormulaR1C1, Is.EqualTo("R[1]C-1"));
+                Assert.That(ws.Cell("B1").FormulaA1, Is.EqualTo("B2-1"));
+            });
 
-                ws.Cell("A1").FormulaA1 = "A2-1";
-                ws.Cell("A1").CopyTo("B1");
-                Assert.AreEqual("R[1]C-1", ws.Cell("A1").FormulaR1C1);
-                Assert.AreEqual("R[1]C-1", ws.Cell("B1").FormulaR1C1);
-                Assert.AreEqual("B2-1", ws.Cell("B1").FormulaA1);
-
-                ws.Cell("A1").FormulaA1 = "B1+1";
-                ws.Cell("A1").CopyTo("A2");
-                Assert.AreEqual("RC[1]+1", ws.Cell("A1").FormulaR1C1);
-                Assert.AreEqual("RC[1]+1", ws.Cell("A2").FormulaR1C1);
-                Assert.AreEqual("B2+1", ws.Cell("A2").FormulaA1);
-            }
+            ws.Cell("A1").FormulaA1 = "B1+1";
+            ws.Cell("A1").CopyTo("A2");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").FormulaR1C1, Is.EqualTo("RC[1]+1"));
+                Assert.That(ws.Cell("A2").FormulaR1C1, Is.EqualTo("RC[1]+1"));
+                Assert.That(ws.Cell("A2").FormulaA1, Is.EqualTo("B2+1"));
+            });
         }
 
         [Test]
         public void CopyFormulaWithSheetNameThatResemblesFormula()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.Worksheets.Add("S10 Data");
-                ws.Cell("A1").Value = "Some value";
-                ws.Cell("A2").Value = 123;
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.Worksheets.Add("S10 Data");
+            ws.Cell("A1").Value = "Some value";
+            ws.Cell("A2").Value = 123;
 
-                ws = wb.Worksheets.Add("Summary");
-                ws.Cell("A1").FormulaA1 = "='S10 Data'!A1";
-                Assert.AreEqual("Some value", ws.Cell("A1").Value);
+            ws = wb.Worksheets.Add("Summary");
+            ws.Cell("A1").FormulaA1 = "='S10 Data'!A1";
+            Assert.That(ws.Cell("A1").Value, Is.EqualTo("Some value"));
 
-                ws.Cell("A1").CopyTo("A2");
-                Assert.AreEqual("'S10 Data'!A2", ws.Cell("A2").FormulaA1);
+            ws.Cell("A1").CopyTo("A2");
+            Assert.That(ws.Cell("A2").FormulaA1, Is.EqualTo("'S10 Data'!A2"));
 
-                ws.Cell("A1").CopyTo("B1");
-                Assert.AreEqual("'S10 Data'!B1", ws.Cell("B1").FormulaA1);
+            ws.Cell("A1").CopyTo("B1");
+            Assert.That(ws.Cell("B1").FormulaA1, Is.EqualTo("'S10 Data'!B1"));
 
-                ws.Cell("A3").FormulaA1 = "=SUM('S10 Data'!A2)";
-                Assert.AreEqual(123, ws.Cell("A3").Value);
-            }
+            ws.Cell("A3").FormulaA1 = "=SUM('S10 Data'!A2)";
+            Assert.That(ws.Cell("A3").Value, Is.EqualTo(123));
         }
 
         [Test]
         public void FormulaWithReferenceIncludingSheetName()
         {
-            using (var wb = new XLWorkbook())
-            {
-                object value;
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").InsertData(Enumerable.Range(1, 50));
-                ws.Cell("B1").FormulaA1 = "=SUM(A1:A50)";
-                value = ws.Cell("B1").Value;
-                Assert.AreEqual(1275, value);
+            using var wb = new XLWorkbook();
+            object value;
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").InsertData(Enumerable.Range(1, 50));
+            ws.Cell("B1").FormulaA1 = "=SUM(A1:A50)";
+            value = ws.Cell("B1").Value;
+            Assert.That(value, Is.EqualTo(1275));
 
-                ws = wb.AddWorksheet("Sheet2");
+            ws = wb.AddWorksheet("Sheet2");
 
-                ws.Cell("A1").FormulaA1 = "=SUM(Sheet1!A1:Sheet1!A50)";
-                value = ws.Cell("A1").Value;
-                Assert.AreEqual(1275, value);
+            ws.Cell("A1").FormulaA1 = "=SUM(Sheet1!A1:Sheet1!A50)";
+            value = ws.Cell("A1").Value;
+            Assert.That(value, Is.EqualTo(1275));
 
-                ws.Cell("B1").FormulaA1 = "=SUM(Sheet1!A1:A50)";
-                value = ws.Cell("B1").Value;
-                Assert.AreEqual(1275, value);
-            }
+            ws.Cell("B1").FormulaA1 = "=SUM(Sheet1!A1:A50)";
+            value = ws.Cell("B1").Value;
+            Assert.That(value, Is.EqualTo(1275));
         }
 
         [Test]
         public void InvalidReferences()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").InsertData(Enumerable.Range(1, 50));
-                ws = wb.AddWorksheet("Sheet2");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").InsertData(Enumerable.Range(1, 50));
+            ws = wb.AddWorksheet("Sheet2");
 
-                ws.Cell("A1").FormulaA1 = "=SUM(Sheet1!A1:Sheet2!A50)";
-                Assert.AreEqual(XLError.IncompatibleValue, ws.Cell("A1").Value);
+            ws.Cell("A1").FormulaA1 = "=SUM(Sheet1!A1:Sheet2!A50)";
+            Assert.That(ws.Cell("A1").Value, Is.EqualTo(XLError.IncompatibleValue));
 
-                ws.Cell("B1").FormulaA1 = "=SUM(UnknownSheet!A50)";
-                Assert.AreEqual(XLError.CellReference, ws.Cell("B1").Value);
-            }
+            ws.Cell("B1").FormulaA1 = "=SUM(UnknownSheet!A50)";
+            Assert.That(ws.Cell("B1").Value, Is.EqualTo(XLError.CellReference));
         }
 
         [Test]
         public void DateAgainstStringComparison()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").Value = new DateTime(2016, 1, 1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Value = new DateTime(2016, 1, 1);
 
-                ws.Cell("A2").FormulaA1 = @"=IF(A1 = """", ""A"", ""B"")";
-                var actual = ws.Cell("A2").Value;
-                Assert.AreEqual(actual, "B");
+            ws.Cell("A2").FormulaA1 = @"=IF(A1 = """", ""A"", ""B"")";
+            var actual = ws.Cell("A2").Value;
+            Assert.That("B", Is.EqualTo(actual));
 
-                ws.Cell("A3").FormulaA1 = @"=IF("""" = A1, ""A"", ""B"")";
-                actual = ws.Cell("A3").Value;
-                Assert.AreEqual(actual, "B");
-            }
+            ws.Cell("A3").FormulaA1 = @"=IF("""" = A1, ""A"", ""B"")";
+            actual = ws.Cell("A3").Value;
+            Assert.That("B", Is.EqualTo(actual));
         }
 
         [Test]
         public void FormulaThatReferencesEntireRow()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().Value = 1;
-                ws.FirstCell().CellRight().Value = 2;
-                ws.FirstCell().CellRight(5).Value = 3;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().Value = 1;
+            ws.FirstCell().CellRight().Value = 2;
+            ws.FirstCell().CellRight(5).Value = 3;
 
-                ws.FirstCell().CellBelow().FormulaA1 = "=SUM(1:1)";
+            ws.FirstCell().CellBelow().FormulaA1 = "=SUM(1:1)";
 
-                var actual = ws.FirstCell().CellBelow().Value;
-                Assert.AreEqual(6, actual);
-            }
+            var actual = ws.FirstCell().CellBelow().Value;
+            Assert.That(actual, Is.EqualTo(6));
         }
 
         [Test]
         public void FormulaThatReferencesEntireColumn()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().Value = 1;
-                ws.FirstCell().CellBelow().Value = 2;
-                ws.FirstCell().CellBelow(5).Value = 3;
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().Value = 1;
+            ws.FirstCell().CellBelow().Value = 2;
+            ws.FirstCell().CellBelow(5).Value = 3;
 
-                ws.FirstCell().CellRight().FormulaA1 = "=SUM(A:A)";
+            ws.FirstCell().CellRight().FormulaA1 = "=SUM(A:A)";
 
-                var actual = ws.FirstCell().CellRight().Value;
-                Assert.AreEqual(6, actual);
-            }
+            var actual = ws.FirstCell().CellRight().Value;
+            Assert.That(actual, Is.EqualTo(6));
         }
 
         [Test]
@@ -161,16 +153,16 @@ namespace ClosedXML.Tests.Excel
         {
             object actual;
             actual = XLWorkbook.EvaluateExpr("=MID(\"This is a test\", 6, 2)");
-            Assert.AreEqual("is", actual);
+            Assert.That(actual, Is.EqualTo("is"));
 
             actual = XLWorkbook.EvaluateExpr("=+MID(\"This is a test\", 6, 2)");
-            Assert.AreEqual("is", actual);
+            Assert.That(actual, Is.EqualTo("is"));
 
             actual = XLWorkbook.EvaluateExpr("=+++++MID(\"This is a test\", 6, 2)");
-            Assert.AreEqual("is", actual);
+            Assert.That(actual, Is.EqualTo("is"));
 
             actual = XLWorkbook.EvaluateExpr("+MID(\"This is a test\", 6, 2)");
-            Assert.AreEqual("is", actual);
+            Assert.That(actual, Is.EqualTo("is"));
         }
 
         [Test]
@@ -178,64 +170,72 @@ namespace ClosedXML.Tests.Excel
         {
             // RTD will never be implemented
             var actual = XLWorkbook.EvaluateExpr("RTD(\"MyRTDServerProdID\",\"MyServer\",\"RaceNum\",\"RunnerID\",\"StatType\")");
-            Assert.AreEqual(XLError.NameNotRecognized, actual);
+            Assert.That(actual, Is.EqualTo(XLError.NameNotRecognized));
         }
 
         [Test]
         public void FormulasWithErrors()
         {
-            Assert.AreEqual(XLError.CellReference, XLWorkbook.EvaluateExpr("YEAR(#REF!)"));
-            Assert.AreEqual(XLError.IncompatibleValue, XLWorkbook.EvaluateExpr("YEAR(#VALUE!)"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("YEAR(#DIV/0!)"));
-            Assert.AreEqual(XLError.NameNotRecognized, XLWorkbook.EvaluateExpr("YEAR(#NAME?)"));
-            Assert.AreEqual(XLError.NoValueAvailable, XLWorkbook.EvaluateExpr("YEAR(#N/A)"));
-            Assert.AreEqual(XLError.NullValue, XLWorkbook.EvaluateExpr("YEAR(#NULL!)"));
-            Assert.AreEqual(XLError.NumberInvalid, XLWorkbook.EvaluateExpr("YEAR(#NUM!)"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#REF!)"), Is.EqualTo(XLError.CellReference));
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#VALUE!)"), Is.EqualTo(XLError.IncompatibleValue));
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#DIV/0!)"), Is.EqualTo(XLError.DivisionByZero));
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#NAME?)"), Is.EqualTo(XLError.NameNotRecognized));
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#N/A)"), Is.EqualTo(XLError.NoValueAvailable));
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#NULL!)"), Is.EqualTo(XLError.NullValue));
+                Assert.That(XLWorkbook.EvaluateExpr("YEAR(#NUM!)"), Is.EqualTo(XLError.NumberInvalid));
+            });
         }
 
         [Test]
         public void LegacyFunctionPropagateErrorWithoutException()
         {
-            Assert.AreEqual(XLError.NameNotRecognized, XLWorkbook.EvaluateExpr("SIN(YEAR(#NAME?))+1"));
+            Assert.That(XLWorkbook.EvaluateExpr("SIN(YEAR(#NAME?))+1"), Is.EqualTo(XLError.NameNotRecognized));
         }
 
         [Test]
         public void UnicodeLetterParsing()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet("Sheet C CÄ");
+            var ws2 = wb.AddWorksheet("ÖC");
+            var ws3 = wb.AddWorksheet("Sheet3");
+
+            ws1.FirstCell().SetValue(100);
+            ws2.FirstCell().SetValue(50);
+
+            ws3.FirstCell().FormulaA1 = "='Sheet C CÄ'!A1";
+            ws3.FirstCell().CellBelow().FormulaA1 = "ÖC!A1";
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb.AddWorksheet("Sheet C CÄ");
-                var ws2 = wb.AddWorksheet("ÖC");
-                var ws3 = wb.AddWorksheet("Sheet3");
-
-                ws1.FirstCell().SetValue(100);
-                ws2.FirstCell().SetValue(50);
-
-                ws3.FirstCell().FormulaA1 = "='Sheet C CÄ'!A1";
-                ws3.FirstCell().CellBelow().FormulaA1 = "ÖC!A1";
-
-                Assert.AreEqual(100, ws3.FirstCell().Value);
-                Assert.AreEqual(50, ws3.FirstCell().CellBelow().Value);
-            }
+                Assert.That(ws3.FirstCell().Value, Is.EqualTo(100));
+                Assert.That(ws3.FirstCell().CellBelow().Value, Is.EqualTo(50));
+            });
         }
 
         [Test, Ignore("Shifting formulas is done by regexp that breaks array formula.")]
         public void ShiftFormula()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("B1").FormulaA1 = "ATAN2(C1,C2)";
+            ws.Cell("B2").FormulaA1 = "DEC2HEX(C2)";
+            ws.Range("B3:B5").FormulaArrayA1 = "DAYS360(C3:C5, D3:D5)";
+
+            ws.Column(1).Delete();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet();
-                ws.Cell("B1").FormulaA1 = "ATAN2(C1,C2)";
-                ws.Cell("B2").FormulaA1 = "DEC2HEX(C2)";
-                ws.Range("B3:B5").FormulaArrayA1 = "DAYS360(C3:C5, D3:D5)";
-
-                ws.Column(1).Delete();
-
-                Assert.AreEqual("ATAN2(B1,B2)", ws.Cell("A1").FormulaA1);
-                Assert.AreEqual("DEC2HEX(B2)", ws.Cell("A2").FormulaA1);
-                Assert.True(ws.Cell("A3").HasArrayFormula);
-                Assert.AreEqual("DAYS360(B3:B5, C3:C5)", ws.Cell("A3").FormulaA1);
-            }
+                Assert.That(ws.Cell("A1").FormulaA1, Is.EqualTo("ATAN2(B1,B2)"));
+                Assert.That(ws.Cell("A2").FormulaA1, Is.EqualTo("DEC2HEX(B2)"));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A3").HasArrayFormula, Is.True);
+                Assert.That(ws.Cell("A3").FormulaA1, Is.EqualTo("DAYS360(B3:B5, C3:C5)"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Misc/HyperlinkTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/HyperlinkTests.cs
@@ -9,24 +9,22 @@ namespace ClosedXML.Tests.Excel.Misc
         [Test]
         public void TestHyperlinks()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws1 = wb.Worksheets.Add("Sheet1");
-                var ws2 = wb.Worksheets.Add("Sheet2");
+            using var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet1");
+            var ws2 = wb.Worksheets.Add("Sheet2");
 
-                var targetCell = ws2.Cell("A1");
-                var targetRange = ws2.Range("A1", "B1");
+            var targetCell = ws2.Cell("A1");
+            var targetRange = ws2.Range("A1", "B1");
 
-                var linkCell1 = ws1.Cell("A1");
-                linkCell1.Value = "Link to IXLCell";
-                linkCell1.SetHyperlink(new XLHyperlink(targetCell));
-                Assert.AreEqual("Sheet2!A1", linkCell1.GetHyperlink().InternalAddress);
+            var linkCell1 = ws1.Cell("A1");
+            linkCell1.Value = "Link to IXLCell";
+            linkCell1.SetHyperlink(new XLHyperlink(targetCell));
+            Assert.That(linkCell1.GetHyperlink().InternalAddress, Is.EqualTo("Sheet2!A1"));
 
-                var linkRange1 = ws1.Cell("A2");
-                linkRange1.Value = "Link to IXLRangeBase";
-                linkRange1.SetHyperlink(new XLHyperlink(targetRange));
-                Assert.AreEqual("Sheet2!A1:B1", linkRange1.GetHyperlink().InternalAddress);
-            }
+            var linkRange1 = ws1.Cell("A2");
+            linkRange1.Value = "Link to IXLRangeBase";
+            linkRange1.SetHyperlink(new XLHyperlink(targetRange));
+            Assert.That(linkRange1.GetHyperlink().InternalAddress, Is.EqualTo("Sheet2!A1:B1"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Misc/SearchTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/SearchTests.cs
@@ -11,68 +11,88 @@ namespace ClosedXML.Tests.Excel.Misc
         [Test]
         public void TestSearch()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\CellValues.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\CellValues.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+
+            IXLCells foundCells;
+
+            foundCells = ws.Search("Initial Value");
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.First();
+                Assert.That(foundCells.Count(), Is.EqualTo(1));
+                Assert.That(foundCells.Single().Address.ToString(), Is.EqualTo("B2"));
+            });
+            Assert.That(foundCells.Single().GetText(), Is.EqualTo("Initial Value"));
 
-                IXLCells foundCells;
+            foundCells = ws.Search("Using");
+            Assert.Multiple(() =>
+            {
+                Assert.That(foundCells.Count(), Is.EqualTo(2));
+                Assert.That(foundCells.First().Address.ToString(), Is.EqualTo("D2"));
+            });
+            Assert.That(foundCells.First().GetText(), Is.EqualTo("Using Get...()"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(foundCells.Count(), Is.EqualTo(2));
+                Assert.That(foundCells.Last().Address.ToString(), Is.EqualTo("E2"));
+            });
+            Assert.That(foundCells.Last().GetText(), Is.EqualTo("Using GetValue<T>()"));
 
-                foundCells = ws.Search("Initial Value");
-                Assert.AreEqual(1, foundCells.Count());
-                Assert.AreEqual("B2", foundCells.Single().Address.ToString());
-                Assert.AreEqual("Initial Value", foundCells.Single().GetText());
+            foundCells = ws.Search("1234");
+            Assert.Multiple(() =>
+            {
+                Assert.That(foundCells.Count(), Is.EqualTo(5));
+                Assert.That(string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()), Is.EqualTo("B5,C5,D5,E5,F5"));
+            });
 
-                foundCells = ws.Search("Using");
-                Assert.AreEqual(2, foundCells.Count());
-                Assert.AreEqual("D2", foundCells.First().Address.ToString());
-                Assert.AreEqual("Using Get...()", foundCells.First().GetText());
-                Assert.AreEqual(2, foundCells.Count());
-                Assert.AreEqual("E2", foundCells.Last().Address.ToString());
-                Assert.AreEqual("Using GetValue<T>()", foundCells.Last().GetText());
+            foundCells = ws.Search("Sep");
+            Assert.Multiple(() =>
+            {
+                Assert.That(foundCells.Count(), Is.EqualTo(1));
+                Assert.That(string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()), Is.EqualTo("G3"));
+            });
 
-                foundCells = ws.Search("1234");
-                Assert.AreEqual(5, foundCells.Count());
-                Assert.AreEqual("B5,C5,D5,E5,F5", string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()));
+            foundCells = ws.Search("1234", CompareOptions.Ordinal, true);
+            Assert.Multiple(() =>
+            {
+                Assert.That(foundCells.Count(), Is.EqualTo(5));
+                Assert.That(string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()), Is.EqualTo("B5,C5,D5,E5,F5"));
+            });
 
-                foundCells = ws.Search("Sep");
-                Assert.AreEqual(1, foundCells.Count());
-                Assert.AreEqual("G3", string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()));
+            foundCells = ws.Search("test case", CompareOptions.Ordinal);
+            Assert.That(foundCells.Count(), Is.EqualTo(0));
 
-                foundCells = ws.Search("1234", CompareOptions.Ordinal, true);
-                Assert.AreEqual(5, foundCells.Count());
-                Assert.AreEqual("B5,C5,D5,E5,F5", string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()));
-
-                foundCells = ws.Search("test case", CompareOptions.Ordinal);
-                Assert.AreEqual(0, foundCells.Count());
-
-                foundCells = ws.Search("test case", CompareOptions.OrdinalIgnoreCase);
-                Assert.AreEqual(6, foundCells.Count());
-            }
+            foundCells = ws.Search("test case", CompareOptions.OrdinalIgnoreCase);
+            Assert.That(foundCells.Count(), Is.EqualTo(6));
         }
 
         [Test]
         public void TestSearch2()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\Formulas.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\Formulas.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+
+            IXLCells foundCells;
+
+            foundCells = ws.Search("3", CompareOptions.Ordinal);
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.First();
+                Assert.That(foundCells.Count(), Is.EqualTo(10));
+                Assert.That(foundCells.First().Address.ToString(), Is.EqualTo("C2"));
+            });
 
-                IXLCells foundCells;
+            foundCells = ws.Search("A2", CompareOptions.Ordinal, true);
+            Assert.That(foundCells.Count(), Is.EqualTo(6));
+            Assert.That(string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()), Is.EqualTo("C2,D2,B6,C6,D6,A11"));
 
-                foundCells = ws.Search("3", CompareOptions.Ordinal);
-                Assert.AreEqual(10, foundCells.Count());
-                Assert.AreEqual("C2", foundCells.First().Address.ToString());
-
-                foundCells = ws.Search("A2", CompareOptions.Ordinal, true);
-                Assert.AreEqual(6, foundCells.Count());
-                Assert.AreEqual("C2,D2,B6,C6,D6,A11", string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()));
-
-                foundCells = ws.Search("RC", CompareOptions.Ordinal, true);
-                Assert.AreEqual(3, foundCells.Count());
-                Assert.AreEqual("E2,E3,E4", string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()));
-            }
+            foundCells = ws.Search("RC", CompareOptions.Ordinal, true);
+            Assert.Multiple(() =>
+            {
+                Assert.That(foundCells.Count(), Is.EqualTo(3));
+                Assert.That(string.Join(",", foundCells.Select(c => c.Address.ToString()).ToArray()), Is.EqualTo("E2,E3,E4"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Misc/StylesTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/StylesTests.cs
@@ -39,40 +39,41 @@ namespace ClosedXML.Tests.Excel.Misc
 
             IXLCell center = range.Cell(2, 2);
 
-            Assert.AreEqual(XLColor.Red, center.Style.Border.TopBorderColor);
-            Assert.AreEqual(XLColor.Red, center.Style.Border.BottomBorderColor);
-            Assert.AreEqual(XLColor.Red, center.Style.Border.LeftBorderColor);
-            Assert.AreEqual(XLColor.Red, center.Style.Border.RightBorderColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(center.Style.Border.TopBorderColor, Is.EqualTo(XLColor.Red));
+                Assert.That(center.Style.Border.BottomBorderColor, Is.EqualTo(XLColor.Red));
+                Assert.That(center.Style.Border.LeftBorderColor, Is.EqualTo(XLColor.Red));
+                Assert.That(center.Style.Border.RightBorderColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLBorderStyleValues.None, range.FirstRow().Cell(1).Style.Border.TopBorder);
-            Assert.AreEqual(XLBorderStyleValues.Thick, range.FirstRow().Cell(2).Style.Border.TopBorder);
-            Assert.AreEqual(XLBorderStyleValues.Double, range.FirstRow().Cell(3).Style.Border.TopBorder);
+                Assert.That(range.FirstRow().Cell(1).Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(range.FirstRow().Cell(2).Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(range.FirstRow().Cell(3).Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.Double));
 
-            Assert.AreEqual(XLBorderStyleValues.None, range.LastRow().Cell(1).Style.Border.BottomBorder);
-            Assert.AreEqual(XLBorderStyleValues.Thick, range.LastRow().Cell(2).Style.Border.BottomBorder);
-            Assert.AreEqual(XLBorderStyleValues.Double, range.LastRow().Cell(3).Style.Border.BottomBorder);
+                Assert.That(range.LastRow().Cell(1).Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(range.LastRow().Cell(2).Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(range.LastRow().Cell(3).Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Double));
 
-            Assert.AreEqual(XLBorderStyleValues.None, range.FirstColumn().Cell(1).Style.Border.LeftBorder);
-            Assert.AreEqual(XLBorderStyleValues.Thick, range.FirstColumn().Cell(2).Style.Border.LeftBorder);
-            Assert.AreEqual(XLBorderStyleValues.Double, range.FirstColumn().Cell(3).Style.Border.LeftBorder);
+                Assert.That(range.FirstColumn().Cell(1).Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(range.FirstColumn().Cell(2).Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(range.FirstColumn().Cell(3).Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Double));
 
-            Assert.AreEqual(XLBorderStyleValues.None, range.LastColumn().Cell(1).Style.Border.RightBorder);
-            Assert.AreEqual(XLBorderStyleValues.Thick, range.LastColumn().Cell(2).Style.Border.RightBorder);
-            Assert.AreEqual(XLBorderStyleValues.Double, range.LastColumn().Cell(3).Style.Border.RightBorder);
+                Assert.That(range.LastColumn().Cell(1).Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(range.LastColumn().Cell(2).Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(range.LastColumn().Cell(3).Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Double));
+            });
         }
 
         [Test]
         public void ResolveThemeColors()
         {
-            using (var wb = new XLWorkbook())
-            {
-                string color;
-                color = wb.Theme.ResolveThemeColor(XLThemeColor.Accent1).Color.ToHex();
-                Assert.AreEqual("FF4F81BD", color);
+            using var wb = new XLWorkbook();
+            string color;
+            color = wb.Theme.ResolveThemeColor(XLThemeColor.Accent1).Color.ToHex();
+            Assert.That(color, Is.EqualTo("FF4F81BD"));
 
-                color = wb.Theme.ResolveThemeColor(XLThemeColor.Background1).Color.ToHex();
-                Assert.AreEqual("FFFFFFFF", color);
-            }
+            color = wb.Theme.ResolveThemeColor(XLThemeColor.Background1).Color.ToHex();
+            Assert.That(color, Is.EqualTo("FFFFFFFF"));
         }
 
         [Theory]
@@ -86,25 +87,26 @@ namespace ClosedXML.Tests.Excel.Misc
         [Test]
         public void SetStyleViaRowReference()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Style
+                .Font.SetFontSize(8)
+                .Font.SetFontColor(XLColor.Green)
+                .Font.SetBold(true);
+
+            var row = ws.Row(1);
+            ws.Cell(1, 1).Value = "Test";
+            row.Cell(2).Value = "Test";
+            row.Cells(3, 3).Value = "Test";
+
+            foreach (var cell in ws.CellsUsed())
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Style
-                   .Font.SetFontSize(8)
-                   .Font.SetFontColor(XLColor.Green)
-                   .Font.SetBold(true);
-
-                var row = ws.Row(1);
-                ws.Cell(1, 1).Value = "Test";
-                row.Cell(2).Value = "Test";
-                row.Cells(3, 3).Value = "Test";
-
-                foreach (var cell in ws.CellsUsed())
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(8, ws.Cell("A1").Style.Font.FontSize);
-                    Assert.AreEqual(XLColor.Green, ws.Cell("B1").Style.Font.FontColor);
-                    Assert.AreEqual(true, ws.Cell("C1").Style.Font.Bold);
-                }
+                    Assert.That(ws.Cell("A1").Style.Font.FontSize, Is.EqualTo(8));
+                    Assert.That(ws.Cell("B1").Style.Font.FontColor, Is.EqualTo(XLColor.Green));
+                    Assert.That(ws.Cell("C1").Style.Font.Bold, Is.True);
+                });
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Misc/StylesTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/StylesTests.cs
@@ -81,7 +81,7 @@ namespace ClosedXML.Tests.Excel.Misc
         {
             var theme = new XLWorkbook().Theme;
             var color = theme.ResolveThemeColor(themeColor);
-            Assert.IsNotNull(color);
+            Assert.That(color, Is.Not.Null);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -170,7 +170,7 @@ namespace ClosedXML.Tests.Excel
             var r = wb.Ranges(rangesAddress);
 
             Assert.That(r, Is.Not.Null);
-            Assert.False(r.Any());
+            Assert.That(r.Any(), Is.False);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -14,7 +14,7 @@ namespace ClosedXML.Tests.Excel
         {
             var wb = new XLWorkbook();
             IXLCell cell = wb.Cell("ABC");
-            Assert.IsNull(cell);
+            Assert.That(cell, Is.Null);
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLCell cell = wb.Cell("Sheet1!Result");
             Assert.IsNotNull(cell);
-            Assert.AreEqual(1, cell.Value);
+            Assert.That(cell.Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLCell cell = wb.Cell("Sheet1!Result");
             Assert.IsNotNull(cell);
-            Assert.AreEqual(1, cell.Value);
+            Assert.That(cell.Value, Is.EqualTo(1));
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace ClosedXML.Tests.Excel
             var wb = new XLWorkbook();
             IXLCells cells = wb.Cells("ABC");
             Assert.IsNotNull(cells);
-            Assert.AreEqual(0, cells.Count());
+            Assert.That(cells.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -56,8 +56,11 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLCells cells = wb.Cells("Sheet1!Result, ABC");
             Assert.IsNotNull(cells);
-            Assert.AreEqual(1, cells.Count());
-            Assert.AreEqual(1, cells.First().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cells.Count(), Is.EqualTo(1));
+                Assert.That(cells.First().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -68,8 +71,11 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLCells cells = wb.Cells("Sheet1!Result, ABC");
             Assert.IsNotNull(cells);
-            Assert.AreEqual(1, cells.Count());
-            Assert.AreEqual(1, cells.First().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cells.Count(), Is.EqualTo(1));
+                Assert.That(cells.First().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -84,8 +90,11 @@ namespace ClosedXML.Tests.Excel
             var c1_full = wb.Cell("Sheet1!C123");
             var c2_full = wb.Cell("'O'Sheet 2'!B7");
 
-            Assert.AreEqual(c1, c1_full);
-            Assert.AreEqual(c2, c2_full);
+            Assert.Multiple(() =>
+            {
+                Assert.That(c1_full, Is.EqualTo(c1));
+                Assert.That(c2_full, Is.EqualTo(c2));
+            });
             Assert.NotNull(c1_full);
             Assert.NotNull(c2_full);
         }
@@ -103,7 +112,7 @@ namespace ClosedXML.Tests.Excel
 
             var c = wb.Cell(address);
 
-            Assert.IsNull(c);
+            Assert.That(c, Is.Null);
         }
 
         [Test]
@@ -115,7 +124,7 @@ namespace ClosedXML.Tests.Excel
 
             var r2 = wb.Range("Sheet1!C123:D125");
 
-            Assert.AreSame(r1, r2);
+            Assert.That(r2, Is.SameAs(r1));
             Assert.NotNull(r2);
         }
 
@@ -128,7 +137,7 @@ namespace ClosedXML.Tests.Excel
 
             var r = wb.Range(rangeAddress);
 
-            Assert.IsNull(r);
+            Assert.That(r, Is.Null);
         }
 
         [Test]
@@ -140,9 +149,12 @@ namespace ClosedXML.Tests.Excel
 
             var r2 = wb.Ranges("Sheet1!A1:B2,Sheet1!C1:E3");
 
-            Assert.AreEqual(2, r2.Count);
-            Assert.AreSame(r1.First(), r2.First());
-            Assert.AreSame(r1.Last(), r2.Last());
+            Assert.That(r2, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(r2.First(), Is.SameAs(r1.First()));
+                Assert.That(r2.Last(), Is.SameAs(r1.Last()));
+            });
         }
 
         [TestCase("Sheet2!C1:D2,Sheet2!F1:G4")]
@@ -163,7 +175,7 @@ namespace ClosedXML.Tests.Excel
         {
             var wb = new XLWorkbook();
             var definedName = wb.DefinedName("ABC");
-            Assert.IsNull(definedName);
+            Assert.That(definedName, Is.Null);
         }
 
         [Test]
@@ -174,9 +186,12 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             var definedName = wb.DefinedName("Sheet1!Result");
             Assert.IsNotNull(definedName);
-            Assert.AreEqual(1, definedName.Ranges.Count);
-            Assert.AreEqual(1, definedName.Ranges.Cells().Count());
-            Assert.AreEqual(1, definedName.Ranges.First().FirstCell().Value);
+            Assert.That(definedName.Ranges, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(definedName.Ranges.Cells().Count(), Is.EqualTo(1));
+                Assert.That(definedName.Ranges.First().FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -185,7 +200,7 @@ namespace ClosedXML.Tests.Excel
             var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet1");
             var definedName = wb.DefinedName("Sheet1!Result");
-            Assert.IsNull(definedName);
+            Assert.That(definedName, Is.Null);
         }
 
         [Test]
@@ -196,9 +211,12 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             var definedName = wb.DefinedName("Sheet1!Result");
             Assert.IsNotNull(definedName);
-            Assert.AreEqual(1, definedName.Ranges.Count);
-            Assert.AreEqual(1, definedName.Ranges.Cells().Count());
-            Assert.AreEqual(1, definedName.Ranges.First().FirstCell().Value);
+            Assert.That(definedName.Ranges, Has.Count.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(definedName.Ranges.Cells().Count(), Is.EqualTo(1));
+                Assert.That(definedName.Ranges.First().FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -206,7 +224,7 @@ namespace ClosedXML.Tests.Excel
         {
             var wb = new XLWorkbook();
             IXLRange range = wb.Range("ABC");
-            Assert.IsNull(range);
+            Assert.That(range, Is.Null);
         }
 
         [Test]
@@ -217,8 +235,11 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLRange range = wb.Range("Sheet1!Result");
             Assert.IsNotNull(range);
-            Assert.AreEqual(1, range.Cells().Count());
-            Assert.AreEqual(1, range.FirstCell().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(range.Cells().Count(), Is.EqualTo(1));
+                Assert.That(range.FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -229,8 +250,11 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLRange range = wb.Range("Sheet1!Result");
             Assert.IsNotNull(range);
-            Assert.AreEqual(1, range.Cells().Count());
-            Assert.AreEqual(1, range.FirstCell().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(range.Cells().Count(), Is.EqualTo(1));
+                Assert.That(range.FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -239,7 +263,7 @@ namespace ClosedXML.Tests.Excel
             var wb = new XLWorkbook();
             IXLRanges ranges = wb.Ranges("ABC");
             Assert.IsNotNull(ranges);
-            Assert.AreEqual(0, ranges.Count());
+            Assert.That(ranges, Is.Empty);
         }
 
         [Test]
@@ -250,8 +274,11 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLRanges ranges = wb.Ranges("Sheet1!Result, ABC");
             Assert.IsNotNull(ranges);
-            Assert.AreEqual(1, ranges.Cells().Count());
-            Assert.AreEqual(1, ranges.First().FirstCell().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ranges.Cells().Count(), Is.EqualTo(1));
+                Assert.That(ranges.First().FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -262,8 +289,11 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLRanges ranges = wb.Ranges("Sheet1!Result, ABC");
             Assert.IsNotNull(ranges);
-            Assert.AreEqual(1, ranges.Cells().Count());
-            Assert.AreEqual(1, ranges.First().FirstCell().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ranges.Cells().Count(), Is.EqualTo(1));
+                Assert.That(ranges.First().FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
@@ -272,8 +302,11 @@ namespace ClosedXML.Tests.Excel
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell(1, 1).SetValue("Test").AddToNamed("TestCell");
-            Assert.AreEqual("Test", wb.Cell("TestCell").GetText());
-            Assert.AreEqual("Test", ws.Cell("TestCell").GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Cell("TestCell").GetText(), Is.EqualTo("Test"));
+                Assert.That(ws.Cell("TestCell").GetText(), Is.EqualTo("Test"));
+            });
         }
 
         [Test]
@@ -284,12 +317,18 @@ namespace ClosedXML.Tests.Excel
             ws.Cell(1, 1).SetValue("Test").AddToNamed("TestCell");
             ws.Cell(2, 1).SetValue("B").AddToNamed("Test2");
             IXLCells wbCells = wb.Cells("TestCell, Test2");
-            Assert.AreEqual("Test", wbCells.First().GetText());
-            Assert.AreEqual("B", wbCells.Last().GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(wbCells.First().GetText(), Is.EqualTo("Test"));
+                Assert.That(wbCells.Last().GetText(), Is.EqualTo("B"));
+            });
 
             IXLCells wsCells = ws.Cells("TestCell, Test2");
-            Assert.AreEqual("Test", wsCells.First().GetText());
-            Assert.AreEqual("B", wsCells.Last().GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(wsCells.First().GetText(), Is.EqualTo("Test"));
+                Assert.That(wsCells.Last().GetText(), Is.EqualTo("B"));
+            });
         }
 
         [Test]
@@ -301,8 +340,8 @@ namespace ClosedXML.Tests.Excel
             ws.Cell(2, 1).SetValue("B");
             IXLRange original = ws.Range("A1:A2");
             original.AddToNamed("TestRange");
-            Assert.AreEqual(original.RangeAddress.ToStringFixed(), wb.Range("TestRange").RangeAddress.ToString());
-            Assert.AreEqual(original.RangeAddress.ToStringFixed(), ws.Range("TestRange").RangeAddress.ToString());
+            Assert.That(wb.Range("TestRange").RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
+            Assert.That(ws.Range("TestRange").RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
         }
 
         [Test]
@@ -316,12 +355,15 @@ namespace ClosedXML.Tests.Excel
             IXLRange original = ws.Range("A1:A2");
             original.AddToNamed("TestRange");
             IXLRanges wbRanges = wb.Ranges("TestRange, Test2");
-            Assert.AreEqual(original.RangeAddress.ToStringFixed(), wbRanges.First().RangeAddress.ToString());
-            Assert.AreEqual("$A$3:$A$3", wbRanges.Last().RangeAddress.ToStringFixed());
+            Assert.Multiple(() =>
+            {
+                Assert.That(wbRanges.First().RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
+                Assert.That(wbRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            });
 
             IXLRanges wsRanges = wb.Ranges("TestRange, Test2");
-            Assert.AreEqual(original.RangeAddress.ToStringFixed(), wsRanges.First().RangeAddress.ToString());
-            Assert.AreEqual("$A$3:$A$3", wsRanges.Last().RangeAddress.ToStringFixed());
+            Assert.That(wsRanges.First().RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
+            Assert.That(wsRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
         }
 
         [Test]
@@ -332,111 +374,123 @@ namespace ClosedXML.Tests.Excel
             wb.DefinedNames.Add("TestRange", "Sheet1!$A$1,Sheet1!$A$3");
 
             IXLRanges wbRanges = ws.Ranges("TestRange");
-            Assert.AreEqual("$A$1:$A$1", wbRanges.First().RangeAddress.ToStringFixed());
-            Assert.AreEqual("$A$3:$A$3", wbRanges.Last().RangeAddress.ToStringFixed());
+            Assert.That(wbRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+            Assert.That(wbRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
 
             IXLRanges wsRanges = ws.Ranges("TestRange");
-            Assert.AreEqual("$A$1:$A$1", wsRanges.First().RangeAddress.ToStringFixed());
-            Assert.AreEqual("$A$3:$A$3", wsRanges.Last().RangeAddress.ToStringFixed());
+            Assert.That(wsRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+            Assert.That(wsRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
         }
 
         [Test]
         public void WbProtect1()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            wb.Protect();
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect();
-                Assert.IsTrue(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsFalse(wb.IsPasswordProtected);
-            }
+                Assert.That(wb.LockStructure, Is.True);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.False);
+            });
         }
 
         [Test]
         public void WbProtect2()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            wb.Protect(XLWorkbookProtectionElements.Windows);
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect(XLWorkbookProtectionElements.Windows);
-                Assert.IsTrue(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsFalse(wb.IsPasswordProtected);
-            }
+                Assert.That(wb.LockStructure, Is.True);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.False);
+            });
         }
 
         [Test]
         public void WbProtect3()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            wb.Protect("Abc@123");
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect("Abc@123");
-                Assert.IsTrue(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsTrue(wb.IsPasswordProtected);
-                Assert.Throws<InvalidOperationException>(() => wb.Protect());
-                Assert.Throws<InvalidOperationException>(() => wb.Unprotect());
-                Assert.Throws<ArgumentException>(() => wb.Unprotect("Cde@345"));
-            }
+                Assert.That(wb.LockStructure, Is.True);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.True);
+            });
+            Assert.Throws<InvalidOperationException>(() => wb.Protect());
+            Assert.Throws<InvalidOperationException>(() => wb.Unprotect());
+            Assert.Throws<ArgumentException>(() => wb.Unprotect("Cde@345"));
         }
 
         [Test]
         public void WbProtect4()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            wb.Protect();
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect();
-                Assert.IsTrue(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsFalse(wb.IsPasswordProtected);
-                wb.Unprotect();
-                wb.Protect("Abc@123");
-                Assert.IsTrue(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsTrue(wb.IsPasswordProtected);
-            }
+                Assert.That(wb.LockStructure, Is.True);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.False);
+            });
+            wb.Unprotect();
+            wb.Protect("Abc@123");
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.LockStructure, Is.True);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.True);
+            });
         }
 
         [Test]
         public void WbProtect5()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            wb.Protect("Abc@123", XLProtectionAlgorithm.DefaultProtectionAlgorithm, XLWorkbookProtectionElements.Windows);
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                wb.Protect("Abc@123", XLProtectionAlgorithm.DefaultProtectionAlgorithm, XLWorkbookProtectionElements.Windows);
-                Assert.IsTrue(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsTrue(wb.IsPasswordProtected);
-                wb.Unprotect("Abc@123");
-                Assert.IsFalse(wb.LockStructure);
-                Assert.IsFalse(wb.LockWindows);
-                Assert.IsFalse(wb.IsPasswordProtected);
-            }
+                Assert.That(wb.LockStructure, Is.True);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.True);
+            });
+            wb.Unprotect("Abc@123");
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.LockStructure, Is.False);
+                Assert.That(wb.LockWindows, Is.False);
+                Assert.That(wb.IsPasswordProtected, Is.False);
+            });
         }
 
         [Test]
         public void FileSharingProperties()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    wb.AddWorksheet("Sheet1").Cell("A1").Value = "Hello world!";
-                    wb.FileSharing.ReadOnlyRecommended = true;
-                    wb.FileSharing.UserName = Environment.UserName;
-                    wb.SaveAs(ms);
-                }
+                wb.AddWorksheet("Sheet1").Cell("A1").Value = "Hello world!";
+                wb.FileSharing.ReadOnlyRecommended = true;
+                wb.FileSharing.UserName = Environment.UserName;
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.IsTrue(wb.FileSharing.ReadOnlyRecommended);
-                    Assert.AreEqual(Environment.UserName, wb.FileSharing.UserName);
-                }
+                    Assert.That(wb.FileSharing.ReadOnlyRecommended, Is.True);
+                    Assert.That(wb.FileSharing.UserName, Is.EqualTo(Environment.UserName));
+                });
             }
         }
 

--- a/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XLWorkbookTests.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLCell cell = wb.Cell("Sheet1!Result");
-            Assert.IsNotNull(cell);
+            Assert.That(cell, Is.Not.Null);
             Assert.That(cell.Value, Is.EqualTo(1));
         }
 
@@ -35,7 +35,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLCell cell = wb.Cell("Sheet1!Result");
-            Assert.IsNotNull(cell);
+            Assert.That(cell, Is.Not.Null);
             Assert.That(cell.Value, Is.EqualTo(1));
         }
 
@@ -44,7 +44,7 @@ namespace ClosedXML.Tests.Excel
         {
             var wb = new XLWorkbook();
             IXLCells cells = wb.Cells("ABC");
-            Assert.IsNotNull(cells);
+            Assert.That(cells, Is.Not.Null);
             Assert.That(cells.Count(), Is.EqualTo(0));
         }
 
@@ -55,7 +55,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLCells cells = wb.Cells("Sheet1!Result, ABC");
-            Assert.IsNotNull(cells);
+            Assert.That(cells, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(cells.Count(), Is.EqualTo(1));
@@ -70,7 +70,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLCells cells = wb.Cells("Sheet1!Result, ABC");
-            Assert.IsNotNull(cells);
+            Assert.That(cells, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(cells.Count(), Is.EqualTo(1));
@@ -95,8 +95,11 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(c1_full, Is.EqualTo(c1));
                 Assert.That(c2_full, Is.EqualTo(c2));
             });
-            Assert.NotNull(c1_full);
-            Assert.NotNull(c2_full);
+            Assert.Multiple(() =>
+            {
+                Assert.That(c1_full, Is.Not.Null);
+                Assert.That(c2_full, Is.Not.Null);
+            });
         }
 
         [TestCase("Sheet1")]
@@ -125,7 +128,7 @@ namespace ClosedXML.Tests.Excel
             var r2 = wb.Range("Sheet1!C123:D125");
 
             Assert.That(r2, Is.SameAs(r1));
-            Assert.NotNull(r2);
+            Assert.That(r2, Is.Not.Null);
         }
 
         [TestCase("Sheet2!C1:D2")]
@@ -166,7 +169,7 @@ namespace ClosedXML.Tests.Excel
 
             var r = wb.Ranges(rangesAddress);
 
-            Assert.NotNull(r);
+            Assert.That(r, Is.Not.Null);
             Assert.False(r.Any());
         }
 
@@ -185,7 +188,7 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             var definedName = wb.DefinedName("Sheet1!Result");
-            Assert.IsNotNull(definedName);
+            Assert.That(definedName, Is.Not.Null);
             Assert.That(definedName.Ranges, Has.Count.EqualTo(1));
             Assert.Multiple(() =>
             {
@@ -210,7 +213,7 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             var definedName = wb.DefinedName("Sheet1!Result");
-            Assert.IsNotNull(definedName);
+            Assert.That(definedName, Is.Not.Null);
             Assert.That(definedName.Ranges, Has.Count.EqualTo(1));
             Assert.Multiple(() =>
             {
@@ -234,7 +237,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLRange range = wb.Range("Sheet1!Result");
-            Assert.IsNotNull(range);
+            Assert.That(range, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(range.Cells().Count(), Is.EqualTo(1));
@@ -249,7 +252,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLRange range = wb.Range("Sheet1!Result");
-            Assert.IsNotNull(range);
+            Assert.That(range, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(range.Cells().Count(), Is.EqualTo(1));
@@ -262,7 +265,7 @@ namespace ClosedXML.Tests.Excel
         {
             var wb = new XLWorkbook();
             IXLRanges ranges = wb.Ranges("ABC");
-            Assert.IsNotNull(ranges);
+            Assert.That(ranges, Is.Not.Null);
             Assert.That(ranges, Is.Empty);
         }
 
@@ -273,7 +276,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result", XLScope.Worksheet);
             IXLRanges ranges = wb.Ranges("Sheet1!Result, ABC");
-            Assert.IsNotNull(ranges);
+            Assert.That(ranges, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(ranges.Cells().Count(), Is.EqualTo(1));
@@ -288,7 +291,7 @@ namespace ClosedXML.Tests.Excel
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().SetValue(1).AddToNamed("Result");
             IXLRanges ranges = wb.Ranges("Sheet1!Result, ABC");
-            Assert.IsNotNull(ranges);
+            Assert.That(ranges, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(ranges.Cells().Count(), Is.EqualTo(1));
@@ -362,8 +365,11 @@ namespace ClosedXML.Tests.Excel
             });
 
             IXLRanges wsRanges = wb.Ranges("TestRange, Test2");
-            Assert.That(wsRanges.First().RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
-            Assert.That(wsRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wsRanges.First().RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
+                Assert.That(wsRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            });
         }
 
         [Test]
@@ -374,12 +380,18 @@ namespace ClosedXML.Tests.Excel
             wb.DefinedNames.Add("TestRange", "Sheet1!$A$1,Sheet1!$A$3");
 
             IXLRanges wbRanges = ws.Ranges("TestRange");
-            Assert.That(wbRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
-            Assert.That(wbRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wbRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(wbRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            });
 
             IXLRanges wsRanges = ws.Ranges("TestRange");
-            Assert.That(wsRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
-            Assert.That(wsRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wsRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(wsRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Misc/XlHelperTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XlHelperTests.cs
@@ -10,55 +10,58 @@ namespace ClosedXML.Tests.Excel
     {
         private static void CheckColumnNumber(int column)
         {
-            Assert.AreEqual(column, XLHelper.GetColumnNumberFromLetter(XLHelper.GetColumnLetterFromNumber(column)));
+            Assert.That(XLHelper.GetColumnNumberFromLetter(XLHelper.GetColumnLetterFromNumber(column)), Is.EqualTo(column));
         }
 
         [Test]
         public void InvalidA1Addresses()
         {
-            Assert.IsFalse(XLHelper.IsValidA1Address(""));
-            Assert.IsFalse(XLHelper.IsValidA1Address("A"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("a"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("-1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AAAA1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("XFG1"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLHelper.IsValidA1Address(""), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("A"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("a"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("-1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AAAA1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("XFG1"), Is.False);
 
-            Assert.IsFalse(XLHelper.IsValidA1Address("@A1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("@AA1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("@AAA1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("[A1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("[AA1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("[AAA1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("{A1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("{AA1"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("{AAA1"));
+                Assert.That(XLHelper.IsValidA1Address("@A1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("@AA1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("@AAA1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("[A1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("[AA1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("[AAA1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("{A1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("{AA1"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("{AAA1"), Is.False);
 
-            Assert.IsFalse(XLHelper.IsValidA1Address("A1@"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AA1@"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AAA1@"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("A1["));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AA1["));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AAA1["));
-            Assert.IsFalse(XLHelper.IsValidA1Address("A1{"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AA1{"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("AAA1{"));
+                Assert.That(XLHelper.IsValidA1Address("A1@"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AA1@"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AAA1@"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("A1["), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AA1["), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AAA1["), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("A1{"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AA1{"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("AAA1{"), Is.False);
 
-            Assert.IsFalse(XLHelper.IsValidA1Address("@A1@"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("@AA1@"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("@AAA1@"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("[A1["));
-            Assert.IsFalse(XLHelper.IsValidA1Address("[AA1["));
-            Assert.IsFalse(XLHelper.IsValidA1Address("[AAA1["));
-            Assert.IsFalse(XLHelper.IsValidA1Address("{A1{"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("{AA1{"));
-            Assert.IsFalse(XLHelper.IsValidA1Address("{AAA1{"));
+                Assert.That(XLHelper.IsValidA1Address("@A1@"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("@AA1@"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("@AAA1@"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("[A1["), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("[AA1["), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("[AAA1["), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("{A1{"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("{AA1{"), Is.False);
+                Assert.That(XLHelper.IsValidA1Address("{AAA1{"), Is.False);
+            });
         }
 
         [Test]
         public void PlusAA1_Is_Not_an_address()
         {
-            Assert.IsFalse(XLHelper.IsValidA1Address("+AA1"));
+            Assert.That(XLHelper.IsValidA1Address("+AA1"), Is.False);
         }
 
         [Test]
@@ -76,38 +79,41 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void ValidA1Addresses()
         {
-            Assert.IsTrue(XLHelper.IsValidA1Address("A1"));
-            Assert.IsTrue(XLHelper.IsValidA1Address("A" + XLHelper.MaxRowNumber));
-            Assert.IsTrue(XLHelper.IsValidA1Address("Z1"));
-            Assert.IsTrue(XLHelper.IsValidA1Address("Z" + XLHelper.MaxRowNumber));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLHelper.IsValidA1Address("A1"), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("A" + XLHelper.MaxRowNumber), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("Z1"), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("Z" + XLHelper.MaxRowNumber), Is.True);
 
-            Assert.IsTrue(XLHelper.IsValidA1Address("AA1"));
-            Assert.IsTrue(XLHelper.IsValidA1Address("AA" + XLHelper.MaxRowNumber));
-            Assert.IsTrue(XLHelper.IsValidA1Address("ZZ1"));
-            Assert.IsTrue(XLHelper.IsValidA1Address("ZZ" + XLHelper.MaxRowNumber));
+                Assert.That(XLHelper.IsValidA1Address("AA1"), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("AA" + XLHelper.MaxRowNumber), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("ZZ1"), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("ZZ" + XLHelper.MaxRowNumber), Is.True);
 
-            Assert.IsTrue(XLHelper.IsValidA1Address("AAA1"));
-            Assert.IsTrue(XLHelper.IsValidA1Address("AAA" + XLHelper.MaxRowNumber));
-            Assert.IsTrue(XLHelper.IsValidA1Address(XLHelper.MaxColumnLetter + "1"));
-            Assert.IsTrue(XLHelper.IsValidA1Address(XLHelper.MaxColumnLetter + XLHelper.MaxRowNumber));
+                Assert.That(XLHelper.IsValidA1Address("AAA1"), Is.True);
+                Assert.That(XLHelper.IsValidA1Address("AAA" + XLHelper.MaxRowNumber), Is.True);
+                Assert.That(XLHelper.IsValidA1Address(XLHelper.MaxColumnLetter + "1"), Is.True);
+                Assert.That(XLHelper.IsValidA1Address(XLHelper.MaxColumnLetter + XLHelper.MaxRowNumber), Is.True);
+            });
         }
 
         [Test]
         public void TestColumnLetterLookup()
         {
-            var columnLetters = new List<String>();
+            var columnLetters = new List<string>();
             for (int c = 1; c <= XLHelper.MaxColumnNumber; c++)
             {
                 var columnLetter = NaiveGetColumnLetterFromNumber(c);
                 columnLetters.Add(columnLetter);
 
-                Assert.AreEqual(columnLetter, XLHelper.GetColumnLetterFromNumber(c));
+                Assert.That(XLHelper.GetColumnLetterFromNumber(c), Is.EqualTo(columnLetter));
             }
 
             foreach (var cl in columnLetters)
             {
                 var columnNumber = NaiveGetColumnNumberFromLetter(cl);
-                Assert.AreEqual(columnNumber, XLHelper.GetColumnNumberFromLetter(cl));
+                Assert.That(XLHelper.GetColumnNumberFromLetter(cl), Is.EqualTo(columnNumber));
             }
         }
 
@@ -124,7 +130,7 @@ namespace ClosedXML.Tests.Excel
         [TestCase("R[-111]C[-222]")]
         public void ValidRCAddresses(string address)
         {
-            Assert.IsTrue(XLHelper.IsValidRCAddress(address));
+            Assert.That(XLHelper.IsValidRCAddress(address), Is.True);
         }
 
         [TestCase("RD")]
@@ -134,7 +140,7 @@ namespace ClosedXML.Tests.Excel
         [TestCase("_R111C222")]
         public void InvalidRCAddresses(string address)
         {
-            Assert.IsFalse(XLHelper.IsValidRCAddress(address));
+            Assert.That(XLHelper.IsValidRCAddress(address), Is.False);
         }
 
         #region Old XLHelper methods
@@ -157,7 +163,7 @@ namespace ClosedXML.Tests.Excel
             //Extra check because we allow users to pass row col positions in as strings
             if (columnLetter[0] <= '9')
             {
-                retVal = Int32.Parse(columnLetter, XLHelper.NumberStyle, XLHelper.ParseCulture);
+                retVal = int.Parse(columnLetter, XLHelper.NumberStyle, XLHelper.ParseCulture);
                 return retVal;
             }
 

--- a/ClosedXML.Tests/Excel/Misc/XmlEncoderTests.cs
+++ b/ClosedXML.Tests/Excel/Misc/XmlEncoderTests.cs
@@ -11,8 +11,11 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void TestControlChars()
         {
-            Assert.AreEqual("_x0001_ _x0002_ _x0003_ _x0004_", XmlEncoder.EncodeString("\u0001 \u0002 \u0003 \u0004"));
-            Assert.AreEqual("_x0005_ _x0006_ _x0007_ _x0008_", XmlEncoder.EncodeString("\u0005 \u0006 \u0007 \u0008"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XmlEncoder.EncodeString("\u0001 \u0002 \u0003 \u0004"), Is.EqualTo("_x0001_ _x0002_ _x0003_ _x0004_"));
+                Assert.That(XmlEncoder.EncodeString("\u0005 \u0006 \u0007 \u0008"), Is.EqualTo("_x0005_ _x0006_ _x0007_ _x0008_"));
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -454,9 +454,12 @@ namespace ClosedXML.Tests.Excel
                     Assert.That(nr.RefersTo, Is.EqualTo("'Sheet 1'!$A$5:$D$5,'Sheet 1'!$A$15:$D$15"));
                     Assert.That(nr.Ranges, Has.Count.EqualTo(2));
                 });
-                Assert.That(nr.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A5:D5"));
-                Assert.That(nr.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A15:D15"));
-                Assert.That(nr.SheetReferencesList, Has.Count.EqualTo(2));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(nr.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A5:D5"));
+                    Assert.That(nr.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A15:D15"));
+                    Assert.That(nr.SheetReferencesList, Has.Count.EqualTo(2));
+                });
                 Assert.Multiple(() =>
                 {
                     Assert.That(nr.SheetReferencesList.First(), Is.EqualTo("'Sheet 1'!$A$5:$D$5"));
@@ -579,8 +582,8 @@ namespace ClosedXML.Tests.Excel
             });
             Assert.That(wsCopy.DefinedName("wsNamedRange").Ranges.First().RangeAddress.ToStringRelative(true),
                 Is.EqualTo("Copy!A3:A3"));
-            Assert.AreEqual("Sheet2!A4:A4",
-                wsCopy.DefinedName("wsNamedRangeAcrossSheets").Ranges.First().RangeAddress.ToStringRelative(true));
+            Assert.That(wsCopy.DefinedName("wsNamedRangeAcrossSheets").Ranges.First().RangeAddress.ToStringRelative(true),
+                Is.EqualTo("Sheet2!A4:A4"));
         }
 
         [Test]
@@ -637,8 +640,11 @@ namespace ClosedXML.Tests.Excel
                         Is.EqualTo("'Sheet 1'!A2:D2"));
                 });
 
-                Assert.That(wb.DefinedNames.ElementAt(1).Name, Is.EqualTo("Named range 4"));
-                Assert.That(wb.DefinedNames.ElementAt(1).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(wb.DefinedNames.ElementAt(1).Name, Is.EqualTo("Named range 4"));
+                    Assert.That(wb.DefinedNames.ElementAt(1).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                });
                 Assert.Multiple(() =>
                 {
                     Assert.That(wb.DefinedNames.ElementAt(1).RefersTo, Is.EqualTo("#REF!"));
@@ -679,12 +685,12 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(wb.DefinedNames.Contains("Sheet1!NameX"), Is.False);
             });
 
-            Assert.IsNotNull(wb.DefinedName("Sheet1!Name"));
+            Assert.That(wb.DefinedName("Sheet1!Name"), Is.Not.Null);
             Assert.That(wb.DefinedName("Sheet1!NameX"), Is.Null);
 
             Boolean found1 = wb.DefinedNames.TryGetValue("Sheet1!Name", out var definedName1);
             Assert.That(found1, Is.True);
-            Assert.IsNotNull(definedName1);
+            Assert.That(definedName1, Is.Not.Null);
             Assert.That(definedName1.Scope, Is.EqualTo(XLNamedRangeScope.Worksheet));
 
             Boolean found2 = wb.DefinedNames.TryGetValue("Sheet1!NameX", out var definedName2);
@@ -705,12 +711,12 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(wb.DefinedNames.Contains("NameX"), Is.False);
             });
 
-            Assert.IsNotNull(wb.DefinedName("Name"));
+            Assert.That(wb.DefinedName("Name"), Is.Not.Null);
             Assert.That(wb.DefinedName("NameX"), Is.Null);
 
             Boolean found1 = wb.DefinedNames.TryGetValue("Name", out var definedName1);
             Assert.That(found1, Is.True);
-            Assert.IsNotNull(definedName1);
+            Assert.That(definedName1, Is.Not.Null);
 
             Boolean found2 = wb.DefinedNames.TryGetValue("NameX", out var definedName2);
             Assert.That(found2, Is.False);
@@ -730,12 +736,12 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(ws.DefinedNames.Contains("NameX"), Is.False);
             });
 
-            Assert.IsNotNull(ws.DefinedName("Name"));
+            Assert.That(ws.DefinedName("Name"), Is.Not.Null);
             Assert.Throws<KeyNotFoundException>(() => ws.DefinedName("NameX"));
 
             Boolean found1 = ws.DefinedNames.TryGetValue("Name", out var definedName1);
             Assert.That(found1, Is.True);
-            Assert.IsNotNull(definedName1);
+            Assert.That(definedName1, Is.Not.Null);
 
             Boolean found2 = ws.DefinedNames.TryGetValue("NameX", out var definedName2);
             Assert.That(found2, Is.False);

--- a/ClosedXML.Tests/Excel/NamedRanges/NamedRangesTests.cs
+++ b/ClosedXML.Tests/Excel/NamedRanges/NamedRangesTests.cs
@@ -23,17 +23,15 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void CanEvaluateNamedMultiRange()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws1 = wb.AddWorksheet("Sheet1");
-                ws1.Range("A1:C1").Value = 1;
-                ws1.Range("A3:C3").Value = 3;
-                wb.DefinedNames.Add("TEST", ws1.Ranges("A1:C1,A3:C3"));
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet("Sheet1");
+            ws1.Range("A1:C1").Value = 1;
+            ws1.Range("A3:C3").Value = 3;
+            wb.DefinedNames.Add("TEST", ws1.Ranges("A1:C1,A3:C3"));
 
-                ws1.Cell(2, 1).FormulaA1 = "=SUM(TEST)";
+            ws1.Cell(2, 1).FormulaA1 = "=SUM(TEST)";
 
-                Assert.AreEqual(12.0, (double)ws1.Cell(2, 1).Value, XLHelper.Epsilon);
-            }
+            Assert.That((double)ws1.Cell(2, 1).Value, Is.EqualTo(12.0).Within(XLHelper.Epsilon));
         }
 
         [Test]
@@ -43,136 +41,151 @@ namespace ClosedXML.Tests.Excel
             var ws1 = wb.Worksheets.Add("Sheet1");
             ws1.Cell("A1").SetValue(1).AddToNamed("value1");
 
-            Assert.AreEqual(1, wb.Cell("value1").Value);
-            Assert.AreEqual(1, wb.Range("value1").FirstCell().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Cell("value1").Value, Is.EqualTo(1));
+                Assert.That(wb.Range("value1").FirstCell().Value, Is.EqualTo(1));
 
-            Assert.AreEqual(1, ws1.Cell("value1").Value);
-            Assert.AreEqual(1, ws1.Range("value1").FirstCell().Value);
+                Assert.That(ws1.Cell("value1").Value, Is.EqualTo(1));
+                Assert.That(ws1.Range("value1").FirstCell().Value, Is.EqualTo(1));
+            });
 
             var ws2 = wb.Worksheets.Add("Sheet2");
 
             ws2.Cell("A1").SetFormulaA1("=value1").AddToNamed("value2");
 
-            Assert.AreEqual(1, wb.Cell("value2").Value);
-            Assert.AreEqual(1, wb.Range("value2").FirstCell().Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Cell("value2").Value, Is.EqualTo(1));
+                Assert.That(wb.Range("value2").FirstCell().Value, Is.EqualTo(1));
 
-            Assert.AreEqual(1, ws2.Cell("value1").Value);
-            Assert.AreEqual(1, ws2.Range("value1").FirstCell().Value);
+                Assert.That(ws2.Cell("value1").Value, Is.EqualTo(1));
+                Assert.That(ws2.Range("value1").FirstCell().Value, Is.EqualTo(1));
 
-            Assert.AreEqual(1, ws2.Cell("value2").Value);
-            Assert.AreEqual(1, ws2.Range("value2").FirstCell().Value);
+                Assert.That(ws2.Cell("value2").Value, Is.EqualTo(1));
+                Assert.That(ws2.Range("value2").FirstCell().Value, Is.EqualTo(1));
+            });
         }
 
         [Test]
         public void CanGetValidNamedRanges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet 1");
+            var ws2 = wb.Worksheets.Add("Sheet 2");
+            var ws3 = wb.Worksheets.Add("Sheet'3");
+
+            ws1.Range("A1:D1").AddToNamed("Named range 1", XLScope.Worksheet);
+            ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
+            ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
+            ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
+            wb.DefinedNames.Add("Named range 5", new XLRanges
             {
-                var ws1 = wb.Worksheets.Add("Sheet 1");
-                var ws2 = wb.Worksheets.Add("Sheet 2");
-                var ws3 = wb.Worksheets.Add("Sheet'3");
+                ws1.Range("A5:D5"),
+                ws3.Range("A5:D5")
+            });
 
-                ws1.Range("A1:D1").AddToNamed("Named range 1", XLScope.Worksheet);
-                ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
-                ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
-                ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
-                wb.DefinedNames.Add("Named range 5", new XLRanges
-                {
-                    ws1.Range("A5:D5"),
-                    ws3.Range("A5:D5")
-                });
+            ws2.Delete();
+            ws3.Delete();
 
-                ws2.Delete();
-                ws3.Delete();
+            var globalValidRanges = wb.DefinedNames.ValidNamedRanges();
+            var globalInvalidRanges = wb.DefinedNames.InvalidNamedRanges();
+            var localValidRanges = ws1.DefinedNames.ValidNamedRanges();
+            var localInvalidRanges = ws1.DefinedNames.InvalidNamedRanges();
 
-                var globalValidRanges = wb.DefinedNames.ValidNamedRanges();
-                var globalInvalidRanges = wb.DefinedNames.InvalidNamedRanges();
-                var localValidRanges = ws1.DefinedNames.ValidNamedRanges();
-                var localInvalidRanges = ws1.DefinedNames.InvalidNamedRanges();
+            Assert.Multiple(() =>
+            {
+                Assert.That(globalValidRanges.Count(), Is.EqualTo(1));
+                Assert.That(globalValidRanges.First().Name, Is.EqualTo("Named range 2"));
 
-                Assert.AreEqual(1, globalValidRanges.Count());
-                Assert.AreEqual("Named range 2", globalValidRanges.First().Name);
+                Assert.That(globalInvalidRanges.Count(), Is.EqualTo(2));
+                Assert.That(globalInvalidRanges.First().Name, Is.EqualTo("Named range 4"));
+                Assert.That(globalInvalidRanges.Last().Name, Is.EqualTo("Named range 5"));
 
-                Assert.AreEqual(2, globalInvalidRanges.Count());
-                Assert.AreEqual("Named range 4", globalInvalidRanges.First().Name);
-                Assert.AreEqual("Named range 5", globalInvalidRanges.Last().Name);
+                Assert.That(localValidRanges.Count(), Is.EqualTo(1));
+                Assert.That(localValidRanges.First().Name, Is.EqualTo("Named range 1"));
 
-                Assert.AreEqual(1, localValidRanges.Count());
-                Assert.AreEqual("Named range 1", localValidRanges.First().Name);
-
-                Assert.AreEqual(0, localInvalidRanges.Count());
-            }
+                Assert.That(localInvalidRanges.Count(), Is.EqualTo(0));
+            });
         }
 
         [Test]
         public void CanRenameNamedRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet("Sheet1");
+            var dn1 = wb.DefinedNames.Add("TEST", "=0.1");
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb.AddWorksheet("Sheet1");
-                var dn1 = wb.DefinedNames.Add("TEST", "=0.1");
+                Assert.That(wb.DefinedNames.TryGetValue("TEST", out _), Is.True);
+                Assert.That(wb.DefinedNames.TryGetValue("TEST1", out _), Is.False);
+            });
 
-                Assert.IsTrue(wb.DefinedNames.TryGetValue("TEST", out _));
-                Assert.IsFalse(wb.DefinedNames.TryGetValue("TEST1", out _));
+            dn1.Name = "TEST1";
 
-                dn1.Name = "TEST1";
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.TryGetValue("TEST", out _), Is.False);
+                Assert.That(wb.DefinedNames.TryGetValue("TEST1", out _), Is.True);
+            });
 
-                Assert.IsFalse(wb.DefinedNames.TryGetValue("TEST", out _));
-                Assert.IsTrue(wb.DefinedNames.TryGetValue("TEST1", out _));
+            var dn2 = wb.DefinedNames.Add("TEST2", "=TEST1*2");
 
-                var dn2 = wb.DefinedNames.Add("TEST2", "=TEST1*2");
+            ws1.Cell(1, 1).FormulaA1 = "TEST1";
+            ws1.Cell(2, 1).FormulaA1 = "TEST1*10";
+            ws1.Cell(3, 1).FormulaA1 = "TEST2";
+            ws1.Cell(4, 1).FormulaA1 = "TEST2*3";
 
-                ws1.Cell(1, 1).FormulaA1 = "TEST1";
-                ws1.Cell(2, 1).FormulaA1 = "TEST1*10";
-                ws1.Cell(3, 1).FormulaA1 = "TEST2";
-                ws1.Cell(4, 1).FormulaA1 = "TEST2*3";
-
-                Assert.AreEqual(0.1, (double)ws1.Cell(1, 1).Value, XLHelper.Epsilon);
-                Assert.AreEqual(1.0, (double)ws1.Cell(2, 1).Value, XLHelper.Epsilon);
-                Assert.AreEqual(0.2, (double)ws1.Cell(3, 1).Value, XLHelper.Epsilon);
-                Assert.AreEqual(0.6, (double)ws1.Cell(4, 1).Value, XLHelper.Epsilon);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That((double)ws1.Cell(1, 1).Value, Is.EqualTo(0.1).Within(XLHelper.Epsilon));
+                Assert.That((double)ws1.Cell(2, 1).Value, Is.EqualTo(1.0).Within(XLHelper.Epsilon));
+                Assert.That((double)ws1.Cell(3, 1).Value, Is.EqualTo(0.2).Within(XLHelper.Epsilon));
+                Assert.That((double)ws1.Cell(4, 1).Value, Is.EqualTo(0.6).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
         public void Can_save_and_load_defined_names()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var sheet1 = wb.Worksheets.Add("Sheet1");
+                var sheet2 = wb.Worksheets.Add("Sheet2");
+
+                wb.DefinedNames.Add("wbNamedRange",
+                    "Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G");
+                sheet1.DefinedNames.Add("sheet1NamedRange",
+                    "Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G");
+                sheet2.DefinedNames.Add("sheet2NamedRange", "Sheet1!A1,Sheet2!A1");
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var sheet1 = wb.Worksheet("Sheet1");
+                var sheet2 = wb.Worksheet("Sheet2");
+
+                Assert.Multiple(() =>
                 {
-                    var sheet1 = wb.Worksheets.Add("Sheet1");
-                    var sheet2 = wb.Worksheets.Add("Sheet2");
+                    Assert.That(wb.DefinedNames.Count(), Is.EqualTo(1));
+                    Assert.That(wb.DefinedNames.Single().Name, Is.EqualTo("wbNamedRange"));
+                    Assert.That(wb.DefinedNames.Single().RefersTo, Is.EqualTo("Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G"));
+                    Assert.That(wb.DefinedNames.Single().Ranges, Has.Count.EqualTo(5));
 
-                    wb.DefinedNames.Add("wbNamedRange",
-                        "Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G");
-                    sheet1.DefinedNames.Add("sheet1NamedRange",
-                        "Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G");
-                    sheet2.DefinedNames.Add("sheet2NamedRange", "Sheet1!A1,Sheet2!A1");
+                    Assert.That(sheet1.DefinedNames.Count(), Is.EqualTo(1));
+                    Assert.That(sheet1.DefinedNames.Single().Name, Is.EqualTo("sheet1NamedRange"));
+                    Assert.That(sheet1.DefinedNames.Single().RefersTo, Is.EqualTo("Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G"));
+                    Assert.That(sheet1.DefinedNames.Single().Ranges, Has.Count.EqualTo(5));
 
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var sheet1 = wb.Worksheet("Sheet1");
-                    var sheet2 = wb.Worksheet("Sheet2");
-
-                    Assert.AreEqual(1, wb.DefinedNames.Count());
-                    Assert.AreEqual("wbNamedRange", wb.DefinedNames.Single().Name);
-                    Assert.AreEqual("Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G", wb.DefinedNames.Single().RefersTo);
-                    Assert.AreEqual(5, wb.DefinedNames.Single().Ranges.Count);
-
-                    Assert.AreEqual(1, sheet1.DefinedNames.Count());
-                    Assert.AreEqual("sheet1NamedRange", sheet1.DefinedNames.Single().Name);
-                    Assert.AreEqual("Sheet1!$B$2,Sheet1!$B$3:$C$3,Sheet2!$D$3:$D$4,Sheet1!$6:$7,Sheet1!$F:$G", sheet1.DefinedNames.Single().RefersTo);
-                    Assert.AreEqual(5, sheet1.DefinedNames.Single().Ranges.Count);
-
-                    Assert.AreEqual(1, sheet2.DefinedNames.Count());
-                    Assert.AreEqual("sheet2NamedRange", sheet2.DefinedNames.Single().Name);
-                    Assert.AreEqual("Sheet1!A1,Sheet2!A1", sheet2.DefinedNames.Single().RefersTo);
-                    Assert.AreEqual(2, sheet2.DefinedNames.Single().Ranges.Count);
-                }
+                    Assert.That(sheet2.DefinedNames.Count(), Is.EqualTo(1));
+                    Assert.That(sheet2.DefinedNames.Single().Name, Is.EqualTo("sheet2NamedRange"));
+                    Assert.That(sheet2.DefinedNames.Single().RefersTo, Is.EqualTo("Sheet1!A1,Sheet2!A1"));
+                    Assert.That(sheet2.DefinedNames.Single().Ranges, Has.Count.EqualTo(2));
+                });
             }
         }
 
@@ -189,16 +202,19 @@ namespace ClosedXML.Tests.Excel
 
             var copy = original.CopyTo(ws2);
 
-            Assert.AreEqual(1, ws1.DefinedNames.Count());
-            Assert.AreEqual(1, ws2.DefinedNames.Count());
-            Assert.AreEqual(2, original.Ranges.Count);
-            Assert.AreEqual(2, copy.Ranges.Count);
-            Assert.AreEqual(original.Name, copy.Name);
-            Assert.AreEqual(original.Scope, copy.Scope);
-            Assert.AreEqual("Sheet1!B2:E6", original.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet2!D1:E2", original.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet2!D1:E2", copy.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet2!B2:E6", copy.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.DefinedNames.Count(), Is.EqualTo(1));
+                Assert.That(ws2.DefinedNames.Count(), Is.EqualTo(1));
+                Assert.That(original.Ranges, Has.Count.EqualTo(2));
+                Assert.That(copy.Ranges, Has.Count.EqualTo(2));
+                Assert.That(copy.Name, Is.EqualTo(original.Name));
+                Assert.That(copy.Scope, Is.EqualTo(original.Scope));
+            });
+            Assert.That(original.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet1!B2:E6"));
+            Assert.That(original.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!D1:E2"));
+            Assert.That(copy.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!D1:E2"));
+            Assert.That(copy.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!B2:E6"));
         }
 
         [Test]
@@ -219,8 +235,11 @@ namespace ClosedXML.Tests.Excel
             originalName.CopyTo(copySheet);
 
             var copyName = copySheet.DefinedNames.Single();
-            Assert.AreEqual("TableName", copyName.Name);
-            Assert.AreEqual("SUM(CopyTable[Data], MiscTable[Data])", copyName.RefersTo);
+            Assert.Multiple(() =>
+            {
+                Assert.That(copyName.Name, Is.EqualTo("TableName"));
+                Assert.That(copyName.RefersTo, Is.EqualTo("SUM(CopyTable[Data], MiscTable[Data])"));
+            });
         }
 
         [Test]
@@ -232,7 +251,7 @@ namespace ClosedXML.Tests.Excel
 
             var copySheet = wb.AddWorksheet();
             var ex = Assert.Throws<InvalidOperationException>(() => name.CopyTo(copySheet))!;
-            Assert.AreEqual("Cannot copy workbook scoped defined name.", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Cannot copy workbook scoped defined name."));
         }
 
         [Test]
@@ -251,20 +270,21 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void DeleteColumnUsedInNamedRange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Column1");
+            ws.FirstCell().CellRight().SetValue("Column2").Style.Font.SetBold();
+            ws.FirstCell().CellRight(2).SetValue("Column3");
+            ws.DefinedNames.Add("MyRange", "A1:C1");
+
+            ws.Column(1).Delete();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Column1");
-                ws.FirstCell().CellRight().SetValue("Column2").Style.Font.SetBold();
-                ws.FirstCell().CellRight(2).SetValue("Column3");
-                ws.DefinedNames.Add("MyRange", "A1:C1");
-
-                ws.Column(1).Delete();
-
-                Assert.IsTrue(ws.Cell("A1").Style.Font.Bold);
-                Assert.AreEqual("Column3", ws.Cell("B1").Value);
-                Assert.AreEqual(Blank.Value, ws.Cell("C1").Value);
-            }
+                Assert.That(ws.Cell("A1").Style.Font.Bold, Is.True);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo("Column3"));
+                Assert.That(ws.Cell("C1").Value, Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
@@ -277,11 +297,14 @@ namespace ClosedXML.Tests.Excel
 
             ws.Name = "Renamed";
 
-            Assert.AreEqual("ABS(Renamed!$B$5)", bookScopedName.RefersTo);
-            Assert.AreEqual("Renamed!$B$5:$B$5", bookScopedName.Ranges.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(bookScopedName.RefersTo, Is.EqualTo("ABS(Renamed!$B$5)"));
+                Assert.That(bookScopedName.Ranges.ToString(), Is.EqualTo("Renamed!$B$5:$B$5"));
 
-            Assert.AreEqual("Renamed!$D$7:$F$14", sheetScopedName.RefersTo);
-            Assert.AreEqual("Renamed!$D$7:$F$14", sheetScopedName.Ranges.ToString());
+                Assert.That(sheetScopedName.RefersTo, Is.EqualTo("Renamed!$D$7:$F$14"));
+                Assert.That(sheetScopedName.Ranges.ToString(), Is.EqualTo("Renamed!$D$7:$F$14"));
+            });
         }
 
         [Test]
@@ -303,139 +326,271 @@ namespace ClosedXML.Tests.Excel
             sheet1.Column(1).InsertColumnsBefore(2);
             sheet1.Column(1).Delete();
 
-            Assert.AreEqual("Sheet1!$C$3,Sheet1!$C$4:$D$4,Sheet2!$D$3:$D$4,Sheet1!$7:$8,Sheet1!$G:$H",
-                wb.DefinedNames.First().RefersTo);
-            Assert.AreEqual("Sheet1!$C$3,Sheet1!$C$4:$D$4,Sheet2!$D$3:$D$4,Sheet1!$7:$8,Sheet1!$G:$H",
-                sheet1.DefinedNames.First().RefersTo);
-            Assert.AreEqual("Sheet1!B2,Sheet2!A1", sheet2.DefinedNames.First().RefersTo);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.First().RefersTo,
+                            Is.EqualTo("Sheet1!$C$3,Sheet1!$C$4:$D$4,Sheet2!$D$3:$D$4,Sheet1!$7:$8,Sheet1!$G:$H"));
+                Assert.That(sheet1.DefinedNames.First().RefersTo,
+                    Is.EqualTo("Sheet1!$C$3,Sheet1!$C$4:$D$4,Sheet2!$D$3:$D$4,Sheet1!$7:$8,Sheet1!$G:$H"));
+                Assert.That(sheet2.DefinedNames.First().RefersTo, Is.EqualTo("Sheet1!B2,Sheet2!A1"));
+            });
 
-            wb.DefinedNames.ForEach(dn => Assert.AreEqual(XLNamedRangeScope.Workbook, dn.Scope));
-            sheet1.DefinedNames.ForEach(dn => Assert.AreEqual(XLNamedRangeScope.Worksheet, dn.Scope));
-            sheet2.DefinedNames.ForEach(dn => Assert.AreEqual(XLNamedRangeScope.Worksheet, dn.Scope));
+            wb.DefinedNames.ForEach(dn => Assert.That(dn.Scope, Is.EqualTo(XLNamedRangeScope.Workbook)));
+            sheet1.DefinedNames.ForEach(dn => Assert.That(dn.Scope, Is.EqualTo(XLNamedRangeScope.Worksheet)));
+            sheet2.DefinedNames.ForEach(dn => Assert.That(dn.Scope, Is.EqualTo(XLNamedRangeScope.Worksheet)));
         }
 
         [Test, Ignore("Muted until shifting is fixed (see #880)")]
         public void NamedRangeBecomesInvalidOnRangeAndWorksheetDeleting()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet 1");
+            var ws2 = wb.Worksheets.Add("Sheet 2");
+            ws1.Range("A1:B2").AddToNamed("Simple", XLScope.Workbook);
+            wb.DefinedNames.Add("Compound", new XLRanges
             {
-                var ws1 = wb.Worksheets.Add("Sheet 1");
-                var ws2 = wb.Worksheets.Add("Sheet 2");
-                ws1.Range("A1:B2").AddToNamed("Simple", XLScope.Workbook);
-                wb.DefinedNames.Add("Compound", new XLRanges
-                {
-                    ws1.Range("C1:D2"),
-                    ws2.Range("A10:D15")
-                });
+                ws1.Range("C1:D2"),
+                ws2.Range("A10:D15")
+            });
 
-                ws1.Rows(1, 5).Delete();
-                ws1.Delete();
+            ws1.Rows(1, 5).Delete();
+            ws1.Delete();
 
-                Assert.AreEqual(2, wb.DefinedNames.Count());
-                Assert.AreEqual(0, wb.DefinedNames.ValidNamedRanges().Count());
-                Assert.AreEqual("#REF!#REF!", wb.DefinedNames.ElementAt(0).RefersTo);
-                Assert.AreEqual("#REF!#REF!,'Sheet 2'!A10:D15", wb.DefinedNames.ElementAt(0).RefersTo);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.Count(), Is.EqualTo(2));
+                Assert.That(wb.DefinedNames.ValidNamedRanges().Count(), Is.EqualTo(0));
+                Assert.That(wb.DefinedNames.ElementAt(0).RefersTo, Is.EqualTo("#REF!#REF!"));
+            });
+            Assert.That(wb.DefinedNames.ElementAt(0).RefersTo, Is.EqualTo("#REF!#REF!,'Sheet 2'!A10:D15"));
         }
 
         [Test, Ignore("Muted until shifting is fixed (see #880)")]
         public void NamedRangeBecomesInvalidOnRangeDeleting()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet 1");
+            ws.Range("A1:B2").AddToNamed("Simple", XLScope.Workbook);
+            wb.DefinedNames.Add("Compound", new XLRanges
             {
-                var ws = wb.Worksheets.Add("Sheet 1");
-                ws.Range("A1:B2").AddToNamed("Simple", XLScope.Workbook);
-                wb.DefinedNames.Add("Compound", new XLRanges
-                {
-                    ws.Range("C1:D2"),
-                    ws.Range("A10:D15")
-                });
+                ws.Range("C1:D2"),
+                ws.Range("A10:D15")
+            });
 
-                ws.Rows(1, 5).Delete();
+            ws.Rows(1, 5).Delete();
 
-                Assert.AreEqual(2, wb.DefinedNames.Count());
-                Assert.AreEqual(0, wb.DefinedNames.ValidNamedRanges().Count());
-                Assert.AreEqual("'Sheet 1'!#REF!", wb.DefinedNames.ElementAt(0).RefersTo);
-                Assert.AreEqual("'Sheet 1'!#REF!,'Sheet 1'!A5:D10", wb.DefinedNames.ElementAt(0).RefersTo);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.Count(), Is.EqualTo(2));
+                Assert.That(wb.DefinedNames.ValidNamedRanges().Count(), Is.EqualTo(0));
+                Assert.That(wb.DefinedNames.ElementAt(0).RefersTo, Is.EqualTo("'Sheet 1'!#REF!"));
+            });
+            Assert.That(wb.DefinedNames.ElementAt(0).RefersTo, Is.EqualTo("'Sheet 1'!#REF!,'Sheet 1'!A5:D10"));
         }
 
         [Test]
         public void NamedRangeMayReferToExpression()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws1 = wb.AddWorksheet("Sheet1");
+                wb.DefinedNames.Add("TEST", "=0.1");
+                wb.DefinedNames.Add("TEST2", "=TEST*2");
+
+                ws1.Cell(1, 1).FormulaA1 = "TEST";
+                ws1.Cell(2, 1).FormulaA1 = "TEST*10";
+                ws1.Cell(3, 1).FormulaA1 = "TEST2";
+                ws1.Cell(4, 1).FormulaA1 = "TEST2*3";
+
+                Assert.Multiple(() =>
                 {
-                    var ws1 = wb.AddWorksheet("Sheet1");
-                    wb.DefinedNames.Add("TEST", "=0.1");
-                    wb.DefinedNames.Add("TEST2", "=TEST*2");
+                    Assert.That((double)ws1.Cell(1, 1).Value, Is.EqualTo(0.1).Within(XLHelper.Epsilon));
+                    Assert.That((double)ws1.Cell(2, 1).Value, Is.EqualTo(1.0).Within(XLHelper.Epsilon));
+                    Assert.That((double)ws1.Cell(3, 1).Value, Is.EqualTo(0.2).Within(XLHelper.Epsilon));
+                    Assert.That((double)ws1.Cell(4, 1).Value, Is.EqualTo(0.6).Within(XLHelper.Epsilon));
+                });
 
-                    ws1.Cell(1, 1).FormulaA1 = "TEST";
-                    ws1.Cell(2, 1).FormulaA1 = "TEST*10";
-                    ws1.Cell(3, 1).FormulaA1 = "TEST2";
-                    ws1.Cell(4, 1).FormulaA1 = "TEST2*3";
+                wb.SaveAs(ms);
+            }
 
-                    Assert.AreEqual(0.1, (double)ws1.Cell(1, 1).Value, XLHelper.Epsilon);
-                    Assert.AreEqual(1.0, (double)ws1.Cell(2, 1).Value, XLHelper.Epsilon);
-                    Assert.AreEqual(0.2, (double)ws1.Cell(3, 1).Value, XLHelper.Epsilon);
-                    Assert.AreEqual(0.6, (double)ws1.Cell(4, 1).Value, XLHelper.Epsilon);
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws1 = wb.Worksheets.First();
 
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
+                Assert.Multiple(() =>
                 {
-                    var ws1 = wb.Worksheets.First();
-
-                    Assert.AreEqual(0.1, (double)ws1.Cell(1, 1).Value, XLHelper.Epsilon);
-                    Assert.AreEqual(1.0, (double)ws1.Cell(2, 1).Value, XLHelper.Epsilon);
-                    Assert.AreEqual(0.2, (double)ws1.Cell(3, 1).Value, XLHelper.Epsilon);
-                    Assert.AreEqual(0.6, (double)ws1.Cell(4, 1).Value, XLHelper.Epsilon);
-                }
+                    Assert.That((double)ws1.Cell(1, 1).Value, Is.EqualTo(0.1).Within(XLHelper.Epsilon));
+                    Assert.That((double)ws1.Cell(2, 1).Value, Is.EqualTo(1.0).Within(XLHelper.Epsilon));
+                    Assert.That((double)ws1.Cell(3, 1).Value, Is.EqualTo(0.2).Within(XLHelper.Epsilon));
+                    Assert.That((double)ws1.Cell(4, 1).Value, Is.EqualTo(0.6).Within(XLHelper.Epsilon));
+                });
             }
         }
 
         [Test]
         public void NamedRangeReferringToMultipleRangesCanBeSavedAndLoaded()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.Worksheets.Add("Sheet 1");
+
+                wb.DefinedNames.Add("Multirange named range", new XLRanges
                 {
-                    var ws = wb.Worksheets.Add("Sheet 1");
+                    ws.Range("A5:D5"),
+                    ws.Range("A15:D15")
+                });
 
-                    wb.DefinedNames.Add("Multirange named range", new XLRanges
-                    {
-                        ws.Range("A5:D5"),
-                        ws.Range("A15:D15")
-                    });
+                wb.SaveAs(ms);
+            }
 
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.DefinedNames.Count(), Is.EqualTo(1));
+                var nr = (XLDefinedName)wb.DefinedNames.Single();
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(1, wb.DefinedNames.Count());
-                    var nr = (XLDefinedName)wb.DefinedNames.Single();
-                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5,'Sheet 1'!$A$15:$D$15", nr.RefersTo);
-                    Assert.AreEqual(2, nr.Ranges.Count);
-                    Assert.AreEqual("'Sheet 1'!A5:D5", nr.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
-                    Assert.AreEqual("'Sheet 1'!A15:D15", nr.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true));
-                    Assert.AreEqual(2, nr.SheetReferencesList.Count);
-                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5", nr.SheetReferencesList.First());
-                    Assert.AreEqual("'Sheet 1'!$A$15:$D$15", nr.SheetReferencesList.Last());
-                }
+                    Assert.That(nr.RefersTo, Is.EqualTo("'Sheet 1'!$A$5:$D$5,'Sheet 1'!$A$15:$D$15"));
+                    Assert.That(nr.Ranges, Has.Count.EqualTo(2));
+                });
+                Assert.That(nr.Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A5:D5"));
+                Assert.That(nr.Ranges.Last().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A15:D15"));
+                Assert.That(nr.SheetReferencesList, Has.Count.EqualTo(2));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(nr.SheetReferencesList.First(), Is.EqualTo("'Sheet 1'!$A$5:$D$5"));
+                    Assert.That(nr.SheetReferencesList.Last(), Is.EqualTo("'Sheet 1'!$A$15:$D$15"));
+                });
             }
         }
 
         [Test]
         public void Defined_names_referencing_sheet_range_become_invalid_when_sheet_is_deleted()
         {
+            using var wb = new XLWorkbook();
+            var ws1 = wb.Worksheets.Add("Sheet 1");
+            var ws2 = wb.Worksheets.Add("Sheet 2");
+            var ws3 = wb.Worksheets.Add("Sheet'3");
+
+            ws1.Range("A1:D1").AddToNamed("Named range 1", XLScope.Worksheet);
+            ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
+            ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
+            ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
+            wb.DefinedNames.Add("Named range 5", new XLRanges
+            {
+                ws1.Range("A5:D5"),
+                ws3.Range("A5:D5")
+            });
+
+            ws2.Delete();
+            ws3.Delete();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.DefinedNames.Count(), Is.EqualTo(1));
+                Assert.That(ws1.DefinedNames.First().Name, Is.EqualTo("Named range 1"));
+                Assert.That(ws1.DefinedNames.First().Scope, Is.EqualTo(XLNamedRangeScope.Worksheet));
+                Assert.That(ws1.DefinedNames.First().RefersTo, Is.EqualTo("'Sheet 1'!$A$1:$D$1"));
+                Assert.That(ws1.DefinedNames.First().Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A1:D1"));
+            });
+
+            Assert.That(wb.DefinedNames.Count(), Is.EqualTo(3));
+
+            Assert.That(wb.DefinedNames.ElementAt(0).Name, Is.EqualTo("Named range 2"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.ElementAt(0).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                Assert.That(wb.DefinedNames.ElementAt(0).RefersTo, Is.EqualTo("'Sheet 1'!$A$2:$D$2"));
+                Assert.That(wb.DefinedNames.ElementAt(0).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A2:D2"));
+            });
+
+            Assert.That(wb.DefinedNames.ElementAt(1).Name, Is.EqualTo("Named range 4"));
+            Assert.That(wb.DefinedNames.ElementAt(1).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.ElementAt(1).RefersTo, Is.EqualTo("#REF!"));
+                Assert.That(wb.DefinedNames.ElementAt(1).Ranges.Any(), Is.False);
+
+                Assert.That(wb.DefinedNames.ElementAt(2).Name, Is.EqualTo("Named range 5"));
+                Assert.That(wb.DefinedNames.ElementAt(2).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                Assert.That(wb.DefinedNames.ElementAt(2).RefersTo, Is.EqualTo("'Sheet 1'!$A$5:$D$5,#REF!"));
+                Assert.That(wb.DefinedNames.ElementAt(2).Ranges, Has.Count.EqualTo(1));
+            });
+            Assert.That(wb.DefinedNames.ElementAt(2).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!A5:D5"));
+        }
+
+        [Test]
+        public void NamedRangesFromDeletedSheetAreSavedWithoutAddress()
+        {
+            // Range address referring to the deleted sheet look like #REF!A1:B2.
+            // But workbooks with such references in named ranges Excel considers as broken files.
+            // It requires #REF!
+
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
+            {
+                wb.Worksheets.Add("Sheet 1");
+                var ws2 = wb.Worksheets.Add("Sheet 2");
+                ws2.Range("A4:D4").AddToNamed("Test named range", XLScope.Workbook);
+                ws2.Delete();
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.DefinedNames.Single().RefersTo, Is.EqualTo("#REF!"));
+            }
+        }
+
+        [Test]
+        public void Only_worksheet_scoped_defined_names_are_copied_when_sheet_is_copied()
+        {
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet("Sheet1");
+            ws1.FirstCell().InsertData(Enumerable.Range(1, 10));
+            wb.DefinedNames.Add("wbNamedRange", ws1.Range("A1:A10"));
+            ws1.DefinedNames.Add("wsNamedRange", ws1.Range("A3"));
+
+            var ws2 = wb.AddWorksheet("Sheet2");
+            ws2.FirstCell().InsertData(Enumerable.Range(101, 10));
+            ws1.DefinedNames.Add("wsNamedRangeAcrossSheets", ws2.Range("A4"));
+
+            ws1.Cell("C1").FormulaA1 = "=wbNamedRange";
+            ws1.Cell("C2").FormulaA1 = "=wsNamedRange";
+            ws1.Cell("C3").FormulaA1 = "=wsNamedRangeAcrossSheets";
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.Cell("C1").Value, Is.EqualTo(1));
+                Assert.That(ws1.Cell("C2").Value, Is.EqualTo(3));
+                Assert.That(ws1.Cell("C3").Value, Is.EqualTo(104));
+            });
+
+            var wsCopy = ws1.CopyTo("Copy");
+            Assert.Multiple(() =>
+            {
+                Assert.That(wsCopy.Cell("C1").Value, Is.EqualTo(1));
+                Assert.That(wsCopy.Cell("C2").Value, Is.EqualTo(3));
+                Assert.That(wsCopy.Cell("C3").Value, Is.EqualTo(104));
+
+                Assert.That(wb.DefinedName("wbNamedRange").Ranges.First().RangeAddress.ToStringRelative(true),
+                    Is.EqualTo("Sheet1!A1:A10"));
+            });
+            Assert.That(wsCopy.DefinedName("wsNamedRange").Ranges.First().RangeAddress.ToStringRelative(true),
+                Is.EqualTo("Copy!A3:A3"));
+            Assert.AreEqual("Sheet2!A4:A4",
+                wsCopy.DefinedName("wsNamedRangeAcrossSheets").Ranges.First().RangeAddress.ToStringRelative(true));
+        }
+
+        [Test]
+        public void Saved_defined_names_become_invalid_on_sheet_deleting()
+        {
+            using var ms = new MemoryStream();
             using (var wb = new XLWorkbook())
             {
                 var ws1 = wb.Worksheets.Add("Sheet 1");
-                var ws2 = wb.Worksheets.Add("Sheet 2");
+                var ws2 = wb.Worksheets.Add("Sheet2");
                 var ws3 = wb.Worksheets.Add("Sheet'3");
 
                 ws1.Range("A1:D1").AddToNamed("Named range 1", XLScope.Worksheet);
@@ -448,172 +603,67 @@ namespace ClosedXML.Tests.Excel
                     ws3.Range("A5:D5")
                 });
 
-                ws2.Delete();
-                ws3.Delete();
-
-                Assert.AreEqual(1, ws1.DefinedNames.Count());
-                Assert.AreEqual("Named range 1", ws1.DefinedNames.First().Name);
-                Assert.AreEqual(XLNamedRangeScope.Worksheet, ws1.DefinedNames.First().Scope);
-                Assert.AreEqual("'Sheet 1'!$A$1:$D$1", ws1.DefinedNames.First().RefersTo);
-                Assert.AreEqual("'Sheet 1'!A1:D1", ws1.DefinedNames.First().Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));
-
-                Assert.AreEqual(3, wb.DefinedNames.Count());
-
-                Assert.AreEqual("Named range 2", wb.DefinedNames.ElementAt(0).Name);
-                Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(0).Scope);
-                Assert.AreEqual("'Sheet 1'!$A$2:$D$2", wb.DefinedNames.ElementAt(0).RefersTo);
-                Assert.AreEqual("'Sheet 1'!A2:D2", wb.DefinedNames.ElementAt(0).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));
-
-                Assert.AreEqual("Named range 4", wb.DefinedNames.ElementAt(1).Name);
-                Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(1).Scope);
-                Assert.AreEqual("#REF!", wb.DefinedNames.ElementAt(1).RefersTo);
-                Assert.IsFalse(wb.DefinedNames.ElementAt(1).Ranges.Any());
-
-                Assert.AreEqual("Named range 5", wb.DefinedNames.ElementAt(2).Name);
-                Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(2).Scope);
-                Assert.AreEqual("'Sheet 1'!$A$5:$D$5,#REF!", wb.DefinedNames.ElementAt(2).RefersTo);
-                Assert.AreEqual(1, wb.DefinedNames.ElementAt(2).Ranges.Count);
-                Assert.AreEqual("'Sheet 1'!A5:D5", wb.DefinedNames.ElementAt(2).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));
+                wb.SaveAs(ms);
             }
-        }
 
-        [Test]
-        public void NamedRangesFromDeletedSheetAreSavedWithoutAddress()
-        {
-            // Range address referring to the deleted sheet look like #REF!A1:B2.
-            // But workbooks with such references in named ranges Excel considers as broken files.
-            // It requires #REF!
-
-            using (var ms = new MemoryStream())
+            using (var wb = new XLWorkbook(ms))
             {
-                using (var wb = new XLWorkbook())
-                {
-                    wb.Worksheets.Add("Sheet 1");
-                    var ws2 = wb.Worksheets.Add("Sheet 2");
-                    ws2.Range("A4:D4").AddToNamed("Test named range", XLScope.Workbook);
-                    ws2.Delete();
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.AreEqual("#REF!", wb.DefinedNames.Single().RefersTo);
-                }
+                wb.Worksheet("Sheet2").Delete();
+                wb.Worksheet("Sheet'3").Delete();
+                wb.Save();
             }
-        }
 
-        [Test]
-        public void Only_worksheet_scoped_defined_names_are_copied_when_sheet_is_copied()
-        {
-            using (var wb = new XLWorkbook())
+            using (var wb = new XLWorkbook(ms))
             {
-                var ws1 = wb.AddWorksheet("Sheet1");
-                ws1.FirstCell().InsertData(Enumerable.Range(1, 10));
-                wb.DefinedNames.Add("wbNamedRange", ws1.Range("A1:A10"));
-                ws1.DefinedNames.Add("wsNamedRange", ws1.Range("A3"));
-
-                var ws2 = wb.AddWorksheet("Sheet2");
-                ws2.FirstCell().InsertData(Enumerable.Range(101, 10));
-                ws1.DefinedNames.Add("wsNamedRangeAcrossSheets", ws2.Range("A4"));
-
-                ws1.Cell("C1").FormulaA1 = "=wbNamedRange";
-                ws1.Cell("C2").FormulaA1 = "=wsNamedRange";
-                ws1.Cell("C3").FormulaA1 = "=wsNamedRangeAcrossSheets";
-
-                Assert.AreEqual(1, ws1.Cell("C1").Value);
-                Assert.AreEqual(3, ws1.Cell("C2").Value);
-                Assert.AreEqual(104, ws1.Cell("C3").Value);
-
-                var wsCopy = ws1.CopyTo("Copy");
-                Assert.AreEqual(1, wsCopy.Cell("C1").Value);
-                Assert.AreEqual(3, wsCopy.Cell("C2").Value);
-                Assert.AreEqual(104, wsCopy.Cell("C3").Value);
-
-                Assert.AreEqual("Sheet1!A1:A10",
-                    wb.DefinedName("wbNamedRange").Ranges.First().RangeAddress.ToStringRelative(true));
-                Assert.AreEqual("Copy!A3:A3",
-                    wsCopy.DefinedName("wsNamedRange").Ranges.First().RangeAddress.ToStringRelative(true));
-                Assert.AreEqual("Sheet2!A4:A4",
-                    wsCopy.DefinedName("wsNamedRangeAcrossSheets").Ranges.First().RangeAddress.ToStringRelative(true));
-            }
-        }
-
-        [Test]
-        public void Saved_defined_names_become_invalid_on_sheet_deleting()
-        {
-            using (var ms = new MemoryStream())
-            {
-                using (var wb = new XLWorkbook())
+                var ws1 = wb.Worksheet("Sheet 1");
+                Assert.Multiple(() =>
                 {
-                    var ws1 = wb.Worksheets.Add("Sheet 1");
-                    var ws2 = wb.Worksheets.Add("Sheet2");
-                    var ws3 = wb.Worksheets.Add("Sheet'3");
+                    Assert.That(ws1.DefinedNames.Count(), Is.EqualTo(1));
+                    Assert.That(ws1.DefinedNames.First().Name, Is.EqualTo("Named range 1"));
+                    Assert.That(ws1.DefinedNames.First().Scope, Is.EqualTo(XLNamedRangeScope.Worksheet));
+                    Assert.That(ws1.DefinedNames.First().RefersTo, Is.EqualTo("'Sheet 1'!$A$1:$D$1"));
+                    Assert.That(ws1.DefinedNames.First().Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true),
+                        Is.EqualTo("'Sheet 1'!A1:D1"));
+                });
 
-                    ws1.Range("A1:D1").AddToNamed("Named range 1", XLScope.Worksheet);
-                    ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
-                    ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
-                    ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
-                    wb.DefinedNames.Add("Named range 5", new XLRanges
-                    {
-                        ws1.Range("A5:D5"),
-                        ws3.Range("A5:D5")
-                    });
+                Assert.That(wb.DefinedNames.Count(), Is.EqualTo(3));
 
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
+                Assert.That(wb.DefinedNames.ElementAt(0).Name, Is.EqualTo("Named range 2"));
+                Assert.Multiple(() =>
                 {
-                    wb.Worksheet("Sheet2").Delete();
-                    wb.Worksheet("Sheet'3").Delete();
-                    wb.Save();
-                }
+                    Assert.That(wb.DefinedNames.ElementAt(0).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                    Assert.That(wb.DefinedNames.ElementAt(0).RefersTo, Is.EqualTo("'Sheet 1'!$A$2:$D$2"));
+                    Assert.That(wb.DefinedNames.ElementAt(0).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true),
+                        Is.EqualTo("'Sheet 1'!A2:D2"));
+                });
 
-                using (var wb = new XLWorkbook(ms))
+                Assert.That(wb.DefinedNames.ElementAt(1).Name, Is.EqualTo("Named range 4"));
+                Assert.That(wb.DefinedNames.ElementAt(1).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                Assert.Multiple(() =>
                 {
-                    var ws1 = wb.Worksheet("Sheet 1");
-                    Assert.AreEqual(1, ws1.DefinedNames.Count());
-                    Assert.AreEqual("Named range 1", ws1.DefinedNames.First().Name);
-                    Assert.AreEqual(XLNamedRangeScope.Worksheet, ws1.DefinedNames.First().Scope);
-                    Assert.AreEqual("'Sheet 1'!$A$1:$D$1", ws1.DefinedNames.First().RefersTo);
-                    Assert.AreEqual("'Sheet 1'!A1:D1",
-                        ws1.DefinedNames.First().Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));
+                    Assert.That(wb.DefinedNames.ElementAt(1).RefersTo, Is.EqualTo("#REF!"));
+                    Assert.That(wb.DefinedNames.ElementAt(1).Ranges.Any(), Is.False);
 
-                    Assert.AreEqual(3, wb.DefinedNames.Count());
-
-                    Assert.AreEqual("Named range 2", wb.DefinedNames.ElementAt(0).Name);
-                    Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(0).Scope);
-                    Assert.AreEqual("'Sheet 1'!$A$2:$D$2", wb.DefinedNames.ElementAt(0).RefersTo);
-                    Assert.AreEqual("'Sheet 1'!A2:D2",
-                        wb.DefinedNames.ElementAt(0).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));
-
-                    Assert.AreEqual("Named range 4", wb.DefinedNames.ElementAt(1).Name);
-                    Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(1).Scope);
-                    Assert.AreEqual("#REF!", wb.DefinedNames.ElementAt(1).RefersTo);
-                    Assert.IsFalse(wb.DefinedNames.ElementAt(1).Ranges.Any());
-
-                    Assert.AreEqual("Named range 5", wb.DefinedNames.ElementAt(2).Name);
-                    Assert.AreEqual(XLNamedRangeScope.Workbook, wb.DefinedNames.ElementAt(2).Scope);
-                    Assert.AreEqual("'Sheet 1'!$A$5:$D$5,#REF!", wb.DefinedNames.ElementAt(2).RefersTo);
-                    Assert.AreEqual(1, wb.DefinedNames.ElementAt(2).Ranges.Count);
-                    Assert.AreEqual("'Sheet 1'!A5:D5",
-                        wb.DefinedNames.ElementAt(2).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true));
-                }
+                    Assert.That(wb.DefinedNames.ElementAt(2).Name, Is.EqualTo("Named range 5"));
+                    Assert.That(wb.DefinedNames.ElementAt(2).Scope, Is.EqualTo(XLNamedRangeScope.Workbook));
+                    Assert.That(wb.DefinedNames.ElementAt(2).RefersTo, Is.EqualTo("'Sheet 1'!$A$5:$D$5,#REF!"));
+                    Assert.That(wb.DefinedNames.ElementAt(2).Ranges, Has.Count.EqualTo(1));
+                });
+                Assert.That(wb.DefinedNames.ElementAt(2).Ranges.Single().RangeAddress.ToString(XLReferenceStyle.A1, true),
+                    Is.EqualTo("'Sheet 1'!A5:D5"));
             }
         }
 
         [Test]
         public void TestInvalidNamedRangeOnWorkbookScope()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Column1");
-                ws.FirstCell().CellRight().SetValue("Column2").Style.Font.SetBold();
-                ws.FirstCell().CellRight(2).SetValue("Column3");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Column1");
+            ws.FirstCell().CellRight().SetValue("Column2").Style.Font.SetBold();
+            ws.FirstCell().CellRight(2).SetValue("Column3");
 
-                Assert.Throws<ArgumentException>(() => wb.DefinedNames.Add("MyRange", "A1:C1"));
-            }
+            Assert.Throws<ArgumentException>(() => wb.DefinedNames.Add("MyRange", "A1:C1"));
         }
 
         [Test]
@@ -623,20 +673,23 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().AddToNamed("Name", XLScope.Worksheet);
 
-            Assert.IsTrue(wb.DefinedNames.Contains("Sheet1!Name"));
-            Assert.IsFalse(wb.DefinedNames.Contains("Sheet1!NameX"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.Contains("Sheet1!Name"), Is.True);
+                Assert.That(wb.DefinedNames.Contains("Sheet1!NameX"), Is.False);
+            });
 
             Assert.IsNotNull(wb.DefinedName("Sheet1!Name"));
-            Assert.IsNull(wb.DefinedName("Sheet1!NameX"));
+            Assert.That(wb.DefinedName("Sheet1!NameX"), Is.Null);
 
             Boolean found1 = wb.DefinedNames.TryGetValue("Sheet1!Name", out var definedName1);
-            Assert.IsTrue(found1);
+            Assert.That(found1, Is.True);
             Assert.IsNotNull(definedName1);
-            Assert.AreEqual(XLNamedRangeScope.Worksheet, definedName1.Scope);
+            Assert.That(definedName1.Scope, Is.EqualTo(XLNamedRangeScope.Worksheet));
 
             Boolean found2 = wb.DefinedNames.TryGetValue("Sheet1!NameX", out var definedName2);
-            Assert.IsFalse(found2);
-            Assert.IsNull(definedName2);
+            Assert.That(found2, Is.False);
+            Assert.That(definedName2, Is.Null);
         }
 
         [Test]
@@ -646,19 +699,22 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().AddToNamed("Name");
 
-            Assert.IsTrue(wb.DefinedNames.Contains("Name"));
-            Assert.IsFalse(wb.DefinedNames.Contains("NameX"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.DefinedNames.Contains("Name"), Is.True);
+                Assert.That(wb.DefinedNames.Contains("NameX"), Is.False);
+            });
 
             Assert.IsNotNull(wb.DefinedName("Name"));
-            Assert.IsNull(wb.DefinedName("NameX"));
+            Assert.That(wb.DefinedName("NameX"), Is.Null);
 
             Boolean found1 = wb.DefinedNames.TryGetValue("Name", out var definedName1);
-            Assert.IsTrue(found1);
+            Assert.That(found1, Is.True);
             Assert.IsNotNull(definedName1);
 
             Boolean found2 = wb.DefinedNames.TryGetValue("NameX", out var definedName2);
-            Assert.IsFalse(found2);
-            Assert.IsNull(definedName2);
+            Assert.That(found2, Is.False);
+            Assert.That(definedName2, Is.Null);
         }
 
         [Test]
@@ -668,19 +724,22 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet("Sheet1");
             ws.FirstCell().AddToNamed("Name", XLScope.Worksheet);
 
-            Assert.IsTrue(ws.DefinedNames.Contains("Name"));
-            Assert.IsFalse(ws.DefinedNames.Contains("NameX"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.DefinedNames.Contains("Name"), Is.True);
+                Assert.That(ws.DefinedNames.Contains("NameX"), Is.False);
+            });
 
             Assert.IsNotNull(ws.DefinedName("Name"));
             Assert.Throws<KeyNotFoundException>(() => ws.DefinedName("NameX"));
 
             Boolean found1 = ws.DefinedNames.TryGetValue("Name", out var definedName1);
-            Assert.IsTrue(found1);
+            Assert.That(found1, Is.True);
             Assert.IsNotNull(definedName1);
 
             Boolean found2 = ws.DefinedNames.TryGetValue("NameX", out var definedName2);
-            Assert.IsFalse(found2);
-            Assert.IsNull(definedName2);
+            Assert.That(found2, Is.False);
+            Assert.That(definedName2, Is.Null);
         }
 
         [Test]
@@ -695,7 +754,7 @@ namespace ClosedXML.Tests.Excel
             a1.SetValue(5).AddToNamed("RAND");
             a2.FormulaA1 = "=RAND * 10";
 
-            Assert.AreEqual(50, a2.GetDouble());
+            Assert.That(a2.GetDouble(), Is.EqualTo(50));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/PageSetup/HeaderFooterTests.cs
+++ b/ClosedXML.Tests/Excel/PageSetup/HeaderFooterTests.cs
@@ -31,20 +31,18 @@ namespace ClosedXML.Tests.Excel
             ws = wb.Worksheets.First();
 
             var newHeader = ws.PageSetup.Header.Center.GetText(XLHFOccurrence.EvenPages);
-            Assert.AreEqual("Changed header", newHeader);
+            Assert.That(newHeader, Is.EqualTo("Changed header"));
         }
 
         [TestCase("")]
         [TestCase("&L&C&\"Arial\"&9 19-10-2017 \n&9&\"Arial\" &P    &N &R")] // https://github.com/ClosedXML/ClosedXML/issues/563
         public void CanSetHeaderFooter(string s)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                {
-                    var header = ws.PageSetup.Header as XLHeaderFooter;
-                    header.SetInnerText(XLHFOccurrence.AllPages, s);
-                }
+                var header = ws.PageSetup.Header as XLHeaderFooter;
+                header.SetInnerText(XLHFOccurrence.AllPages, s);
             }
         }
     }

--- a/ClosedXML.Tests/Excel/PageSetup/PageBreaksTests.cs
+++ b/ClosedXML.Tests/Excel/PageSetup/PageBreaksTests.cs
@@ -38,7 +38,7 @@ namespace ClosedXML.Tests.Excel
 
             sheet.PageSetup.AddHorizontalPageBreak(10);
             sheet.Row(5).InsertRowsAbove(1);
-            Assert.AreEqual(11, sheet.PageSetup.RowBreaks[0]);
+            Assert.That(sheet.PageSetup.RowBreaks[0], Is.EqualTo(11));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace ClosedXML.Tests.Excel
 
             sheet.PageSetup.AddHorizontalPageBreak(10);
             sheet.Row(15).InsertRowsAbove(1);
-            Assert.AreEqual(10, sheet.PageSetup.RowBreaks[0]);
+            Assert.That(sheet.PageSetup.RowBreaks[0], Is.EqualTo(10));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace ClosedXML.Tests.Excel
 
             sheet.PageSetup.AddVerticalPageBreak(10);
             sheet.Column(5).InsertColumnsBefore(1);
-            Assert.AreEqual(11, sheet.PageSetup.ColumnBreaks[0]);
+            Assert.That(sheet.PageSetup.ColumnBreaks[0], Is.EqualTo(11));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace ClosedXML.Tests.Excel
 
             sheet.PageSetup.AddVerticalPageBreak(10);
             sheet.Column(15).InsertColumnsBefore(1);
-            Assert.AreEqual(10, sheet.PageSetup.ColumnBreaks[0]);
+            Assert.That(sheet.PageSetup.ColumnBreaks[0], Is.EqualTo(10));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/PageSetup/PageLayoutTests.cs
+++ b/ClosedXML.Tests/Excel/PageSetup/PageLayoutTests.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Tests.Excel.PageSetup
         {
             TestHelper.CreateSaveLoadAssert(
                 (_, ws) => ws.PageSetup.FirstPageNumber = -3,
-                (_, ws) => Assert.AreEqual(-3, ws.PageSetup.FirstPageNumber),
+                (_, ws) => Assert.That(ws.PageSetup.FirstPageNumber, Is.EqualTo(-3)),
                 @"Other\PageSetup\Negative_first_page_number.xlsx");
         }
     }

--- a/ClosedXML.Tests/Excel/PageSetup/PrintAreaTests.cs
+++ b/ClosedXML.Tests/Excel/PageSetup/PrintAreaTests.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Tests.Excel
                 (_, ws) =>
                 {
                     var actualPrintAddresses = ws.PageSetup.PrintAreas.Select(pa => pa.RangeAddress.ToStringRelative());
-                    CollectionAssert.AreEqual(printAreaRangeAddresses, actualPrintAddresses);
+                    Assert.That(actualPrintAddresses, Is.EqualTo(printAreaRangeAddresses).AsCollection);
                 });
         }
     }

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotCacheTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotCacheTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             var pivotCache = wb.PivotCaches.Add(range);
             ws.Cell("A1").Value = "Pastry";
 
-            Assert.AreEqual(new[] { "Name" }, pivotCache.FieldNames);
+            Assert.That(pivotCache.FieldNames, Is.EqualTo(new[] { "Name" }));
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             ws.Cell("A1").Value = "Pastry";
             pivotCache.Refresh();
 
-            Assert.AreEqual(new[] { "Pastry" }, pivotCache.FieldNames);
+            Assert.That(pivotCache.FieldNames, Is.EqualTo(new[] { "Pastry" }));
         }
 
         [Test]
@@ -48,9 +48,12 @@ namespace ClosedXML.Tests.Excel.PivotTables
 
             pivotCache.Refresh();
 
-            Assert.AreEqual(XLItemsToRetain.None, pivotCache.ItemsToRetainPerField);
-            Assert.AreEqual(false, pivotCache.SaveSourceData);
-            Assert.AreEqual(true, pivotCache.RefreshDataOnOpen);
+            Assert.Multiple(() =>
+            {
+                Assert.That(pivotCache.ItemsToRetainPerField, Is.EqualTo(XLItemsToRetain.None));
+                Assert.That(pivotCache.SaveSourceData, Is.False);
+                Assert.That(pivotCache.RefreshDataOnOpen, Is.True);
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotDataFieldsTests.cs
@@ -28,8 +28,8 @@ namespace ClosedXML.Tests.Excel.PivotTables
 
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() => pt.Values.Add("Wrong field name"));
 
-            Assert.NotNull(ex);
-            StringAssert.StartsWith("Field 'Wrong field name' is not in the fields of a pivot cache. Should be one of 'Name','Price'.", ex.Message);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex.Message, Does.StartWith("Field 'Wrong field name' is not in the fields of a pivot cache. Should be one of 'Name','Price'."));
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableAxisFieldTests.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
 
             colorField.SetCustomName("Changed color");
 
-            Assert.AreEqual("Changed color", pt.RowLabels.Get(0).CustomName);
+            Assert.That(pt.RowLabels.Get(0).CustomName, Is.EqualTo("Changed color"));
         }
 
         [Test]
@@ -43,9 +43,9 @@ namespace ClosedXML.Tests.Excel.PivotTables
             var colorField = pt.RowLabels.Add("Color");
 
             var ex1 = Assert.Throws<ArgumentException>(() => idField.SetCustomName("Color"))!;
-            Assert.AreEqual("Custom name 'Color' is already used by another field.", ex1.Message);
+            Assert.That(ex1.Message, Is.EqualTo("Custom name 'Color' is already used by another field."));
             var ex2 = Assert.Throws<ArgumentException>(() => colorField.SetCustomName("Custom ID"));
-            Assert.AreEqual("Custom name 'Custom ID' is already used by another field.", ex2.Message);
+            Assert.That(ex2.Message, Is.EqualTo("Custom name 'Custom ID' is already used by another field."));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -29,7 +29,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             var ptSheet = wb.AddWorksheet();
             var pt = ptSheet.PivotTables.Add("pt", ptSheet.Cell("A1"), range);
             var internalPt = (XLPivotTable)pt;
-            Assert.IsEmpty(internalPt.PivotFields[0].Items);
+            Assert.That(internalPt.PivotFields[0].Items, Is.Empty);
 
             var idField = pt.RowLabels.Add("ID", "Item ID").AddSubtotal(XLSubtotalFunction.Automatic);
 
@@ -108,15 +108,15 @@ namespace ClosedXML.Tests.Excel.PivotTables
 
             pt.RowLabels.Clear();
 
-            Assert.IsEmpty(pt.RowLabels);
+            Assert.That(pt.RowLabels, Is.Empty);
 
             // Clear should also remove custom names and axis, otherwise there are problems loading
             // file with such remains in Excel.
             var internalPt = (XLPivotTable)pt;
-            Assert.Null(internalPt.PivotFields[0].Name);
-            Assert.Null(internalPt.PivotFields[0].Axis);
-            Assert.Null(internalPt.PivotFields[1].Name);
-            Assert.Null(internalPt.PivotFields[1].Axis);
+            Assert.That(internalPt.PivotFields[0].Name, Is.Null);
+            Assert.That(internalPt.PivotFields[0].Axis, Is.Null);
+            Assert.That(internalPt.PivotFields[1].Name, Is.Null);
+            Assert.That(internalPt.PivotFields[1].Axis, Is.Null);
         }
 
         #endregion
@@ -244,7 +244,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             pt.RowLabels.Remove("id");
             pt.RowLabels.Remove("ID"); // Doesnt throw on already removed.
 
-            Assert.IsEmpty(pt.RowLabels);
+            Assert.That(pt.RowLabels, Is.Empty);
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -33,16 +33,22 @@ namespace ClosedXML.Tests.Excel.PivotTables
 
             var idField = pt.RowLabels.Add("ID", "Item ID").AddSubtotal(XLSubtotalFunction.Automatic);
 
-            Assert.AreEqual("ID", idField.SourceName);
-            Assert.AreEqual("Item ID", idField.CustomName);
-            Assert.AreEqual("Item ID", pt.RowLabels.Single().CustomName);
+            Assert.Multiple(() =>
+            {
+                Assert.That(idField.SourceName, Is.EqualTo("ID"));
+                Assert.That(idField.CustomName, Is.EqualTo("Item ID"));
+                Assert.That(pt.RowLabels.Single().CustomName, Is.EqualTo("Item ID"));
+            });
 
             // Adds values and default aggregation func to items of the field
             var fieldItems = internalPt.PivotFields[0].Items;
-            Assert.AreEqual(2, fieldItems.Count);
-            Assert.AreEqual(XLPivotItemType.Data, fieldItems[0].ItemType);
-            Assert.AreEqual(0, fieldItems[0].ItemIndex);
-            Assert.AreEqual(XLPivotItemType.Default, fieldItems[1].ItemType);
+            Assert.That(fieldItems, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(fieldItems[0].ItemType, Is.EqualTo(XLPivotItemType.Data));
+                Assert.That(fieldItems[0].ItemIndex, Is.EqualTo(0));
+                Assert.That(fieldItems[1].ItemType, Is.EqualTo(XLPivotItemType.Default));
+            });
         }
 
         [Test]
@@ -60,7 +66,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             pt.RowLabels.Add("ID", "Item ID");
 
             var ex = Assert.Throws<InvalidOperationException>(() => pt.RowLabels.Add("ID", "Item ID"))!;
-            Assert.AreEqual("Custom name 'Item ID' is already used.", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Custom name 'Item ID' is already used."));
         }
 
         [Test]
@@ -78,7 +84,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             Assert.DoesNotThrow(() => pt.RowLabels.Add("ID", "Item ID"));
 
             var ex = Assert.Throws<InvalidOperationException>(() => pt.RowLabels.Add("nonexistent"))!;
-            Assert.AreEqual("Field 'nonexistent' not found in pivot cache.", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Field 'nonexistent' not found in pivot cache."));
         }
 
         #endregion
@@ -132,8 +138,11 @@ namespace ClosedXML.Tests.Excel.PivotTables
             var idField = pt.RowLabels.Add("ID", "Item ID");
             pt.ColumnLabels.Add("Color");
 
-            Assert.True(pt.RowLabels.Contains("id"));
-            Assert.True(pt.RowLabels.Contains(idField));
+            Assert.Multiple(() =>
+            {
+                Assert.That(pt.RowLabels.Contains("id"), Is.True);
+                Assert.That(pt.RowLabels.Contains(idField), Is.True);
+            });
             Assert.False(pt.RowLabels.Contains("color"));
             Assert.False(pt.RowLabels.Contains("nonexistent"));
         }
@@ -157,9 +166,9 @@ namespace ClosedXML.Tests.Excel.PivotTables
             pt.RowLabels.Add("ID", "Item ID");
             pt.ColumnLabels.Add("Color");
 
-            Assert.AreEqual("ID", pt.RowLabels.Get("id").SourceName);
+            Assert.That(pt.RowLabels.Get("id").SourceName, Is.EqualTo("ID"));
             var ex = Assert.Throws<KeyNotFoundException>(() => pt.RowLabels.Get("color"))!;
-            Assert.AreEqual("Field with source name 'color' not found in AxisRow.", ex.Message);
+            Assert.That(ex.Message, Is.EqualTo("Field with source name 'color' not found in AxisRow."));
         }
 
         #endregion
@@ -181,7 +190,7 @@ namespace ClosedXML.Tests.Excel.PivotTables
             pt.RowLabels.Add("ID", "Item ID");
             pt.ColumnLabels.Add("Color");
 
-            Assert.AreEqual("ID", pt.RowLabels.Get(0).SourceName);
+            Assert.That(pt.RowLabels.Get(0).SourceName, Is.EqualTo("ID"));
             Assert.Throws<IndexOutOfRangeException>(() => pt.RowLabels.Get(-2));
             Assert.Throws<IndexOutOfRangeException>(() => pt.RowLabels.Get(1));
         }
@@ -205,10 +214,13 @@ namespace ClosedXML.Tests.Excel.PivotTables
             var idField = pt.RowLabels.Add("ID", "Item ID");
             pt.ColumnLabels.Add("Color");
 
-            Assert.AreEqual(0, pt.RowLabels.IndexOf("ID"));
-            Assert.AreEqual(0, pt.RowLabels.IndexOf(idField));
-            Assert.AreEqual(-1, pt.RowLabels.IndexOf("item id"));
-            Assert.AreEqual(-1, pt.RowLabels.IndexOf("Color"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(pt.RowLabels.IndexOf("ID"), Is.EqualTo(0));
+                Assert.That(pt.RowLabels.IndexOf(idField), Is.EqualTo(0));
+                Assert.That(pt.RowLabels.IndexOf("item id"), Is.EqualTo(-1));
+                Assert.That(pt.RowLabels.IndexOf("Color"), Is.EqualTo(-1));
+            });
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFieldsTests.cs
@@ -143,8 +143,8 @@ namespace ClosedXML.Tests.Excel.PivotTables
                 Assert.That(pt.RowLabels.Contains("id"), Is.True);
                 Assert.That(pt.RowLabels.Contains(idField), Is.True);
             });
-            Assert.False(pt.RowLabels.Contains("color"));
-            Assert.False(pt.RowLabels.Contains("nonexistent"));
+            Assert.That(pt.RowLabels.Contains("color"), Is.False);
+            Assert.That(pt.RowLabels.Contains("nonexistent"), Is.False);
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFiltersTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableFiltersTests.cs
@@ -20,23 +20,23 @@ namespace ClosedXML.Tests.Excel.PivotTables
             var pt = ws.PivotTables.Add("pt", ws.Cell("E2"), data);
 
             // No filter, the table is at the original cell
-            Assert.AreEqual("E2", ((XLPivotTable)pt).Area.ToString());
+            Assert.That(((XLPivotTable)pt).Area.ToString(), Is.EqualTo("E2"));
 
             pt.ReportFilters.Add("City");
 
             // First filter also adds divider row between filter and the table.
-            Assert.AreEqual("E4", ((XLPivotTable)pt).Area.ToString());
+            Assert.That(((XLPivotTable)pt).Area.ToString(), Is.EqualTo("E4"));
 
             pt.ReportFilters.Add("Flavor");
 
             // When second filter is added, there is no need to add second divider row.
-            Assert.AreEqual("E5", ((XLPivotTable)pt).Area.ToString());
+            Assert.That(((XLPivotTable)pt).Area.ToString(), Is.EqualTo("E5"));
 
             pt.ReportFilters.Remove("City");
-            Assert.AreEqual("E4", ((XLPivotTable)pt).Area.ToString());
+            Assert.That(((XLPivotTable)pt).Area.ToString(), Is.EqualTo("E4"));
 
             pt.ReportFilters.Remove("Flavor");
-            Assert.AreEqual("E2", ((XLPivotTable)pt).Area.ToString());
+            Assert.That(((XLPivotTable)pt).Area.ToString(), Is.EqualTo("E2"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/PivotTables/XLPivotTableTests.cs
+++ b/ClosedXML.Tests/Excel/PivotTables/XLPivotTableTests.cs
@@ -15,19 +15,15 @@ namespace ClosedXML.Tests
         {
             Assert.DoesNotThrow(() =>
             {
-                using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
-                using (var wb = new XLWorkbook(stream))
-                {
-                    var ws = wb.Worksheet("PastrySalesData");
-                    var table = ws.Table("PastrySalesData");
-                    var ptSheet = wb.Worksheets.Add("BlankPivotTable");
-                    ptSheet.PivotTables.Add("pvt", ptSheet.Cell(1, 1), table);
+                using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
+                using var wb = new XLWorkbook(stream);
+                var ws = wb.Worksheet("PastrySalesData");
+                var table = ws.Table("PastrySalesData");
+                var ptSheet = wb.Worksheets.Add("BlankPivotTable");
+                ptSheet.PivotTables.Add("pvt", ptSheet.Cell(1, 1), table);
 
-                    using (var ms = new MemoryStream())
-                    {
-                        wb.SaveAs(ms, true);
-                    }
-                }
+                using var ms = new MemoryStream();
+                wb.SaveAs(ms, true);
             });
         }
 
@@ -35,175 +31,167 @@ namespace ClosedXML.Tests
         public void TestPivotTableVersioningAttributes()
         {
             // Pivot cache definitions in input file has created and refreshed version attributes = 3
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\VersioningAttributes\inputfile.xlsx")))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\VersioningAttributes\inputfile.xlsx"));
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
-                {
-                    var wb = new XLWorkbook(stream);
+                var wb = new XLWorkbook(stream);
 
-                    var data = wb.Worksheet("Data");
+                var data = wb.Worksheet("Data");
 
-                    var pt = data.RangeUsed().CreatePivotTable(wb.AddWorksheet("pvt2").FirstCell(), "pvt2");
+                var pt = data.RangeUsed().CreatePivotTable(wb.AddWorksheet("pvt2").FirstCell(), "pvt2");
 
-                    pt.ColumnLabels.Add("Sex");
-                    pt.RowLabels.Add("FullName");
-                    pt.Values.Add("Id", "Count of Id").SetSummaryFormula(XLPivotSummary.Count);
+                pt.ColumnLabels.Add("Sex");
+                pt.RowLabels.Add("FullName");
+                pt.Values.Add("Id", "Count of Id").SetSummaryFormula(XLPivotSummary.Count);
 
-                    return wb;
-                    // Pivot cache definitions in output file has created and refreshed version attributes = 5
-                }, @"Other\PivotTableReferenceFiles\VersioningAttributes\outputfile.xlsx");
-            }
+                return wb;
+                // Pivot cache definitions in output file has created and refreshed version attributes = 5
+            }, @"Other\PivotTableReferenceFiles\VersioningAttributes\outputfile.xlsx");
         }
 
         [Test]
         public void PivotTableOptionsSaveTest()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("PastrySalesData");
+            var table = ws.Table("PastrySalesData");
+            var ptSheet = wb.Worksheets.Add("BlankPivotTable");
+            var pt = ptSheet.PivotTables.Add("pvtOptionsTest", ptSheet.Cell(1, 1), table);
+
+            pt.ColumnHeaderCaption = "clmn header";
+            pt.RowHeaderCaption = "row header";
+
+            pt.AutofitColumns = true;
+            pt.PreserveCellFormatting = false;
+            pt.ShowGrandTotalsColumns = true;
+            pt.ShowGrandTotalsRows = true;
+            pt.UseCustomListsForSorting = false;
+            pt.ShowExpandCollapseButtons = false;
+            pt.ShowContextualTooltips = false;
+            pt.DisplayCaptionsAndDropdowns = false;
+            pt.RepeatRowLabels = true;
+            pt.PivotCache.SaveSourceData = false;
+            pt.EnableShowDetails = false;
+            pt.ShowColumnHeaders = false;
+            pt.ShowRowHeaders = false;
+
+            pt.MergeAndCenterWithLabels = true; // MergeItem
+            pt.RowLabelIndent = 12; // Indent
+            pt.FilterAreaOrder = XLFilterAreaOrder.OverThenDown; // PageOverThenDown
+            pt.FilterFieldsPageWrap = 14; // PageWrap
+            pt.ErrorValueReplacement = "error test"; // ErrorCaption
+            pt.EmptyCellReplacement = "empty test"; // MissingCaption
+
+            pt.FilteredItemsInSubtotals = true; // Subtotal filtered page items
+            pt.AllowMultipleFilters = false; // MultipleFieldFilters
+
+            pt.ShowPropertiesInTooltips = false;
+            pt.ClassicPivotTableLayout = true;
+            pt.ShowEmptyItemsOnRows = true;
+            pt.ShowEmptyItemsOnColumns = true;
+            pt.DisplayItemLabels = false;
+            pt.SortFieldsAtoZ = true;
+
+            pt.PrintExpandCollapsedButtons = true;
+            pt.PrintTitles = true;
+
+            pt.PivotCache.RefreshDataOnOpen = false;
+            pt.PivotCache.ItemsToRetainPerField = XLItemsToRetain.Max;
+            pt.EnableCellEditing = true;
+            pt.ShowValuesRow = true;
+            pt.ShowRowStripes = true;
+            pt.ShowColumnStripes = true;
+            pt.Theme = XLPivotTableTheme.PivotStyleDark13;
+
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
+
+            ms.Position = 0;
+
+            using var wbassert = new XLWorkbook(ms);
+            var wsassert = wbassert.Worksheet("BlankPivotTable");
+            var ptassert = wsassert.PivotTable("pvtOptionsTest");
+            Assert.That(ptassert, Is.Not.Null, "name save failure");
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheet("PastrySalesData");
-                var table = ws.Table("PastrySalesData");
-                var ptSheet = wb.Worksheets.Add("BlankPivotTable");
-                var pt = ptSheet.PivotTables.Add("pvtOptionsTest", ptSheet.Cell(1, 1), table);
-
-                pt.ColumnHeaderCaption = "clmn header";
-                pt.RowHeaderCaption = "row header";
-
-                pt.AutofitColumns = true;
-                pt.PreserveCellFormatting = false;
-                pt.ShowGrandTotalsColumns = true;
-                pt.ShowGrandTotalsRows = true;
-                pt.UseCustomListsForSorting = false;
-                pt.ShowExpandCollapseButtons = false;
-                pt.ShowContextualTooltips = false;
-                pt.DisplayCaptionsAndDropdowns = false;
-                pt.RepeatRowLabels = true;
-                pt.PivotCache.SaveSourceData = false;
-                pt.EnableShowDetails = false;
-                pt.ShowColumnHeaders = false;
-                pt.ShowRowHeaders = false;
-
-                pt.MergeAndCenterWithLabels = true; // MergeItem
-                pt.RowLabelIndent = 12; // Indent
-                pt.FilterAreaOrder = XLFilterAreaOrder.OverThenDown; // PageOverThenDown
-                pt.FilterFieldsPageWrap = 14; // PageWrap
-                pt.ErrorValueReplacement = "error test"; // ErrorCaption
-                pt.EmptyCellReplacement = "empty test"; // MissingCaption
-
-                pt.FilteredItemsInSubtotals = true; // Subtotal filtered page items
-                pt.AllowMultipleFilters = false; // MultipleFieldFilters
-
-                pt.ShowPropertiesInTooltips = false;
-                pt.ClassicPivotTableLayout = true;
-                pt.ShowEmptyItemsOnRows = true;
-                pt.ShowEmptyItemsOnColumns = true;
-                pt.DisplayItemLabels = false;
-                pt.SortFieldsAtoZ = true;
-
-                pt.PrintExpandCollapsedButtons = true;
-                pt.PrintTitles = true;
-
-                pt.PivotCache.RefreshDataOnOpen = false;
-                pt.PivotCache.ItemsToRetainPerField = XLItemsToRetain.Max;
-                pt.EnableCellEditing = true;
-                pt.ShowValuesRow = true;
-                pt.ShowRowStripes = true;
-                pt.ShowColumnStripes = true;
-                pt.Theme = XLPivotTableTheme.PivotStyleDark13;
-
-                using (var ms = new MemoryStream())
-                {
-                    wb.SaveAs(ms, true);
-
-                    ms.Position = 0;
-
-                    using (var wbassert = new XLWorkbook(ms))
-                    {
-                        var wsassert = wbassert.Worksheet("BlankPivotTable");
-                        var ptassert = wsassert.PivotTable("pvtOptionsTest");
-                        Assert.AreNotEqual(null, ptassert, "name save failure");
-                        Assert.AreEqual("clmn header", ptassert.ColumnHeaderCaption, "ColumnHeaderCaption save failure");
-                        Assert.AreEqual("row header", ptassert.RowHeaderCaption, "RowHeaderCaption save failure");
-                        Assert.AreEqual(true, ptassert.MergeAndCenterWithLabels, "MergeAndCenterWithLabels save failure");
-                        Assert.AreEqual(12, ptassert.RowLabelIndent, "RowLabelIndent save failure");
-                        Assert.AreEqual(XLFilterAreaOrder.OverThenDown, ptassert.FilterAreaOrder, "FilterAreaOrder save failure");
-                        Assert.AreEqual(14, ptassert.FilterFieldsPageWrap, "FilterFieldsPageWrap save failure");
-                        Assert.AreEqual("error test", ptassert.ErrorValueReplacement, "ErrorValueReplacement save failure");
-                        Assert.AreEqual("empty test", ptassert.EmptyCellReplacement, "EmptyCellReplacement save failure");
-                        Assert.AreEqual(true, ptassert.AutofitColumns, "AutofitColumns save failure");
-                        Assert.AreEqual(false, ptassert.PreserveCellFormatting, "PreserveCellFormatting save failure");
-                        Assert.AreEqual(true, ptassert.ShowGrandTotalsRows, "ShowGrandTotalsRows save failure");
-                        Assert.AreEqual(true, ptassert.ShowGrandTotalsColumns, "ShowGrandTotalsColumns save failure");
-                        Assert.AreEqual(true, ptassert.FilteredItemsInSubtotals, "FilteredItemsInSubtotals save failure");
-                        Assert.AreEqual(false, ptassert.AllowMultipleFilters, "AllowMultipleFilters save failure");
-                        Assert.AreEqual(false, ptassert.UseCustomListsForSorting, "UseCustomListsForSorting save failure");
-                        Assert.AreEqual(false, ptassert.ShowExpandCollapseButtons, "ShowExpandCollapseButtons save failure");
-                        Assert.AreEqual(false, ptassert.ShowContextualTooltips, "ShowContextualTooltips save failure");
-                        Assert.AreEqual(false, ptassert.ShowPropertiesInTooltips, "ShowPropertiesInTooltips save failure");
-                        Assert.AreEqual(false, ptassert.DisplayCaptionsAndDropdowns, "DisplayCaptionsAndDropdowns save failure");
-                        Assert.AreEqual(true, ptassert.ClassicPivotTableLayout, "ClassicPivotTableLayout save failure");
-                        Assert.AreEqual(true, ptassert.ShowEmptyItemsOnRows, "ShowEmptyItemsOnRows save failure");
-                        Assert.AreEqual(true, ptassert.ShowEmptyItemsOnColumns, "ShowEmptyItemsOnColumns save failure");
-                        Assert.AreEqual(false, ptassert.DisplayItemLabels, "DisplayItemLabels save failure");
-                        Assert.AreEqual(true, ptassert.SortFieldsAtoZ, "SortFieldsAtoZ save failure");
-                        Assert.AreEqual(true, ptassert.PrintExpandCollapsedButtons, "PrintExpandCollapsedButtons save failure");
-                        Assert.AreEqual(true, ptassert.RepeatRowLabels, "RepeatRowLabels save failure");
-                        Assert.AreEqual(true, ptassert.PrintTitles, "PrintTitles save failure");
-                        Assert.AreEqual(false, ptassert.PivotCache.SaveSourceData, "SaveSourceData save failure");
-                        Assert.AreEqual(false, ptassert.EnableShowDetails, "EnableShowDetails save failure");
-                        Assert.AreEqual(false, ptassert.PivotCache.RefreshDataOnOpen, "RefreshDataOnOpen save failure");
-                        Assert.AreEqual(XLItemsToRetain.Max, ptassert.PivotCache.ItemsToRetainPerField, "ItemsToRetainPerField save failure");
-                        Assert.AreEqual(true, ptassert.EnableCellEditing, "EnableCellEditing save failure");
-                        Assert.AreEqual(XLPivotTableTheme.PivotStyleDark13, ptassert.Theme, "Theme save failure");
-                        Assert.AreEqual(true, ptassert.ShowValuesRow, "ShowValuesRow save failure");
-                        Assert.AreEqual(false, ptassert.ShowRowHeaders, "ShowRowHeaders save failure");
-                        Assert.AreEqual(false, ptassert.ShowColumnHeaders, "ShowColumnHeaders save failure");
-                        Assert.AreEqual(true, ptassert.ShowRowStripes, "ShowRowStripes save failure");
-                        Assert.AreEqual(true, ptassert.ShowColumnStripes, "ShowColumnStripes save failure");
-                    }
-                }
-            }
+                Assert.That(ptassert.ColumnHeaderCaption, Is.EqualTo("clmn header"), "ColumnHeaderCaption save failure");
+                Assert.That(ptassert.RowHeaderCaption, Is.EqualTo("row header"), "RowHeaderCaption save failure");
+                Assert.That(ptassert.MergeAndCenterWithLabels, Is.True, "MergeAndCenterWithLabels save failure");
+                Assert.That(ptassert.RowLabelIndent, Is.EqualTo(12), "RowLabelIndent save failure");
+                Assert.That(ptassert.FilterAreaOrder, Is.EqualTo(XLFilterAreaOrder.OverThenDown), "FilterAreaOrder save failure");
+                Assert.That(ptassert.FilterFieldsPageWrap, Is.EqualTo(14), "FilterFieldsPageWrap save failure");
+                Assert.That(ptassert.ErrorValueReplacement, Is.EqualTo("error test"), "ErrorValueReplacement save failure");
+                Assert.That(ptassert.EmptyCellReplacement, Is.EqualTo("empty test"), "EmptyCellReplacement save failure");
+                Assert.That(ptassert.AutofitColumns, Is.True, "AutofitColumns save failure");
+                Assert.That(ptassert.PreserveCellFormatting, Is.False, "PreserveCellFormatting save failure");
+                Assert.That(ptassert.ShowGrandTotalsRows, Is.True, "ShowGrandTotalsRows save failure");
+                Assert.That(ptassert.ShowGrandTotalsColumns, Is.True, "ShowGrandTotalsColumns save failure");
+                Assert.That(ptassert.FilteredItemsInSubtotals, Is.True, "FilteredItemsInSubtotals save failure");
+                Assert.That(ptassert.AllowMultipleFilters, Is.False, "AllowMultipleFilters save failure");
+                Assert.That(ptassert.UseCustomListsForSorting, Is.False, "UseCustomListsForSorting save failure");
+                Assert.That(ptassert.ShowExpandCollapseButtons, Is.False, "ShowExpandCollapseButtons save failure");
+                Assert.That(ptassert.ShowContextualTooltips, Is.False, "ShowContextualTooltips save failure");
+                Assert.That(ptassert.ShowPropertiesInTooltips, Is.False, "ShowPropertiesInTooltips save failure");
+                Assert.That(ptassert.DisplayCaptionsAndDropdowns, Is.False, "DisplayCaptionsAndDropdowns save failure");
+                Assert.That(ptassert.ClassicPivotTableLayout, Is.True, "ClassicPivotTableLayout save failure");
+                Assert.That(ptassert.ShowEmptyItemsOnRows, Is.True, "ShowEmptyItemsOnRows save failure");
+                Assert.That(ptassert.ShowEmptyItemsOnColumns, Is.True, "ShowEmptyItemsOnColumns save failure");
+                Assert.That(ptassert.DisplayItemLabels, Is.False, "DisplayItemLabels save failure");
+                Assert.That(ptassert.SortFieldsAtoZ, Is.True, "SortFieldsAtoZ save failure");
+                Assert.That(ptassert.PrintExpandCollapsedButtons, Is.True, "PrintExpandCollapsedButtons save failure");
+                Assert.That(ptassert.RepeatRowLabels, Is.True, "RepeatRowLabels save failure");
+                Assert.That(ptassert.PrintTitles, Is.True, "PrintTitles save failure");
+                Assert.That(ptassert.PivotCache.SaveSourceData, Is.False, "SaveSourceData save failure");
+                Assert.That(ptassert.EnableShowDetails, Is.False, "EnableShowDetails save failure");
+                Assert.That(ptassert.PivotCache.RefreshDataOnOpen, Is.False, "RefreshDataOnOpen save failure");
+                Assert.That(ptassert.PivotCache.ItemsToRetainPerField, Is.EqualTo(XLItemsToRetain.Max), "ItemsToRetainPerField save failure");
+                Assert.That(ptassert.EnableCellEditing, Is.True, "EnableCellEditing save failure");
+                Assert.That(ptassert.Theme, Is.EqualTo(XLPivotTableTheme.PivotStyleDark13), "Theme save failure");
+                Assert.That(ptassert.ShowValuesRow, Is.True, "ShowValuesRow save failure");
+                Assert.That(ptassert.ShowRowHeaders, Is.False, "ShowRowHeaders save failure");
+                Assert.That(ptassert.ShowColumnHeaders, Is.False, "ShowColumnHeaders save failure");
+                Assert.That(ptassert.ShowRowStripes, Is.True, "ShowRowStripes save failure");
+                Assert.That(ptassert.ShowColumnStripes, Is.True, "ShowColumnStripes save failure");
+            });
         }
 
         [TestCase(true)]
         [TestCase(false)]
         public void PivotFieldOptionsSaveTest(bool withDefaults)
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("PastrySalesData");
+            var table = ws.Table("PastrySalesData");
+
+            var ptSheet = wb.Worksheets.Add("pvtFieldOptionsTest");
+            var pt = ptSheet.PivotTables.Add("pvtFieldOptionsTest", ptSheet.Cell(1, 1), table);
+
+            var field = pt.RowLabels.Add("Name")
+                .SetSubtotalCaption("Test caption")
+                .SetCustomName("Test name");
+            SetFieldOptions(field, withDefaults);
+
+            pt.ColumnLabels.Add("Month");
+            pt.Values.Add("NumberOfOrders").SetSummaryFormula(XLPivotSummary.Sum);
+
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
+
+            ms.Position = 0;
+
+            using var wbassert = new XLWorkbook(ms);
+            var wsassert = wbassert.Worksheet("pvtFieldOptionsTest");
+            var ptassert = wsassert.PivotTable("pvtFieldOptionsTest");
+            var pfassert = ptassert.RowLabels.Get("Name");
+            Assert.That(pfassert, Is.Not.Null, "name save failure");
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheet("PastrySalesData");
-                var table = ws.Table("PastrySalesData");
-
-                var ptSheet = wb.Worksheets.Add("pvtFieldOptionsTest");
-                var pt = ptSheet.PivotTables.Add("pvtFieldOptionsTest", ptSheet.Cell(1, 1), table);
-
-                var field = pt.RowLabels.Add("Name")
-                    .SetSubtotalCaption("Test caption")
-                    .SetCustomName("Test name");
-                SetFieldOptions(field, withDefaults);
-
-                pt.ColumnLabels.Add("Month");
-                pt.Values.Add("NumberOfOrders").SetSummaryFormula(XLPivotSummary.Sum);
-
-                using (var ms = new MemoryStream())
-                {
-                    wb.SaveAs(ms, true);
-
-                    ms.Position = 0;
-
-                    using (var wbassert = new XLWorkbook(ms))
-                    {
-                        var wsassert = wbassert.Worksheet("pvtFieldOptionsTest");
-                        var ptassert = wsassert.PivotTable("pvtFieldOptionsTest");
-                        var pfassert = ptassert.RowLabels.Get("Name");
-                        Assert.AreNotEqual(null, pfassert, "name save failure");
-                        Assert.AreEqual("Test caption", pfassert.SubtotalCaption, "SubtotalCaption save failure");
-                        Assert.AreEqual("Test name", pfassert.CustomName, "CustomName save failure");
-                        AssertFieldOptions(pfassert, withDefaults);
-                    }
-                }
-            }
+                Assert.That(pfassert.SubtotalCaption, Is.EqualTo("Test caption"), "SubtotalCaption save failure");
+                Assert.That(pfassert.CustomName, Is.EqualTo("Test name"), "CustomName save failure");
+            });
+            AssertFieldOptions(pfassert, withDefaults);
         }
 
         [Test]
@@ -296,37 +284,33 @@ namespace ClosedXML.Tests
         [Test]
         public void CopyPivotTableTests()
         {
-            using (var ms = new MemoryStream())
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws1 = wb.Worksheet("pvt1");
-                var pt1 = ws1.PivotTables.First() as XLPivotTable;
+            using var ms = new MemoryStream();
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws1 = wb.Worksheet("pvt1");
+            var pt1 = ws1.PivotTables.First() as XLPivotTable;
 
-                Assert.Throws<InvalidOperationException>(() => pt1.CopyTo(pt1.TargetCell));
+            Assert.Throws<InvalidOperationException>(() => pt1.CopyTo(pt1.TargetCell));
 
-                var pt2 = pt1.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
+            var pt2 = pt1.CopyTo(ws1.Cell("AB100")) as XLPivotTable;
 
-                AssertPivotTablesAreEqual(pt1, pt2, compareName: false);
+            AssertPivotTablesAreEqual(pt1, pt2, compareName: false);
 
-                var ws2 = wb.AddWorksheet("Copy Of pvt1");
-                AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell()) as XLPivotTable, compareName: true);
+            var ws2 = wb.AddWorksheet("Copy Of pvt1");
+            AssertPivotTablesAreEqual(pt1, pt1.CopyTo(ws2.FirstCell()) as XLPivotTable, compareName: true);
 
-                using (var wb2 = new XLWorkbook())
-                {
-                    wb.Worksheet("PastrySalesData").CopyTo(wb2);
+            using var wb2 = new XLWorkbook();
+            wb.Worksheet("PastrySalesData").CopyTo(wb2);
 
-                    AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()) as XLPivotTable, compareName: true);
-                }
-            }
+            AssertPivotTablesAreEqual(pt1, pt1.CopyTo(wb2.AddWorksheet("pvt").FirstCell()) as XLPivotTable, compareName: true);
         }
 
-        private void AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, Boolean compareName)
+        private void AssertPivotTablesAreEqual(XLPivotTable original, XLPivotTable copy, bool compareName)
         {
-            Assert.AreEqual(compareName, original.Name.Equals(copy.Name));
+            Assert.That(original.Name.Equals(copy.Name), Is.EqualTo(compareName));
 
             var comparer = new PivotTableComparer(compareName: compareName, compareRelId: false, compareTargetCellAddress: false);
-            Assert.IsTrue(comparer.Equals(original, copy));
+            Assert.That(comparer.Equals(original, copy), Is.True);
         }
 
         private class Pastry
@@ -363,79 +347,77 @@ namespace ClosedXML.Tests
         [Test]
         public void BlankPivotTableField()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
+                // Based on .\ClosedXML\ClosedXML.Examples\PivotTables\PivotTables.cs
+                // But with empty column for Month
+                var pastries = new List<Pastry>
                 {
-                    // Based on .\ClosedXML\ClosedXML.Examples\PivotTables\PivotTables.cs
-                    // But with empty column for Month
-                    var pastries = new List<Pastry>
-                    {
-                        new Pastry("Croissant", 101, 150, 60.2, "", new DateTime(2016, 04, 21)),
-                        new Pastry("Croissant", 101, 250, 50.42, "", new DateTime(2016, 05, 03)),
-                        new Pastry("Croissant", 101, 134, 22.12, "", new DateTime(2016, 06, 24)),
-                        new Pastry("Doughnut", 102, 250, 89.99, "", new DateTime(2017, 04, 23)),
-                        new Pastry("Doughnut", 102, 225, 70, "", new DateTime(2016, 05, 24)),
-                        new Pastry("Doughnut", 102, 210, 75.33, "", new DateTime(2016, 06, 02)),
-                        new Pastry("Bearclaw", 103, 134, 10.24, "", new DateTime(2016, 04, 27)),
-                        new Pastry("Bearclaw", 103, 184, 33.33, "", new DateTime(2016, 05, 20)),
-                        new Pastry("Bearclaw", 103, 124, 25, "", new DateTime(2017, 06, 05)),
-                        new Pastry("Danish", 104, 394, -20.24, "", null),
-                        new Pastry("Danish", 104, 190, 60, "", new DateTime(2017, 05, 08)),
-                        new Pastry("Danish", 104, 221, 24.76, "", new DateTime(2016, 06, 21)),
+                    new Pastry("Croissant", 101, 150, 60.2, "", new DateTime(2016, 04, 21)),
+                    new Pastry("Croissant", 101, 250, 50.42, "", new DateTime(2016, 05, 03)),
+                    new Pastry("Croissant", 101, 134, 22.12, "", new DateTime(2016, 06, 24)),
+                    new Pastry("Doughnut", 102, 250, 89.99, "", new DateTime(2017, 04, 23)),
+                    new Pastry("Doughnut", 102, 225, 70, "", new DateTime(2016, 05, 24)),
+                    new Pastry("Doughnut", 102, 210, 75.33, "", new DateTime(2016, 06, 02)),
+                    new Pastry("Bearclaw", 103, 134, 10.24, "", new DateTime(2016, 04, 27)),
+                    new Pastry("Bearclaw", 103, 184, 33.33, "", new DateTime(2016, 05, 20)),
+                    new Pastry("Bearclaw", 103, 124, 25, "", new DateTime(2017, 06, 05)),
+                    new Pastry("Danish", 104, 394, -20.24, "", null),
+                    new Pastry("Danish", 104, 190, 60, "", new DateTime(2017, 05, 08)),
+                    new Pastry("Danish", 104, 221, 24.76, "", new DateTime(2016, 06, 21)),
 
-                        // Deliberately add different casings of same string to ensure pivot table doesn't duplicate it.
-                        new Pastry("Scone", 105, 135, 0, "", new DateTime(2017, 04, 22)),
-                        new Pastry("SconE", 105, 122, 5.19, "", new DateTime(2017, 05, 03)),
-                        new Pastry("SCONE", 105, 243, 44.2, "", new DateTime(2017, 06, 14)),
+                    // Deliberately add different casings of same string to ensure pivot table doesn't duplicate it.
+                    new Pastry("Scone", 105, 135, 0, "", new DateTime(2017, 04, 22)),
+                    new Pastry("SconE", 105, 122, 5.19, "", new DateTime(2017, 05, 03)),
+                    new Pastry("SCONE", 105, 243, 44.2, "", new DateTime(2017, 06, 14)),
 
-                        // For ContainsBlank and integer rows/columns test
-                        new Pastry("Scone", null, 255, 18.4, "", null),
-                    };
+                    // For ContainsBlank and integer rows/columns test
+                    new Pastry("Scone", null, 255, 18.4, "", null),
+                };
 
-                    var wb = new XLWorkbook();
+                var wb = new XLWorkbook();
 
-                    var sheet = wb.Worksheets.Add("PastrySalesData");
-                    // Insert our list of pastry data into the "PastrySalesData" sheet at cell 1,1
-                    var table = sheet.Cell(1, 1).InsertTable(pastries, "PastrySalesData", true);
-                    sheet.Cell("F11").Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
-                    sheet.Columns().AdjustToContents();
+                var sheet = wb.Worksheets.Add("PastrySalesData");
+                // Insert our list of pastry data into the "PastrySalesData" sheet at cell 1,1
+                var table = sheet.Cell(1, 1).InsertTable(pastries, "PastrySalesData", true);
+                sheet.Cell("F11").Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                sheet.Columns().AdjustToContents();
 
-                    IXLWorksheet ptSheet;
-                    IXLPivotTable pt;
+                IXLWorksheet ptSheet;
+                IXLPivotTable pt;
 
-                    for (var i = 1; i <= 5; i++)
-                    {
-                        // Add a new sheet for our pivot table
-                        ptSheet = wb.Worksheets.Add("pvt" + i);
+                for (var i = 1; i <= 5; i++)
+                {
+                    // Add a new sheet for our pivot table
+                    ptSheet = wb.Worksheets.Add("pvt" + i);
 
-                        // Create the pivot table, using the data from the "PastrySalesData" table
-                        pt = ptSheet.PivotTables.Add("pvt" + i, ptSheet.Cell(1, 1), table);
+                    // Create the pivot table, using the data from the "PastrySalesData" table
+                    pt = ptSheet.PivotTables.Add("pvt" + i, ptSheet.Cell(1, 1), table);
 
-                        if (i == 1 || i == 4 || i == 5)
-                            pt.ColumnLabels.Add("Name");
-                        else if (i == 2 || i == 3)
-                            pt.RowLabels.Add("Name");
+                    if (i == 1 || i == 4 || i == 5)
+                        pt.ColumnLabels.Add("Name");
+                    else if (i == 2 || i == 3)
+                        pt.RowLabels.Add("Name");
 
-                        if (i == 1 || i == 3)
-                            pt.RowLabels.Add("Month");
-                        else if (i == 2 || i == 4)
-                            pt.ColumnLabels.Add("Month");
-                        else if (i == 5)
-                            pt.RowLabels.Add("BakeDate");
+                    if (i == 1 || i == 3)
+                        pt.RowLabels.Add("Month");
+                    else if (i == 2 || i == 4)
+                        pt.ColumnLabels.Add("Month");
+                    else if (i == 5)
+                        pt.RowLabels.Add("BakeDate");
 
-                        // The values in our table will come from the "NumberOfOrders" field
-                        // The default calculation setting is a total of each row/column
-                        pt.Values.Add("NumberOfOrders", "NumberOfOrdersPercentageOfBearclaw")
-                            .ShowAsPercentageFrom("Name").And("Bearclaw")
-                            .NumberFormat.Format = "0%";
+                    // The values in our table will come from the "NumberOfOrders" field
+                    // The default calculation setting is a total of each row/column
+                    pt.Values.Add("NumberOfOrders", "NumberOfOrdersPercentageOfBearclaw")
+                        .ShowAsPercentageFrom("Name").And("Bearclaw")
+                        .NumberFormat.Format = "0%";
 
-                        ptSheet.Columns().AdjustToContents();
-                    }
+                    ptSheet.Columns().AdjustToContents();
+                }
 
-                    return wb;
-                }, @"Other\PivotTableReferenceFiles\BlankPivotTableField\BlankPivotTableField.xlsx");
-            }
+                return wb;
+            }, @"Other\PivotTableReferenceFiles\BlankPivotTableField\BlankPivotTableField.xlsx");
         }
 
         [Test]
@@ -470,16 +452,14 @@ namespace ClosedXML.Tests
         [Test]
         public void PivotTableWithNoneTheme()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\PivotTableWithNoneTheme\inputfile.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\PivotTableWithNoneTheme\inputfile.xlsx"));
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
-                {
-                    var wb = new XLWorkbook(stream);
-                    wb.SaveAs(ms);
-                    return wb;
-                }, @"Other\PivotTableReferenceFiles\PivotTableWithNoneTheme\outputfile.xlsx");
-            }
+                var wb = new XLWorkbook(stream);
+                wb.SaveAs(ms);
+                return wb;
+            }, @"Other\PivotTableReferenceFiles\PivotTableWithNoneTheme\outputfile.xlsx");
         }
 
         [Test]
@@ -547,8 +527,11 @@ namespace ClosedXML.Tests
                         .ReportFilters
                         .ToArray();
 
-                    Assert.AreEqual("Month", pageFields[0].SourceName);
-                    Assert.AreEqual("Name", pageFields[1].SourceName);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(pageFields[0].SourceName, Is.EqualTo("Month"));
+                        Assert.That(pageFields[1].SourceName, Is.EqualTo("Name"));
+                    });
                 }
             }
 
@@ -590,8 +573,11 @@ namespace ClosedXML.Tests
                         .ColumnLabels
                         .ToArray();
 
-                    Assert.AreEqual("Month", columnLabels[0].SourceName);
-                    Assert.AreEqual("Name", columnLabels[1].SourceName);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(columnLabels[0].SourceName, Is.EqualTo("Month"));
+                        Assert.That(columnLabels[1].SourceName, Is.EqualTo("Name"));
+                    });
                 }
             }
 
@@ -634,9 +620,12 @@ namespace ClosedXML.Tests
                         .RowLabels
                         .ToArray();
 
-                    Assert.AreEqual("Month", rowLabels[0].SourceName);
-                    Assert.AreEqual("Name", rowLabels[1].SourceName);
-                    Assert.AreEqual("{{Values}}", rowLabels[2].SourceName);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(rowLabels[0].SourceName, Is.EqualTo("Month"));
+                        Assert.That(rowLabels[1].SourceName, Is.EqualTo("Name"));
+                        Assert.That(rowLabels[2].SourceName, Is.EqualTo("{{Values}}"));
+                    });
                 }
             }
         }
@@ -668,52 +657,50 @@ namespace ClosedXML.Tests
                 new Pastry("Scone", null, 255, 18.4, "", null),
             };
 
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.Worksheets.Add("PastrySalesData");
-                    var table = ws.FirstCell().InsertTable(pastries, "PastrySalesData", true);
+                var ws = wb.Worksheets.Add("PastrySalesData");
+                var table = ws.FirstCell().InsertTable(pastries, "PastrySalesData", true);
 
-                    var pvtSheet = wb.Worksheets.Add("pvt");
-                    var pvt = table.CreatePivotTable(pvtSheet.FirstCell(), "PastryPvt");
+                var pvtSheet = wb.Worksheets.Add("pvt");
+                var pvt = table.CreatePivotTable(pvtSheet.FirstCell(), "PastryPvt");
 
-                    pvt.ColumnLabels.Add("Month");
-                    pvt.RowLabels.Add("Name");
-                    pvt.Values.Add("NumberOfOrders").SetSummaryFormula(XLPivotSummary.Sum);
+                pvt.ColumnLabels.Add("Month");
+                pvt.RowLabels.Add("Name");
+                pvt.Values.Add("NumberOfOrders").SetSummaryFormula(XLPivotSummary.Sum);
 
-                    //Deliberately try to save twice
-                    wb.SaveAs(ms);
-                    wb.SaveAs(ms);
-                }
+                //Deliberately try to save twice
+                wb.SaveAs(ms);
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.AreEqual(1, wb.Worksheets.SelectMany(ws => ws.PivotTables).Count());
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.Worksheets.SelectMany(ws => ws.PivotTables).Count(), Is.EqualTo(1));
             }
         }
 
         [Test]
         public void TwoPivotWithOneSourceTest()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\TwoPivotTablesWithSingleSource\input.xlsx")))
-                TestHelper.CreateAndCompare(() =>
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\TwoPivotTablesWithSingleSource\input.xlsx"));
+            TestHelper.CreateAndCompare(() =>
+            {
+                var wb = new XLWorkbook(stream);
+                var srcRange = wb.Range("Sheet1!$B$2:$H$207");
+
+                var pivotSource = wb.PivotCaches.Add(srcRange);
+
+                foreach (var pt in wb.Worksheets.SelectMany(ws => ws.PivotTables))
                 {
-                    var wb = new XLWorkbook(stream);
-                    var srcRange = wb.Range("Sheet1!$B$2:$H$207");
+                    pt.PivotCache = pivotSource;
+                }
 
-                    var pivotSource = wb.PivotCaches.Add(srcRange);
-
-                    foreach (var pt in wb.Worksheets.SelectMany(ws => ws.PivotTables))
-                    {
-                        pt.PivotCache = pivotSource;
-                    }
-
-                    return wb;
-                }, @"Other\PivotTableReferenceFiles\TwoPivotTablesWithSingleSource\output.xlsx");
+                return wb;
+            }, @"Other\PivotTableReferenceFiles\TwoPivotTablesWithSingleSource\output.xlsx");
         }
 
         [Test]
@@ -730,27 +717,31 @@ namespace ClosedXML.Tests
         public void ClearPivotTableRenderedRange()
         {
             // https://github.com/ClosedXML/ClosedXML/pull/856
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\ClearPivotTableRenderedRangeWhenLoading\inputfile.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\PivotTableReferenceFiles\ClearPivotTableRenderedRangeWhenLoading\inputfile.xlsx"));
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var wb = new XLWorkbook(stream))
+                var ws = wb.Worksheet("Sheet1");
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheet("Sheet1");
-                    Assert.IsTrue(ws.Cell("B1").IsEmpty());
-                    Assert.IsTrue(ws.Cell("C2").IsEmpty());
-                    Assert.IsTrue(ws.Cell("D5").IsEmpty());
-                    wb.SaveAs(ms);
-                }
+                    Assert.That(ws.Cell("B1").IsEmpty(), Is.True);
+                    Assert.That(ws.Cell("C2").IsEmpty(), Is.True);
+                    Assert.That(ws.Cell("D5").IsEmpty(), Is.True);
+                });
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheet("Sheet1");
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheet("Sheet1");
-                    Assert.IsTrue(ws.Cell("B1").IsEmpty());
-                    Assert.IsTrue(ws.Cell("C2").IsEmpty());
-                    Assert.IsTrue(ws.Cell("D5").IsEmpty());
-                }
+                    Assert.That(ws.Cell("B1").IsEmpty(), Is.True);
+                    Assert.That(ws.Cell("C2").IsEmpty(), Is.True);
+                    Assert.That(ws.Cell("D5").IsEmpty(), Is.True);
+                });
             }
         }
 
@@ -770,8 +761,8 @@ namespace ClosedXML.Tests
             var rangePivot1 = ws.PivotTables.Add("rangePivot1", ws.Cell("D1"), range);
             var rangePivot2 = ws.PivotTables.Add("rangePivot2", ws.Cell("D20"), range);
 
-            Assert.AreNotSame(rangePivot1, rangePivot2);
-            Assert.AreSame(rangePivot1.PivotCache, rangePivot2.PivotCache);
+            Assert.That(rangePivot2, Is.Not.SameAs(rangePivot1));
+            Assert.That(rangePivot2.PivotCache, Is.SameAs(rangePivot1.PivotCache));
         }
 
         [Test]
@@ -790,8 +781,8 @@ namespace ClosedXML.Tests
             var tablePivot1 = ws.PivotTables.Add("tablePivot1", ws.Cell("J1"), table);
             var tablePivot2 = ws.PivotTables.Add("tablePivot2", ws.Cell("J20"), table);
 
-            Assert.AreNotSame(tablePivot1, tablePivot2);
-            Assert.AreSame(tablePivot1.PivotCache, tablePivot2.PivotCache);
+            Assert.That(tablePivot2, Is.Not.SameAs(tablePivot1));
+            Assert.That(tablePivot2.PivotCache, Is.SameAs(tablePivot1.PivotCache));
         }
 
         [Test]
@@ -815,8 +806,11 @@ namespace ClosedXML.Tests
             var tablePivot1 = ws.PivotTables.Add("tablePivot1", ws.Cell("J1"), matchingRange);
 
             var cacheSource = (XLPivotSourceReference)((XLPivotCache)tablePivot1.PivotCache).Source;
-            Assert.True(cacheSource.UsesName);
-            Assert.AreEqual("Test table", cacheSource.Name);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cacheSource.UsesName, Is.True);
+                Assert.That(cacheSource.Name, Is.EqualTo("Test table"));
+            });
         }
 
         [Test]
@@ -846,7 +840,7 @@ namespace ClosedXML.Tests
             TestHelper.LoadAndAssert(wb =>
             {
                 // Check that existing pivot table is loaded.
-                Assert.True(wb.Worksheet("pivot").PivotTables.Contains("Pastries"));
+                Assert.That(wb.Worksheet("pivot").PivotTables.Contains("Pastries"), Is.True);
             }, @"Other\PivotTableReferenceFiles\ChartsheetAndPivotTable.xlsx");
         }
 
@@ -867,13 +861,19 @@ namespace ClosedXML.Tests
             var pt = ws.PivotTables.Add("pt", ws.Cell("E1"), data);
             pt.ReportFilters.Add("City");
 
-            // Even when we added filter and a gap row, the target cell is still E1
-            Assert.AreEqual("E1", pt.TargetCell.Address.ToString());
-            Assert.AreEqual("E3", ((XLPivotTable)pt).Area.FirstPoint.ToString());
+            Assert.Multiple(() =>
+            {
+                // Even when we added filter and a gap row, the target cell is still E1
+                Assert.That(pt.TargetCell.Address.ToString(), Is.EqualTo("E1"));
+                Assert.That(((XLPivotTable)pt).Area.FirstPoint.ToString(), Is.EqualTo("E3"));
+            });
 
             pt.TargetCell = ws.Cell("E2");
-            Assert.AreEqual("E2", pt.TargetCell.Address.ToString());
-            Assert.AreEqual("E4", ((XLPivotTable)pt).Area.FirstPoint.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(pt.TargetCell.Address.ToString(), Is.EqualTo("E2"));
+                Assert.That(((XLPivotTable)pt).Area.FirstPoint.ToString(), Is.EqualTo("E4"));
+            });
         }
 
         #endregion
@@ -901,7 +901,7 @@ namespace ClosedXML.Tests
 
             // Indirect detection of filter fields layout: The address of pivot table are is
             // determined by filter area order.
-            Assert.AreEqual(tableAddress, ((XLPivotTable)pt).Area.ToString());
+            Assert.That(((XLPivotTable)pt).Area.ToString(), Is.EqualTo(tableAddress));
         }
 
         #endregion
@@ -961,15 +961,18 @@ namespace ClosedXML.Tests
 
         private static void AssertFieldOptions(IXLPivotField field, bool withDefaults)
         {
-            Assert.AreEqual(!withDefaults, field.SubtotalsAtTop, "SubtotalsAtTop save failure");
-            Assert.AreEqual(!withDefaults, field.ShowBlankItems, "ShowBlankItems save failure");
-            Assert.AreEqual(!withDefaults, field.Outline, "Outline save failure");
-            Assert.AreEqual(!withDefaults, field.Compact, "Compact save failure");
-            Assert.AreEqual(withDefaults, field.Collapsed, "Collapsed save failure");
-            Assert.AreEqual(withDefaults, field.InsertBlankLines, "InsertBlankLines save failure");
-            Assert.AreEqual(withDefaults, field.RepeatItemLabels, "RepeatItemLabels save failure");
-            Assert.AreEqual(withDefaults, field.InsertPageBreaks, "InsertPageBreaks save failure");
-            Assert.AreEqual(withDefaults, field.IncludeNewItemsInFilter, "IncludeNewItemsInFilter save failure");
+            Assert.Multiple(() =>
+            {
+                Assert.That(field.SubtotalsAtTop, Is.EqualTo(!withDefaults), "SubtotalsAtTop save failure");
+                Assert.That(field.ShowBlankItems, Is.EqualTo(!withDefaults), "ShowBlankItems save failure");
+                Assert.That(field.Outline, Is.EqualTo(!withDefaults), "Outline save failure");
+                Assert.That(field.Compact, Is.EqualTo(!withDefaults), "Compact save failure");
+                Assert.That(field.Collapsed, Is.EqualTo(withDefaults), "Collapsed save failure");
+                Assert.That(field.InsertBlankLines, Is.EqualTo(withDefaults), "InsertBlankLines save failure");
+                Assert.That(field.RepeatItemLabels, Is.EqualTo(withDefaults), "RepeatItemLabels save failure");
+                Assert.That(field.InsertPageBreaks, Is.EqualTo(withDefaults), "InsertPageBreaks save failure");
+                Assert.That(field.IncludeNewItemsInFilter, Is.EqualTo(withDefaults), "IncludeNewItemsInFilter save failure");
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Protection/HashAlgorithmTests.cs
+++ b/ClosedXML.Tests/Excel/Protection/HashAlgorithmTests.cs
@@ -9,8 +9,8 @@ namespace ClosedXML.Tests.Excel.Protection
         [Test]
         public void TestEmptyPassword()
         {
-            Assert.IsEmpty(CryptographicAlgorithms.GetPasswordHash(Algorithm.SHA512, string.Empty));
-            Assert.IsEmpty(CryptographicAlgorithms.GetPasswordHash(Algorithm.SimpleHash, string.Empty));
+            Assert.That(CryptographicAlgorithms.GetPasswordHash(Algorithm.SHA512, string.Empty), Is.Empty);
+            Assert.That(CryptographicAlgorithms.GetPasswordHash(Algorithm.SimpleHash, string.Empty), Is.Empty);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Protection/HashAlgorithmTests.cs
+++ b/ClosedXML.Tests/Excel/Protection/HashAlgorithmTests.cs
@@ -17,14 +17,14 @@ namespace ClosedXML.Tests.Excel.Protection
         public void TestSHA512()
         {
             var hash = CryptographicAlgorithms.GetPasswordHash(Algorithm.SHA512, "12345", "aVvPw1DNH3evPqRAd/y3UQ==", 100000);
-            Assert.AreEqual("E+qAhyIg/HM0dUrPaENfimFOZp7wlOkJsf/sdG+AGHOA9grOv7VLb1ik2vuYohljI9G36e0ea9wnixCK0MMuyQ==", hash);
+            Assert.That(hash, Is.EqualTo("E+qAhyIg/HM0dUrPaENfimFOZp7wlOkJsf/sdG+AGHOA9grOv7VLb1ik2vuYohljI9G36e0ea9wnixCK0MMuyQ=="));
         }
 
         [Test]
         public void TestSimple()
         {
             var hash = CryptographicAlgorithms.GetPasswordHash(Algorithm.SimpleHash, "12345");
-            Assert.AreEqual("CA9C", hash);
+            Assert.That(hash, Is.EqualTo("CA9C"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Protection/XLSheetProtectionTests.cs
+++ b/ClosedXML.Tests/Excel/Protection/XLSheetProtectionTests.cs
@@ -20,7 +20,7 @@ namespace ClosedXML.Tests.Excel.Worksheets
                 ws.Protect().AllowedElements = XLSheetProtectionElements.Everything;
 
                 foreach (var element in Enum.GetValues(typeof(XLSheetProtectionElements)).Cast<XLSheetProtectionElements>())
-                    Assert.IsTrue(ws.Protection.AllowedElements.HasFlag(element), element.ToString());
+                    Assert.That(ws.Protection.AllowedElements.HasFlag(element), Is.True, element.ToString());
             }
 
             using (var wb = new XLWorkbook())
@@ -29,7 +29,7 @@ namespace ClosedXML.Tests.Excel.Worksheets
                 ws.Protect().AllowElement(XLSheetProtectionElements.Everything);
 
                 foreach (var element in Enum.GetValues(typeof(XLSheetProtectionElements)).Cast<XLSheetProtectionElements>())
-                    Assert.IsTrue(ws.Protection.AllowedElements.HasFlag(element), element.ToString());
+                    Assert.That(ws.Protection.AllowedElements.HasFlag(element), Is.True, element.ToString());
             }
 
             using (var wb = new XLWorkbook())
@@ -38,7 +38,7 @@ namespace ClosedXML.Tests.Excel.Worksheets
                 ws.Protect().AllowEverything();
 
                 foreach (var element in Enum.GetValues(typeof(XLSheetProtectionElements)).Cast<XLSheetProtectionElements>())
-                    Assert.IsTrue(ws.Protection.AllowedElements.HasFlag(element), element.ToString());
+                    Assert.That(ws.Protection.AllowedElements.HasFlag(element), Is.True, element.ToString());
             }
         }
 
@@ -54,7 +54,7 @@ namespace ClosedXML.Tests.Excel.Worksheets
                     .Cast<XLSheetProtectionElements>()
                     .Where(e => e != XLSheetProtectionElements.None))
 
-                    Assert.IsFalse(ws.Protection.AllowedElements.HasFlag(element), element.ToString());
+                    Assert.That(ws.Protection.AllowedElements.HasFlag(element), Is.False, element.ToString());
             }
 
             using (var wb = new XLWorkbook())
@@ -66,77 +66,82 @@ namespace ClosedXML.Tests.Excel.Worksheets
                     .Cast<XLSheetProtectionElements>()
                     .Where(e => e != XLSheetProtectionElements.None))
 
-                    Assert.IsFalse(ws.Protection.AllowedElements.HasFlag(element), element.ToString());
+                    Assert.That(ws.Protection.AllowedElements.HasFlag(element), Is.False, element.ToString());
             }
         }
 
         [Test]
         public void ChangeHashingAlgorithm()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet();
+                ws.Protect("123", Algorithm.SimpleHash);
+
+                wb.SaveAs(ms);
+            }
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.AddWorksheet();
-                    ws.Protect("123", Algorithm.SimpleHash);
+                    Assert.That(ws.Protection.IsProtected, Is.True);
+                    Assert.That(ws.Protection.Algorithm, Is.EqualTo(Algorithm.SimpleHash));
+                });
 
-                    wb.SaveAs(ms);
-                }
+                ws.Unprotect("123");
+                ws.Protect("123", Algorithm.SHA512);
+                wb.Save();
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    Assert.IsTrue(ws.Protection.IsProtected);
-                    Assert.AreEqual(Algorithm.SimpleHash, ws.Protection.Algorithm);
+                    Assert.That(ws.Protection.IsProtected, Is.True);
+                    Assert.That(ws.Protection.Algorithm, Is.EqualTo(Algorithm.SHA512));
+                });
 
-                    ws.Unprotect("123");
-                    ws.Protect("123", Algorithm.SHA512);
-                    wb.Save();
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    Assert.IsTrue(ws.Protection.IsProtected);
-                    Assert.AreEqual(Algorithm.SHA512, ws.Protection.Algorithm);
-
-                    Assert.DoesNotThrow(() => ws.Unprotect("123"));
-                }
+                Assert.DoesNotThrow(() => ws.Unprotect("123"));
             }
         }
 
         [Test]
         public void CopyProtectionFromAnotherSheet()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\SheetProtection.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\SheetProtection.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws1 = wb.Worksheet("Protected Password = 123");
+            var p1 = ws1.Protection.CastTo<XLSheetProtection>();
+            Assert.That(p1.IsProtected, Is.True);
+
+            var ws2 = ws1.CopyTo("New worksheet");
+            Assert.That(ws2.Protection.IsProtected, Is.False);
+            var p2 = ws2.Protection.CopyFrom(p1).CastTo<XLSheetProtection>();
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb.Worksheet("Protected Password = 123");
-                var p1 = ws1.Protection.CastTo<XLSheetProtection>();
-                Assert.IsTrue(p1.IsProtected);
+                Assert.That(p2.IsProtected, Is.True);
+                Assert.That(p2.IsPasswordProtected, Is.True);
+                Assert.That(p2.Algorithm, Is.EqualTo(p1.Algorithm));
+                Assert.That(p2.PasswordHash, Is.EqualTo(p1.PasswordHash));
+                Assert.That(p2.Base64EncodedSalt, Is.EqualTo(p1.Base64EncodedSalt));
+                Assert.That(p2.SpinCount, Is.EqualTo(p1.SpinCount));
 
-                var ws2 = ws1.CopyTo("New worksheet");
-                Assert.IsFalse(ws2.Protection.IsProtected);
-                var p2 = ws2.Protection.CopyFrom(p1).CastTo<XLSheetProtection>();
+                Assert.That(p2.AllowedElements.HasFlag(XLSheetProtectionElements.InsertColumns), Is.True);
+                Assert.That(p2.AllowedElements.HasFlag(XLSheetProtectionElements.InsertRows), Is.True);
+                Assert.That(p2.AllowedElements.HasFlag(XLSheetProtectionElements.InsertHyperlinks), Is.False);
+            });
 
-                Assert.IsTrue(p2.IsProtected);
-                Assert.IsTrue(p2.IsPasswordProtected);
-                Assert.AreEqual(p1.Algorithm, p2.Algorithm);
-                Assert.AreEqual(p1.PasswordHash, p2.PasswordHash);
-                Assert.AreEqual(p1.Base64EncodedSalt, p2.Base64EncodedSalt);
-                Assert.AreEqual(p1.SpinCount, p2.SpinCount);
-
-                Assert.IsTrue(p2.AllowedElements.HasFlag(XLSheetProtectionElements.InsertColumns));
-                Assert.IsTrue(p2.AllowedElements.HasFlag(XLSheetProtectionElements.InsertRows));
-                Assert.IsFalse(p2.AllowedElements.HasFlag(XLSheetProtectionElements.InsertHyperlinks));
-
-                Assert.Throws<InvalidOperationException>(() => ws2.Unprotect());
-                ws2.Unprotect("123");
-            }
+            Assert.Throws<InvalidOperationException>(() => ws2.Unprotect());
+            ws2.Unprotect("123");
         }
 
         [Test]
@@ -149,45 +154,44 @@ namespace ClosedXML.Tests.Excel.Worksheets
                 .AllowElement(XLSheetProtectionElements.FormatEverything)
                 .DisallowElement(XLSheetProtectionElements.FormatCells);
 
-            Assert.AreEqual(XLSheetProtectionElements.FormatColumns | XLSheetProtectionElements.FormatRows | XLSheetProtectionElements.SelectEverything, ws1.Protection.AllowedElements);
+            Assert.That(ws1.Protection.AllowedElements, Is.EqualTo(XLSheetProtectionElements.FormatColumns | XLSheetProtectionElements.FormatRows | XLSheetProtectionElements.SelectEverything));
 
             ws2.Protection = ws1.Protection;
 
-            Assert.IsFalse(ReferenceEquals(ws1.Protection, ws2.Protection));
-            Assert.IsTrue(ws2.Protection.IsProtected);
-            Assert.AreEqual(XLSheetProtectionElements.FormatColumns | XLSheetProtectionElements.FormatRows | XLSheetProtectionElements.SelectEverything, ws2.Protection.AllowedElements);
-            Assert.AreEqual((ws1.Protection as XLSheetProtection).PasswordHash, (ws2.Protection as XLSheetProtection).PasswordHash);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(ws1.Protection, ws2.Protection), Is.False);
+                Assert.That(ws2.Protection.IsProtected, Is.True);
+                Assert.That(ws2.Protection.AllowedElements, Is.EqualTo(XLSheetProtectionElements.FormatColumns | XLSheetProtectionElements.FormatRows | XLSheetProtectionElements.SelectEverything));
+                Assert.That((ws2.Protection as XLSheetProtection).PasswordHash, Is.EqualTo((ws1.Protection as XLSheetProtection).PasswordHash));
+            });
         }
 
         [Test]
         public void TestUnprotectWorksheetWithNoPassword()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SHA512PasswordProtection.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet("Sheet1");
-                Assert.IsTrue(ws.Protection.IsProtected);
-                ws.Unprotect();
-                Assert.IsFalse(ws.Protection.IsProtected);
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SHA512PasswordProtection.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("Sheet1");
+            Assert.That(ws.Protection.IsProtected, Is.True);
+            ws.Unprotect();
+            Assert.That(ws.Protection.IsProtected, Is.False);
         }
 
         [Test]
         public void TestWorksheetWithSHA512Protection()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SHA512PasswordProtection.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheet("Sheet2");
-                Assert.IsTrue(ws.Protection.IsProtected);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SHA512PasswordProtection.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheet("Sheet2");
+            Assert.That(ws.Protection.IsProtected, Is.True);
 
-                // Password required
-                Assert.Throws<InvalidOperationException>(() => ws.Unprotect());
+            // Password required
+            Assert.Throws<InvalidOperationException>(() => ws.Unprotect());
 
-                Assert.AreEqual(Algorithm.SHA512, ws.Protection.Algorithm);
-                ws.Unprotect("abc");
-                Assert.IsFalse(ws.Protection.IsProtected);
-            }
+            Assert.That(ws.Protection.Algorithm, Is.EqualTo(Algorithm.SHA512));
+            ws.Unprotect("abc");
+            Assert.That(ws.Protection.IsProtected, Is.False);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Protection/XLWorkbookProtectionTests.cs
+++ b/ClosedXML.Tests/Excel/Protection/XLWorkbookProtectionTests.cs
@@ -14,230 +14,239 @@ namespace ClosedXML.Tests
         [Test]
         public void CanChangeProtectionAlgorithm()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var stream = GetProtectedWorkbookStreamWithPassword())
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var stream = GetProtectedWorkbookStreamWithPassword())
-                using (var wb = new XLWorkbook(stream))
+                Assert.That(wb.Protection.Algorithm, Is.EqualTo(Algorithm.SHA512));
+                wb.Unprotect("12345");
+                wb.Protect("12345", Algorithm.SimpleHash);
+
+                wb.SaveAs(ms);
+            }
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(Algorithm.SHA512, wb.Protection.Algorithm);
-                    wb.Unprotect("12345");
-                    wb.Protect("12345", Algorithm.SimpleHash);
-
-                    wb.SaveAs(ms);
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.IsTrue(wb.IsPasswordProtected);
-                    Assert.AreEqual(Algorithm.SimpleHash, wb.Protection.Algorithm);
-                }
+                    Assert.That(wb.IsPasswordProtected, Is.True);
+                    Assert.That(wb.Protection.Algorithm, Is.EqualTo(Algorithm.SimpleHash));
+                });
             }
         }
 
         [Test]
         public void CanChangeToPasswordProtected()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var stream = GetProtectedWorkbookStreamWithoutPassword())
+            using (var wb = new XLWorkbook(stream))
+
             {
-                using (var stream = GetProtectedWorkbookStreamWithoutPassword())
-                using (var wb = new XLWorkbook(stream))
+                wb.Unprotect();
+                wb.Protection.Protect("12345");
 
+                Assert.That(wb.Protection.IsPasswordProtected, Is.True);
+
+                wb.SaveAs(ms);
+            }
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    wb.Unprotect();
-                    wb.Protection.Protect("12345");
-
-                    Assert.IsTrue(wb.Protection.IsPasswordProtected);
-
-                    wb.SaveAs(ms);
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.IsTrue(wb.Protection.IsPasswordProtected);
-                    Assert.AreEqual(Algorithm.SimpleHash, wb.Protection.Algorithm);
-                    Assert.AreNotEqual("", wb.Protection.PasswordHash);
-                }
+                    Assert.That(wb.Protection.IsPasswordProtected, Is.True);
+                    Assert.That(wb.Protection.Algorithm, Is.EqualTo(Algorithm.SimpleHash));
+                });
+                Assert.That(wb.Protection.PasswordHash, Is.Not.Empty);
             }
         }
 
         [Test]
         public void CanChangeToProtectedWithoutPassword()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var stream = GetProtectedWorkbookStreamWithPassword())
+            using (var wb = new XLWorkbook(stream))
+
             {
-                using (var stream = GetProtectedWorkbookStreamWithPassword())
-                using (var wb = new XLWorkbook(stream))
+                wb.Unprotect("12345");
+                wb.Protection.Protect();
 
+                Assert.Multiple(() =>
                 {
-                    wb.Unprotect("12345");
-                    wb.Protection.Protect();
+                    Assert.That(wb.Protection.IsPasswordProtected, Is.False);
+                    Assert.That(wb.Protection.IsProtected, Is.True);
+                });
 
-                    Assert.IsFalse(wb.Protection.IsPasswordProtected);
-                    Assert.IsTrue(wb.Protection.IsProtected);
+                wb.SaveAs(ms);
+            }
 
-                    wb.SaveAs(ms);
-                }
+            ms.Seek(0, SeekOrigin.Begin);
 
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.IsFalse(wb.Protection.IsPasswordProtected);
-                    Assert.IsTrue(wb.Protection.IsProtected);
-                    Assert.AreEqual(Algorithm.SimpleHash, wb.Protection.Algorithm);
-                    Assert.AreEqual("", wb.Protection.PasswordHash);
-                }
+                    Assert.That(wb.Protection.IsPasswordProtected, Is.False);
+                    Assert.That(wb.Protection.IsProtected, Is.True);
+                    Assert.That(wb.Protection.Algorithm, Is.EqualTo(Algorithm.SimpleHash));
+                    Assert.That(wb.Protection.PasswordHash, Is.Empty);
+                });
             }
         }
 
         [Test]
         public void CannotUnprotectIfNoPassword()
         {
-            using (var stream = GetProtectedWorkbookStreamWithoutPassword())
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ex = Assert.Throws<ArgumentException>(() => wb.Unprotect("dummy password"));
-                Assert.AreEqual("Invalid password", ex.Message);
-            }
+            using var stream = GetProtectedWorkbookStreamWithoutPassword();
+            using var wb = new XLWorkbook(stream);
+            var ex = Assert.Throws<ArgumentException>(() => wb.Unprotect("dummy password"));
+            Assert.That(ex.Message, Is.EqualTo("Invalid password"));
         }
 
         [Test]
         public void CannotUnprotectWithoutPassword()
         {
-            using (var stream = GetProtectedWorkbookStreamWithPassword())
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ex = Assert.Throws<InvalidOperationException>(() => wb.Unprotect());
-                Assert.AreEqual("The workbook structure is password protected", ex.Message);
-            }
+            using var stream = GetProtectedWorkbookStreamWithPassword();
+            using var wb = new XLWorkbook(stream);
+            var ex = Assert.Throws<InvalidOperationException>(() => wb.Unprotect());
+            Assert.That(ex.Message, Is.EqualTo("The workbook structure is password protected"));
         }
 
         [Test]
         [Theory]
         public void CanProtectWithPassword(Algorithm algorithm)
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                wb.AddWorksheet();
+
+                Assert.That(wb.Protection.IsProtected, Is.False);
+
+                wb.Protection.Protect("12345", algorithm);
+
+                wb.Protection.AllowNone();
+                Assert.Multiple(() =>
                 {
-                    wb.AddWorksheet();
+                    Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure), Is.False);
+                    Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows), Is.False);
+                });
 
-                    Assert.IsFalse(wb.Protection.IsProtected);
+                wb.SaveAs(ms);
+            }
 
-                    wb.Protection.Protect("12345", algorithm);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                    wb.Protection.AllowNone();
-                    Assert.IsFalse(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure));
-                    Assert.IsFalse(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows));
-
-                    wb.SaveAs(ms);
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.IsTrue(wb.Protection.IsPasswordProtected);
-                    Assert.IsTrue(wb.Protection.IsProtected);
+                    Assert.That(wb.Protection.IsPasswordProtected, Is.True);
+                    Assert.That(wb.Protection.IsProtected, Is.True);
 
-                    Assert.AreEqual(algorithm, wb.Protection.Algorithm);
-                    Assert.AreNotEqual("", wb.Protection.PasswordHash);
+                    Assert.That(wb.Protection.Algorithm, Is.EqualTo(algorithm));
+                });
+                Assert.That(wb.Protection.PasswordHash, Is.Not.Empty);
 
-                    Assert.IsFalse(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure));
-                    Assert.IsFalse(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure), Is.False);
+                    Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows), Is.False);
+                });
 
-                    var ex = Assert.Throws<ArgumentException>(() => wb.Unprotect("dummy password"));
-                    Assert.AreEqual("Invalid password", ex.Message);
+                var ex = Assert.Throws<ArgumentException>(() => wb.Unprotect("dummy password"));
+                Assert.That(ex.Message, Is.EqualTo("Invalid password"));
 
-                    wb.Protection.Unprotect("12345");
+                wb.Protection.Unprotect("12345");
 
-                    wb.Save();
-                }
+                wb.Save();
             }
         }
 
         [Test]
         public void CanUnprotectWithoutPassword()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var stream = GetProtectedWorkbookStreamWithoutPassword())
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var stream = GetProtectedWorkbookStreamWithoutPassword())
-                using (var wb = new XLWorkbook(stream))
-                {
-                    // Unprotect without password
-                    wb.Unprotect();
+                // Unprotect without password
+                wb.Unprotect();
 
-                    Assert.IsFalse(wb.Protection.IsProtected);
+                Assert.That(wb.Protection.IsProtected, Is.False);
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.IsFalse(wb.Protection.IsProtected);
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.Protection.IsProtected, Is.False);
             }
         }
 
         [Test]
         public void CanUnprotectWithPassword()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var stream = GetProtectedWorkbookStreamWithPassword())
+            using (var wb = new XLWorkbook(stream))
             {
-                using (var stream = GetProtectedWorkbookStreamWithPassword())
-                using (var wb = new XLWorkbook(stream))
-                {
-                    // Unprotect with password
-                    wb.Unprotect("12345");
+                // Unprotect with password
+                wb.Unprotect("12345");
 
-                    Assert.IsFalse(wb.Protection.IsProtected);
+                Assert.That(wb.Protection.IsProtected, Is.False);
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.IsFalse(wb.Protection.IsProtected);
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.Protection.IsProtected, Is.False);
             }
         }
 
         [Test]
         public void CopyProtectionFromAnotherWorkbook()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\WorkbookProtection.xlsx")))
-            using (var wb1 = new XLWorkbook(stream))
-            using (var wb2 = new XLWorkbook())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\Misc\WorkbookProtection.xlsx"));
+            using var wb1 = new XLWorkbook(stream);
+            using var wb2 = new XLWorkbook();
+            wb2.AddWorksheet();
+
+            var p1 = wb1.Protection.CastTo<XLWorkbookProtection>();
+            Assert.Multiple(() =>
             {
-                wb2.AddWorksheet();
+                Assert.That(p1.IsProtected, Is.True);
 
-                var p1 = wb1.Protection.CastTo<XLWorkbookProtection>();
-                Assert.IsTrue(p1.IsProtected);
+                Assert.That(wb2.Protection.IsProtected, Is.False);
+            });
+            var p2 = wb2.Protection.CopyFrom(wb1.Protection).CastTo<XLWorkbookProtection>();
 
-                Assert.IsFalse(wb2.Protection.IsProtected);
-                var p2 = wb2.Protection.CopyFrom(wb1.Protection).CastTo<XLWorkbookProtection>();
+            Assert.Multiple(() =>
+            {
+                Assert.That(p2.IsProtected, Is.True);
+                Assert.That(p2.IsPasswordProtected, Is.True);
+                Assert.That(p2.Algorithm, Is.EqualTo(p1.Algorithm));
+                Assert.That(p2.PasswordHash, Is.EqualTo(p1.PasswordHash));
+                Assert.That(p2.Base64EncodedSalt, Is.EqualTo(p1.Base64EncodedSalt));
+                Assert.That(p2.SpinCount, Is.EqualTo(p1.SpinCount));
 
-                Assert.IsTrue(p2.IsProtected);
-                Assert.IsTrue(p2.IsPasswordProtected);
-                Assert.AreEqual(p1.Algorithm, p2.Algorithm);
-                Assert.AreEqual(p1.PasswordHash, p2.PasswordHash);
-                Assert.AreEqual(p1.Base64EncodedSalt, p2.Base64EncodedSalt);
-                Assert.AreEqual(p1.SpinCount, p2.SpinCount);
+                Assert.That(p2.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows), Is.True);
+                Assert.That(p2.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure), Is.False);
+            });
 
-                Assert.IsTrue(p2.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows));
-                Assert.IsFalse(p2.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure));
-
-                Assert.Throws<InvalidOperationException>(() => wb2.Unprotect());
-                wb2.Unprotect("Abc@123");
-            }
+            Assert.Throws<InvalidOperationException>(() => wb2.Unprotect());
+            wb2.Unprotect("Abc@123");
         }
 
         [Test]
@@ -251,50 +260,55 @@ namespace ClosedXML.Tests
 
             list.ForEach(el => el.Protect());
 
-            list.ForEach(el => Assert.IsTrue(el.IsProtected));
-            list.ForEach(el => Assert.IsFalse(el.IsPasswordProtected));
+            list.ForEach(el => Assert.That(el.IsProtected, Is.True));
+            list.ForEach(el => Assert.That(el.IsPasswordProtected, Is.False));
 
             list.ForEach(el => el.Unprotect());
 
-            list.ForEach(el => Assert.IsFalse(el.IsProtected));
-            list.ForEach(el => Assert.IsFalse(el.IsPasswordProtected));
+            list.ForEach(el => Assert.That(el.IsProtected, Is.False));
+            list.ForEach(el => Assert.That(el.IsPasswordProtected, Is.False));
 
             list.ForEach(el => el.Protect("password"));
 
-            list.ForEach(el => Assert.IsTrue(el.IsProtected));
-            list.ForEach(el => Assert.IsTrue(el.IsPasswordProtected));
+            list.ForEach(el => Assert.That(el.IsProtected, Is.True));
+            list.ForEach(el => Assert.That(el.IsPasswordProtected, Is.True));
 
             list.ForEach(el => el.Unprotect("password"));
 
-            list.ForEach(el => Assert.IsFalse(el.IsProtected));
-            list.ForEach(el => Assert.IsFalse(el.IsPasswordProtected));
+            list.ForEach(el => Assert.That(el.IsProtected, Is.False));
+            list.ForEach(el => Assert.That(el.IsPasswordProtected, Is.False));
         }
 
         [Test]
         public void LoadProtectionWithoutPasswordFromFile()
         {
-            using (var stream = GetProtectedWorkbookStreamWithoutPassword())
-            using (var wb = new XLWorkbook(stream))
+            using var stream = GetProtectedWorkbookStreamWithoutPassword();
+            using var wb = new XLWorkbook(stream);
+            Assert.Multiple(() =>
             {
-                Assert.IsFalse(wb.Protection.IsPasswordProtected);
-                Assert.IsTrue(wb.Protection.IsProtected);
-                Assert.AreEqual("", wb.Protection.PasswordHash);
-                Assert.IsTrue(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows));
-                Assert.IsFalse(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure));
-            }
+                Assert.That(wb.Protection.IsPasswordProtected, Is.False);
+                Assert.That(wb.Protection.IsProtected, Is.True);
+                Assert.That(wb.Protection.PasswordHash, Is.Empty);
+                Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows), Is.True);
+                Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure), Is.False);
+            });
         }
 
         [Test]
         public void LoadProtectionWithPasswordFromFile()
         {
-            using (var stream = GetProtectedWorkbookStreamWithPassword())
-            using (var wb = new XLWorkbook(stream))
+            using var stream = GetProtectedWorkbookStreamWithPassword();
+            using var wb = new XLWorkbook(stream);
+            Assert.Multiple(() =>
             {
-                Assert.IsTrue(wb.Protection.IsPasswordProtected);
-                Assert.AreNotEqual("", wb.Protection.PasswordHash);
-                Assert.IsTrue(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows));
-                Assert.IsFalse(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure));
-            }
+                Assert.That(wb.Protection.IsPasswordProtected, Is.True);
+                Assert.That(wb.Protection.PasswordHash, Is.Not.Empty);
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Windows), Is.True);
+                Assert.That(wb.Protection.AllowedElements.HasFlag(XLWorkbookProtectionElements.Structure), Is.False);
+            });
         }
 
         [Test]
@@ -310,16 +324,22 @@ namespace ClosedXML.Tests
                 .AllowElement(XLWorkbookProtectionElements.Windows)
                 .DisallowElement(XLWorkbookProtectionElements.Structure);
 
-            Assert.IsTrue(wb1.Protection.IsProtected);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb1.Protection.IsProtected, Is.True);
 
-            Assert.AreEqual(XLWorkbookProtectionElements.Windows, wb1.Protection.AllowedElements);
+                Assert.That(wb1.Protection.AllowedElements, Is.EqualTo(XLWorkbookProtectionElements.Windows));
+            });
 
             wb2.Protection = wb1.Protection;
 
-            Assert.IsFalse(ReferenceEquals(wb1.Protection, wb2.Protection));
-            Assert.IsTrue(wb2.Protection.IsProtected);
-            Assert.AreEqual(XLWorkbookProtectionElements.Windows, wb2.Protection.AllowedElements);
-            Assert.AreEqual(wb1.Protection.PasswordHash, wb2.Protection.PasswordHash);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ReferenceEquals(wb1.Protection, wb2.Protection), Is.False);
+                Assert.That(wb2.Protection.IsProtected, Is.True);
+                Assert.That(wb2.Protection.AllowedElements, Is.EqualTo(XLWorkbookProtectionElements.Windows));
+                Assert.That(wb2.Protection.PasswordHash, Is.EqualTo(wb1.Protection.PasswordHash));
+            });
         }
 
         private Stream GetProtectedWorkbookStreamWithoutPassword() => TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Protection\protectstructurewithoutpassword.xlsx"));

--- a/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
@@ -27,24 +27,30 @@ namespace ClosedXML.Tests
             ws.Cell(1, 3).CopyFrom(column1.Column(1, 7));
 
             IXLColumn column2 = ws.Column(2);
-            Assert.AreEqual(XLColor.Red, column2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromArgb(1, 1, 1), column2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromHtml("#CCCCCC"), column2.Cell(3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromIndex(26), column2.Cell(4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromColor(Color.MediumSeaGreen),
-                column2.Cell(5).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromName("Blue"), column2.Cell(6).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromTheme(XLThemeColor.Accent3), column2.Cell(7).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(column2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromArgb(1, 1, 1)));
+                Assert.That(column2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromHtml("#CCCCCC")));
+                Assert.That(column2.Cell(4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromIndex(26)));
+                Assert.That(column2.Cell(5).Style.Fill.BackgroundColor,
+                    Is.EqualTo(XLColor.FromColor(Color.MediumSeaGreen)));
+                Assert.That(column2.Cell(6).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromName("Blue")));
+                Assert.That(column2.Cell(7).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromTheme(XLThemeColor.Accent3)));
+            });
 
             IXLColumn column3 = ws.Column(3);
-            Assert.AreEqual(XLColor.Red, column3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromArgb(1, 1, 1), column3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromHtml("#CCCCCC"), column3.Cell(3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromIndex(26), column3.Cell(4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromColor(Color.MediumSeaGreen),
-                column3.Cell(5).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromName("Blue"), column3.Cell(6).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromTheme(XLThemeColor.Accent3), column3.Cell(7).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(column3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(column3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromArgb(1, 1, 1)));
+                Assert.That(column3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromHtml("#CCCCCC")));
+                Assert.That(column3.Cell(4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromIndex(26)));
+                Assert.That(column3.Cell(5).Style.Fill.BackgroundColor,
+                    Is.EqualTo(XLColor.FromColor(Color.MediumSeaGreen)));
+                Assert.That(column3.Cell(6).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromName("Blue")));
+                Assert.That(column3.Cell(7).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromTheme(XLThemeColor.Accent3)));
+            });
         }
 
         [Test]
@@ -60,27 +66,33 @@ namespace ClosedXML.Tests
             ws.Cell(3, 1).CopyFrom(row1.Row(1, 7));
 
             IXLRow row2 = ws.Row(2);
-            Assert.AreEqual(XLColor.Red, row2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromArgb(1, 1, 1), row2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromHtml("#CCCCCC"), row2.Cell(3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromIndex(26), row2.Cell(4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromColor(Color.MediumSeaGreen), row2.Cell(5).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromName("Blue"), row2.Cell(6).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromTheme(XLThemeColor.Accent3), row2.Cell(7).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(row2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromArgb(1, 1, 1)));
+                Assert.That(row2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromHtml("#CCCCCC")));
+                Assert.That(row2.Cell(4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromIndex(26)));
+                Assert.That(row2.Cell(5).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromColor(Color.MediumSeaGreen)));
+                Assert.That(row2.Cell(6).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromName("Blue")));
+                Assert.That(row2.Cell(7).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromTheme(XLThemeColor.Accent3)));
+            });
 
             IXLRow row3 = ws.Row(3);
-            Assert.AreEqual(XLColor.Red, row3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromArgb(1, 1, 1), row3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromHtml("#CCCCCC"), row3.Cell(3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromIndex(26), row3.Cell(4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromColor(Color.MediumSeaGreen), row3.Cell(5).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromName("Blue"), row3.Cell(6).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FromTheme(XLThemeColor.Accent3), row3.Cell(7).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(row3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromArgb(1, 1, 1)));
+                Assert.That(row3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromHtml("#CCCCCC")));
+                Assert.That(row3.Cell(4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromIndex(26)));
+                Assert.That(row3.Cell(5).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromColor(Color.MediumSeaGreen)));
+                Assert.That(row3.Cell(6).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromName("Blue")));
+                Assert.That(row3.Cell(7).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FromTheme(XLThemeColor.Accent3)));
 
-            Assert.AreEqual(3, ws.ConditionalFormats.Count());
-            Assert.IsTrue(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B1:B1").Values.Any(v => v.Value.Value == "G1" && v.Value.IsFormula));
-            Assert.IsTrue(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B2:B2").Values.Any(v => v.Value.Value == "G2" && v.Value.IsFormula));
-            Assert.IsTrue(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B3:B3").Values.Any(v => v.Value.Value == "G3" && v.Value.IsFormula));
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(3));
+                Assert.That(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B1:B1").Values.Any(v => v.Value.Value == "G1" && v.Value.IsFormula), Is.True);
+                Assert.That(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B2:B2").Values.Any(v => v.Value.Value == "G2" && v.Value.IsFormula), Is.True);
+                Assert.That(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B3:B3").Values.Any(v => v.Value.Value == "G3" && v.Value.IsFormula), Is.True);
+            });
         }
 
         [Test]
@@ -97,9 +109,12 @@ namespace ClosedXML.Tests
 
             ws.Cell(5, 2).CopyFrom(ws.Row(2).Row(1, 7));
 
-            Assert.AreEqual(2, ws.ConditionalFormats.Count());
-            Assert.IsTrue(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B1:B3").Values.Any(v => v.Value.Value == "G1" && v.Value.IsFormula));
-            Assert.IsTrue(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "C5:C5").Values.Any(v => v.Value.Value == "H5" && v.Value.IsFormula));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(2));
+                Assert.That(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "B1:B3").Values.Any(v => v.Value.Value == "G1" && v.Value.IsFormula), Is.True);
+                Assert.That(ws.ConditionalFormats.Single(x => x.Range.RangeAddress.ToStringRelative() == "C5:C5").Values.Any(v => v.Value.Value == "H5" && v.Value.IsFormula), Is.True);
+            });
         }
 
         [Test]
@@ -124,16 +139,19 @@ namespace ClosedXML.Tests
 
             ws2.FirstCell().CopyFrom(ws1.Range("B1:B4"));
 
-            Assert.AreEqual(1, ws2.ConditionalFormats.Count());
-            Assert.IsTrue(ws2.ConditionalFormats.All(x => x.Ranges.All(s => s.Worksheet == ws2)), "A conditional format was created for another worksheet.");
-            Assert.IsTrue(ws2.ConditionalFormats
-                .Single(x => x.Range.RangeAddress.ToStringRelative() == "A1:A2")
-                .Values.Any(v => v.Value.Value == "E1" && v.Value.IsFormula), "The formula has not been transferred correctly.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws2.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws2.ConditionalFormats.All(x => x.Ranges.All(s => s.Worksheet == ws2)), Is.True, "A conditional format was created for another worksheet.");
+                Assert.That(ws2.ConditionalFormats
+                    .Single(x => x.Range.RangeAddress.ToStringRelative() == "A1:A2")
+                    .Values.Any(v => v.Value.Value == "E1" && v.Value.IsFormula), Is.True, "The formula has not been transferred correctly.");
 
-            Assert.AreEqual("Sheet1", ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("Sheet2", ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("A1:J2", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
-            Assert.AreEqual("A1:A2", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+                Assert.That(ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name, Is.EqualTo("Sheet1"));
+                Assert.That(ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name, Is.EqualTo("Sheet2"));
+                Assert.That(ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo("A1:J2"));
+            });
+            Assert.That(ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(), Is.EqualTo("A1:A2"));
         }
 
         private static void FillRow(IXLRow row1)

--- a/ClosedXML.Tests/Excel/Ranges/InsertingRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/InsertingRangesTests.cs
@@ -24,17 +24,23 @@ namespace ClosedXML.Tests
             column1.InsertColumnsBefore(1);
             column2.InsertColumnsBefore(1);
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Column(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FrenchLilac, ws.Column(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FrenchLilac, ws.Column(3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FrenchLilac, ws.Column(4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Xanadu, ws.Column(5).Style.Fill.BackgroundColor);
+            Assert.That(ws.Column(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(ws.Column(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FrenchLilac));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Column(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FrenchLilac));
+                Assert.That(ws.Column(4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FrenchLilac));
+                Assert.That(ws.Column(5).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Xanadu));
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Cell(2, 1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Fulvous, ws.Cell(2, 2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Fulvous, ws.Cell(2, 3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Fulvous, ws.Cell(2, 4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.MacaroniAndCheese, ws.Cell(2, 5).Style.Fill.BackgroundColor);
+                Assert.That(ws.Cell(2, 1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            });
+            Assert.That(ws.Cell(2, 2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Fulvous));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(2, 3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Fulvous));
+                Assert.That(ws.Cell(2, 4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Fulvous));
+                Assert.That(ws.Cell(2, 5).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.MacaroniAndCheese));
+            });
         }
 
         [Test]
@@ -49,9 +55,12 @@ namespace ClosedXML.Tests
             IXLRangeRow r = ws.Range("B4").InsertRowsAbove(1).First();
             r.Cell(1).SetValue("A");
 
-            Assert.AreEqual("X", ws.Cell("B3").GetText());
-            Assert.AreEqual("A", ws.Cell("B4").GetText());
-            Assert.AreEqual("B", ws.Cell("B5").GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("B3").GetText(), Is.EqualTo("X"));
+                Assert.That(ws.Cell("B4").GetText(), Is.EqualTo("A"));
+                Assert.That(ws.Cell("B5").GetText(), Is.EqualTo("B"));
+            });
         }
 
         [Test]
@@ -70,17 +79,23 @@ namespace ClosedXML.Tests
             row1.InsertRowsAbove(1);
             row2.InsertRowsAbove(1);
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Row(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FrenchLilac, ws.Row(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FrenchLilac, ws.Row(3).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.FrenchLilac, ws.Row(4).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Xanadu, ws.Row(5).Style.Fill.BackgroundColor);
+            Assert.That(ws.Row(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(ws.Row(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FrenchLilac));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FrenchLilac));
+                Assert.That(ws.Row(4).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.FrenchLilac));
+                Assert.That(ws.Row(5).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Xanadu));
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Cell(1, 2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Fulvous, ws.Cell(2, 2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Fulvous, ws.Cell(3, 2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Fulvous, ws.Cell(4, 2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.MacaroniAndCheese, ws.Cell(5, 2).Style.Fill.BackgroundColor);
+                Assert.That(ws.Cell(1, 2).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            });
+            Assert.That(ws.Cell(2, 2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Fulvous));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(3, 2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Fulvous));
+                Assert.That(ws.Cell(4, 2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Fulvous));
+                Assert.That(ws.Cell(5, 2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.MacaroniAndCheese));
+            });
         }
 
         [Test]
@@ -94,7 +109,7 @@ namespace ClosedXML.Tests
             ws.Cell("A3").SetValue("Cell with comment").GetComment().AddText("Comment here");
 
             ws.Row(1).InsertRowsBelow(2);
-            Assert.AreEqual("Comment here", ws.Cell("A5").GetComment().Text);
+            Assert.That(ws.Cell("A5").GetComment().Text, Is.EqualTo("Comment here"));
         }
 
         [Test]
@@ -108,7 +123,7 @@ namespace ClosedXML.Tests
             ws.Cell("C1").SetValue("Cell with comment").GetComment().AddText("Comment here");
 
             ws.Column(1).InsertColumnsAfter(2);
-            Assert.AreEqual("Comment here", ws.Cell("E1").GetComment().Text);
+            Assert.That(ws.Cell("E1").GetComment().Text, Is.EqualTo("Comment here"));
         }
 
         [Test]
@@ -131,33 +146,32 @@ namespace ClosedXML.Tests
         [TestCase("B1:B8", "A1:C4", -1, "B1:B8")]  // More rows, shift left
         public void ShiftColumnsValid(string thisRangeAddress, string shiftedRangeAddress, int shiftedColumns, string expectedRange)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var thisRange = ws.Range(thisRangeAddress) as XLRange;
+            var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
+
+            thisRange.WorksheetRangeShiftedColumns(shiftedRange, shiftedColumns);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                var thisRange = ws.Range(thisRangeAddress) as XLRange;
-                var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
-
-                thisRange.WorksheetRangeShiftedColumns(shiftedRange, shiftedColumns);
-
-                Assert.IsTrue(thisRange.RangeAddress.IsValid);
-                Assert.AreEqual(expectedRange, thisRange.RangeAddress.ToString());
-            }
+                Assert.That(thisRange.RangeAddress.IsValid, Is.True);
+                Assert.That(thisRange.RangeAddress.ToString(), Is.EqualTo(expectedRange));
+            });
         }
 
         [Test]
         [TestCase("B1:B4", "A1:C4", -2)] // Shift left too much
         public void ShiftColumnsInvalid(string thisRangeAddress, string shiftedRangeAddress, int shiftedColumns)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1");
-                var thisRange = ws.Range(thisRangeAddress) as XLRange;
-                var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var thisRange = ws.Range(thisRangeAddress) as XLRange;
+            var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
 
-                thisRange.WorksheetRangeShiftedColumns(shiftedRange, shiftedColumns);
+            thisRange.WorksheetRangeShiftedColumns(shiftedRange, shiftedColumns);
 
-                Assert.IsFalse(thisRange.RangeAddress.IsValid);
-            }
+            Assert.That(thisRange.RangeAddress.IsValid, Is.False);
         }
 
         [Test]
@@ -181,33 +195,32 @@ namespace ClosedXML.Tests
         [TestCase("A2:D2", "A1:C4", -1, "A2:D2")]   // More columns, shift up
         public void ShiftRowsValid(string thisRangeAddress, string shiftedRangeAddress, int shiftedRows, string expectedRange)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var thisRange = ws.Range(thisRangeAddress) as XLRange;
+            var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
+
+            thisRange.WorksheetRangeShiftedRows(shiftedRange, shiftedRows);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                var thisRange = ws.Range(thisRangeAddress) as XLRange;
-                var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
-
-                thisRange.WorksheetRangeShiftedRows(shiftedRange, shiftedRows);
-
-                Assert.IsTrue(thisRange.RangeAddress.IsValid);
-                Assert.AreEqual(expectedRange, thisRange.RangeAddress.ToString());
-            }
+                Assert.That(thisRange.RangeAddress.IsValid, Is.True);
+                Assert.That(thisRange.RangeAddress.ToString(), Is.EqualTo(expectedRange));
+            });
         }
 
         [Test]
         [TestCase("A2:C2", "A1:C4", -2)] // Shift up too much
         public void ShiftRowsInvalid(string thisRangeAddress, string shiftedRangeAddress, int shiftedRows)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1");
-                var thisRange = ws.Range(thisRangeAddress) as XLRange;
-                var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var thisRange = ws.Range(thisRangeAddress) as XLRange;
+            var shiftedRange = ws.Range(shiftedRangeAddress) as XLRange;
 
-                thisRange.WorksheetRangeShiftedRows(shiftedRange, shiftedRows);
+            thisRange.WorksheetRangeShiftedRows(shiftedRange, shiftedRows);
 
-                Assert.IsFalse(thisRange.RangeAddress.IsValid);
-            }
+            Assert.That(thisRange.RangeAddress.IsValid, Is.False);
         }
 
         [Test]
@@ -268,30 +281,28 @@ namespace ClosedXML.Tests
         public void MergedRangesConsistencyWhenInsertingRows()
         {
             // https://github.com/ClosedXML/ClosedXML/issues/1013
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            //create merged row
+            ws.Cell("A1").Value = "Merged Row(1) of Range (A1:F1)";
+            ws.Range("A1:F1").Row(1).Merge();
+
+            var row = ws.FirstRow();
+
+            // Add some lines and copy format & merging
+            for (var r = 1; r <= 10; r++)
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                row.InsertRowsBelow(1);         // insert a row below row 1, as a row 2
+                row.CopyTo(row.RowBelow());     // copy format and merging from row 1 to row 2
 
-                //create merged row
-                ws.Cell("A1").Value = "Merged Row(1) of Range (A1:F1)";
-                ws.Range("A1:F1").Row(1).Merge();
+                var duplicates = ws.MergedRanges
+                    .GroupBy(s => s.ToString())
+                    .Where(g => g.Count() > 1)
+                    .Select(y => new { Element = y.Key, Counter = y.Count() })
+                    .ToList();
 
-                var row = ws.FirstRow();
-
-                // Add some lines and copy format & merging
-                for (var r = 1; r <= 10; r++)
-                {
-                    row.InsertRowsBelow(1);         // insert a row below row 1, as a row 2
-                    row.CopyTo(row.RowBelow());     // copy format and merging from row 1 to row 2
-
-                    var duplicates = ws.MergedRanges
-                        .GroupBy(s => s.ToString())
-                        .Where(g => g.Count() > 1)
-                        .Select(y => new { Element = y.Key, Counter = y.Count() })
-                        .ToList();
-
-                    Assert.AreEqual(0, duplicates.Count);
-                }
+                Assert.That(duplicates.Count, Is.EqualTo(0));
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/MergedRangesTests.cs
@@ -17,8 +17,11 @@ namespace ClosedXML.Tests
             string first = ws.FirstCellUsed(XLCellsUsedOptions.All).Address.ToStringRelative();
             string last = ws.LastCellUsed(XLCellsUsedOptions.All).Address.ToStringRelative();
 
-            Assert.AreEqual("B2", first);
-            Assert.AreEqual("D4", last);
+            Assert.Multiple(() =>
+            {
+                Assert.That(first, Is.EqualTo("B2"));
+                Assert.That(last, Is.EqualTo("D4"));
+            });
         }
 
         [TestCase("A1:A2", "A1:A2")]
@@ -28,18 +31,19 @@ namespace ClosedXML.Tests
         [TestCase("C7:D7", "E7:F7")]
         public void MergedRangesShiftedOnColumnInsert(string originalRange, string expectedRange)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            var range = ws.Range(originalRange).Merge();
+
+            ws.Column(2).InsertColumnsAfter(2);
+
+            var mr = ws.MergedRanges.ToArray();
+            Assert.That(mr.Length, Is.EqualTo(1));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("MRShift");
-                var range = ws.Range(originalRange).Merge();
-
-                ws.Column(2).InsertColumnsAfter(2);
-
-                var mr = ws.MergedRanges.ToArray();
-                Assert.AreEqual(1, mr.Length);
-                Assert.AreSame(range, mr.Single());
-                Assert.AreEqual(expectedRange, range.RangeAddress.ToString());
-            }
+                Assert.That(mr.Single(), Is.SameAs(range));
+                Assert.That(range.RangeAddress.ToString(), Is.EqualTo(expectedRange));
+            });
         }
 
         [TestCase("A1:B1", "A1:B1")]
@@ -49,18 +53,19 @@ namespace ClosedXML.Tests
         [TestCase("G4:G5", "G6:G7")]
         public void MergedRangesShiftedOnRowInsert(string originalRange, string expectedRange)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            var range = ws.Range(originalRange).Merge();
+
+            ws.Row(2).InsertRowsBelow(2);
+
+            var mr = ws.MergedRanges.ToArray();
+            Assert.That(mr.Length, Is.EqualTo(1));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("MRShift");
-                var range = ws.Range(originalRange).Merge();
-
-                ws.Row(2).InsertRowsBelow(2);
-
-                var mr = ws.MergedRanges.ToArray();
-                Assert.AreEqual(1, mr.Length);
-                Assert.AreSame(range, mr.Single());
-                Assert.AreEqual(expectedRange, range.RangeAddress.ToString());
-            }
+                Assert.That(mr.Single(), Is.SameAs(range));
+                Assert.That(range.RangeAddress.ToString(), Is.EqualTo(expectedRange));
+            });
         }
 
         [TestCase("A1:A2", true, "A1:A2")]
@@ -70,25 +75,29 @@ namespace ClosedXML.Tests
         [TestCase("C7:D7", true, "B7:C7")]
         public void MergedRangesShiftedOnColumnDelete(string originalRange, bool expectedExist, string expectedRange)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            var range = ws.Range(originalRange).Merge();
+
+            ws.Column(2).Delete();
+
+            var mr = ws.MergedRanges.ToArray();
+            if (expectedExist)
             {
-                var ws = wb.AddWorksheet("MRShift");
-                var range = ws.Range(originalRange).Merge();
-
-                ws.Column(2).Delete();
-
-                var mr = ws.MergedRanges.ToArray();
-                if (expectedExist)
+                Assert.That(mr.Length, Is.EqualTo(1));
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(1, mr.Length);
-                    Assert.AreSame(range, mr.Single());
-                    Assert.AreEqual(expectedRange, range.RangeAddress.ToString());
-                }
-                else
+                    Assert.That(mr.Single(), Is.SameAs(range));
+                    Assert.That(range.RangeAddress.ToString(), Is.EqualTo(expectedRange));
+                });
+            }
+            else
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(0, mr.Length);
-                    Assert.IsFalse(range.RangeAddress.IsValid);
-                }
+                    Assert.That(mr.Length, Is.EqualTo(0));
+                    Assert.That(range.RangeAddress.IsValid, Is.False);
+                });
             }
         }
 
@@ -99,261 +108,274 @@ namespace ClosedXML.Tests
         [TestCase("G4:G5", true, "G3:G4")]
         public void MergedRangesShiftedOnRowDelete(string originalRange, bool expectedExist, string expectedRange)
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            var range = ws.Range(originalRange).Merge();
+
+            ws.Row(2).Delete();
+
+            var mr = ws.MergedRanges.ToArray();
+            if (expectedExist)
             {
-                var ws = wb.AddWorksheet("MRShift");
-                var range = ws.Range(originalRange).Merge();
-
-                ws.Row(2).Delete();
-
-                var mr = ws.MergedRanges.ToArray();
-                if (expectedExist)
+                Assert.That(mr.Length, Is.EqualTo(1));
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(1, mr.Length);
-                    Assert.AreSame(range, mr.Single());
-                    Assert.AreEqual(expectedRange, range.RangeAddress.ToString());
-                }
-                else
+                    Assert.That(mr.Single(), Is.SameAs(range));
+                    Assert.That(range.RangeAddress.ToString(), Is.EqualTo(expectedRange));
+                });
+            }
+            else
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(0, mr.Length);
-                    Assert.IsFalse(range.RangeAddress.IsValid);
-                }
+                    Assert.That(mr.Length, Is.EqualTo(0));
+                    Assert.That(range.RangeAddress.IsValid, Is.False);
+                });
             }
         }
 
         [Test]
         public void ShiftRangeRightBreaksMerges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            ws.Range("B2:C3").Merge();
+            ws.Range("B4:C5").Merge();
+            ws.Range("F2:G3").Merge(); // to be broken
+            ws.Range("F4:G5").Merge(); // to be broken
+            ws.Range("H1:I2").Merge();
+            ws.Range("H5:I6").Merge();
+
+            ws.Range("D3:E4").InsertColumnsAfter(2);
+
+            var mr = ws.MergedRanges.ToArray();
+            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("MRShift");
-                ws.Range("B2:C3").Merge();
-                ws.Range("B4:C5").Merge();
-                ws.Range("F2:G3").Merge(); // to be broken
-                ws.Range("F4:G5").Merge(); // to be broken
-                ws.Range("H1:I2").Merge();
-                ws.Range("H5:I6").Merge();
-
-                ws.Range("D3:E4").InsertColumnsAfter(2);
-
-                var mr = ws.MergedRanges.ToArray();
-                Assert.AreEqual(4, mr.Length);
-                Assert.AreEqual("H1:I2", mr[0].RangeAddress.ToString());
-                Assert.AreEqual("B2:C3", mr[1].RangeAddress.ToString());
-                Assert.AreEqual("B4:C5", mr[2].RangeAddress.ToString());
-                Assert.AreEqual("H5:I6", mr[3].RangeAddress.ToString());
-            }
+                Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("H1:I2"));
+                Assert.That(mr[1].RangeAddress.ToString(), Is.EqualTo("B2:C3"));
+                Assert.That(mr[2].RangeAddress.ToString(), Is.EqualTo("B4:C5"));
+                Assert.That(mr[3].RangeAddress.ToString(), Is.EqualTo("H5:I6"));
+            });
         }
 
         [Test]
         public void ShiftRangeLeftBreaksMerges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            ws.Range("B2:C3").Merge();
+            ws.Range("B4:C5").Merge();
+            ws.Range("F2:G3").Merge(); // to be broken
+            ws.Range("F4:G5").Merge(); // to be broken
+            ws.Range("H1:I2").Merge();
+            ws.Range("H5:I6").Merge();
+
+            ws.Range("D3:E4").Delete(XLShiftDeletedCells.ShiftCellsLeft);
+
+            var mr = ws.MergedRanges.ToArray();
+            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("MRShift");
-                ws.Range("B2:C3").Merge();
-                ws.Range("B4:C5").Merge();
-                ws.Range("F2:G3").Merge(); // to be broken
-                ws.Range("F4:G5").Merge(); // to be broken
-                ws.Range("H1:I2").Merge();
-                ws.Range("H5:I6").Merge();
-
-                ws.Range("D3:E4").Delete(XLShiftDeletedCells.ShiftCellsLeft);
-
-                var mr = ws.MergedRanges.ToArray();
-                Assert.AreEqual(4, mr.Length);
-                Assert.AreEqual("H1:I2", mr[0].RangeAddress.ToString());
-                Assert.AreEqual("B2:C3", mr[1].RangeAddress.ToString());
-                Assert.AreEqual("B4:C5", mr[2].RangeAddress.ToString());
-                Assert.AreEqual("H5:I6", mr[3].RangeAddress.ToString());
-            }
+                Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("H1:I2"));
+                Assert.That(mr[1].RangeAddress.ToString(), Is.EqualTo("B2:C3"));
+                Assert.That(mr[2].RangeAddress.ToString(), Is.EqualTo("B4:C5"));
+                Assert.That(mr[3].RangeAddress.ToString(), Is.EqualTo("H5:I6"));
+            });
         }
 
         [Test]
         public void RangeShiftDownBreaksMerges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            ws.Range("B2:C3").Merge();
+            ws.Range("D2:E3").Merge();
+            ws.Range("B6:C7").Merge(); // to be broken
+            ws.Range("D6:E7").Merge(); // to be broken
+            ws.Range("A8:B9").Merge();
+            ws.Range("E8:F9").Merge();
+
+            ws.Range("C4:D5").InsertRowsBelow(2);
+
+            var mr = ws.MergedRanges.ToArray();
+            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("MRShift");
-                ws.Range("B2:C3").Merge();
-                ws.Range("D2:E3").Merge();
-                ws.Range("B6:C7").Merge(); // to be broken
-                ws.Range("D6:E7").Merge(); // to be broken
-                ws.Range("A8:B9").Merge();
-                ws.Range("E8:F9").Merge();
-
-                ws.Range("C4:D5").InsertRowsBelow(2);
-
-                var mr = ws.MergedRanges.ToArray();
-                Assert.AreEqual(4, mr.Length);
-                Assert.AreEqual("B2:C3", mr[0].RangeAddress.ToString());
-                Assert.AreEqual("D2:E3", mr[1].RangeAddress.ToString());
-                Assert.AreEqual("A8:B9", mr[2].RangeAddress.ToString());
-                Assert.AreEqual("E8:F9", mr[3].RangeAddress.ToString());
-            }
+                Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("B2:C3"));
+                Assert.That(mr[1].RangeAddress.ToString(), Is.EqualTo("D2:E3"));
+                Assert.That(mr[2].RangeAddress.ToString(), Is.EqualTo("A8:B9"));
+                Assert.That(mr[3].RangeAddress.ToString(), Is.EqualTo("E8:F9"));
+            });
         }
 
         [Test]
         public void RangeShiftUpBreaksMerges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("MRShift");
+            ws.Range("B2:C3").Merge();
+            ws.Range("D2:E3").Merge();
+            ws.Range("B6:C7").Merge(); // to be broken
+            ws.Range("D6:E7").Merge(); // to be broken
+            ws.Range("A8:B9").Merge();
+            ws.Range("E8:F9").Merge();
+
+            ws.Range("C4:D5").Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+            var mr = ws.MergedRanges.ToArray();
+            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("MRShift");
-                ws.Range("B2:C3").Merge();
-                ws.Range("D2:E3").Merge();
-                ws.Range("B6:C7").Merge(); // to be broken
-                ws.Range("D6:E7").Merge(); // to be broken
-                ws.Range("A8:B9").Merge();
-                ws.Range("E8:F9").Merge();
-
-                ws.Range("C4:D5").Delete(XLShiftDeletedCells.ShiftCellsUp);
-
-                var mr = ws.MergedRanges.ToArray();
-                Assert.AreEqual(4, mr.Length);
-                Assert.AreEqual("B2:C3", mr[0].RangeAddress.ToString());
-                Assert.AreEqual("D2:E3", mr[1].RangeAddress.ToString());
-                Assert.AreEqual("A8:B9", mr[2].RangeAddress.ToString());
-                Assert.AreEqual("E8:F9", mr[3].RangeAddress.ToString());
-            }
+                Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("B2:C3"));
+                Assert.That(mr[1].RangeAddress.ToString(), Is.EqualTo("D2:E3"));
+                Assert.That(mr[2].RangeAddress.ToString(), Is.EqualTo("A8:B9"));
+                Assert.That(mr[3].RangeAddress.ToString(), Is.EqualTo("E8:F9"));
+            });
         }
 
         [Test]
         public void MergedCellsAcquireFirstCellStyle()
         {
-            using (XLWorkbook wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
-                ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
-                ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
-                ws.Range("A1:A3").Merge();
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
+            ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
+            ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
+            ws.Range("A1:A3").Merge();
 
-                Assert.AreEqual(XLColor.Red, ws.Cell("A1").Style.Fill.BackgroundColor);
-                Assert.AreEqual(XLColor.Red, ws.Cell("A2").Style.Fill.BackgroundColor);
-                Assert.AreEqual(XLColor.Red, ws.Cell("A3").Style.Fill.BackgroundColor);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Cell("A2").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Cell("A3").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+            });
         }
 
         [Test]
         public void MergedCellsLooseData()
         {
-            using (XLWorkbook wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Range("A1:A3").SetValue(100);
-                ws.Range("A1:A3").Merge();
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Range("A1:A3").SetValue(100);
+            ws.Range("A1:A3").Merge();
 
-                Assert.AreEqual(100, ws.Cell("A1").Value);
-                Assert.AreEqual(Blank.Value, ws.Cell("A2").Value);
-                Assert.AreEqual(Blank.Value, ws.Cell("A3").Value);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(100));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(Blank.Value));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
         public void MergedCellsLooseConditionalFormats()
         {
-            using (XLWorkbook wb = new XLWorkbook())
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").AddConditionalFormat().WhenContains("1").Fill.BackgroundColor = XLColor.Red;
+            ws.Cell("A2").AddConditionalFormat().WhenContains("2").Fill.BackgroundColor = XLColor.Yellow;
+
+            ws.Range("A1:A2").Merge();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").AddConditionalFormat().WhenContains("1").Fill.BackgroundColor = XLColor.Red;
-                ws.Cell("A2").AddConditionalFormat().WhenContains("2").Fill.BackgroundColor = XLColor.Yellow;
-
-                ws.Range("A1:A2").Merge();
-
-                Assert.AreEqual(1, ws.ConditionalFormats.Count());
-                Assert.AreEqual("A1:A1", ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToString());
-            }
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A1"));
+            });
         }
 
         [Test]
         public void MergedCellsLooseDataValidation()
         {
-            using (XLWorkbook wb = new XLWorkbook())
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").CreateDataValidation().WholeNumber.Between(1, 2);
+            ws.Cell("A2").CreateDataValidation().Date.GreaterThan(new System.DateTime(2018, 1, 1));
+
+            ws.Range("A1:A2").Merge();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").CreateDataValidation().WholeNumber.Between(1, 2);
-                ws.Cell("A2").CreateDataValidation().Date.GreaterThan(new System.DateTime(2018, 1, 1));
-
-                ws.Range("A1:A2").Merge();
-
-                Assert.IsTrue(ws.Cell("A1").HasDataValidation);
-                Assert.AreEqual("1", ws.Cell("A1").GetDataValidation().MinValue);
-                Assert.AreEqual("2", ws.Cell("A1").GetDataValidation().MaxValue);
-                Assert.IsFalse(ws.Cell("A2").HasDataValidation);
-            }
+                Assert.That(ws.Cell("A1").HasDataValidation, Is.True);
+                Assert.That(ws.Cell("A1").GetDataValidation().MinValue, Is.EqualTo("1"));
+                Assert.That(ws.Cell("A1").GetDataValidation().MaxValue, Is.EqualTo("2"));
+                Assert.That(ws.Cell("A2").HasDataValidation, Is.False);
+            });
         }
 
         [Test]
         public void UnmergedCellsPreserveStyle()
         {
-            using (XLWorkbook wb = new XLWorkbook())
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var range = ws.Range("B2:D4");
+            range.Style.Fill.SetBackgroundColor(XLColor.Yellow);
+            range.Style.Border.SetOutsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetOutsideBorderColor(XLColor.DarkBlue)
+                .Border.SetInsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetInsideBorderColor(XLColor.Pink);
+            range.Cells().ForEach(c => c.Value = c.Address.ToString());
+
+            var firstCell = ws.Cell("B2");
+            firstCell.Style.Fill.SetBackgroundColor(XLColor.Red)
+                .Alignment.SetHorizontal(XLAlignmentHorizontalValues.Center)
+                .Font.SetBold();
+
+            range.Merge();
+            range.Unmerge();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                var range = ws.Range("B2:D4");
-                range.Style.Fill.SetBackgroundColor(XLColor.Yellow);
-                range.Style.Border.SetOutsideBorder(XLBorderStyleValues.Thick)
-                    .Border.SetOutsideBorderColor(XLColor.DarkBlue)
-                    .Border.SetInsideBorder(XLBorderStyleValues.Thin)
-                    .Border.SetInsideBorderColor(XLColor.Pink);
-                range.Cells().ForEach(c => c.Value = c.Address.ToString());
+                Assert.That(range.Cells().All(c => c.Style.Fill.BackgroundColor == XLColor.Red), Is.True);
+                Assert.That(range.Cells().Where(c => !c.Equals(firstCell)).All(c => c.Value.Equals(Blank.Value)), Is.True);
+                Assert.That(firstCell.Value, Is.EqualTo("B2"));
 
-                var firstCell = ws.Cell("B2");
-                firstCell.Style.Fill.SetBackgroundColor(XLColor.Red)
-                    .Alignment.SetHorizontal(XLAlignmentHorizontalValues.Center)
-                    .Font.SetBold();
+                Assert.That(ws.Cell("B2").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("B2").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B2").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B2").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thick));
 
-                range.Merge();
-                range.Unmerge();
+                Assert.That(ws.Cell("C2").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("C2").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C2").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C2").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
 
-                Assert.IsTrue(range.Cells().All(c => c.Style.Fill.BackgroundColor == XLColor.Red));
-                Assert.IsTrue(range.Cells().Where(c => !c.Equals(firstCell)).All(c => c.Value.Equals(Blank.Value)));
-                Assert.AreEqual("B2", firstCell.Value);
+                Assert.That(ws.Cell("D2").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("D2").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("D2").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("D2").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
 
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("B2").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B2").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B2").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("B2").Style.Border.LeftBorder);
+                Assert.That(ws.Cell("B3").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B3").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B3").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B3").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thick));
 
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("C2").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C2").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C2").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C2").Style.Border.LeftBorder);
+                Assert.That(ws.Cell("C3").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C3").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C3").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C3").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
 
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("D2").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("D2").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D2").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D2").Style.Border.LeftBorder);
+                Assert.That(ws.Cell("D3").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("D3").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("D3").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("D3").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
 
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B3").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B3").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B3").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("B3").Style.Border.LeftBorder);
+                Assert.That(ws.Cell("B4").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B4").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("B4").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("B4").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thick));
 
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C3").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C3").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C3").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C3").Style.Border.LeftBorder);
+                Assert.That(ws.Cell("C4").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C4").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C4").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("C4").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
 
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D3").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("D3").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D3").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D3").Style.Border.LeftBorder);
-
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B4").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B4").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("B4").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("B4").Style.Border.LeftBorder);
-
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C4").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C4").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("C4").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C4").Style.Border.LeftBorder);
-
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D4").Style.Border.TopBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("D4").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thick, ws.Cell("D4").Style.Border.BottomBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("D4").Style.Border.LeftBorder);
-            }
+                Assert.That(ws.Cell("D4").Style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("D4").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("D4").Style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(ws.Cell("D4").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
+            });
         }
 
         [Test]
@@ -367,7 +389,7 @@ namespace ClosedXML.Tests
                 ws.Cell("A3").Value = 1;
                 ws.Cell("A4").Value = 1;
                 ws.Cell("B1").FormulaA1 = "SUM(A:A)";
-                Assert.AreEqual(1, ws.Cell("B1").Value);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
             }
 
             using (var workbook = new XLWorkbook())
@@ -375,7 +397,7 @@ namespace ClosedXML.Tests
                 var ws = workbook.AddWorksheet();
                 ws.Range("A2:A4").Merge().SetValue(1);
                 ws.Cell("B1").FormulaA1 = "SUM(A:A)";
-                Assert.AreEqual(1, ws.Cell("B1").Value);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
             }
         }
 
@@ -390,7 +412,7 @@ namespace ClosedXML.Tests
                 ws.Cell("A3").FormulaA1 = "=1";
                 ws.Cell("A4").FormulaA1 = "=1";
                 ws.Cell("B1").FormulaA1 = "SUM(A:A)";
-                Assert.AreEqual(1, ws.Cell("B1").Value);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
             }
 
             using (var workbook = new XLWorkbook())
@@ -401,7 +423,7 @@ namespace ClosedXML.Tests
                 ws.Cell("A3").SetFormulaA1("=1");
                 ws.Cell("A4").SetFormulaA1("=1");
                 ws.Cell("B1").SetFormulaA1("SUM(A:A)");
-                Assert.AreEqual(1, ws.Cell("B1").Value);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
             }
 
             using (var workbook = new XLWorkbook())
@@ -412,7 +434,7 @@ namespace ClosedXML.Tests
                 ws.Cell("A3").FormulaR1C1 = "=1";
                 ws.Cell("A4").FormulaR1C1 = "=1";
                 ws.Cell("B1").FormulaR1C1 = "SUM(A:A)";
-                Assert.AreEqual(1, ws.Cell("B1").Value);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
             }
 
             using (var workbook = new XLWorkbook())
@@ -423,7 +445,7 @@ namespace ClosedXML.Tests
                 ws.Cell("A3").SetFormulaR1C1("=1");
                 ws.Cell("A4").SetFormulaR1C1("=1");
                 ws.Cell("B1").SetFormulaR1C1("SUM(A:A)");
-                Assert.AreEqual(1, ws.Cell("B1").Value);
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
             }
         }
 
@@ -436,8 +458,11 @@ namespace ClosedXML.Tests
 
             range.Merge();
 
-            Assert.IsFalse(range.IsMerged());
-            Assert.AreEqual(0, ws.MergedRanges.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(range.IsMerged(), Is.False);
+                Assert.That(ws.MergedRanges.Count, Is.EqualTo(0));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/MergedRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/MergedRangesTests.cs
@@ -38,7 +38,7 @@ namespace ClosedXML.Tests
             ws.Column(2).InsertColumnsAfter(2);
 
             var mr = ws.MergedRanges.ToArray();
-            Assert.That(mr.Length, Is.EqualTo(1));
+            Assert.That(mr, Has.Length.EqualTo(1));
             Assert.Multiple(() =>
             {
                 Assert.That(mr.Single(), Is.SameAs(range));
@@ -60,7 +60,7 @@ namespace ClosedXML.Tests
             ws.Row(2).InsertRowsBelow(2);
 
             var mr = ws.MergedRanges.ToArray();
-            Assert.That(mr.Length, Is.EqualTo(1));
+            Assert.That(mr, Has.Length.EqualTo(1));
             Assert.Multiple(() =>
             {
                 Assert.That(mr.Single(), Is.SameAs(range));
@@ -84,7 +84,7 @@ namespace ClosedXML.Tests
             var mr = ws.MergedRanges.ToArray();
             if (expectedExist)
             {
-                Assert.That(mr.Length, Is.EqualTo(1));
+                Assert.That(mr, Has.Length.EqualTo(1));
                 Assert.Multiple(() =>
                 {
                     Assert.That(mr.Single(), Is.SameAs(range));
@@ -117,7 +117,7 @@ namespace ClosedXML.Tests
             var mr = ws.MergedRanges.ToArray();
             if (expectedExist)
             {
-                Assert.That(mr.Length, Is.EqualTo(1));
+                Assert.That(mr, Has.Length.EqualTo(1));
                 Assert.Multiple(() =>
                 {
                     Assert.That(mr.Single(), Is.SameAs(range));
@@ -149,7 +149,7 @@ namespace ClosedXML.Tests
             ws.Range("D3:E4").InsertColumnsAfter(2);
 
             var mr = ws.MergedRanges.ToArray();
-            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.That(mr, Has.Length.EqualTo(4));
             Assert.Multiple(() =>
             {
                 Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("H1:I2"));
@@ -174,7 +174,7 @@ namespace ClosedXML.Tests
             ws.Range("D3:E4").Delete(XLShiftDeletedCells.ShiftCellsLeft);
 
             var mr = ws.MergedRanges.ToArray();
-            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.That(mr, Has.Length.EqualTo(4));
             Assert.Multiple(() =>
             {
                 Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("H1:I2"));
@@ -199,7 +199,7 @@ namespace ClosedXML.Tests
             ws.Range("C4:D5").InsertRowsBelow(2);
 
             var mr = ws.MergedRanges.ToArray();
-            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.That(mr, Has.Length.EqualTo(4));
             Assert.Multiple(() =>
             {
                 Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("B2:C3"));
@@ -224,7 +224,7 @@ namespace ClosedXML.Tests
             ws.Range("C4:D5").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
             var mr = ws.MergedRanges.ToArray();
-            Assert.That(mr.Length, Is.EqualTo(4));
+            Assert.That(mr, Has.Length.EqualTo(4));
             Assert.Multiple(() =>
             {
                 Assert.That(mr[0].RangeAddress.ToString(), Is.EqualTo("B2:C3"));

--- a/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -15,18 +15,16 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void FindExistingMatches()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
 
-                for (int i = 1; i <= TEST_COUNT; i++)
+            for (int i = 1; i <= TEST_COUNT; i++)
+            {
+                for (int j = 2; j <= 4; j++)
                 {
-                    for (int j = 2; j <= 4; j++)
-                    {
-                        var address = new XLAddress(ws, i * 2, j, false, false);
-                        Assert.True(index.Contains(in address));
-                    }
+                    var address = new XLAddress(ws, i * 2, j, false, false);
+                    Assert.That(index.Contains(in address), Is.True);
                 }
             }
         }
@@ -34,234 +32,231 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void FindNonExistingMatches()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
 
-                for (int i = 1; i <= TEST_COUNT; i++)
-                {
-                    var address = new XLAddress(ws, i * 2 + 1, 3, false, false);
-                    Assert.False(index.Contains(in address));
-                }
+            for (int i = 1; i <= TEST_COUNT; i++)
+            {
+                var address = new XLAddress(ws, i * 2 + 1, 3, false, false);
+                Assert.False(index.Contains(in address));
             }
         }
 
         [Test]
         public void FindExistingIntersections()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
+
+            for (int i = 1; i <= TEST_COUNT; i++)
             {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+                var rangeAddress = new XLRangeAddress(
+                    new XLAddress(ws, i * 2, 1 + i % 4, false, false),
+                    new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
 
-                for (int i = 1; i <= TEST_COUNT; i++)
-                {
-                    var rangeAddress = new XLRangeAddress(
-                        new XLAddress(ws, i * 2, 1 + i % 4, false, false),
-                        new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
+                Assert.That(index.Intersects(in rangeAddress), Is.True);
+            }
 
-                    Assert.True(index.Intersects(in rangeAddress));
-                }
-
-                for (int i = 2; i < 4; i++)
-                {
-                    var columnAddress = XLRangeAddress.EntireColumn(ws, i);
-                    Assert.True(index.Intersects(in columnAddress));
-                }
+            for (int i = 2; i < 4; i++)
+            {
+                var columnAddress = XLRangeAddress.EntireColumn(ws, i);
+                Assert.That(index.Intersects(in columnAddress), Is.True);
             }
         }
 
         [Test]
         public void FindNonExistingIntersections()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
+
+            for (int i = 1; i <= TEST_COUNT; i++)
             {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+                var rangeAddress = new XLRangeAddress(
+                    new XLAddress(ws, i * 2 + 1, 1 + i % 4, false, false),
+                    new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
 
-                for (int i = 1; i <= TEST_COUNT; i++)
-                {
-                    var rangeAddress = new XLRangeAddress(
-                        new XLAddress(ws, i * 2 + 1, 1 + i % 4, false, false),
-                        new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
-
-                    Assert.False(index.Intersects(in rangeAddress));
-                }
-
-                var columnAddress = XLRangeAddress.EntireColumn(ws, 1);
-                Assert.False(index.Intersects(in columnAddress));
-                columnAddress = XLRangeAddress.EntireColumn(ws, 5);
-                Assert.False(index.Intersects(in columnAddress));
+                Assert.False(index.Intersects(in rangeAddress));
             }
+
+            var columnAddress = XLRangeAddress.EntireColumn(ws, 1);
+            Assert.False(index.Intersects(in columnAddress));
+            columnAddress = XLRangeAddress.EntireColumn(ws, 5);
+            Assert.False(index.Intersects(in columnAddress));
         }
 
         [Test]
         public void FindMatchAfterColumnShifting()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
 
-                ws.Column(1).InsertColumnsBefore(1000);
+            ws.Column(1).InsertColumnsBefore(1000);
 
-                var address = new XLAddress(ws, 102, 1004, false, false);
+            var address = new XLAddress(ws, 102, 1004, false, false);
 
-                Assert.True(index.Contains(in address));
-            }
+            Assert.That(index.Contains(in address), Is.True);
         }
 
         [Test]
         public void FindIntersectionsAfterColumnShifting()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
 
-                ws.Column(3).InsertColumnsBefore(2);
+            ws.Column(3).InsertColumnsBefore(2);
 
-                var rangeAddress = new XLRangeAddress(ws, "F102:E103");
+            var rangeAddress = new XLRangeAddress(ws, "F102:E103");
 
-                Assert.True(index.Intersects(in rangeAddress));
-            }
+            Assert.That(index.Intersects(in rangeAddress), Is.True);
         }
 
         [Test]
         public void FindMatchAfterRowShifting()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
 
-                ws.Row(10).InsertRowsBelow(3);
+            ws.Row(10).InsertRowsBelow(3);
 
-                var address = new XLAddress(ws, 103, 4, false, false);
+            var address = new XLAddress(ws, 103, 4, false, false);
 
-                Assert.True(index.Contains(in address));
-            }
+            Assert.That(index.Contains(in address), Is.True);
         }
 
         [Test]
         public void FindIntersectionsAfterRowShifting()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var index = FillIndexWithTestData(ws);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var index = FillIndexWithTestData(ws);
 
-                ws.Row(10).InsertRowsBelow(3);
+            ws.Row(10).InsertRowsBelow(3);
 
-                var rangeAddress = new XLRangeAddress(ws, "C103:E103");
+            var rangeAddress = new XLRangeAddress(ws, "C103:E103");
 
-                Assert.True(index.Intersects(in rangeAddress));
-            }
+            Assert.That(index.Intersects(in rangeAddress), Is.True);
         }
 
         [Test]
         public void CreateQuadTree()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var quadTree = new Quadrant();
+            var range = ws.Range("BT76:CA87");
+
+            quadTree.Add(range);
+
+            var level0 = quadTree;
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var quadTree = new Quadrant();
-                var range = ws.Range("BT76:CA87");
-
-                quadTree.Add(range);
-
-                var level0 = quadTree;
-                Assert.AreEqual(1, level0.MinimumColumn);
-                Assert.AreEqual(XLHelper.MaxColumnNumber, level0.MaximumColumn);
-                Assert.AreEqual(1, level0.MinimumRow);
-                Assert.AreEqual(XLHelper.MaxRowNumber, level0.MaximumRow);
-                Assert.IsNull(level0.Ranges);
-                Assert.AreEqual(128, level0.Children.Count());
-                Assert.True(level0.Children.All(child => child.Level == 1));
-                Assert.AreEqual(64, level0.Children.Count(child =>
+                Assert.That(level0.MinimumColumn, Is.EqualTo(1));
+                Assert.That(level0.MaximumColumn, Is.EqualTo(XLHelper.MaxColumnNumber));
+                Assert.That(level0.MinimumRow, Is.EqualTo(1));
+                Assert.That(level0.MaximumRow, Is.EqualTo(XLHelper.MaxRowNumber));
+            });
+            Assert.That(level0.Ranges, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(level0.Children, Has.Count.EqualTo(128));
+                Assert.That(level0.Children.All(child => child.Level == 1), Is.True);
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(level0.Children.Count(child =>
                     child.MinimumColumn == 1 &&
                     child.MaximumColumn == 8192 &&
-                    child.X == 0));
-                Assert.AreEqual(64, level0.Children.Count(child =>
+                    child.X == 0), Is.EqualTo(64));
+                Assert.That(level0.Children.Count(child =>
                     child.MinimumColumn == 8193 &&
                     child.MaximumColumn == 16384 &&
-                    child.X == 1));
-                Assert.AreEqual(2, level0.Children.Count(child =>
+                    child.X == 1), Is.EqualTo(64));
+                Assert.That(level0.Children.Count(child =>
                     child.MinimumRow == 1 &&
                     child.MaximumRow == 8192 &&
-                    child.Y == 0));
-                Assert.AreEqual(2, level0.Children.Count(child =>
+                    child.Y == 0), Is.EqualTo(2));
+                Assert.That(level0.Children.Count(child =>
                     child.MinimumRow == 16385 &&
                     child.MaximumRow == 24576 &&
-                    child.Y == 2));
+                    child.Y == 2), Is.EqualTo(2));
+            });
 
-                Assert.True(level0.Children.ElementAt(0).Children.Any());
-                Assert.True(level0.Children.Skip(1).All(child => child.Children == null));
+            Assert.Multiple(() =>
+            {
+                Assert.That(level0.Children.ElementAt(0).Children.Any(), Is.True);
+                Assert.That(level0.Children.Skip(1).All(child => child.Children == null), Is.True);
+            });
 
-                var level8 = level0
-                    .Children.First() // 1
-                    .Children.First() // 2
-                    .Children.First() // 3
-                    .Children.First() // 4
-                    .Children.First() // 5
-                    .Children.First() // 6
-                    .Children.First() // 7
-                    .Children.Last(); // 8
+            var level8 = level0
+                .Children.First() // 1
+                .Children.First() // 2
+                .Children.First() // 3
+                .Children.First() // 4
+                .Children.First() // 5
+                .Children.First() // 6
+                .Children.First() // 7
+                .Children.Last(); // 8
 
-                Assert.AreEqual(65, level8.MinimumColumn);
-                Assert.AreEqual(65, level8.MinimumRow);
-                Assert.AreEqual(128, level8.MaximumColumn);
-                Assert.AreEqual(128, level8.MaximumRow);
+            Assert.Multiple(() =>
+            {
+                Assert.That(level8.MinimumColumn, Is.EqualTo(65));
+                Assert.That(level8.MinimumRow, Is.EqualTo(65));
+                Assert.That(level8.MaximumColumn, Is.EqualTo(128));
+                Assert.That(level8.MaximumRow, Is.EqualTo(128));
+            });
 
-                var level9 = level8.Children.First();
-                Assert.NotNull(level9.Ranges);
-                Assert.AreEqual(range, level9.Ranges.Single());
-            }
+            var level9 = level8.Children.First();
+            Assert.NotNull(level9.Ranges);
+            Assert.That(level9.Ranges.Single(), Is.EqualTo(range));
         }
 
         [Test]
         public void XLRangesCountChangesCorrectly()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
+            var range1 = ws.Range("A1:B2");
+            var range2 = ws.Range("A2:B3");
+            var range3 = ws.Range("A1:B2"); // same as range1
+
+            var ranges = new XLRanges();
+            ranges.Add(range1);
+            Assert.That(ranges, Has.Count.EqualTo(1));
+            ranges.Add(range2);
+            Assert.That(ranges, Has.Count.EqualTo(2));
+            ranges.Add(range3);
+            Assert.That(ranges, Has.Count.EqualTo(2));
+
+            Assert.That(ranges, Has.Count.EqualTo(ranges.Count));
+
+            // Add many entries to activate QuadTree
+            for (int i = 1; i <= TEST_COUNT; i++)
             {
-                var ws = wb.Worksheets.Add("Sheet1") as XLWorksheet;
-                var range1 = ws.Range("A1:B2");
-                var range2 = ws.Range("A2:B3");
-                var range3 = ws.Range("A1:B2"); // same as range1
-
-                var ranges = new XLRanges();
-                ranges.Add(range1);
-                Assert.AreEqual(1, ranges.Count);
-                ranges.Add(range2);
-                Assert.AreEqual(2, ranges.Count);
-                ranges.Add(range3);
-                Assert.AreEqual(2, ranges.Count);
-
-                Assert.AreEqual(ranges.Count, ranges.Count());
-
-                // Add many entries to activate QuadTree
-                for (int i = 1; i <= TEST_COUNT; i++)
-                {
-                    ranges.Add(ws.Range(i * 2, 2, i * 2, 4));
-                }
-
-                Assert.AreEqual(2 + TEST_COUNT, ranges.Count);
-
-                for (int i = 1; i <= TEST_COUNT; i++)
-                {
-                    ranges.Remove(ws.Range(i * 2, 2, i * 2, 4));
-                }
-
-                Assert.AreEqual(2, ranges.Count);
-
-                ranges.Remove(range3);
-                Assert.AreEqual(1, ranges.Count);
-                ranges.Remove(range2);
-                Assert.AreEqual(0, ranges.Count);
-                ranges.Remove(range1);
-                Assert.AreEqual(0, ranges.Count);
+                ranges.Add(ws.Range(i * 2, 2, i * 2, 4));
             }
+
+            Assert.That(ranges, Has.Count.EqualTo(2 + TEST_COUNT));
+
+            for (int i = 1; i <= TEST_COUNT; i++)
+            {
+                ranges.Remove(ws.Range(i * 2, 2, i * 2, 4));
+            }
+
+            Assert.That(ranges, Has.Count.EqualTo(2));
+
+            ranges.Remove(range3);
+            Assert.That(ranges, Has.Count.EqualTo(1));
+            ranges.Remove(range2);
+            Assert.That(ranges.Count, Is.EqualTo(0));
+            ranges.Remove(range1);
+            Assert.That(ranges.Count, Is.EqualTo(0));
         }
 
         private IXLRangeIndex CreateRangeIndex(IXLWorksheet worksheet)

--- a/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -213,7 +213,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             });
 
             var level9 = level8.Children.First();
-            Assert.NotNull(level9.Ranges);
+            Assert.That(level9.Ranges, Is.Not.Null);
             Assert.That(level9.Ranges.Single(), Is.EqualTo(range));
         }
 

--- a/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -39,7 +39,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             for (int i = 1; i <= TEST_COUNT; i++)
             {
                 var address = new XLAddress(ws, i * 2 + 1, 3, false, false);
-                Assert.False(index.Contains(in address));
+                Assert.That(index.Contains(in address), Is.False);
             }
         }
 
@@ -79,13 +79,13 @@ namespace ClosedXML.Tests.Excel.Ranges
                     new XLAddress(ws, i * 2 + 1, 1 + i % 4, false, false),
                     new XLAddress(ws, i * 2 + 1, 8 - i % 3, false, false));
 
-                Assert.False(index.Intersects(in rangeAddress));
+                Assert.That(index.Intersects(in rangeAddress), Is.False);
             }
 
             var columnAddress = XLRangeAddress.EntireColumn(ws, 1);
-            Assert.False(index.Intersects(in columnAddress));
+            Assert.That(index.Intersects(in columnAddress), Is.False);
             columnAddress = XLRangeAddress.EntireColumn(ws, 5);
-            Assert.False(index.Intersects(in columnAddress));
+            Assert.That(index.Intersects(in columnAddress), Is.False);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Ranges/RangeShiftingTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangeShiftingTests.cs
@@ -8,74 +8,64 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void CellsContentShiftedAfterColumnDeleted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                SetContent(ws.Cell("D4"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            SetContent(ws.Cell("D4"));
 
-                ws.Column("C").Delete();
+            ws.Column("C").Delete();
 
-                AssertContent(ws.Cell("C4"), "D4");
-            }
+            AssertContent(ws.Cell("C4"), "D4");
         }
 
         [Test]
         public void CellsContentShiftedAfterRowDeleted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                SetContent(ws.Cell("D4"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            SetContent(ws.Cell("D4"));
 
-                ws.Row(3).Delete();
+            ws.Row(3).Delete();
 
-                AssertContent(ws.Cell("D3"), "D4");
-            }
+            AssertContent(ws.Cell("D3"), "D4");
         }
 
         [Test]
         public void CellsContentShiftedAfterColumnInserted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                SetContent(ws.Cell("D4"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            SetContent(ws.Cell("D4"));
 
-                ws.Column("C").InsertColumnsBefore(1);
+            ws.Column("C").InsertColumnsBefore(1);
 
-                AssertContent(ws.Cell("E4"), "D4");
-            }
+            AssertContent(ws.Cell("E4"), "D4");
         }
 
         [Test]
         public void CellsContentShiftedAfterRowInserted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                SetContent(ws.Cell("D4"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            SetContent(ws.Cell("D4"));
 
-                ws.Row(3).InsertRowsAbove(1);
+            ws.Row(3).InsertRowsAbove(1);
 
-                AssertContent(ws.Cell("D5"), "D4");
-            }
+            AssertContent(ws.Cell("D5"), "D4");
         }
 
         [Test]
         public void CellsContentShiftAfterRangeDeleted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                SetContent(ws.Cell("D4"));
-                SetContent(ws.Cell("F8"));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            SetContent(ws.Cell("D4"));
+            SetContent(ws.Cell("F8"));
 
-                ws.Range("B2:C5").Delete(XLShiftDeletedCells.ShiftCellsLeft);
-                ws.Range("E5:F7").Delete(XLShiftDeletedCells.ShiftCellsUp);
+            ws.Range("B2:C5").Delete(XLShiftDeletedCells.ShiftCellsLeft);
+            ws.Range("E5:F7").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-                AssertContent(ws.Cell("B4"), "D4");
-                AssertContent(ws.Cell("F5"), "F8");
-            }
+            AssertContent(ws.Cell("B4"), "D4");
+            AssertContent(ws.Cell("F5"), "F8");
         }
 
         [Theory]
@@ -98,8 +88,11 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             deletedRange.Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-            Assert.IsTrue(mergedRange.IsMerged());
-            Assert.AreEqual(deletedRangeAddress, mergedRange.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(mergedRange.IsMerged(), Is.True);
+                Assert.That(mergedRange.RangeAddress.ToString(), Is.EqualTo(deletedRangeAddress));
+            });
         }
 
         [Theory]
@@ -122,8 +115,11 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             deletedRange.Delete(XLShiftDeletedCells.ShiftCellsLeft);
 
-            Assert.IsTrue(mergedRange.IsMerged());
-            Assert.AreEqual(deletedRangeAddress, mergedRange.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(mergedRange.IsMerged(), Is.True);
+                Assert.That(mergedRange.RangeAddress.ToString(), Is.EqualTo(deletedRangeAddress));
+            });
         }
 
         private void SetContent(IXLCell cell)
@@ -135,10 +131,16 @@ namespace ClosedXML.Tests.Excel.Ranges
 
         private void AssertContent(IXLCell cell, string originalAddress)
         {
-            Assert.AreEqual($"\"Formula \" & \"{originalAddress}\"", cell.FormulaA1);
-            Assert.AreEqual(XLColor.Green, cell.Style.Fill.BackgroundColor);
-            Assert.True(cell.HasComment);
-            Assert.AreEqual($"Some comment {originalAddress}", cell.GetComment().Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.FormulaA1, Is.EqualTo($"\"Formula \" & \"{originalAddress}\""));
+                Assert.That(cell.Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.HasComment, Is.True);
+                Assert.That(cell.GetComment().Text, Is.EqualTo($"Some comment {originalAddress}"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/RangesConsolidationTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangesConsolidationTests.cs
@@ -25,13 +25,16 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             var consRanges = ranges.Consolidate().ToList();
 
-            Assert.AreEqual(6, consRanges.Count);
-            Assert.AreEqual("A1:E9", consRanges[0].RangeAddress.ToString());
-            Assert.AreEqual("F2:F12", consRanges[1].RangeAddress.ToString());
-            Assert.AreEqual("G6:I9", consRanges[2].RangeAddress.ToString());
-            Assert.AreEqual("A10:B10", consRanges[3].RangeAddress.ToString());
-            Assert.AreEqual("E10:E12", consRanges[4].RangeAddress.ToString());
-            Assert.AreEqual("I10:I13", consRanges[5].RangeAddress.ToString());
+            Assert.That(consRanges, Has.Count.EqualTo(6));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consRanges[0].RangeAddress.ToString(), Is.EqualTo("A1:E9"));
+                Assert.That(consRanges[1].RangeAddress.ToString(), Is.EqualTo("F2:F12"));
+                Assert.That(consRanges[2].RangeAddress.ToString(), Is.EqualTo("G6:I9"));
+                Assert.That(consRanges[3].RangeAddress.ToString(), Is.EqualTo("A10:B10"));
+                Assert.That(consRanges[4].RangeAddress.ToString(), Is.EqualTo("E10:E12"));
+                Assert.That(consRanges[5].RangeAddress.ToString(), Is.EqualTo("I10:I13"));
+            });
         }
 
         [Test]
@@ -53,10 +56,13 @@ namespace ClosedXML.Tests.Excel.Ranges
                 .ThenBy(r => r.RangeAddress.FirstAddress.ColumnNumber)
                 .ToList();
 
-            Assert.AreEqual(3, consRanges.Count);
-            Assert.AreEqual("D:F", consRanges[0].RangeAddress.ToString());
-            Assert.AreEqual("A5:C7", consRanges[1].RangeAddress.ToString());
-            Assert.AreEqual("G5:XFD7", consRanges[2].RangeAddress.ToString());
+            Assert.That(consRanges, Has.Count.EqualTo(3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consRanges[0].RangeAddress.ToString(), Is.EqualTo("D:F"));
+                Assert.That(consRanges[1].RangeAddress.ToString(), Is.EqualTo("A5:C7"));
+                Assert.That(consRanges[2].RangeAddress.ToString(), Is.EqualTo("G5:XFD7"));
+            });
         }
 
         [Test]
@@ -90,17 +96,20 @@ namespace ClosedXML.Tests.Excel.Ranges
                 .ThenBy(r => r.RangeAddress.FirstAddress.ColumnNumber)
                 .ToList();
 
-            Assert.AreEqual(9, consRanges.Count);
-            Assert.AreEqual("Sheet1!$A$1:$E$9", consRanges[0].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet1!$F$2:$F$12", consRanges[1].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet1!$G$6:$I$9", consRanges[2].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet1!$A$10:$B$10", consRanges[3].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet1!$E$10:$E$12", consRanges[4].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet1!$I$10:$I$13", consRanges[5].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
+            Assert.That(consRanges, Has.Count.EqualTo(9));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consRanges[0].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$A$1:$E$9"));
+                Assert.That(consRanges[1].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$F$2:$F$12"));
+                Assert.That(consRanges[2].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$G$6:$I$9"));
+                Assert.That(consRanges[3].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$A$10:$B$10"));
+                Assert.That(consRanges[4].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$E$10:$E$12"));
+                Assert.That(consRanges[5].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$I$10:$I$13"));
 
-            Assert.AreEqual("Sheet2!$D:$F", consRanges[6].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet2!$A$5:$C$7", consRanges[7].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("Sheet2!$G$5:$XFD$7", consRanges[8].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true));
+                Assert.That(consRanges[6].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet2!$D:$F"));
+                Assert.That(consRanges[7].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet2!$A$5:$C$7"));
+                Assert.That(consRanges[8].RangeAddress.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet2!$G$5:$XFD$7"));
+            });
         }
 
         [Test]
@@ -116,11 +125,14 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             var consRanges = ranges.Consolidate().ToList();
 
-            Assert.AreEqual(4, consRanges.Count);
-            Assert.AreEqual("A1:C1", consRanges[0].RangeAddress.ToString());
-            Assert.AreEqual("E1:G1", consRanges[1].RangeAddress.ToString());
-            Assert.AreEqual("A3:C3", consRanges[2].RangeAddress.ToString());
-            Assert.AreEqual("E3:G3", consRanges[3].RangeAddress.ToString());
+            Assert.That(consRanges, Has.Count.EqualTo(4));
+            Assert.Multiple(() =>
+            {
+                Assert.That(consRanges[0].RangeAddress.ToString(), Is.EqualTo("A1:C1"));
+                Assert.That(consRanges[1].RangeAddress.ToString(), Is.EqualTo("E1:G1"));
+                Assert.That(consRanges[2].RangeAddress.ToString(), Is.EqualTo("A3:C3"));
+                Assert.That(consRanges[3].RangeAddress.ToString(), Is.EqualTo("E3:G3"));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/SortTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/SortTests.cs
@@ -34,7 +34,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             for (var row = 1; row <= values.Length; ++row)
             {
                 var sortedValue = ws.Cell(row, 1).Value;
-                Assert.AreEqual(values[row - 1], sortedValue);
+                Assert.That(sortedValue, Is.EqualTo(values[row - 1]));
             }
         }
 
@@ -57,7 +57,7 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             ws.Range(1, 1, values.Length, 1).Sort("1", sortOrder);
 
-            Assert.AreEqual(Blank.Value, ws.Cell(3, 1).Value);
+            Assert.That(ws.Cell(3, 1).Value, Is.EqualTo(Blank.Value));
         }
 
         [Test]
@@ -72,10 +72,13 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             ws.Range("A1:A3").Sort(1, ignoreBlanks: false);
 
-            // Since blank is treated as empty string, it is not shuffled to the end.
-            Assert.AreEqual(Blank.Value, ws.Cell("A1").Value);
-            Assert.AreEqual(string.Empty, ws.Cell("A2").Value);
-            Assert.AreEqual("Text", ws.Cell("A3").Value);
+            Assert.Multiple(() =>
+            {
+                // Since blank is treated as empty string, it is not shuffled to the end.
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(Blank.Value));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(""));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo("Text"));
+            });
         }
 
         [TestCase(true, "a", "A")]
@@ -92,8 +95,11 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             ws.Range("A1:A2").Sort(1, matchCase: matchCase);
 
-            Assert.AreEqual(expectedFirst, ws.Cell("A1").Value);
-            Assert.AreEqual(expectedSecond, ws.Cell("A2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(expectedFirst));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(expectedSecond));
+            });
         }
 
         [Test]
@@ -110,12 +116,15 @@ namespace ClosedXML.Tests.Excel.Ranges
 
             ws.Range("A1:B4").Sort("2 ASC, 1 DESC");
 
-            Assert.AreEqual(1, ws.Cell("A1").Value);
-            Assert.AreEqual(1, ws.Cell("B1").Value);
-            Assert.AreEqual(2, ws.Cell("A2").Value);
-            Assert.AreEqual(2, ws.Cell("B2").Value);
-            Assert.AreEqual(1, ws.Cell("A3").Value);
-            Assert.AreEqual(2, ws.Cell("B3").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("B3").Value, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -132,12 +141,15 @@ namespace ClosedXML.Tests.Excel.Ranges
             // Doesn't have parameters, so it is first rows ASC, second row ASC.
             ws.Range("A1:C2").SortLeftToRight();
 
-            Assert.AreEqual(1, ws.Cell("A1").Value);
-            Assert.AreEqual(1, ws.Cell("A2").Value);
-            Assert.AreEqual(2, ws.Cell("B1").Value);
-            Assert.AreEqual(1, ws.Cell("B2").Value);
-            Assert.AreEqual(2, ws.Cell("C1").Value);
-            Assert.AreEqual(2, ws.Cell("C2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(1));
+                Assert.That(ws.Cell("C1").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("C2").Value, Is.EqualTo(2));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -282,8 +282,11 @@ namespace ClosedXML.Tests.Excel.Ranges
             var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
 
             Assert.That(usedCells, Has.Count.EqualTo(11));
-            Assert.That(usedCells.First().Address.ToString(), Is.EqualTo("B2"));
-            Assert.That(usedCells.Last().Address.ToString(), Is.EqualTo("B12"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(usedCells.First().Address.ToString(), Is.EqualTo("B2"));
+                Assert.That(usedCells.Last().Address.ToString(), Is.EqualTo("B12"));
+            });
         }
 
         [Test]
@@ -296,8 +299,11 @@ namespace ClosedXML.Tests.Excel.Ranges
             var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
 
             Assert.That(usedCells, Has.Count.EqualTo(11));
-            Assert.That(usedCells.First().Address.ToString(), Is.EqualTo("B2"));
-            Assert.That(usedCells.Last().Address.ToString(), Is.EqualTo("B12"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(usedCells.First().Address.ToString(), Is.EqualTo("B2"));
+                Assert.That(usedCells.Last().Address.ToString(), Is.EqualTo("B12"));
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/UsedAndUnusedCellsTests.cs
@@ -9,6 +9,12 @@ namespace ClosedXML.Tests.Excel.Ranges
     {
         private XLWorkbook workbook;
 
+        [TearDown]
+        public void Cleanup()
+        {
+            workbook.Dispose();
+        }
+        
         [SetUp]
         public void SetupWorkbook()
         {
@@ -31,7 +37,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(2, i);
+            Assert.That(i, Is.EqualTo(2));
 
             i = 0;
             row = workbook.Worksheets.First().FirstRow().RowBelow();
@@ -39,38 +45,36 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(1, i);
+            Assert.That(i, Is.EqualTo(1));
 
             i = 0;
             row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-            Assert.AreEqual(6, row.RowNumber());
+            Assert.That(row.RowNumber(), Is.EqualTo(6));
             foreach (var cell in row.Cells())
             {
                 i++;
             }
-            Assert.AreEqual(1, i);
+            Assert.That(i, Is.EqualTo(1));
 
             i = 0;
             row = workbook.Worksheets.First().LastRowUsed(XLCellsUsedOptions.All);
-            Assert.AreEqual(6, row.RowNumber());
+            Assert.That(row.RowNumber(), Is.EqualTo(6));
             foreach (var cell in row.CellsUsed())
             {
                 i++;
             }
-            Assert.AreEqual(0, i);
+            Assert.That(i, Is.EqualTo(0));
         }
 
         [Test(Description = "See 1443")]
         public void FirstRowUsedRegression()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
 
-                ws.Range("B3:F6").SetValue(100);
+            ws.Range("B3:F6").SetValue(100);
 
-                Assert.AreEqual(3, ws.FirstRowUsed(XLCellsUsedOptions.AllContents).RowNumber());
-            }
+            Assert.That(ws.FirstRowUsed(XLCellsUsedOptions.AllContents).RowNumber(), Is.EqualTo(3));
         }
 
         [Test]
@@ -82,7 +86,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(3, i);
+            Assert.That(i, Is.EqualTo(3));
 
             i = 0;
             row = workbook.Worksheets.First().FirstRow().RowBelow(); //This row has no empty cells BETWEEN used cells
@@ -90,7 +94,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(1, i);
+            Assert.That(i, Is.EqualTo(1));
         }
 
         [Test]
@@ -102,7 +106,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(2, i);
+            Assert.That(i, Is.EqualTo(2));
 
             i = 0;
             column = workbook.Worksheets.First().FirstColumn().ColumnRight().ColumnRight();
@@ -110,7 +114,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(1, i);
+            Assert.That(i, Is.EqualTo(1));
 
             i = 0;
             column = workbook.Worksheets.First().Column(2);
@@ -118,7 +122,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(3, i);
+            Assert.That(i, Is.EqualTo(3));
 
             i = 0;
             column = workbook.Worksheets.First().Column(2);
@@ -126,7 +130,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(2, i);
+            Assert.That(i, Is.EqualTo(2));
         }
 
         [Test]
@@ -138,7 +142,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(4, i);
+            Assert.That(i, Is.EqualTo(4));
 
             i = 0;
             column = workbook.Worksheets.First().FirstColumn().ColumnRight().ColumnRight(); //This column has no empty cells BETWEEN used cells
@@ -146,7 +150,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(1, i);
+            Assert.That(i, Is.EqualTo(1));
         }
 
         [Test]
@@ -159,7 +163,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(6, i);
+            Assert.That(i, Is.EqualTo(6));
         }
 
         [Test]
@@ -172,7 +176,7 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(5, i);
+            Assert.That(i, Is.EqualTo(5));
         }
 
         [Test]
@@ -185,23 +189,21 @@ namespace ClosedXML.Tests.Excel.Ranges
             {
                 i++;
             }
-            Assert.AreEqual(18, i);
+            Assert.That(i, Is.EqualTo(18));
         }
 
         [Test]
         public void GetCellsUsedNonRectangular()
         {
-            using (XLWorkbook wb = new XLWorkbook())
-            {
-                var sheet = wb.AddWorksheet("page1");
+            using XLWorkbook wb = new XLWorkbook();
+            var sheet = wb.AddWorksheet("page1");
 
-                sheet.Range("C1:E1").Value = "row1";
-                sheet.Range("A2:E2").Value = "row2";
+            sheet.Range("C1:E1").Value = "row1";
+            sheet.Range("A2:E2").Value = "row2";
 
-                var used = sheet.RangeUsed().RangeAddress.ToString(XLReferenceStyle.A1);
+            var used = sheet.RangeUsed().RangeAddress.ToString(XLReferenceStyle.A1);
 
-                Assert.AreEqual("A1:E2", used);
-            }
+            Assert.That(used, Is.EqualTo("A1:E2"));
         }
 
         [TestCase(true, "A1:D2", "A1")]
@@ -217,185 +219,181 @@ namespace ClosedXML.Tests.Excel.Ranges
         public void RangeUsedIncludesMergedCells(bool includeFormatting, string expectedRange,
             params string[] cellsWithValues)
         {
-            using (XLWorkbook wb = new XLWorkbook())
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            foreach (var cellAddress in cellsWithValues)
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                foreach (var cellAddress in cellsWithValues)
-                {
-                    ws.Cell(cellAddress).Value = "Not empty";
-                }
-                ws.Range("B2:D2").Merge();
-
-                var options = includeFormatting
-                    ? XLCellsUsedOptions.All
-                    : XLCellsUsedOptions.AllContents | XLCellsUsedOptions.MergedRanges;
-                var actual = ws.RangeUsed(options).RangeAddress;
-
-                Assert.AreEqual(expectedRange, actual.ToString());
+                ws.Cell(cellAddress).Value = "Not empty";
             }
+            ws.Range("B2:D2").Merge();
+
+            var options = includeFormatting
+                ? XLCellsUsedOptions.All
+                : XLCellsUsedOptions.AllContents | XLCellsUsedOptions.MergedRanges;
+            var actual = ws.RangeUsed(options).RangeAddress;
+
+            Assert.That(actual.ToString(), Is.EqualTo(expectedRange));
         }
 
         [Test]
         public void LastCellUsedPredicateConsidersMergedRanges()
         {
-            using (XLWorkbook wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
-                ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
-                ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
-                ws.Range("A1:C1").Merge();
-                ws.Range("A2:C2").Merge();
-                ws.Range("A3:C3").Merge();
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
+            ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
+            ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
+            ws.Range("A1:C1").Merge();
+            ws.Range("A2:C2").Merge();
+            ws.Range("A3:C3").Merge();
 
-                var actual = ws.LastCellUsed(XLCellsUsedOptions.All,
-                    c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
+            var actual = ws.LastCellUsed(XLCellsUsedOptions.All,
+                c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
 
-                Assert.AreEqual("C2", actual.Address.ToString());
-            }
+            Assert.That(actual.Address.ToString(), Is.EqualTo("C2"));
         }
 
         [Test]
         public void FirstCellUsedPredicateConsidersMergedRanges()
         {
-            using (XLWorkbook wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
-                ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
-                ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
-                ws.Range("A1:C1").Merge();
-                ws.Range("A2:C2").Merge();
-                ws.Range("A3:C3").Merge();
+            using XLWorkbook wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Style.Fill.BackgroundColor = XLColor.Red;
+            ws.Cell("A2").Style.Fill.BackgroundColor = XLColor.Yellow;
+            ws.Cell("A3").Style.Fill.BackgroundColor = XLColor.Green;
+            ws.Range("A1:C1").Merge();
+            ws.Range("A2:C2").Merge();
+            ws.Range("A3:C3").Merge();
 
-                var actual = ws.FirstCellUsed(XLCellsUsedOptions.All,
-                    c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
+            var actual = ws.FirstCellUsed(XLCellsUsedOptions.All,
+                c => c.Style.Fill.BackgroundColor == XLColor.Yellow);
 
-                Assert.AreEqual("A2", actual.Address.ToString());
-            }
+            Assert.That(actual.Address.ToString(), Is.EqualTo("A2"));
         }
 
         [Test]
         public void ApplyingDataValidationMakesCellNotEmpty()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.Range("B2:B12").CreateDataValidation()
-                    .Decimal.EqualOrGreaterThan(0);
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.Range("B2:B12").CreateDataValidation()
+                .Decimal.EqualOrGreaterThan(0);
 
-                var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
+            var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
 
-                Assert.AreEqual(11, usedCells.Count);
-                Assert.AreEqual("B2", usedCells.First().Address.ToString());
-                Assert.AreEqual("B12", usedCells.Last().Address.ToString());
-            }
+            Assert.That(usedCells, Has.Count.EqualTo(11));
+            Assert.That(usedCells.First().Address.ToString(), Is.EqualTo("B2"));
+            Assert.That(usedCells.Last().Address.ToString(), Is.EqualTo("B12"));
         }
 
         [Test]
         public void MergeMakesCellNotEmpty()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.Range("B2:B12").Merge();
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.Range("B2:B12").Merge();
 
-                var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
+            var usedCells = ws.CellsUsed(XLCellsUsedOptions.All).ToList();
 
-                Assert.AreEqual(11, usedCells.Count);
-                Assert.AreEqual("B2", usedCells.First().Address.ToString());
-                Assert.AreEqual("B12", usedCells.Last().Address.ToString());
-            }
+            Assert.That(usedCells, Has.Count.EqualTo(11));
+            Assert.That(usedCells.First().Address.ToString(), Is.EqualTo("B2"));
+            Assert.That(usedCells.Last().Address.ToString(), Is.EqualTo("B12"));
         }
 
         [Test]
         public void FirstCellUsedNotHangingOnLargeCFRules()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Gold);
+
+            var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Gold);
-
-                var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
-
-                Assert.AreEqual(0, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                Assert.AreEqual("A1", firstCell.Address.ToString());
-            }
+                Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(0));
+                Assert.That(firstCell.Address.ToString(), Is.EqualTo("A1"));
+            });
         }
 
         [Test]
         public void LastCellUsedNotHangingOnLargeCFRules()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Gold);
+
+            var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Gold);
-
-                var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
-
-                Assert.AreEqual(0, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                Assert.AreEqual(XLHelper.LastCell, lastCell.Address.ToString());
-            }
+                Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(0));
+                Assert.That(lastCell.Address.ToString(), Is.EqualTo(XLHelper.LastCell));
+            });
         }
 
         [Test]
         public void FirstCellUsedNotHangingOnLargeDVRules()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.CreateDataValidation().WholeNumber.GreaterThan(0);
+
+            var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.CreateDataValidation().WholeNumber.GreaterThan(0);
-
-                var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
-
-                Assert.AreEqual(0, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                Assert.AreEqual("A1", firstCell.Address.ToString());
-            }
+                Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(0));
+                Assert.That(firstCell.Address.ToString(), Is.EqualTo("A1"));
+            });
         }
 
         [Test]
         public void LastCellUsedNotHangingOnLargeDVRules()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.CreateDataValidation().WholeNumber.GreaterThan(0);
+
+            var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.CreateDataValidation().WholeNumber.GreaterThan(0);
-
-                var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
-
-                Assert.AreEqual(0, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                Assert.AreEqual(XLHelper.LastCell, lastCell.Address.ToString());
-            }
+                Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(0));
+                Assert.That(lastCell.Address.ToString(), Is.EqualTo(XLHelper.LastCell));
+            });
         }
 
         [Test]
         public void FirstCellUsedNotHangingOnLargeMergedRanges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.Merge();
+
+            var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.Merge();
-
-                var firstCell = ws.FirstCellUsed(XLCellsUsedOptions.All);
-
-                Assert.AreEqual(0, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                Assert.AreEqual("A1", firstCell.Address.ToString());
-            }
+                Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(0));
+                Assert.That(firstCell.Address.ToString(), Is.EqualTo("A1"));
+            });
         }
 
         [Test]
         public void LastCellUsedNotHangingOnLargeMergedRanges()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            ws.Merge();
+
+            var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
-                ws.Merge();
-
-                var lastCell = ws.LastCellUsed(XLCellsUsedOptions.All);
-
-                Assert.AreEqual(0, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                Assert.AreEqual(XLHelper.LastCell, lastCell.Address.ToString());
-            }
+                Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(0));
+                Assert.That(lastCell.Address.ToString(), Is.EqualTo(XLHelper.LastCell));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeAddressTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeAddressTests.cs
@@ -13,19 +13,22 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLRangeAddress address = ws.Cell(1, 1).AsRange().RangeAddress;
 
-            Assert.AreEqual("A1:A1", address.ToString());
-            Assert.AreEqual("Sheet1!R1C1:R1C1", address.ToString(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("A1:A1"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1, true), Is.EqualTo("Sheet1!R1C1:R1C1"));
 
-            Assert.AreEqual("A1:A1", address.ToStringRelative());
-            Assert.AreEqual("Sheet1!A1:A1", address.ToStringRelative(true));
+                Assert.That(address.ToStringRelative(), Is.EqualTo("A1:A1"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("Sheet1!A1:A1"));
 
-            Assert.AreEqual("$A$1:$A$1", address.ToStringFixed());
-            Assert.AreEqual("$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1:R1C1", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("Sheet1!$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet1!R1C1:R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("Sheet1!$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
+                Assert.That(address.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("R1C1:R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("Sheet1!$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("Sheet1!R1C1:R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("Sheet1!$A$1:$A$1"));
+            });
         }
 
         [Test]
@@ -34,19 +37,22 @@ namespace ClosedXML.Tests
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet 1");
             IXLRangeAddress address = ws.Cell(1, 1).AsRange().RangeAddress;
 
-            Assert.AreEqual("A1:A1", address.ToString());
-            Assert.AreEqual("'Sheet 1'!R1C1:R1C1", address.ToString(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("A1:A1"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1, true), Is.EqualTo("'Sheet 1'!R1C1:R1C1"));
 
-            Assert.AreEqual("A1:A1", address.ToStringRelative());
-            Assert.AreEqual("'Sheet 1'!A1:A1", address.ToStringRelative(true));
+                Assert.That(address.ToStringRelative(), Is.EqualTo("A1:A1"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("'Sheet 1'!A1:A1"));
 
-            Assert.AreEqual("$A$1:$A$1", address.ToStringFixed());
-            Assert.AreEqual("$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("R1C1:R1C1", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("'Sheet 1'!$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("'Sheet 1'!R1C1:R1C1", address.ToStringFixed(XLReferenceStyle.R1C1, true));
-            Assert.AreEqual("'Sheet 1'!$A$1:$A$1", address.ToStringFixed(XLReferenceStyle.Default, true));
+                Assert.That(address.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("R1C1:R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!$A$1:$A$1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("'Sheet 1'!R1C1:R1C1"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!$A$1:$A$1"));
+            });
         }
 
         [TestCase("B2:E5", "B2:E5")]
@@ -67,8 +73,11 @@ namespace ClosedXML.Tests
 
             var normalizedAddress = rangeAddress.Normalize();
 
-            Assert.AreSame(ws, rangeAddress.Worksheet);
-            Assert.AreEqual(expectedAddress, normalizedAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.Worksheet, Is.SameAs(ws));
+                Assert.That(normalizedAddress.ToString(), Is.EqualTo(expectedAddress));
+            });
         }
 
         [Test]
@@ -76,13 +85,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddress();
 
-            Assert.AreEqual("#REF!", address.ToString());
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.Default, true));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToString(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1, true), Is.EqualTo("'Sheet 1'!#REF!"));
+            });
         }
 
         [Test]
@@ -90,13 +102,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddress();
 
-            Assert.AreEqual("#REF!", address.ToStringFixed());
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringFixed(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("'Sheet 1'!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("'Sheet 1'!#REF!"));
+            });
         }
 
         [Test]
@@ -104,8 +119,11 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddress();
 
-            Assert.AreEqual("#REF!", address.ToStringRelative());
-            Assert.AreEqual("'Sheet 1'!#REF!", address.ToStringRelative(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringRelative(), Is.EqualTo("#REF!"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("'Sheet 1'!#REF!"));
+            });
         }
 
         [Test]
@@ -113,13 +131,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!A1:B2", address.ToString());
-            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!R1C1:R2C2", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("#REF!A1:B2", address.ToString(XLReferenceStyle.Default, true));
-            Assert.AreEqual("#REF!R1C1:R2C2", address.ToString(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("#REF!A1:B2"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("#REF!A1:B2"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("#REF!A1:B2"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("#REF!R1C1:R2C2"));
+                Assert.That(address.ToString(XLReferenceStyle.A1, true), Is.EqualTo("#REF!A1:B2"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("#REF!A1:B2"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1, true), Is.EqualTo("#REF!R1C1:R2C2"));
+            });
         }
 
         [Test]
@@ -127,13 +148,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed());
-            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!R1C1:R2C2", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("#REF!$A$1:$B$2", address.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("#REF!R1C1:R2C2", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringFixed(), Is.EqualTo("#REF!$A$1:$B$2"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("#REF!$A$1:$B$2"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("#REF!$A$1:$B$2"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("#REF!R1C1:R2C2"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("#REF!$A$1:$B$2"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("#REF!$A$1:$B$2"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("#REF!R1C1:R2C2"));
+            });
         }
 
         [Test]
@@ -141,8 +165,11 @@ namespace ClosedXML.Tests
         {
             var address = ProduceAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!A1:B2", address.ToStringRelative());
-            Assert.AreEqual("#REF!A1:B2", address.ToStringRelative(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringRelative(), Is.EqualTo("#REF!A1:B2"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("#REF!A1:B2"));
+            });
         }
 
         [Test]
@@ -150,13 +177,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!#REF!", address.ToString());
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.Default, true));
-            Assert.AreEqual("#REF!#REF!", address.ToString(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToString(), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.A1), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.A1, true), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.Default, true), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToString(XLReferenceStyle.R1C1, true), Is.EqualTo("#REF!#REF!"));
+            });
         }
 
         [Test]
@@ -164,13 +194,16 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed());
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.A1));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.Default));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.A1, true));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.Default, true));
-            Assert.AreEqual("#REF!#REF!", address.ToStringFixed(XLReferenceStyle.R1C1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringFixed(), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.A1, true), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.Default, true), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringFixed(XLReferenceStyle.R1C1, true), Is.EqualTo("#REF!#REF!"));
+            });
         }
 
         [Test]
@@ -178,32 +211,39 @@ namespace ClosedXML.Tests
         {
             var address = ProduceInvalidAddressOnDeletedWorksheet();
 
-            Assert.AreEqual("#REF!#REF!", address.ToStringRelative());
-            Assert.AreEqual("#REF!#REF!", address.ToStringRelative(true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(address.ToStringRelative(), Is.EqualTo("#REF!#REF!"));
+                Assert.That(address.ToStringRelative(true), Is.EqualTo("#REF!#REF!"));
+            });
         }
 
         [Test]
         public void FullSpanAddressCannotChange()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            var wsRange = ws.AsRange();
+            var row = ws.FirstRow().RowBelow(4).AsRange();
+            var column = ws.FirstColumn().ColumnRight(4).AsRange();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(wsRange.RangeAddress.ToString(), Is.EqualTo($"1:{XLHelper.MaxRowNumber}"));
+                Assert.That(row.RangeAddress.ToString(), Is.EqualTo("5:5"));
+                Assert.That(column.RangeAddress.ToString(), Is.EqualTo("E:E"));
+            });
 
-                var wsRange = ws.AsRange();
-                var row = ws.FirstRow().RowBelow(4).AsRange();
-                var column = ws.FirstColumn().ColumnRight(4).AsRange();
+            ws.Columns("Y:Z").Delete();
+            ws.Rows("9:10").Delete();
 
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", wsRange.RangeAddress.ToString());
-                Assert.AreEqual("5:5", row.RangeAddress.ToString());
-                Assert.AreEqual("E:E", column.RangeAddress.ToString());
-
-                ws.Columns("Y:Z").Delete();
-                ws.Rows("9:10").Delete();
-
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", wsRange.RangeAddress.ToString());
-                Assert.AreEqual("5:5", row.RangeAddress.ToString());
-                Assert.AreEqual("E:E", column.RangeAddress.ToString());
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(wsRange.RangeAddress.ToString(), Is.EqualTo($"1:{XLHelper.MaxRowNumber}"));
+                Assert.That(row.RangeAddress.ToString(), Is.EqualTo("5:5"));
+                Assert.That(column.RangeAddress.ToString(), Is.EqualTo("E:E"));
+            });
         }
 
         [Test]
@@ -214,25 +254,25 @@ namespace ClosedXML.Tests
             XLRangeAddress rangeAddress;
 
             rangeAddress = (XLRangeAddress)ws.Range(ws.Cell("A1"), ws.Cell("C3")).RangeAddress;
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.True);
 
             rangeAddress = (XLRangeAddress)ws.Range(ws.Cell("C3"), ws.Cell("A1")).RangeAddress;
-            Assert.IsFalse(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.False);
 
             rangeAddress = (XLRangeAddress)ws.Range("B2:B1").RangeAddress;
-            Assert.IsFalse(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.False);
 
             rangeAddress = (XLRangeAddress)ws.Range("B2:B10").RangeAddress;
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.True);
 
             rangeAddress = (XLRangeAddress)ws.Range("B:B").RangeAddress;
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.True);
 
             rangeAddress = (XLRangeAddress)ws.Range("2:2").RangeAddress;
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.True);
 
             rangeAddress = (XLRangeAddress)ws.RangeAddress;
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.That(rangeAddress.IsNormalized, Is.True);
         }
 
         [Test]
@@ -245,8 +285,11 @@ namespace ClosedXML.Tests
                 new XLAddress(5, 5, false, false)
             );
 
-            Assert.IsTrue(rangeAddress.IsValid);
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.True);
+                Assert.That(rangeAddress.IsNormalized, Is.True);
+            });
             Assert.Throws<InvalidOperationException>(() => rangeAddress.AsRange());
 
             var ws = new XLWorkbook().AddWorksheet() as XLWorksheet;
@@ -256,8 +299,11 @@ namespace ClosedXML.Tests
                 new XLAddress(ws, 5, 5, false, false)
             );
 
-            Assert.IsTrue(rangeAddress.IsValid);
-            Assert.IsTrue(rangeAddress.IsNormalized);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.True);
+                Assert.That(rangeAddress.IsNormalized, Is.True);
+            });
             Assert.DoesNotThrow(() => rangeAddress.AsRange());
         }
 
@@ -269,24 +315,39 @@ namespace ClosedXML.Tests
             IXLRangeAddress rangeAddress;
 
             rangeAddress = ws.Range("D4:E4").RangeAddress.Relative(ws.Range("A1:E4").RangeAddress, ws.Range("B10:F14").RangeAddress);
-            Assert.IsTrue(rangeAddress.IsValid);
-            Assert.AreEqual("E13:F13", rangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.True);
+                Assert.That(rangeAddress.ToString(), Is.EqualTo("E13:F13"));
+            });
 
             rangeAddress = ws.Range("D4:E4").RangeAddress.Relative(ws.Range("B10:F14").RangeAddress, ws.Range("A1:E4").RangeAddress);
-            Assert.IsFalse(rangeAddress.IsValid);
-            Assert.AreEqual("#REF!", rangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.False);
+                Assert.That(rangeAddress.ToString(), Is.EqualTo("#REF!"));
+            });
 
             rangeAddress = ws.Range("C3").RangeAddress.Relative(ws.Range("A1:B2").RangeAddress, ws.Range("C3").RangeAddress);
-            Assert.IsTrue(rangeAddress.IsValid);
-            Assert.AreEqual("E5:E5", rangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.True);
+                Assert.That(rangeAddress.ToString(), Is.EqualTo("E5:E5"));
+            });
 
             rangeAddress = ws.Range("B2").RangeAddress.Relative(ws.Range("A1").RangeAddress, ws.Range("C3").RangeAddress);
-            Assert.IsTrue(rangeAddress.IsValid);
-            Assert.AreEqual("D4:D4", rangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.True);
+                Assert.That(rangeAddress.ToString(), Is.EqualTo("D4:D4"));
+            });
 
             rangeAddress = ws.Range("A1").RangeAddress.Relative(ws.Range("B2").RangeAddress, ws.Range("A1").RangeAddress);
-            Assert.IsFalse(rangeAddress.IsValid);
-            Assert.AreEqual("#REF!", rangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.IsValid, Is.False);
+                Assert.That(rangeAddress.ToString(), Is.EqualTo("#REF!"));
+            });
         }
 
         [Test]
@@ -296,20 +357,29 @@ namespace ClosedXML.Tests
 
             var range = ws.Range("B3:E5");
             var rangeAddress = range.RangeAddress as IXLRangeAddress;
-            Assert.AreEqual(4, rangeAddress.ColumnSpan);
-            Assert.AreEqual(3, rangeAddress.RowSpan);
-            Assert.AreEqual(12, rangeAddress.NumberOfCells);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.ColumnSpan, Is.EqualTo(4));
+                Assert.That(rangeAddress.RowSpan, Is.EqualTo(3));
+                Assert.That(rangeAddress.NumberOfCells, Is.EqualTo(12));
+            });
 
             range = ws.Range("E5:B3");
             rangeAddress = range.RangeAddress as IXLRangeAddress;
-            Assert.AreEqual(4, rangeAddress.ColumnSpan);
-            Assert.AreEqual(3, rangeAddress.RowSpan);
-            Assert.AreEqual(12, rangeAddress.NumberOfCells);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.ColumnSpan, Is.EqualTo(4));
+                Assert.That(rangeAddress.RowSpan, Is.EqualTo(3));
+                Assert.That(rangeAddress.NumberOfCells, Is.EqualTo(12));
+            });
 
             rangeAddress = ProduceAddressOnDeletedWorksheet();
-            Assert.AreEqual(2, rangeAddress.ColumnSpan);
-            Assert.AreEqual(2, rangeAddress.RowSpan);
-            Assert.AreEqual(4, rangeAddress.NumberOfCells);
+            Assert.Multiple(() =>
+            {
+                Assert.That(rangeAddress.ColumnSpan, Is.EqualTo(2));
+                Assert.That(rangeAddress.RowSpan, Is.EqualTo(2));
+                Assert.That(rangeAddress.NumberOfCells, Is.EqualTo(4));
+            });
 
             rangeAddress = ProduceInvalidAddress();
             Assert.Throws<InvalidOperationException>(() => { var x = rangeAddress.ColumnSpan; });

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -17,7 +17,7 @@ namespace ClosedXML.Tests
             IXLRange range = ws.Range("A1:B2");
             bool actual = range.IsEmpty();
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -28,7 +28,7 @@ namespace ClosedXML.Tests
             IXLRange range = ws.Range("A1:B2");
             bool actual = range.IsEmpty(XLCellsUsedOptions.All);
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace ClosedXML.Tests
             IXLRange range = ws.Range("A1:B2");
             bool actual = range.IsEmpty();
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace ClosedXML.Tests
             IXLRange range = ws.Range("A1:B2");
             bool actual = range.IsEmpty(XLCellsUsedOptions.AllContents);
             bool expected = true;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace ClosedXML.Tests
             IXLRange range = ws.Range("A1:B2");
             bool actual = range.IsEmpty(XLCellsUsedOptions.All);
             bool expected = false;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace ClosedXML.Tests
             IXLRange range = ws.Range("A1:B2");
             bool actual = range.IsEmpty();
             bool expected = false;
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -87,8 +87,11 @@ namespace ClosedXML.Tests
             ws.Cell(1, 1).Value = "Hello World!";
             wb.DefinedNames.Add("SingleCell", "Sheet1!$A$1");
             IXLRange range = wb.Range("SingleCell");
-            Assert.AreEqual(1, range.CellsUsed().Count());
-            Assert.AreEqual("Hello World!", range.CellsUsed().Single().GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(range.CellsUsed().Count(), Is.EqualTo(1));
+                Assert.That(range.CellsUsed().Single().GetText(), Is.EqualTo("Hello World!"));
+            });
         }
 
         [Test]
@@ -105,9 +108,13 @@ namespace ClosedXML.Tests
             wb.DefinedNames.Add("FNameColumn", String.Format("{0}[{1}]", table.Name, "FName"));
 
             IXLRange namedRange = wb.Range("FNameColumn");
-            Assert.AreEqual(3, namedRange.Cells().Count());
-            Assert.IsTrue(
-                namedRange.CellsUsed().Select(cell => cell.GetText()).SequenceEqual(new[] { "John", "Hank", "Dagny" }));
+            Assert.Multiple(() =>
+            {
+                Assert.That(namedRange.Cells().Count(), Is.EqualTo(3));
+                Assert.That(
+                    namedRange.CellsUsed().Select(cell => cell.GetText()).SequenceEqual(new[] { "John", "Hank", "Dagny" }),
+                    Is.True);
+            });
         }
 
         [Test]
@@ -116,7 +123,7 @@ namespace ClosedXML.Tests
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.Worksheets.Add("Sheet1");
             ws.Cell(1, 1).SetValue("Test").AddToNamed("TestCell", XLScope.Worksheet);
-            Assert.AreEqual("Test", ws.Cell("TestCell").GetText());
+            Assert.That(ws.Cell("TestCell").GetText(), Is.EqualTo("Test"));
         }
 
         [Test]
@@ -127,8 +134,11 @@ namespace ClosedXML.Tests
             ws.Cell(1, 1).SetValue("Test").AddToNamed("TestCell", XLScope.Worksheet);
             ws.Cell(2, 1).SetValue("B");
             IXLCells cells = ws.Cells("TestCell, A2");
-            Assert.AreEqual("Test", cells.First().GetText());
-            Assert.AreEqual("B", cells.Last().GetText());
+            Assert.Multiple(() =>
+            {
+                Assert.That(cells.First().GetText(), Is.EqualTo("Test"));
+                Assert.That(cells.Last().GetText(), Is.EqualTo("B"));
+            });
         }
 
         [Test]
@@ -141,7 +151,7 @@ namespace ClosedXML.Tests
             IXLRange original = ws.Range("A1:A2");
             original.AddToNamed("TestRange", XLScope.Worksheet);
             IXLRange named = ws.Range("TestRange");
-            Assert.AreEqual(original.RangeAddress.ToStringFixed(), named.RangeAddress.ToString());
+            Assert.That(named.RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
         }
 
         [Test]
@@ -155,8 +165,11 @@ namespace ClosedXML.Tests
             IXLRange original = ws.Range("A1:A2");
             original.AddToNamed("TestRange", XLScope.Worksheet);
             IXLRanges namedRanges = ws.Ranges("TestRange, A3");
-            Assert.AreEqual(original.RangeAddress.ToStringFixed(), namedRanges.First().RangeAddress.ToString());
-            Assert.AreEqual("$A$3:$A$3", namedRanges.Last().RangeAddress.ToStringFixed());
+            Assert.Multiple(() =>
+            {
+                Assert.That(namedRanges.First().RangeAddress.ToString(), Is.EqualTo(original.RangeAddress.ToStringFixed()));
+                Assert.That(namedRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
+            });
         }
 
         [Test]
@@ -167,8 +180,8 @@ namespace ClosedXML.Tests
             ws.DefinedNames.Add("TestRange", "Sheet1!$A$1,Sheet1!$A$3");
             IXLRanges namedRanges = ws.Ranges("TestRange");
 
-            Assert.AreEqual("$A$1:$A$1", namedRanges.First().RangeAddress.ToStringFixed());
-            Assert.AreEqual("$A$3:$A$3", namedRanges.Last().RangeAddress.ToStringFixed());
+            Assert.That(namedRanges.First().RangeAddress.ToStringFixed(), Is.EqualTo("$A$1:$A$1"));
+            Assert.That(namedRanges.Last().RangeAddress.ToStringFixed(), Is.EqualTo("$A$3:$A$3"));
         }
 
         //[Test]
@@ -190,120 +203,120 @@ namespace ClosedXML.Tests
         [Test]
         public void GrowRange()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                Assert.AreEqual("A1:B2", ws.Cell("A1").AsRange().Grow().RangeAddress.ToString());
-                Assert.AreEqual("A1:B3", ws.Cell("A2").AsRange().Grow().RangeAddress.ToString());
-                Assert.AreEqual("A1:C2", ws.Cell("B1").AsRange().Grow().RangeAddress.ToString());
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            Assert.That(ws.Cell("A1").AsRange().Grow().RangeAddress.ToString(), Is.EqualTo("A1:B2"));
+            Assert.That(ws.Cell("A2").AsRange().Grow().RangeAddress.ToString(), Is.EqualTo("A1:B3"));
+            Assert.That(ws.Cell("B1").AsRange().Grow().RangeAddress.ToString(), Is.EqualTo("A1:C2"));
 
-                Assert.AreEqual("E4:G6", ws.Cell("F5").AsRange().Grow().RangeAddress.ToString());
-                Assert.AreEqual("D3:H7", ws.Cell("F5").AsRange().Grow(2).RangeAddress.ToString());
-                Assert.AreEqual("A1:DB105", ws.Cell("F5").AsRange().Grow(100).RangeAddress.ToString());
-            }
+            Assert.That(ws.Cell("F5").AsRange().Grow().RangeAddress.ToString(), Is.EqualTo("E4:G6"));
+            Assert.That(ws.Cell("F5").AsRange().Grow(2).RangeAddress.ToString(), Is.EqualTo("D3:H7"));
+            Assert.That(ws.Cell("F5").AsRange().Grow(100).RangeAddress.ToString(), Is.EqualTo("A1:DB105"));
         }
 
         [Test]
         public void ShrinkRange()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                Assert.Null(ws.Cell("A1").AsRange().Shrink());
-                Assert.Null(ws.Range("B2:C3").Shrink());
-                Assert.AreEqual("C3:C3", ws.Range("B2:D4").Shrink().RangeAddress.ToString());
-                Assert.AreEqual("K11:P16", ws.Range("A1:Z26").Shrink(10).RangeAddress.ToString());
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            Assert.Null(ws.Cell("A1").AsRange().Shrink());
+            Assert.Null(ws.Range("B2:C3").Shrink());
+            Assert.That(ws.Range("B2:D4").Shrink().RangeAddress.ToString(), Is.EqualTo("C3:C3"));
+            Assert.That(ws.Range("A1:Z26").Shrink(10).RangeAddress.ToString(), Is.EqualTo("K11:P16"));
 
-                // Grow and shrink back
-                Assert.AreEqual("Z26:Z26", ws.Cell("Z26").AsRange().Grow(10).Shrink(10).RangeAddress.ToString());
-            }
+            // Grow and shrink back
+            Assert.That(ws.Cell("Z26").AsRange().Grow(10).Shrink(10).RangeAddress.ToString(), Is.EqualTo("Z26:Z26"));
         }
 
         [Test]
         public void Intersection()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(ws.Range("B9:I11").Intersection(ws.Range("D4:G16")).ToString(), Is.EqualTo("D9:G11"));
+                Assert.That(ws.Range("E9:I11").Intersection(ws.Range("D4:G16")).ToString(), Is.EqualTo("E9:G11"));
+                Assert.That(ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16")).ToString(), Is.EqualTo("E9:E9"));
+                Assert.That(ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange()).ToString(), Is.EqualTo("E9:E9"));
+            });
 
-                Assert.AreEqual("D9:G11", ws.Range("B9:I11").Intersection(ws.Range("D4:G16")).ToString());
-                Assert.AreEqual("E9:G11", ws.Range("E9:I11").Intersection(ws.Range("D4:G16")).ToString());
-                Assert.AreEqual("E9:E9", ws.Cell("E9").AsRange().Intersection(ws.Range("D4:G16")).ToString());
-                Assert.AreEqual("E9:E9", ws.Range("D4:G16").Intersection(ws.Cell("E9").AsRange()).ToString());
+            XLRangeAddress rangeAddress;
 
-                XLRangeAddress rangeAddress;
+            rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange());
+            Assert.That(rangeAddress.IsValid, Is.False);
 
-                rangeAddress = (XLRangeAddress)ws.Cell("C3").AsRange().Intersection(ws.Cell("A1").AsRange());
-                Assert.IsFalse(rangeAddress.IsValid);
+            rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange());
+            Assert.That(rangeAddress.IsValid, Is.False);
 
-                rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange());
-                Assert.IsFalse(rangeAddress.IsValid);
+            Assert.Null(ws.Range("A1:C3").Intersection(null));
 
-                Assert.Null(ws.Range("A1:C3").Intersection(null));
-
-                var otherWs = wb.AddWorksheet("Sheet2");
-                Assert.Null(ws.Intersection(otherWs));
-                Assert.Null(ws.Cell("A1").AsRange().Intersection(otherWs.Cell("A2").AsRange()));
-            }
+            var otherWs = wb.AddWorksheet("Sheet2");
+            Assert.Null(ws.Intersection(otherWs));
+            Assert.Null(ws.Cell("A1").AsRange().Intersection(otherWs.Cell("A2").AsRange()));
         }
 
         [Test]
         public void Union()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(ws.Range("B9:I11").Union(ws.Range("D4:G16")).Count(), Is.EqualTo(64));
+                Assert.That(ws.Range("E9:I11").Union(ws.Range("D4:G16")).Count(), Is.EqualTo(58));
+                Assert.That(ws.Cell("E9").AsRange().Union(ws.Range("D4:G16")).Count(), Is.EqualTo(52));
+                Assert.That(ws.Range("D4:G16").Union(ws.Cell("E9").AsRange()).Count(), Is.EqualTo(52));
 
-                Assert.AreEqual(64, ws.Range("B9:I11").Union(ws.Range("D4:G16")).Count());
-                Assert.AreEqual(58, ws.Range("E9:I11").Union(ws.Range("D4:G16")).Count());
-                Assert.AreEqual(52, ws.Cell("E9").AsRange().Union(ws.Range("D4:G16")).Count());
-                Assert.AreEqual(52, ws.Range("D4:G16").Union(ws.Cell("E9").AsRange()).Count());
+                Assert.That(ws.Cell("A1").AsRange().Union(ws.Cell("C3").AsRange()).Count(), Is.EqualTo(2));
 
-                Assert.AreEqual(2, ws.Cell("A1").AsRange().Union(ws.Cell("C3").AsRange()).Count());
+                Assert.That(ws.Range("A1:C3").Union(null).Count(), Is.EqualTo(9));
+            });
 
-                Assert.AreEqual(9, ws.Range("A1:C3").Union(null).Count());
-
-                var otherWs = wb.AddWorksheet("Sheet2");
-                Assert.False(ws.Union(otherWs).Any());
-                Assert.False(ws.Cell("A1").AsRange().Union(otherWs.Cell("A2").AsRange()).Any());
-            }
+            var otherWs = wb.AddWorksheet("Sheet2");
+            Assert.False(ws.Union(otherWs).Any());
+            Assert.False(ws.Cell("A1").AsRange().Union(otherWs.Cell("A2").AsRange()).Any());
         }
 
         [Test]
         public void Difference()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(ws.Range("B9:I11").Difference(ws.Range("D4:G16")).Count(), Is.EqualTo(12));
+                Assert.That(ws.Range("E9:I11").Difference(ws.Range("D4:G16")).Count(), Is.EqualTo(6));
+                Assert.That(ws.Cell("E9").AsRange().Difference(ws.Range("D4:G16")).Count(), Is.EqualTo(0));
+                Assert.That(ws.Range("D4:G16").Difference(ws.Cell("E9").AsRange()).Count(), Is.EqualTo(51));
 
-                Assert.AreEqual(12, ws.Range("B9:I11").Difference(ws.Range("D4:G16")).Count());
-                Assert.AreEqual(6, ws.Range("E9:I11").Difference(ws.Range("D4:G16")).Count());
-                Assert.AreEqual(0, ws.Cell("E9").AsRange().Difference(ws.Range("D4:G16")).Count());
-                Assert.AreEqual(51, ws.Range("D4:G16").Difference(ws.Cell("E9").AsRange()).Count());
+                Assert.That(ws.Cell("A1").AsRange().Difference(ws.Cell("C3").AsRange()).Count(), Is.EqualTo(1));
 
-                Assert.AreEqual(1, ws.Cell("A1").AsRange().Difference(ws.Cell("C3").AsRange()).Count());
+                Assert.That(ws.Range("A1:C3").Difference(null).Count(), Is.EqualTo(9));
+            });
 
-                Assert.AreEqual(9, ws.Range("A1:C3").Difference(null).Count());
-
-                var otherWs = wb.AddWorksheet("Sheet2");
-                Assert.False(ws.Difference(otherWs).Any());
-                Assert.False(ws.Cell("A1").AsRange().Difference(otherWs.Cell("A2").AsRange()).Any());
-            }
+            var otherWs = wb.AddWorksheet("Sheet2");
+            Assert.False(ws.Difference(otherWs).Any());
+            Assert.False(ws.Cell("A1").AsRange().Difference(otherWs.Cell("A2").AsRange()).Any());
         }
 
         [Test]
         public void SurroundingCells()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
+                Assert.That(ws.FirstCell().AsRange().SurroundingCells().Count(), Is.EqualTo(3));
+                Assert.That(ws.Cell("C3").AsRange().SurroundingCells().Count(), Is.EqualTo(8));
+                Assert.That(ws.Range("C3:D6").AsRange().SurroundingCells().Count(), Is.EqualTo(16));
 
-                Assert.AreEqual(3, ws.FirstCell().AsRange().SurroundingCells().Count());
-                Assert.AreEqual(8, ws.Cell("C3").AsRange().SurroundingCells().Count());
-                Assert.AreEqual(16, ws.Range("C3:D6").AsRange().SurroundingCells().Count());
-
-                Assert.AreEqual(0, ws.Range("C3:D6").AsRange().SurroundingCells(c => !c.IsEmpty()).Count());
-            }
+                Assert.That(ws.Range("C3:D6").AsRange().SurroundingCells(c => !c.IsEmpty()).Count(), Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -313,8 +326,11 @@ namespace ClosedXML.Tests
             ws.Range("C3:D7").AddConditionalFormat();
             ws.Range("B2:E3").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("C4:D7", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative(), Is.EqualTo("C4:D7"));
+            });
         }
 
         [Test]
@@ -324,8 +340,11 @@ namespace ClosedXML.Tests
             ws.Range("C3:D7").AddConditionalFormat();
             ws.Range("C3:D3").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("C4:D7", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative(), Is.EqualTo("C4:D7"));
+            });
         }
 
         [Test]
@@ -335,8 +354,11 @@ namespace ClosedXML.Tests
             ws.Range("C3:D7").AddConditionalFormat();
             ws.Range("B7:E8").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("C3:D6", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative(), Is.EqualTo("C3:D6"));
+            });
         }
 
         [Test]
@@ -346,8 +368,11 @@ namespace ClosedXML.Tests
             ws.Range("C3:D7").AddConditionalFormat();
             ws.Range("C7:D7").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("C3:D6", ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.Single().Range.RangeAddress.ToStringRelative(), Is.EqualTo("C3:D6"));
+            });
         }
 
         [Test]
@@ -357,9 +382,12 @@ namespace ClosedXML.Tests
             ws.Range("C3:D7").AddConditionalFormat();
             ws.Range("C5:E5").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("C3:D4", ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToStringRelative());
-            Assert.AreEqual("C6:D7", ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToStringRelative(), Is.EqualTo("C3:D4"));
+            });
+            Assert.That(ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToStringRelative(), Is.EqualTo("C6:D7"));
         }
 
         [Test]
@@ -369,9 +397,12 @@ namespace ClosedXML.Tests
             ws.Range("C3:G4").AddConditionalFormat();
             ws.Range("E2:E4").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("C3:D4", ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToStringRelative());
-            Assert.AreEqual("F3:G4", ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToStringRelative(), Is.EqualTo("C3:D4"));
+            });
+            Assert.That(ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToStringRelative(), Is.EqualTo("F3:G4"));
         }
 
         [Test]
@@ -381,7 +412,7 @@ namespace ClosedXML.Tests
             ws.Range("C3:G4").AddConditionalFormat();
             ws.Range("B2:G4").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(0, ws.ConditionalFormats.Count());
+            Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -391,9 +422,12 @@ namespace ClosedXML.Tests
             ws.Range("C3:G4").AddConditionalFormat();
             ws.Range("C2:D3").Clear(XLClearOptions.ConditionalFormats);
 
-            Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws.ConditionalFormats.Single().Ranges.Count);
-            Assert.AreEqual("C3:G4", ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToStringRelative());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.ConditionalFormats.Count(), Is.EqualTo(1));
+                Assert.That(ws.ConditionalFormats.Single().Ranges, Has.Count.EqualTo(1));
+            });
+            Assert.That(ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToStringRelative(), Is.EqualTo("C3:G4"));
         }
 
         [Test]
@@ -408,10 +442,13 @@ namespace ClosedXML.Tests
             ranges.RemoveAll(null, false);
             ws.FirstColumn().InsertColumnsBefore(1);
 
-            Assert.AreEqual(0, ranges.Count);
-            // if ranges were not disposed they addresses should change
-            Assert.AreEqual("B1:B2", rangesCopy.First().RangeAddress.ToString());
-            Assert.AreEqual("C1:C2", rangesCopy.Last().RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ranges.Count, Is.EqualTo(0));
+                // if ranges were not disposed they addresses should change
+                Assert.That(rangesCopy.First().RangeAddress.ToString(), Is.EqualTo("B1:B2"));
+            });
+            Assert.That(rangesCopy.Last().RangeAddress.ToString(), Is.EqualTo("C1:C2"));
         }
 
         [Test]
@@ -426,8 +463,8 @@ namespace ClosedXML.Tests
 
             ranges.RemoveAll(r => r.Intersects(otherRange));
 
-            Assert.AreEqual(1, ranges.Count);
-            Assert.AreEqual("A1:A2", ranges.Single().RangeAddress.ToString());
+            Assert.That(ranges, Has.Count.EqualTo(1));
+            Assert.That(ranges.Single().RangeAddress.ToString(), Is.EqualTo("A1:A2"));
         }
 
         [Test]
@@ -462,10 +499,10 @@ namespace ClosedXML.Tests
 
             var actualRanges = ranges.ToList();
 
-            Assert.AreEqual(expectedRanges.Count, actualRanges.Count);
+            Assert.That(actualRanges, Has.Count.EqualTo(expectedRanges.Count));
             for (int i = 0; i < actualRanges.Count; i++)
             {
-                Assert.AreEqual(expectedRanges[i], actualRanges[i]);
+                Assert.That(actualRanges[i], Is.EqualTo(expectedRanges[i]));
             }
         }
 
@@ -478,10 +515,13 @@ namespace ClosedXML.Tests
             ws.Range("B1:C1").Clear(XLClearOptions.All);
             ws.Range("B2:C2").Clear(XLClearOptions.Sparklines);
 
-            Assert.AreEqual(1, ws.SparklineGroups.Single().Count());
-            Assert.IsFalse(ws.Cell("B1").HasSparkline);
-            Assert.IsFalse(ws.Cell("B2").HasSparkline);
-            Assert.IsTrue(ws.Cell("B3").HasSparkline);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(1));
+                Assert.That(ws.Cell("B1").HasSparkline, Is.False);
+                Assert.That(ws.Cell("B2").HasSparkline, Is.False);
+                Assert.That(ws.Cell("B3").HasSparkline, Is.True);
+            });
         }
 
         [TestCase("B2:G7", "D4:E5", true, "B2:G3,B4:C5,D4:E5,F4:G5,B6:G7")]
@@ -511,7 +551,7 @@ namespace ClosedXML.Tests
 
             var actualAddresses = string.Join(",", result.Select(r => r.RangeAddress.ToString()));
 
-            Assert.AreEqual(expectedResult, actualAddresses);
+            Assert.That(actualAddresses, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -538,21 +578,24 @@ namespace ClosedXML.Tests
 
             range.Sort("3 DESC");
 
-            Assert.AreEqual(32, ws.Cell("A2").Value);
-            Assert.AreEqual( 6, ws.Cell("A3").Value);
-            Assert.AreEqual( 7, ws.Cell("A4").Value);
-            Assert.AreEqual( 2, ws.Cell("A5").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(32));
+                Assert.That(ws.Cell("A3").Value, Is.EqualTo(6));
+                Assert.That(ws.Cell("A4").Value, Is.EqualTo(7));
+                Assert.That(ws.Cell("A5").Value, Is.EqualTo(2));
 
-            Assert.AreEqual( 2, ws.Cell("B2").Value);
-            Assert.AreEqual( 9, ws.Cell("B3").Value);
-            Assert.AreEqual( 5, ws.Cell("B4").Value);
-            Assert.AreEqual(14, ws.Cell("B5").Value);
+                Assert.That(ws.Cell("B2").Value, Is.EqualTo(2));
+                Assert.That(ws.Cell("B3").Value, Is.EqualTo(9));
+                Assert.That(ws.Cell("B4").Value, Is.EqualTo(5));
+                Assert.That(ws.Cell("B5").Value, Is.EqualTo(14));
 
-            // Formulas has been moved around and their coordinates fixed after move
-            Assert.AreEqual("A2*B2 & \"(Waffle)\"", ws.Cell("C2").FormulaA1);
-            Assert.AreEqual("A3*B3 & \"(Shortcake)\"", ws.Cell("C3").FormulaA1);
-            Assert.AreEqual("A4*B4 & \"(Cake)\"", ws.Cell("C4").FormulaA1);
-            Assert.AreEqual("A5*B5 & \"(Pie)\"", ws.Cell("C5").FormulaA1);
+                // Formulas has been moved around and their coordinates fixed after move
+                Assert.That(ws.Cell("C2").FormulaA1, Is.EqualTo("A2*B2 & \"(Waffle)\""));
+                Assert.That(ws.Cell("C3").FormulaA1, Is.EqualTo("A3*B3 & \"(Shortcake)\""));
+                Assert.That(ws.Cell("C4").FormulaA1, Is.EqualTo("A4*B4 & \"(Cake)\""));
+                Assert.That(ws.Cell("C5").FormulaA1, Is.EqualTo("A5*B5 & \"(Pie)\""));
+            });
         }
 
         [TestCase("PY(4)", "_xlfn._xlws.PY(4)")]
@@ -564,7 +607,7 @@ namespace ClosedXML.Tests
             var ws = wb.AddWorksheet();
             ws.Range("A1:B2").FormulaArrayA1 = formula;
             var masterCellFormula = ws.Cell("A1").FormulaA1;
-            Assert.AreEqual(expected, masterCellFormula);
+            Assert.That(masterCellFormula, Is.EqualTo(expected));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -279,8 +279,8 @@ namespace ClosedXML.Tests
             });
 
             var otherWs = wb.AddWorksheet("Sheet2");
-            Assert.False(ws.Union(otherWs).Any());
-            Assert.False(ws.Cell("A1").AsRange().Union(otherWs.Cell("A2").AsRange()).Any());
+            Assert.That(ws.Union(otherWs).Any(), Is.False);
+            Assert.That(ws.Cell("A1").AsRange().Union(otherWs.Cell("A2").AsRange()).Any(), Is.False);
         }
 
         [Test]
@@ -302,8 +302,8 @@ namespace ClosedXML.Tests
             });
 
             var otherWs = wb.AddWorksheet("Sheet2");
-            Assert.False(ws.Difference(otherWs).Any());
-            Assert.False(ws.Cell("A1").AsRange().Difference(otherWs.Cell("A2").AsRange()).Any());
+            Assert.That(ws.Difference(otherWs).Any(), Is.False);
+            Assert.That(ws.Cell("A1").AsRange().Difference(otherWs.Cell("A2").AsRange()).Any(), Is.False);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -219,13 +219,16 @@ namespace ClosedXML.Tests
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Sheet1");
-            Assert.Null(ws.Cell("A1").AsRange().Shrink());
-            Assert.Null(ws.Range("B2:C3").Shrink());
-            Assert.That(ws.Range("B2:D4").Shrink().RangeAddress.ToString(), Is.EqualTo("C3:C3"));
-            Assert.That(ws.Range("A1:Z26").Shrink(10).RangeAddress.ToString(), Is.EqualTo("K11:P16"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A1").AsRange().Shrink(), Is.Null);
+                Assert.That(ws.Range("B2:C3").Shrink(), Is.Null);
+                Assert.That(ws.Range("B2:D4").Shrink().RangeAddress.ToString(), Is.EqualTo("C3:C3"));
+                Assert.That(ws.Range("A1:Z26").Shrink(10).RangeAddress.ToString(), Is.EqualTo("K11:P16"));
 
-            // Grow and shrink back
-            Assert.That(ws.Cell("Z26").AsRange().Grow(10).Shrink(10).RangeAddress.ToString(), Is.EqualTo("Z26:Z26"));
+                // Grow and shrink back
+                Assert.That(ws.Cell("Z26").AsRange().Grow(10).Shrink(10).RangeAddress.ToString(), Is.EqualTo("Z26:Z26"));
+            });
         }
 
         [Test]
@@ -250,11 +253,11 @@ namespace ClosedXML.Tests
             rangeAddress = (XLRangeAddress)ws.Cell("A1").AsRange().Intersection(ws.Cell("C3").AsRange());
             Assert.That(rangeAddress.IsValid, Is.False);
 
-            Assert.Null(ws.Range("A1:C3").Intersection(null));
+            Assert.That(ws.Range("A1:C3").Intersection(null), Is.Null);
 
             var otherWs = wb.AddWorksheet("Sheet2");
-            Assert.Null(ws.Intersection(otherWs));
-            Assert.Null(ws.Cell("A1").AsRange().Intersection(otherWs.Cell("A2").AsRange()));
+            Assert.That(ws.Intersection(otherWs), Is.Null);
+            Assert.That(ws.Cell("A1").AsRange().Intersection(otherWs.Cell("A2").AsRange()), Is.Null);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/RichText/XLImmutableRichTextTests.cs
+++ b/ClosedXML.Tests/Excel/RichText/XLImmutableRichTextTests.cs
@@ -24,24 +24,24 @@ namespace ClosedXML.Tests.Excel.RichText
             // Assert equal
             var immutableRichText = XLImmutableRichText.Create(richText);
             var equalImmutableRichText = XLImmutableRichText.Create(richText);
-            Assert.AreEqual(immutableRichText, equalImmutableRichText);
+            Assert.That(equalImmutableRichText, Is.EqualTo(immutableRichText));
 
             // Different font of a first run
             richText.ElementAt(0).SetBold(false);
             var withDifferentTextRunFont = XLImmutableRichText.Create(richText);
-            Assert.AreNotEqual(immutableRichText, withDifferentTextRunFont);
+            Assert.That(withDifferentTextRunFont, Is.Not.EqualTo(immutableRichText));
             richText.ElementAt(0).SetBold(true);
 
             // Different phonetic properties
             richText.Phonetics.SetAlignment(XLPhoneticAlignment.Left);
             var withDifferentPhoneticsProps = XLImmutableRichText.Create(richText);
-            Assert.AreNotEqual(immutableRichText, withDifferentPhoneticsProps);
+            Assert.That(withDifferentPhoneticsProps, Is.Not.EqualTo(immutableRichText));
             richText.Phonetics.SetAlignment(XLPhoneticAlignment.Distributed);
 
             // Different phonetic runs
             richText.Phonetics.Add("せかい", 6, 8);
             var withDifferentTextPhonetics = XLImmutableRichText.Create(richText);
-            Assert.AreNotEqual(immutableRichText, withDifferentTextPhonetics);
+            Assert.That(withDifferentTextPhonetics, Is.Not.EqualTo(immutableRichText));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/RichText/XLRichStringTests.cs
+++ b/ClosedXML.Tests/Excel/RichText/XLRichStringTests.cs
@@ -22,11 +22,11 @@ namespace ClosedXML.Tests
 
             IXLRichText richText = cell.GetRichText();
 
-            Assert.AreEqual("12", richText.ToString());
+            Assert.That(richText.ToString(), Is.EqualTo("12"));
 
             richText.AddText("34");
 
-            Assert.AreEqual("1234", cell.GetText());
+            Assert.That(cell.GetText(), Is.EqualTo("1234"));
         }
 
         /// <summary>
@@ -42,14 +42,17 @@ namespace ClosedXML.Tests
             string text = "Hello";
             richString.AddText(text).SetBold().SetFontColor(XLColor.Red);
 
-            Assert.AreEqual(cell.GetText(), text);
-            Assert.AreEqual(cell.GetRichText().First().Bold, true);
-            Assert.AreEqual(cell.GetRichText().First().FontColor, XLColor.Red);
+            Assert.Multiple(() =>
+            {
+                Assert.That(text, Is.EqualTo(cell.GetText()));
+                Assert.That(true, Is.EqualTo(cell.GetRichText().First().Bold));
+                Assert.That(XLColor.Red, Is.EqualTo(cell.GetRichText().First().FontColor));
 
-            Assert.AreEqual(1, richString.Count);
+                Assert.That(richString, Has.Count.EqualTo(1));
+            });
 
             richString.AddText("World");
-            Assert.AreEqual(richString.First().Text, text, "Item in collection is not the same as the one returned");
+            Assert.That(text, Is.EqualTo(richString.First().Text), "Item in collection is not the same as the one returned");
         }
 
         [Test]
@@ -57,7 +60,7 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            Int32 number = 123;
+            int number = 123;
 
             cell.SetValue(number).Style
                 .Font.SetBold()
@@ -65,14 +68,17 @@ namespace ClosedXML.Tests
 
             string text = number.ToString();
 
-            Assert.AreEqual(cell.GetRichText().ToString(), text);
-            Assert.AreEqual(cell.GetRichText().First().Bold, true);
-            Assert.AreEqual(cell.GetRichText().First().FontColor, XLColor.Red);
+            Assert.Multiple(() =>
+            {
+                Assert.That(text, Is.EqualTo(cell.GetRichText().ToString()));
+                Assert.That(true, Is.EqualTo(cell.GetRichText().First().Bold));
+                Assert.That(XLColor.Red, Is.EqualTo(cell.GetRichText().First().FontColor));
 
-            Assert.AreEqual(1, cell.GetRichText().Count);
+                Assert.That(cell.GetRichText(), Has.Count.EqualTo(1));
+            });
 
             cell.GetRichText().AddText("World");
-            Assert.AreEqual(cell.GetRichText().First().Text, text, "Item in collection is not the same as the one returned");
+            Assert.That(text, Is.EqualTo(cell.GetRichText().First().Text), "Item in collection is not the same as the one returned");
         }
 
         [Test]
@@ -80,7 +86,7 @@ namespace ClosedXML.Tests
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
             IXLCell cell = ws.Cell(1, 1);
-            Int32 number = 123;
+            int number = 123;
             cell.Value = number;
             cell.Style
                 .Font.SetBold()
@@ -88,14 +94,17 @@ namespace ClosedXML.Tests
 
             string text = number.ToString();
 
-            Assert.AreEqual(cell.GetRichText().ToString(), text);
-            Assert.AreEqual(cell.GetRichText().First().Bold, true);
-            Assert.AreEqual(cell.GetRichText().First().FontColor, XLColor.Red);
+            Assert.Multiple(() =>
+            {
+                Assert.That(text, Is.EqualTo(cell.GetRichText().ToString()));
+                Assert.That(true, Is.EqualTo(cell.GetRichText().First().Bold));
+                Assert.That(XLColor.Red, Is.EqualTo(cell.GetRichText().First().FontColor));
 
-            Assert.AreEqual(1, cell.GetRichText().Count);
+                Assert.That(cell.GetRichText(), Has.Count.EqualTo(1));
+            });
 
             cell.GetRichText().AddText("World");
-            Assert.AreEqual(cell.GetRichText().First().Text, text, "Item in collection is not the same as the one returned");
+            Assert.That(text, Is.EqualTo(cell.GetRichText().First().Text), "Item in collection is not the same as the one returned");
         }
 
         /// <summary>
@@ -112,11 +121,14 @@ namespace ClosedXML.Tests
             richString.AddText("World!");
 
             richString.ClearText();
-            String expected = String.Empty;
-            String actual = richString.ToString();
-            Assert.AreEqual(expected, actual);
+            string expected = string.Empty;
+            string actual = richString.ToString();
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Is.EqualTo(expected));
 
-            Assert.AreEqual(0, richString.Count);
+                Assert.That(richString.Count, Is.EqualTo(0));
+            });
         }
 
         [Test]
@@ -129,7 +141,7 @@ namespace ClosedXML.Tests
             richString.AddText(" ");
             richString.AddText("World!");
 
-            Assert.AreEqual(3, richString.Count);
+            Assert.That(richString, Has.Count.EqualTo(3));
         }
 
         [Test]
@@ -139,27 +151,27 @@ namespace ClosedXML.Tests
             IXLCell cell = ws.Cell(1, 1);
             cell.GetRichText().AddText("123");
 
-            Assert.AreEqual(true, cell.HasRichText);
+            Assert.That(cell.HasRichText, Is.True);
 
             cell.Value = "123";
 
-            Assert.AreEqual(false, cell.HasRichText);
+            Assert.That(cell.HasRichText, Is.False);
 
             cell.GetRichText().AddText("123");
 
-            Assert.AreEqual(true, cell.HasRichText);
+            Assert.That(cell.HasRichText, Is.True);
 
             cell.Value = 123;
 
-            Assert.AreEqual(false, cell.HasRichText);
+            Assert.That(cell.HasRichText, Is.False);
 
             cell.GetRichText().AddText("123");
 
-            Assert.AreEqual(true, cell.HasRichText);
+            Assert.That(cell.HasRichText, Is.True);
 
             cell.SetValue("123");
 
-            Assert.AreEqual(false, cell.HasRichText);
+            Assert.That(cell.HasRichText, Is.False);
         }
 
         /// <summary>
@@ -175,13 +187,16 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(0);
 
-            Assert.AreEqual(richString.First(), actual.First());
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual.First(), Is.EqualTo(richString.First()));
 
-            Assert.AreEqual(1, actual.Count);
+                Assert.That(actual, Has.Count.EqualTo(1));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().First().Bold);
+            Assert.That(ws.Cell(1, 1).GetRichText().First().Bold, Is.True);
         }
 
         [Test]
@@ -196,18 +211,24 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(0);
 
-            Assert.AreEqual(richString.ElementAt(0), actual.ElementAt(0));
-            Assert.AreEqual(richString.ElementAt(1), actual.ElementAt(1));
-            Assert.AreEqual(richString.ElementAt(2), actual.ElementAt(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual.ElementAt(0), Is.EqualTo(richString.ElementAt(0)));
+                Assert.That(actual.ElementAt(1), Is.EqualTo(richString.ElementAt(1)));
+                Assert.That(actual.ElementAt(2), Is.EqualTo(richString.ElementAt(2)));
 
-            Assert.AreEqual(3, actual.Count);
-            Assert.AreEqual(3, richString.Count);
+                Assert.That(actual, Has.Count.EqualTo(3));
+                Assert.That(richString, Has.Count.EqualTo(3));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().First().Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().Last().Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Bold, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Bold, Is.False);
+            });
         }
 
         [Test]
@@ -220,33 +241,48 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(2);
 
-            Assert.AreEqual(1, actual.Count); // substring was in one piece
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(1)); // substring was in one piece
 
-            Assert.AreEqual(2, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(2)); // The text was split because of the substring
 
-            Assert.AreEqual("llo", actual.First().Text);
+                Assert.That(actual.First().Text, Is.EqualTo("llo"));
+            });
 
-            Assert.AreEqual("He", richString.First().Text);
-            Assert.AreEqual("llo", richString.Last().Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.First().Text, Is.EqualTo("He"));
+                Assert.That(richString.Last().Text, Is.EqualTo("llo"));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Bold, Is.True);
+            });
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Italic, Is.True);
 
-            Assert.AreEqual(true, actual.First().Italic);
+                Assert.That(actual.First().Italic, Is.True);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().First().FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().Last().FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.First().FontSize);
+                Assert.That(actual.First().FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -259,37 +295,52 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(2, 2);
 
-            Assert.AreEqual(1, actual.Count); // substring was in one piece
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(1)); // substring was in one piece
 
-            Assert.AreEqual(3, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(3)); // The text was split because of the substring
 
-            Assert.AreEqual("ll", actual.First().Text);
+                Assert.That(actual.First().Text, Is.EqualTo("ll"));
+            });
 
-            Assert.AreEqual("He", richString.First().Text);
-            Assert.AreEqual("ll", richString.ElementAt(1).Text);
-            Assert.AreEqual("o", richString.Last().Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.First().Text, Is.EqualTo("He"));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo("ll"));
+                Assert.That(richString.Last().Text, Is.EqualTo("o"));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().Last().Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Bold, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Bold, Is.False);
+            });
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Italic, Is.True);
 
-            Assert.AreEqual(false, actual.First().Italic);
+                Assert.That(actual.First().Italic, Is.False);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().First().FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().Last().FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.First().FontSize);
+                Assert.That(actual.First().FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -302,33 +353,48 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(0, 2);
 
-            Assert.AreEqual(1, actual.Count); // substring was in one piece
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(1)); // substring was in one piece
 
-            Assert.AreEqual(2, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(2)); // The text was split because of the substring
 
-            Assert.AreEqual("He", actual.First().Text);
+                Assert.That(actual.First().Text, Is.EqualTo("He"));
+            });
 
-            Assert.AreEqual("He", richString.First().Text);
-            Assert.AreEqual("llo", richString.Last().Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.First().Text, Is.EqualTo("He"));
+                Assert.That(richString.Last().Text, Is.EqualTo("llo"));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().First().Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().Last().Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Bold, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Bold, Is.False);
+            });
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().First().Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().Last().Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().Italic, Is.True);
 
-            Assert.AreEqual(false, actual.First().Italic);
+                Assert.That(actual.First().Italic, Is.False);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().First().FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().Last().FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().First().FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().Last().FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.First().FontSize);
+                Assert.That(actual.First().FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -343,41 +409,56 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(21);
 
-            Assert.AreEqual(1, actual.Count); // substring was in one piece
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(1)); // substring was in one piece
 
-            Assert.AreEqual(4, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(4)); // The text was split because of the substring
 
-            Assert.AreEqual("bors!", actual.First().Text);
+                Assert.That(actual.First().Text, Is.EqualTo("bors!"));
+            });
 
-            Assert.AreEqual("Good Morning", richString.ElementAt(0).Text);
-            Assert.AreEqual(" my ", richString.ElementAt(1).Text);
-            Assert.AreEqual("neigh", richString.ElementAt(2).Text);
-            Assert.AreEqual("bors!", richString.ElementAt(3).Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.ElementAt(0).Text, Is.EqualTo("Good Morning"));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo(" my "));
+                Assert.That(richString.ElementAt(2).Text, Is.EqualTo("neigh"));
+                Assert.That(richString.ElementAt(3).Text, Is.EqualTo("bors!"));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Bold, Is.True);
+            });
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Italic, Is.True);
 
-            Assert.AreEqual(true, actual.First().Italic);
+                Assert.That(actual.First().Italic, Is.True);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.First().FontSize);
+                Assert.That(actual.First().FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -392,44 +473,59 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(13);
 
-            Assert.AreEqual(2, actual.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(2));
 
-            Assert.AreEqual(4, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(4)); // The text was split because of the substring
 
-            Assert.AreEqual("my ", actual.ElementAt(0).Text);
-            Assert.AreEqual("neighbors!", actual.ElementAt(1).Text);
+                Assert.That(actual.ElementAt(0).Text, Is.EqualTo("my "));
+                Assert.That(actual.ElementAt(1).Text, Is.EqualTo("neighbors!"));
+            });
 
-            Assert.AreEqual("Good Morning", richString.ElementAt(0).Text);
-            Assert.AreEqual(" ", richString.ElementAt(1).Text);
-            Assert.AreEqual("my ", richString.ElementAt(2).Text);
-            Assert.AreEqual("neighbors!", richString.ElementAt(3).Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.ElementAt(0).Text, Is.EqualTo("Good Morning"));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo(" "));
+                Assert.That(richString.ElementAt(2).Text, Is.EqualTo("my "));
+                Assert.That(richString.ElementAt(3).Text, Is.EqualTo("neighbors!"));
+            });
 
             actual.ElementAt(1).SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Bold, Is.True);
+            });
 
             richString.Last().SetItalic();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Italic, Is.True);
 
-            Assert.AreEqual(false, actual.ElementAt(0).Italic);
-            Assert.AreEqual(true, actual.ElementAt(1).Italic);
+                Assert.That(actual.ElementAt(0).Italic, Is.False);
+                Assert.That(actual.ElementAt(1).Italic, Is.True);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.ElementAt(0).FontSize);
-            Assert.AreEqual(20, actual.ElementAt(1).FontSize);
+                Assert.That(actual.ElementAt(0).FontSize, Is.EqualTo(20));
+                Assert.That(actual.ElementAt(1).FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -444,18 +540,24 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(5, 10);
 
-            Assert.AreEqual(2, actual.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(2));
 
-            Assert.AreEqual(5, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(5)); // The text was split because of the substring
 
-            Assert.AreEqual("Morning", actual.ElementAt(0).Text);
-            Assert.AreEqual(" my", actual.ElementAt(1).Text);
+                Assert.That(actual.ElementAt(0).Text, Is.EqualTo("Morning"));
+                Assert.That(actual.ElementAt(1).Text, Is.EqualTo(" my"));
+            });
 
-            Assert.AreEqual("Good ", richString.ElementAt(0).Text);
-            Assert.AreEqual("Morning", richString.ElementAt(1).Text);
-            Assert.AreEqual(" my", richString.ElementAt(2).Text);
-            Assert.AreEqual(" ", richString.ElementAt(3).Text);
-            Assert.AreEqual("neighbors!", richString.ElementAt(4).Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.ElementAt(0).Text, Is.EqualTo("Good "));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo("Morning"));
+                Assert.That(richString.ElementAt(2).Text, Is.EqualTo(" my"));
+                Assert.That(richString.ElementAt(3).Text, Is.EqualTo(" "));
+                Assert.That(richString.ElementAt(4).Text, Is.EqualTo("neighbors!"));
+            });
         }
 
         [Test]
@@ -470,19 +572,25 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(5, 15);
 
-            Assert.AreEqual(3, actual.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(3));
 
-            Assert.AreEqual(5, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(5)); // The text was split because of the substring
 
-            Assert.AreEqual("Morning", actual.ElementAt(0).Text);
-            Assert.AreEqual(" my ", actual.ElementAt(1).Text);
-            Assert.AreEqual("neig", actual.ElementAt(2).Text);
+                Assert.That(actual.ElementAt(0).Text, Is.EqualTo("Morning"));
+                Assert.That(actual.ElementAt(1).Text, Is.EqualTo(" my "));
+                Assert.That(actual.ElementAt(2).Text, Is.EqualTo("neig"));
+            });
 
-            Assert.AreEqual("Good ", richString.ElementAt(0).Text);
-            Assert.AreEqual("Morning", richString.ElementAt(1).Text);
-            Assert.AreEqual(" my ", richString.ElementAt(2).Text);
-            Assert.AreEqual("neig", richString.ElementAt(3).Text);
-            Assert.AreEqual("hbors!", richString.ElementAt(4).Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.ElementAt(0).Text, Is.EqualTo("Good "));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo("Morning"));
+                Assert.That(richString.ElementAt(2).Text, Is.EqualTo(" my "));
+                Assert.That(richString.ElementAt(3).Text, Is.EqualTo("neig"));
+                Assert.That(richString.ElementAt(4).Text, Is.EqualTo("hbors!"));
+            });
         }
 
         [Test]
@@ -497,41 +605,56 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(0, 4);
 
-            Assert.AreEqual(1, actual.Count); // substring was in one piece
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(1)); // substring was in one piece
 
-            Assert.AreEqual(4, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(4)); // The text was split because of the substring
 
-            Assert.AreEqual("Good", actual.First().Text);
+                Assert.That(actual.First().Text, Is.EqualTo("Good"));
+            });
 
-            Assert.AreEqual("Good", richString.ElementAt(0).Text);
-            Assert.AreEqual(" Morning", richString.ElementAt(1).Text);
-            Assert.AreEqual(" my ", richString.ElementAt(2).Text);
-            Assert.AreEqual("neighbors!", richString.ElementAt(3).Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.ElementAt(0).Text, Is.EqualTo("Good"));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo(" Morning"));
+                Assert.That(richString.ElementAt(2).Text, Is.EqualTo(" my "));
+                Assert.That(richString.ElementAt(3).Text, Is.EqualTo("neighbors!"));
+            });
 
             actual.First().SetBold();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Bold, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Bold, Is.False);
+            });
 
             richString.First().SetItalic();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Italic, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Italic, Is.False);
 
-            Assert.AreEqual(true, actual.First().Italic);
+                Assert.That(actual.First().Italic, Is.True);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.First().FontSize);
+                Assert.That(actual.First().FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -546,44 +669,59 @@ namespace ClosedXML.Tests
 
             IXLFormattedText<IXLRichText> actual = richString.Substring(0, 15);
 
-            Assert.AreEqual(2, actual.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(actual, Has.Count.EqualTo(2));
 
-            Assert.AreEqual(4, richString.Count); // The text was split because of the substring
+                Assert.That(richString, Has.Count.EqualTo(4)); // The text was split because of the substring
 
-            Assert.AreEqual("Good Morning", actual.ElementAt(0).Text);
-            Assert.AreEqual(" my", actual.ElementAt(1).Text);
+                Assert.That(actual.ElementAt(0).Text, Is.EqualTo("Good Morning"));
+                Assert.That(actual.ElementAt(1).Text, Is.EqualTo(" my"));
+            });
 
-            Assert.AreEqual("Good Morning", richString.ElementAt(0).Text);
-            Assert.AreEqual(" my", richString.ElementAt(1).Text);
-            Assert.AreEqual(" ", richString.ElementAt(2).Text);
-            Assert.AreEqual("neighbors!", richString.ElementAt(3).Text);
+            Assert.Multiple(() =>
+            {
+                Assert.That(richString.ElementAt(0).Text, Is.EqualTo("Good Morning"));
+                Assert.That(richString.ElementAt(1).Text, Is.EqualTo(" my"));
+                Assert.That(richString.ElementAt(2).Text, Is.EqualTo(" "));
+                Assert.That(richString.ElementAt(3).Text, Is.EqualTo("neighbors!"));
+            });
 
             actual.ElementAt(1).SetBold();
 
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(0).Bold);
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(1).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Bold);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Bold);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Bold, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Bold, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Bold, Is.False);
+            });
 
             richString.First().SetItalic();
 
-            Assert.AreEqual(true, ws.Cell(1, 1).GetRichText().ElementAt(0).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(1).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(2).Italic);
-            Assert.AreEqual(false, ws.Cell(1, 1).GetRichText().ElementAt(3).Italic);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).Italic, Is.True);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).Italic, Is.False);
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).Italic, Is.False);
 
-            Assert.AreEqual(true, actual.ElementAt(0).Italic);
-            Assert.AreEqual(false, actual.ElementAt(1).Italic);
+                Assert.That(actual.ElementAt(0).Italic, Is.True);
+                Assert.That(actual.ElementAt(1).Italic, Is.False);
+            });
 
             richString.SetFontSize(20);
 
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize);
-            Assert.AreEqual(20, ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(0).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(1).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(2).FontSize, Is.EqualTo(20));
+                Assert.That(ws.Cell(1, 1).GetRichText().ElementAt(3).FontSize, Is.EqualTo(20));
 
-            Assert.AreEqual(20, actual.ElementAt(0).FontSize);
-            Assert.AreEqual(20, actual.ElementAt(1).FontSize);
+                Assert.That(actual.ElementAt(0).FontSize, Is.EqualTo(20));
+                Assert.That(actual.ElementAt(1).FontSize, Is.EqualTo(20));
+            });
         }
 
         [Test]
@@ -646,10 +784,16 @@ namespace ClosedXML.Tests
             var otherRichText = otherCell.GetRichText();
             otherRichText.CopyFrom(original);
 
-            Assert.AreEqual("HelloWorld", otherCell.Value);
-            Assert.AreEqual(2, otherRichText.Count);
-            Assert.AreEqual(XLColor.Red, otherRichText.First().FontColor);
-            Assert.AreEqual(XLColor.Blue, otherRichText.Last().FontColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(otherCell.Value, Is.EqualTo("HelloWorld"));
+                Assert.That(otherRichText, Has.Count.EqualTo(2));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(otherRichText.First().FontColor, Is.EqualTo(XLColor.Red));
+                Assert.That(otherRichText.Last().FontColor, Is.EqualTo(XLColor.Blue));
+            });
         }
 
         /// <summary>
@@ -666,35 +810,33 @@ namespace ClosedXML.Tests
             richString.AddText("World");
             string expected = "Hello World";
             string actual = richString.ToString();
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
 
             richString.AddText("!");
             expected = "Hello World!";
             actual = richString.ToString();
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
 
             richString.ClearText();
-            expected = String.Empty;
+            expected = string.Empty;
             actual = richString.ToString();
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test(Description = "See #1361")]
         public void CanClearInlinedRichText()
         {
-            using (var outputStream = new MemoryStream())
+            using var outputStream = new MemoryStream();
+            using (var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlinedRichText\ChangeRichText\inputfile.xlsx")))
+            using (var workbook = new XLWorkbook(inputStream))
             {
-                using (var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlinedRichText\ChangeRichText\inputfile.xlsx")))
-                using (var workbook = new XLWorkbook(inputStream))
-                {
-                    workbook.Worksheets.First().Cell("A1").Value = "";
-                    workbook.SaveAs(outputStream);
-                }
+                workbook.Worksheets.First().Cell("A1").Value = "";
+                workbook.SaveAs(outputStream);
+            }
 
-                using (var wb = new XLWorkbook(outputStream))
-                {
-                    Assert.AreEqual("", wb.Worksheets.First().Cell("A1").Value);
-                }
+            using (var wb = new XLWorkbook(outputStream))
+            {
+                Assert.That(wb.Worksheets.First().Cell("A1").Value, Is.EqualTo(""));
             }
         }
 
@@ -704,68 +846,70 @@ namespace ClosedXML.Tests
             static void AssertRichText(IXLRichText richText)
             {
                 Assert.IsNotNull(richText);
-                Assert.IsTrue(richText.Any());
-                Assert.AreEqual("3", richText.ElementAt(2).Text);
-                Assert.AreEqual(XLColor.Red, richText.ElementAt(2).FontColor);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(richText.Any(), Is.True);
+                    Assert.That(richText.ElementAt(2).Text, Is.EqualTo("3"));
+                    Assert.That(richText.ElementAt(2).FontColor, Is.EqualTo(XLColor.Red));
+                });
             }
 
-            using (var outputStream = new MemoryStream())
+            using var outputStream = new MemoryStream();
+            using (var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlinedRichText\ChangeRichText\inputfile.xlsx")))
+            using (var workbook = new XLWorkbook(inputStream))
             {
-                using (var inputStream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlinedRichText\ChangeRichText\inputfile.xlsx")))
-                using (var workbook = new XLWorkbook(inputStream))
-                {
-                    var richText = workbook.Worksheets.First().Cell("A1").GetRichText();
-                    AssertRichText(richText);
-                    richText.AddText(" - changed");
-                    workbook.SaveAs(outputStream);
-                }
+                var richText = workbook.Worksheets.First().Cell("A1").GetRichText();
+                AssertRichText(richText);
+                richText.AddText(" - changed");
+                workbook.SaveAs(outputStream);
+            }
 
-                using (var wb = new XLWorkbook(outputStream))
+            using (var wb = new XLWorkbook(outputStream))
+            {
+                var cell = wb.Worksheets.First().Cell("A1");
+                Assert.Multiple(() =>
                 {
-                    var cell = wb.Worksheets.First().Cell("A1");
-                    Assert.IsFalse(cell.ShareString);
-                    Assert.IsTrue(cell.HasRichText);
-                    var rt = cell.GetRichText();
-                    Assert.AreEqual("Year (range: 3 yrs) - changed", rt.ToString());
-                    AssertRichText(rt);
-                }
+                    Assert.That(cell.ShareString, Is.False);
+                    Assert.That(cell.HasRichText, Is.True);
+                });
+                var rt = cell.GetRichText();
+                Assert.That(rt.ToString(), Is.EqualTo("Year (range: 3 yrs) - changed"));
+                AssertRichText(rt);
             }
         }
 
         [Test]
         public void ClearInlineRichTextWhenRelevant()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
+                using (var wb = new XLWorkbook())
                 {
-                    using (var wb = new XLWorkbook())
-                    {
-                        var ws = wb.AddWorksheet();
-                        var cell = ws.FirstCell();
+                    var ws = wb.AddWorksheet();
+                    var cell = ws.FirstCell();
 
-                        cell.GetRichText().AddText("Bold").SetBold().AddText(" and red").SetBold().SetFontColor(XLColor.Red);
-                        cell.ShareString = false;
+                    cell.GetRichText().AddText("Bold").SetBold().AddText(" and red").SetBold().SetFontColor(XLColor.Red);
+                    cell.ShareString = false;
 
-                        //wb.SaveAs(ms);
-                        wb.SaveAs(ms);
-                    }
-                    ms.Seek(0, SeekOrigin.Begin);
+                    //wb.SaveAs(ms);
+                    wb.SaveAs(ms);
+                }
+                ms.Seek(0, SeekOrigin.Begin);
 
-                    var wb2 = new XLWorkbook(ms);
-                    {
-                        var ws = wb2.Worksheets.First();
-                        var cell = ws.FirstCell();
+                var wb2 = new XLWorkbook(ms);
+                {
+                    var ws = wb2.Worksheets.First();
+                    var cell = ws.FirstCell();
 
-                        cell.FormulaA1 = "=1 + 2";
-                        wb2.SaveAs(ms);
-                    }
+                    cell.FormulaA1 = "=1 + 2";
+                    wb2.SaveAs(ms);
+                }
 
-                    ms.Seek(0, SeekOrigin.Begin);
+                ms.Seek(0, SeekOrigin.Begin);
 
-                    return wb2;
-                }, @"Other\InlinedRichText\ChangeRichTextToFormula\output.xlsx");
-            }
+                return wb2;
+            }, @"Other\InlinedRichText\ChangeRichTextToFormula\output.xlsx");
         }
 
         [Test]
@@ -776,20 +920,20 @@ namespace ClosedXML.Tests
             var cell = ws.Cell(1, 1);
             var richText = cell.GetRichText();
 
-            Assert.AreEqual(cell.Value, richText.Text);
+            Assert.That(richText.Text, Is.EqualTo(cell.Value));
 
             richText.AddText("Hello");
-            Assert.AreEqual(cell.Value, "Hello");
+            Assert.That("Hello", Is.EqualTo(cell.Value));
 
             var world = richText.AddText(" World");
-            Assert.AreEqual(cell.Value, "Hello World");
+            Assert.That("Hello World", Is.EqualTo(cell.Value));
 
             world.Text = " World!";
-            Assert.AreEqual(cell.Value, "Hello World!");
-            Assert.AreEqual(cell.GetRichText().Text, "Hello World!");
+            Assert.That("Hello World!", Is.EqualTo(cell.Value));
+            Assert.That("Hello World!", Is.EqualTo(cell.GetRichText().Text));
 
             richText.ClearText();
-            Assert.AreEqual(cell.Value, string.Empty);
+            Assert.That(string.Empty, Is.EqualTo(cell.Value));
         }
 
         [Test]
@@ -827,8 +971,11 @@ namespace ClosedXML.Tests
             {
                 var ws = wb.Worksheets.First();
                 var richText = ws.Cell(1, 1).GetRichText();
-                Assert.AreEqual(textWithSpaces, richText.First().Text);
-                Assert.AreEqual(phoneticsWithSpace, richText.Phonetics.First().Text);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(richText.First().Text, Is.EqualTo(textWithSpaces));
+                    Assert.That(richText.Phonetics.First().Text, Is.EqualTo(phoneticsWithSpace));
+                });
             }
         }
 

--- a/ClosedXML.Tests/Excel/RichText/XLRichStringTests.cs
+++ b/ClosedXML.Tests/Excel/RichText/XLRichStringTests.cs
@@ -45,7 +45,7 @@ namespace ClosedXML.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(text, Is.EqualTo(cell.GetText()));
-                Assert.That(true, Is.EqualTo(cell.GetRichText().First().Bold));
+                Assert.That(cell.GetRichText().First().Bold, Is.EqualTo(true));
                 Assert.That(XLColor.Red, Is.EqualTo(cell.GetRichText().First().FontColor));
 
                 Assert.That(richString, Has.Count.EqualTo(1));
@@ -71,7 +71,7 @@ namespace ClosedXML.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(text, Is.EqualTo(cell.GetRichText().ToString()));
-                Assert.That(true, Is.EqualTo(cell.GetRichText().First().Bold));
+                Assert.That(cell.GetRichText().First().Bold, Is.EqualTo(true));
                 Assert.That(XLColor.Red, Is.EqualTo(cell.GetRichText().First().FontColor));
 
                 Assert.That(cell.GetRichText(), Has.Count.EqualTo(1));
@@ -97,7 +97,7 @@ namespace ClosedXML.Tests
             Assert.Multiple(() =>
             {
                 Assert.That(text, Is.EqualTo(cell.GetRichText().ToString()));
-                Assert.That(true, Is.EqualTo(cell.GetRichText().First().Bold));
+                Assert.That(cell.GetRichText().First().Bold, Is.EqualTo(true));
                 Assert.That(XLColor.Red, Is.EqualTo(cell.GetRichText().First().FontColor));
 
                 Assert.That(cell.GetRichText(), Has.Count.EqualTo(1));
@@ -845,7 +845,7 @@ namespace ClosedXML.Tests
         {
             static void AssertRichText(IXLRichText richText)
             {
-                Assert.IsNotNull(richText);
+                Assert.That(richText, Is.Not.Null);
                 Assert.Multiple(() =>
                 {
                     Assert.That(richText.Any(), Is.True);
@@ -923,17 +923,17 @@ namespace ClosedXML.Tests
             Assert.That(richText.Text, Is.EqualTo(cell.Value));
 
             richText.AddText("Hello");
-            Assert.That("Hello", Is.EqualTo(cell.Value));
+            Assert.That(cell.Value, Is.EqualTo("Hello"));
 
             var world = richText.AddText(" World");
-            Assert.That("Hello World", Is.EqualTo(cell.Value));
+            Assert.That(cell.Value, Is.EqualTo("Hello World"));
 
             world.Text = " World!";
-            Assert.That("Hello World!", Is.EqualTo(cell.Value));
-            Assert.That("Hello World!", Is.EqualTo(cell.GetRichText().Text));
+            Assert.That(cell.Value, Is.EqualTo("Hello World!"));
+            Assert.That(cell.GetRichText().Text, Is.EqualTo("Hello World!"));
 
             richText.ClearText();
-            Assert.That(string.Empty, Is.EqualTo(cell.Value));
+            Assert.That(cell.Value, Is.EqualTo(string.Empty));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Rows/RowTests.cs
+++ b/ClosedXML.Tests/Excel/Rows/RowTests.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Tests.Excel
             var ws = wb.AddWorksheet();
             ws.FirstCell().SetValue("Hello world!");
             var rowsUsed = ws.Column(1).AsRange().RowsUsed();
-            Assert.AreEqual(1, rowsUsed.Count());
+            Assert.That(rowsUsed.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -26,7 +26,7 @@ namespace ClosedXML.Tests.Excel
             ws.FirstCell().SetValue("Test").Style.Font.SetBold();
             ws.FirstRow().CopyTo(ws.Row(2));
 
-            Assert.IsTrue(ws.Cell("A2").Style.Font.Bold);
+            Assert.That(ws.Cell("A2").Style.Font.Bold, Is.True);
         }
 
         [Test]
@@ -45,41 +45,47 @@ namespace ClosedXML.Tests.Excel
 
             IXLRow rowIns = ws.Row(1).InsertRowsAbove(1).First();
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Row(1).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Row(1).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, ws.Row(1).Cell(3).Style.Fill.BackgroundColor);
+            Assert.That(ws.Row(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(ws.Row(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(ws.Row(1).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
 
-            Assert.AreEqual(XLColor.Red, ws.Row(2).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(2).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(2).Cell(3).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(2).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(2).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(2).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Row(3).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Row(3).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Row(3).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(3).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Row(3).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Row(3).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(4).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(4).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(4).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", ws.Row(3).Cell(2).GetText());
+                Assert.That(ws.Row(3).Cell(2).GetText(), Is.EqualTo("X"));
 
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, rowIns.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, rowIns.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(ws.Style.Fill.BackgroundColor, rowIns.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(rowIns.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            });
+            Assert.That(rowIns.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
+            Assert.That(rowIns.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(ws.Style.Fill.BackgroundColor));
 
-            Assert.AreEqual(XLColor.Red, row1.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row1.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row1.Cell(3).Style.Fill.BackgroundColor);
+            Assert.That(row1.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+            Assert.Multiple(() =>
+            {
+                Assert.That(row1.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row1.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, row2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, row2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, row2.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(row2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(row2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, row3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row3.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", row2.Cell(2).GetText());
+                Assert.That(row2.Cell(2).GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
@@ -98,41 +104,44 @@ namespace ClosedXML.Tests.Excel
 
             IXLRow rowIns = ws.Row(2).InsertRowsAbove(1).First();
 
-            Assert.AreEqual(XLColor.Red, ws.Row(1).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(1).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(1).Cell(3).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(1).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Red, ws.Row(2).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(2).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(2).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(2).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(2).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(2).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Row(3).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Row(3).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Row(3).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(3).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Row(3).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Row(3).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(4).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(4).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(4).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", ws.Row(3).Cell(2).GetText());
+                Assert.That(ws.Row(3).Cell(2).GetText(), Is.EqualTo("X"));
 
-            Assert.AreEqual(XLColor.Red, rowIns.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, rowIns.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, rowIns.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(rowIns.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(rowIns.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(rowIns.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Red, row1.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row1.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row1.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row1.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row1.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row1.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, row2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, row2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, row2.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(row2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(row2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, row3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row3.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", row2.Cell(2).GetText());
+                Assert.That(row2.Cell(2).GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
@@ -151,71 +160,75 @@ namespace ClosedXML.Tests.Excel
 
             IXLRow rowIns = ws.Row(3).InsertRowsAbove(1).First();
 
-            Assert.AreEqual(XLColor.Red, ws.Row(1).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(1).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(1).Cell(3).Style.Fill.BackgroundColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(1).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(1).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(1).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Row(2).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Row(2).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Row(2).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(2).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Row(2).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Row(2).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Yellow, ws.Row(3).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, ws.Row(3).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, ws.Row(3).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(3).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(ws.Row(3).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Row(3).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, ws.Row(4).Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(ws.Row(4).Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(4).Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Row(4).Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", ws.Row(2).Cell(2).GetText());
+                Assert.That(ws.Row(2).Cell(2).GetText(), Is.EqualTo("X"));
 
-            Assert.AreEqual(XLColor.Yellow, rowIns.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, rowIns.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, rowIns.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(rowIns.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(rowIns.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(rowIns.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, row1.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row1.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row1.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row1.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row1.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row1.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual(XLColor.Yellow, row2.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Green, row2.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Yellow, row2.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row2.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
+                Assert.That(row2.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(row2.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Yellow));
 
-            Assert.AreEqual(XLColor.Red, row3.Cell(1).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row3.Cell(2).Style.Fill.BackgroundColor);
-            Assert.AreEqual(XLColor.Red, row3.Cell(3).Style.Fill.BackgroundColor);
+                Assert.That(row3.Cell(1).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(2).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(row3.Cell(3).Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
 
-            Assert.AreEqual("X", row2.Cell(2).GetText());
+                Assert.That(row2.Cell(2).GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
         public void InsertingRowsAbove4()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+
+            ws.Row(2).Height = 15;
+            ws.Row(3).Height = 20;
+            ws.Row(4).Height = 25;
+            ws.Row(5).Height = 35;
+
+            ws.Row(2).FirstCell().SetValue("Row height: 15");
+            ws.Row(3).FirstCell().SetValue("Row height: 20");
+            ws.Row(4).FirstCell().SetValue("Row height: 25");
+            ws.Row(5).FirstCell().SetValue("Row height: 35");
+
+            ws.Range("3:3").InsertRowsAbove(1);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.Worksheets.Add("Sheet1");
+                Assert.That(ws.Row(2).Height, Is.EqualTo(15));
+                Assert.That(ws.Row(4).Height, Is.EqualTo(20));
+                Assert.That(ws.Row(5).Height, Is.EqualTo(25));
+                Assert.That(ws.Row(6).Height, Is.EqualTo(35));
 
-                ws.Row(2).Height = 15;
-                ws.Row(3).Height = 20;
-                ws.Row(4).Height = 25;
-                ws.Row(5).Height = 35;
-
-                ws.Row(2).FirstCell().SetValue("Row height: 15");
-                ws.Row(3).FirstCell().SetValue("Row height: 20");
-                ws.Row(4).FirstCell().SetValue("Row height: 25");
-                ws.Row(5).FirstCell().SetValue("Row height: 35");
-
-                ws.Range("3:3").InsertRowsAbove(1);
-
-                Assert.AreEqual(15, ws.Row(2).Height);
-                Assert.AreEqual(20, ws.Row(4).Height);
-                Assert.AreEqual(25, ws.Row(5).Height);
-                Assert.AreEqual(35, ws.Row(6).Height);
-
-                Assert.AreEqual(20, ws.Row(3).Height);
-                ws.Row(3).ClearHeight();
-                Assert.AreEqual(ws.RowHeight, ws.Row(3).Height);
-            }
+                Assert.That(ws.Row(3).Height, Is.EqualTo(20));
+            });
+            ws.Row(3).ClearHeight();
+            Assert.That(ws.Row(3).Height, Is.EqualTo(ws.RowHeight));
         }
 
         [Test]
@@ -231,7 +244,7 @@ namespace ClosedXML.Tests.Excel
             foreach (IXLRangeRow row in ws.Range("A1:C3").RowsUsed())
                 count++;
 
-            Assert.AreEqual(0, count);
+            Assert.That(count, Is.EqualTo(0));
         }
 
         [Test]
@@ -243,10 +256,10 @@ namespace ClosedXML.Tests.Excel
             ws.Cell(1, 3).SetValue("Test");
 
             IXLRangeRow fromRow = ws.Row(1).RowUsed();
-            Assert.AreEqual("B1:C1", fromRow.RangeAddress.ToStringRelative());
+            Assert.That(fromRow.RangeAddress.ToStringRelative(), Is.EqualTo("B1:C1"));
 
             IXLRangeRow fromRange = ws.Range("A1:E1").FirstRow().RowUsed();
-            Assert.AreEqual("B1:C1", fromRange.RangeAddress.ToStringRelative());
+            Assert.That(fromRange.RangeAddress.ToStringRelative(), Is.EqualTo("B1:C1"));
         }
 
         [Test]
@@ -259,8 +272,11 @@ namespace ClosedXML.Tests.Excel
 
             var range = ws.Column(1).AsRange();
 
-            Assert.AreEqual(100, range.RowsUsed(XLCellsUsedOptions.DataValidation).Count());
-            Assert.AreEqual(100, range.RowsUsed(XLCellsUsedOptions.All).Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(range.RowsUsed(XLCellsUsedOptions.DataValidation).Count(), Is.EqualTo(100));
+                Assert.That(range.RowsUsed(XLCellsUsedOptions.All).Count(), Is.EqualTo(100));
+            });
         }
 
         [Test]
@@ -273,8 +289,11 @@ namespace ClosedXML.Tests.Excel
 
             var range = ws.Column(1).AsRange();
 
-            Assert.AreEqual(100, range.RowsUsed(XLCellsUsedOptions.ConditionalFormats).Count());
-            Assert.AreEqual(100, range.RowsUsed(XLCellsUsedOptions.All).Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(range.RowsUsed(XLCellsUsedOptions.ConditionalFormats).Count(), Is.EqualTo(100));
+                Assert.That(range.RowsUsed(XLCellsUsedOptions.All).Count(), Is.EqualTo(100));
+            });
         }
 
         [Test]
@@ -292,7 +311,7 @@ namespace ClosedXML.Tests.Excel
 
             var row = new XLRow(ws, -1);
 
-            Assert.IsFalse(row.RangeAddress.IsValid);
+            Assert.That(row.RangeAddress.IsValid, Is.False);
         }
 
         [Test]
@@ -312,8 +331,11 @@ namespace ClosedXML.Tests.Excel
 
             rows.Height = 30;
 
-            Assert.AreEqual(30, ws.Row(11).Height, XLHelper.Epsilon);
-            Assert.AreEqual(30, ws.RowHeight, XLHelper.Epsilon);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(11).Height, Is.EqualTo(30).Within(XLHelper.Epsilon));
+                Assert.That(ws.RowHeight, Is.EqualTo(30).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -325,8 +347,11 @@ namespace ClosedXML.Tests.Excel
 
             rows.Height = 30;
 
-            Assert.AreEqual(30, ws.Row(11).Height, XLHelper.Epsilon);
-            Assert.AreEqual(defaultRowHeight, ws.RowHeight, XLHelper.Epsilon);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(11).Height, Is.EqualTo(30).Within(XLHelper.Epsilon));
+                Assert.That(ws.RowHeight, Is.EqualTo(defaultRowHeight).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -339,9 +364,12 @@ namespace ClosedXML.Tests.Excel
 
             rows.Height = 30;
 
-            Assert.AreEqual(30, ws.Row(3).Height, XLHelper.Epsilon);
-            Assert.AreEqual(defaultRowHeight, ws.Row(11).Height, XLHelper.Epsilon);
-            Assert.AreEqual(defaultRowHeight, ws.RowHeight, XLHelper.Epsilon);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Row(3).Height, Is.EqualTo(30).Within(XLHelper.Epsilon));
+                Assert.That(ws.Row(11).Height, Is.EqualTo(defaultRowHeight).Within(XLHelper.Epsilon));
+                Assert.That(ws.RowHeight, Is.EqualTo(defaultRowHeight).Within(XLHelper.Epsilon));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML.Tests/Excel/Saving/SavingTests.cs
@@ -223,7 +223,7 @@ namespace ClosedXML.Tests.Excel.Saving
 
             // Assert
             Assert.That(File.Exists(existing.Path), Is.True);
-            Assert.Greater(new FileInfo(existing.Path).Length, 0);
+            Assert.That(new FileInfo(existing.Path).Length, Is.GreaterThan(0));
         }
 
         [Test]
@@ -540,7 +540,7 @@ namespace ClosedXML.Tests.Excel.Saving
                 var cf = sheet.ConditionalFormats
                     .OrderBy(x => x.Range.RangeAddress.FirstAddress.ColumnNumber)
                     .ToArray();
-                Assert.That(cf.Length, Is.EqualTo(2));
+                Assert.That(cf, Has.Length.EqualTo(2));
                 Assert.Multiple(() =>
                 {
                     Assert.That(cf[0].ConditionalFormatType, Is.EqualTo(XLConditionalFormatType.ColorScale));
@@ -698,14 +698,14 @@ namespace ClosedXML.Tests.Excel.Saving
 
             ws.Row(1).InsertRowsAbove(1);
             var dv = ws.DataValidations.ToArray();
-            Assert.That(dv.Length, Is.EqualTo(1));
+            Assert.That(dv, Has.Length.EqualTo(1));
             Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B5:B5"));
 
             Assert.DoesNotThrow(() => wb.SaveAs(ms));
 
             ws.Column(1).InsertColumnsBefore(1);
             dv = ws.DataValidations.ToArray();
-            Assert.That(dv.Length, Is.EqualTo(1));
+            Assert.That(dv, Has.Length.EqualTo(1));
             Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("C5:C5"));
 
             Assert.DoesNotThrow(() => wb.SaveAs(ms));

--- a/ClosedXML.Tests/Excel/Saving/SavingTests.cs
+++ b/ClosedXML.Tests/Excel/Saving/SavingTests.cs
@@ -32,54 +32,48 @@ namespace ClosedXML.Tests.Excel.Saving
         [Test]
         public void CanSaveEmptyFile()
         {
-            using (var ms = new MemoryStream())
-            using (var wb = new XLWorkbook())
-            {
-                wb.AddWorksheet("Sheet1");
-                wb.SaveAs(ms);
-            }
+            using var ms = new MemoryStream();
+            using var wb = new XLWorkbook();
+            wb.AddWorksheet("Sheet1");
+            wb.SaveAs(ms);
         }
 
         [Test]
         public void CanSuccessfullySaveFileMultipleTimes()
         {
-            using (var memoryStream = new MemoryStream())
-            using (var wb = new XLWorkbook())
+            using var memoryStream = new MemoryStream();
+            using var wb = new XLWorkbook();
+            var sheet = wb.Worksheets.Add("TestSheet");
+
+            // Comments might cause duplicate VmlDrawing Id's - ensure it's tested:
+            sheet.Cell(1, 1).GetComment().AddText("abc");
+
+            wb.SaveAs(memoryStream, validate: true);
+
+            for (int i = 1; i <= 3; i++)
             {
-                var sheet = wb.Worksheets.Add("TestSheet");
-
-                // Comments might cause duplicate VmlDrawing Id's - ensure it's tested:
-                sheet.Cell(1, 1).GetComment().AddText("abc");
-
+                sheet.Cell(i, 1).Value = "test" + i;
                 wb.SaveAs(memoryStream, validate: true);
-
-                for (int i = 1; i <= 3; i++)
-                {
-                    sheet.Cell(i, 1).Value = "test" + i;
-                    wb.SaveAs(memoryStream, validate: true);
-                }
             }
         }
 
         [Test]
         public void CanEscape_xHHHH_Correctly()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    ws.FirstCell().Value = "Reserve_TT_A_BLOCAGE_CAG_x6904_2";
-                    wb.SaveAs(ms);
-                }
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.FirstCell().Value = "Reserve_TT_A_BLOCAGE_CAG_x6904_2";
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    Assert.AreEqual("Reserve_TT_A_BLOCAGE_CAG_x6904_2", ws.FirstCell().Value);
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                Assert.That(ws.FirstCell().Value, Is.EqualTo("Reserve_TT_A_BLOCAGE_CAG_x6904_2"));
             }
         }
 
@@ -88,25 +82,23 @@ namespace ClosedXML.Tests.Excel.Saving
         {
             // https://github.com/ClosedXML/ClosedXML/issues/435
 
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (XLWorkbook book1 = new XLWorkbook())
             {
-                using (XLWorkbook book1 = new XLWorkbook())
-                {
-                    book1.AddWorksheet("sheet1");
-                    book1.AddWorksheet("sheet2");
+                book1.AddWorksheet("sheet1");
+                book1.AddWorksheet("sheet2");
 
-                    book1.SaveAs(ms);
-                }
-                ms.Position = 0;
+                book1.SaveAs(ms);
+            }
+            ms.Position = 0;
 
-                using (XLWorkbook book2 = new XLWorkbook(ms))
-                {
-                    var ws = book2.Worksheet(1);
-                    Assert.AreEqual("sheet1", ws.Name);
-                    ws.Delete();
-                    book2.Save();
-                    book2.Save();
-                }
+            using (XLWorkbook book2 = new XLWorkbook(ms))
+            {
+                var ws = book2.Worksheet(1);
+                Assert.That(ws.Name, Is.EqualTo("sheet1"));
+                ws.Delete();
+                book2.Save();
+                book2.Save();
             }
         }
 
@@ -119,156 +111,146 @@ namespace ClosedXML.Tests.Excel.Saving
             {
                 Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(culture);
 
-                using (var wb = new XLWorkbook())
-                {
-                    var memoryStream = new MemoryStream();
-                    var ws = wb.Worksheets.Add("Sheet1");
+                using var wb = new XLWorkbook();
+                var memoryStream = new MemoryStream();
+                var ws = wb.Worksheets.Add("Sheet1");
 
-                    wb.SaveAs(memoryStream, true);
-                }
+                wb.SaveAs(memoryStream, true);
             }
         }
 
         [Test]
         public void NotSaveCachedValueWhenFlagIsFalse()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (XLWorkbook book1 = new XLWorkbook())
             {
-                using (XLWorkbook book1 = new XLWorkbook())
-                {
-                    var sheet = book1.AddWorksheet("sheet1");
-                    sheet.Cell("A1").Value = 123;
-                    sheet.Cell("A2").FormulaA1 = "A1*10";
-                    book1.RecalculateAllFormulas();
-                    var options = new SaveOptions { EvaluateFormulasBeforeSaving = false };
+                var sheet = book1.AddWorksheet("sheet1");
+                sheet.Cell("A1").Value = 123;
+                sheet.Cell("A2").FormulaA1 = "A1*10";
+                book1.RecalculateAllFormulas();
+                var options = new SaveOptions { EvaluateFormulasBeforeSaving = false };
 
-                    book1.SaveAs(ms, options);
-                }
-                ms.Position = 0;
+                book1.SaveAs(ms, options);
+            }
+            ms.Position = 0;
 
-                using (XLWorkbook book2 = new XLWorkbook(ms))
-                {
-                    var ws = book2.Worksheet(1);
+            using (XLWorkbook book2 = new XLWorkbook(ms))
+            {
+                var ws = book2.Worksheet(1);
 
-                    Assert.AreEqual(Blank.Value, ws.Cell("A2").CachedValue);
-                }
+                Assert.That(ws.Cell("A2").CachedValue, Is.EqualTo(Blank.Value));
             }
         }
 
         [Test]
         public void SaveCachedValueWhenFlagIsTrue()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (XLWorkbook book1 = new XLWorkbook())
             {
-                using (XLWorkbook book1 = new XLWorkbook())
+                var sheet = book1.AddWorksheet("sheet1");
+                sheet.Cell("A1").Value = 123;
+                sheet.Cell("A2").FormulaA1 = "A1*10";
+                sheet.Cell("A3").FormulaA1 = "TEXT(A2, \"# ###\")";
+                var options = new SaveOptions { EvaluateFormulasBeforeSaving = true };
+
+                book1.SaveAs(ms, options);
+            }
+            ms.Position = 0;
+
+            using (XLWorkbook book2 = new XLWorkbook(ms))
+            {
+                var ws = book2.Worksheet(1);
+
+                Assert.Multiple(() =>
                 {
-                    var sheet = book1.AddWorksheet("sheet1");
-                    sheet.Cell("A1").Value = 123;
-                    sheet.Cell("A2").FormulaA1 = "A1*10";
-                    sheet.Cell("A3").FormulaA1 = "TEXT(A2, \"# ###\")";
-                    var options = new SaveOptions { EvaluateFormulasBeforeSaving = true };
+                    Assert.That(ws.Cell("A2").CachedValue, Is.EqualTo(1230));
 
-                    book1.SaveAs(ms, options);
-                }
-                ms.Position = 0;
-
-                using (XLWorkbook book2 = new XLWorkbook(ms))
-                {
-                    var ws = book2.Worksheet(1);
-
-                    Assert.AreEqual(1230, ws.Cell("A2").CachedValue);
-
-                    Assert.AreEqual("1 230", ws.Cell("A3").CachedValue);
-                }
+                    Assert.That(ws.Cell("A3").CachedValue, Is.EqualTo("1 230"));
+                });
             }
         }
 
         [Test]
         public void CanSaveAsCopyReadOnlyFile()
         {
-            using (var original = new TemporaryFile())
+            using var original = new TemporaryFile();
+            try
             {
-                try
+                using var copy = new TemporaryFile();
+                // Arrange
+                using (var wb = new XLWorkbook())
                 {
-                    using (var copy = new TemporaryFile())
-                    {
-                        // Arrange
-                        using (var wb = new XLWorkbook())
-                        {
-                            var sheet = wb.Worksheets.Add("TestSheet");
-                            wb.SaveAs(original.Path);
-                        }
-                        File.SetAttributes(original.Path, FileAttributes.ReadOnly);
-
-                        // Act
-                        using (var wb = new XLWorkbook(original.Path))
-                        {
-                            wb.SaveAs(copy.Path);
-                        }
-
-                        // Assert
-                        Assert.IsTrue(File.Exists(copy.Path));
-                        Assert.IsFalse(File.GetAttributes(copy.Path).HasFlag(FileAttributes.ReadOnly));
-                    }
+                    var sheet = wb.Worksheets.Add("TestSheet");
+                    wb.SaveAs(original.Path);
                 }
-                finally
+                File.SetAttributes(original.Path, FileAttributes.ReadOnly);
+
+                // Act
+                using (var wb = new XLWorkbook(original.Path))
                 {
-                    // Tear down
-                    File.SetAttributes(original.Path, FileAttributes.Normal);
+                    wb.SaveAs(copy.Path);
                 }
+
+                Assert.Multiple(() =>
+                {
+                    // Assert
+                    Assert.That(File.Exists(copy.Path), Is.True);
+                    Assert.That(File.GetAttributes(copy.Path).HasFlag(FileAttributes.ReadOnly), Is.False);
+                });
+            }
+            finally
+            {
+                // Tear down
+                File.SetAttributes(original.Path, FileAttributes.Normal);
             }
         }
 
         [Test]
         public void CanSaveAsOverwriteExistingFile()
         {
-            using (var existing = new TemporaryFile())
+            using var existing = new TemporaryFile();
+            // Arrange
+            File.WriteAllText(existing.Path, "");
+
+            // Act
+            using (var wb = new XLWorkbook())
             {
-                // Arrange
-                File.WriteAllText(existing.Path, "");
-
-                // Act
-                using (var wb = new XLWorkbook())
-                {
-                    var sheet = wb.Worksheets.Add("TestSheet");
-                    wb.SaveAs(existing.Path);
-                }
-
-                // Assert
-                Assert.IsTrue(File.Exists(existing.Path));
-                Assert.Greater(new FileInfo(existing.Path).Length, 0);
+                var sheet = wb.Worksheets.Add("TestSheet");
+                wb.SaveAs(existing.Path);
             }
+
+            // Assert
+            Assert.That(File.Exists(existing.Path), Is.True);
+            Assert.Greater(new FileInfo(existing.Path).Length, 0);
         }
 
         [Test]
         public void CannotSaveAsOverwriteExistingReadOnlyFile()
         {
-            using (var existing = new TemporaryFile())
+            using var existing = new TemporaryFile();
+            try
             {
-                try
-                {
-                    // Arrange
-                    File.WriteAllText(existing.Path, "");
-                    File.SetAttributes(existing.Path, FileAttributes.ReadOnly);
+                // Arrange
+                File.WriteAllText(existing.Path, "");
+                File.SetAttributes(existing.Path, FileAttributes.ReadOnly);
 
-                    // Act
-                    TestDelegate saveAs = () =>
-                    {
-                        using (var wb = new XLWorkbook())
-                        {
-                            var sheet = wb.Worksheets.Add("TestSheet");
-                            wb.SaveAs(existing.Path);
-                        }
-                    };
-
-                    // Assert
-                    Assert.Throws(typeof(UnauthorizedAccessException), saveAs);
-                }
-                finally
+                // Act
+                TestDelegate saveAs = () =>
                 {
-                    // Tear down
-                    File.SetAttributes(existing.Path, FileAttributes.Normal);
-                }
+                    using var wb = new XLWorkbook();
+                    var sheet = wb.Worksheets.Add("TestSheet");
+                    wb.SaveAs(existing.Path);
+                };
+
+                // Assert
+                Assert.Throws(typeof(UnauthorizedAccessException), saveAs);
+            }
+            finally
+            {
+                // Tear down
+                File.SetAttributes(existing.Path, FileAttributes.Normal);
             }
         }
 
@@ -277,61 +259,58 @@ namespace ClosedXML.Tests.Excel.Saving
         {
             // https://github.com/ClosedXML/ClosedXML/issues/666
 
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb1 = new XLWorkbook())
             {
-                using (var wb1 = new XLWorkbook())
-                {
-                    var ws = wb1.Worksheets.Add("Page Breaks");
-                    ws.PageSetup.PrintAreas.Add("A1:D5");
-                    ws.PageSetup.AddHorizontalPageBreak(2);
-                    ws.PageSetup.AddVerticalPageBreak(2);
-                    wb1.SaveAs(ms);
-                    wb1.Save();
-                }
-                using (var wb2 = new XLWorkbook(ms))
-                {
-                    var ws = wb2.Worksheets.First();
+                var ws = wb1.Worksheets.Add("Page Breaks");
+                ws.PageSetup.PrintAreas.Add("A1:D5");
+                ws.PageSetup.AddHorizontalPageBreak(2);
+                ws.PageSetup.AddVerticalPageBreak(2);
+                wb1.SaveAs(ms);
+                wb1.Save();
+            }
+            using (var wb2 = new XLWorkbook(ms))
+            {
+                var ws = wb2.Worksheets.First();
 
-                    Assert.AreEqual(1, ws.PageSetup.ColumnBreaks.Count);
-                    Assert.AreEqual(1, ws.PageSetup.RowBreaks.Count);
-                }
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws.PageSetup.ColumnBreaks, Has.Count.EqualTo(1));
+                    Assert.That(ws.PageSetup.RowBreaks, Has.Count.EqualTo(1));
+                });
             }
         }
 
         [Test]
         public void CanSaveFileWithPictureAndComment()
         {
-            using (var ms = new MemoryStream())
-            using (var wb = new XLWorkbook())
-            using (var imageStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("D4").Value = "Hello world.";
+            using var ms = new MemoryStream();
+            using var wb = new XLWorkbook();
+            using var imageStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable)).GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg");
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("D4").Value = "Hello world.";
 
-                ws.AddPicture(imageStream, "MyPicture")
-                    .WithPlacement(XLPicturePlacement.FreeFloating)
-                    .MoveTo(50, 50)
-                    .WithSize(200, 200);
+            ws.AddPicture(imageStream, "MyPicture")
+                .WithPlacement(XLPicturePlacement.FreeFloating)
+                .MoveTo(50, 50)
+                .WithSize(200, 200);
 
-                ws.Cell("D4").GetComment().SetVisible().AddText("This is a comment");
+            ws.Cell("D4").GetComment().SetVisible().AddText("This is a comment");
 
-                wb.SaveAs(ms);
-            }
+            wb.SaveAs(ms);
         }
 
         [Test]
         public void PreserveChartsWhenSaving()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Charts\PreserveCharts\inputfile.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Charts\PreserveCharts\inputfile.xlsx"));
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
-                {
-                    var wb = new XLWorkbook(stream);
-                    wb.SaveAs(ms);
-                    return wb;
-                }, @"Other\Charts\PreserveCharts\outputfile.xlsx");
-            }
+                var wb = new XLWorkbook(stream);
+                wb.SaveAs(ms);
+                return wb;
+            }, @"Other\Charts\PreserveCharts\outputfile.xlsx");
         }
 
         [Test]
@@ -359,18 +338,16 @@ namespace ClosedXML.Tests.Excel.Saving
         [TestCase("xltm", SpreadsheetDocumentType.MacroEnabledTemplate)]
         public void SavesAsProperSpreadsheetDocumentType(string extension, SpreadsheetDocumentType expectedType)
         {
-            using (var tf = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), extension)))
+            using var tf = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), extension));
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    wb.Worksheets.Add("Sheet1");
-                    wb.SaveAs(tf.Path);
-                }
+                wb.Worksheets.Add("Sheet1");
+                wb.SaveAs(tf.Path);
+            }
 
-                using (var package = SpreadsheetDocument.Open(tf.Path, false))
-                {
-                    Assert.AreEqual(expectedType, package.DocumentType);
-                }
+            using (var package = SpreadsheetDocument.Open(tf.Path, false))
+            {
+                Assert.That(package.DocumentType, Is.EqualTo(expectedType));
             }
         }
 
@@ -378,49 +355,43 @@ namespace ClosedXML.Tests.Excel.Saving
         public void CanSaveTemplateAsWorkbook()
         {
             // See #1375
-            using (var template = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "xltx")))
-            using (var workbook = new TemporaryFile())
+            using var template = new TemporaryFile(Path.ChangeExtension(Path.GetTempFileName(), "xltx"));
+            using var workbook = new TemporaryFile();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    wb.AddWorksheet();
-                    wb.SaveAs(template.Path);
-                }
-                using (var wb = new XLWorkbook(template.Path))
-                {
-                    wb.SaveAs(workbook.Path);
-                }
-                using (var package = SpreadsheetDocument.Open(workbook.Path, false))
-                {
-                    Assert.AreEqual(SpreadsheetDocumentType.Workbook, package.DocumentType);
-                }
+                wb.AddWorksheet();
+                wb.SaveAs(template.Path);
+            }
+            using (var wb = new XLWorkbook(template.Path))
+            {
+                wb.SaveAs(workbook.Path);
+            }
+            using (var package = SpreadsheetDocument.Open(workbook.Path, false))
+            {
+                Assert.That(package.DocumentType, Is.EqualTo(SpreadsheetDocumentType.Workbook));
             }
         }
 
         [Test]
         public void SaveAsWithNoExtensionFails()
         {
-            using (var tf = new TemporaryFile("FileWithNoExtension"))
-            using (var wb = new XLWorkbook())
-            {
-                wb.Worksheets.Add("Sheet1");
-                TestDelegate action = () => wb.SaveAs(tf.Path);
+            using var tf = new TemporaryFile("FileWithNoExtension");
+            using var wb = new XLWorkbook();
+            wb.Worksheets.Add("Sheet1");
+            TestDelegate action = () => wb.SaveAs(tf.Path);
 
-                Assert.Throws<ArgumentException>(action);
-            }
+            Assert.Throws<ArgumentException>(action);
         }
 
         [Test]
         public void SaveAsWithUnsupportedExtensionFails()
         {
-            using (var tf = new TemporaryFile("FileWithBadExtension.bad"))
-            using (var wb = new XLWorkbook())
-            {
-                wb.Worksheets.Add("Sheet1");
-                TestDelegate action = () => wb.SaveAs(tf.Path);
+            using var tf = new TemporaryFile("FileWithBadExtension.bad");
+            using var wb = new XLWorkbook();
+            wb.Worksheets.Add("Sheet1");
+            TestDelegate action = () => wb.SaveAs(tf.Path);
 
-                Assert.Throws<ArgumentException>(action);
-            }
+            Assert.Throws<ArgumentException>(action);
         }
 
         [Test]
@@ -428,66 +399,71 @@ namespace ClosedXML.Tests.Excel.Saving
         {
             var formulaValue = "=IF(TRUE, 1, 0)";
             var quotedFormulaValue = '\'' + formulaValue;
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet("Sheet1");
+                var cell = ws.FirstCell();
+                cell.SetValue(quotedFormulaValue);
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    var cell = ws.FirstCell();
-                    cell.SetValue(quotedFormulaValue);
-                    Assert.IsFalse(cell.HasFormula);
-                    Assert.AreEqual(formulaValue, cell.Value);
-                    Assert.AreEqual(XLDataType.Text, cell.DataType);
-                    Assert.True(cell.Style.IncludeQuotePrefix);
+                    Assert.That(cell.HasFormula, Is.False);
+                    Assert.That(cell.Value, Is.EqualTo(formulaValue));
+                    Assert.That(cell.DataType, Is.EqualTo(XLDataType.Text));
+                });
+                Assert.That(cell.Style.IncludeQuotePrefix, Is.True);
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                var cell = ws.FirstCell();
+                Assert.That(cell.HasFormula, Is.False);
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var cell = ws.FirstCell();
-                    Assert.IsFalse(cell.HasFormula);
-                    Assert.IsFalse(cell.HasFormula);
-                    Assert.AreEqual(formulaValue, cell.Value);
-                    Assert.AreEqual(XLDataType.Text, cell.DataType);
-                    Assert.True(cell.Style.IncludeQuotePrefix);
-                }
+                    Assert.That(cell.HasFormula, Is.False);
+                    Assert.That(cell.Value, Is.EqualTo(formulaValue));
+                    Assert.That(cell.DataType, Is.EqualTo(XLDataType.Text));
+                });
+                Assert.That(cell.Style.IncludeQuotePrefix, Is.True);
             }
         }
 
         [Test]
         public void PreserveHeightOfEmptyRowsOnSaving()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.RowHeight = 50;
+                ws.Row(2).Height = 0;
+                ws.Row(3).Height = 20;
+                ws.Row(4).Height = 100;
+
+                ws.CopyTo("Sheet2");
+                wb.SaveAs(ms);
+            }
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                foreach (var sheetName in new[] { "Sheet1", "Sheet2" })
                 {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    ws.RowHeight = 50;
-                    ws.Row(2).Height = 0;
-                    ws.Row(3).Height = 20;
-                    ws.Row(4).Height = 100;
+                    var ws = wb.Worksheet(sheetName);
 
-                    ws.CopyTo("Sheet2");
-                    wb.SaveAs(ms);
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    foreach (var sheetName in new[] { "Sheet1", "Sheet2" })
+                    Assert.Multiple(() =>
                     {
-                        var ws = wb.Worksheet(sheetName);
-
-                        Assert.AreEqual(50, ws.Row(1).Height);
-                        Assert.AreEqual(0, ws.Row(2).Height);
-                        Assert.AreEqual(20, ws.Row(3).Height);
-                        Assert.AreEqual(100, ws.Row(4).Height);
-                    }
+                        Assert.That(ws.Row(1).Height, Is.EqualTo(50));
+                        Assert.That(ws.Row(2).Height, Is.EqualTo(0));
+                        Assert.That(ws.Row(3).Height, Is.EqualTo(20));
+                        Assert.That(ws.Row(4).Height, Is.EqualTo(100));
+                    });
                 }
             }
         }
@@ -495,32 +471,33 @@ namespace ClosedXML.Tests.Excel.Saving
         [Test]
         public void PreserveWidthOfEmptyColumnsOnSaving()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.Column(2).Width = 0;
+                ws.Column(3).Width = 20;
+                ws.Column(4).Width = 100;
+
+                ws.CopyTo("Sheet2");
+                wb.SaveAs(ms);
+            }
+
+            ms.Seek(0, SeekOrigin.Begin);
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                foreach (var sheetName in new[] { "Sheet1", "Sheet2" })
                 {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    ws.Column(2).Width = 0;
-                    ws.Column(3).Width = 20;
-                    ws.Column(4).Width = 100;
+                    var ws = wb.Worksheet(sheetName);
 
-                    ws.CopyTo("Sheet2");
-                    wb.SaveAs(ms);
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    foreach (var sheetName in new[] { "Sheet1", "Sheet2" })
+                    Assert.Multiple(() =>
                     {
-                        var ws = wb.Worksheet(sheetName);
-
-                        Assert.AreEqual(ws.ColumnWidth, ws.Column(1).Width);
-                        Assert.AreEqual(0, ws.Column(2).Width);
-                        Assert.AreEqual(20, ws.Column(3).Width);
-                        Assert.AreEqual(100, ws.Column(4).Width);
-                    }
+                        Assert.That(ws.Column(1).Width, Is.EqualTo(ws.ColumnWidth));
+                        Assert.That(ws.Column(2).Width, Is.EqualTo(0));
+                        Assert.That(ws.Column(3).Width, Is.EqualTo(20));
+                        Assert.That(ws.Column(4).Width, Is.EqualTo(100));
+                    });
                 }
             }
         }
@@ -528,112 +505,105 @@ namespace ClosedXML.Tests.Excel.Saving
         [Test]
         public void PreserveAlignmentOnSaving()
         {
-            using (var input = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\HorizontalAlignment.xlsx")))
-            using (var output = new MemoryStream())
+            using var input = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\HorizontalAlignment.xlsx"));
+            using var output = new MemoryStream();
+            using (var wb = new XLWorkbook(input))
             {
-                using (var wb = new XLWorkbook(input))
-                {
-                    wb.SaveAs(output);
-                }
+                wb.SaveAs(output);
+            }
 
-                using (var wb = new XLWorkbook(output))
-                {
-                    Assert.AreEqual(XLAlignmentHorizontalValues.Center, wb.Worksheets.First().Cell("B1").Style.Alignment.Horizontal);
-                }
+            using (var wb = new XLWorkbook(output))
+            {
+                Assert.That(wb.Worksheets.First().Cell("B1").Style.Alignment.Horizontal, Is.EqualTo(XLAlignmentHorizontalValues.Center));
             }
         }
 
         [Test]
         public void PreserveMultipleColorScalesOnSaving()
         {
-            using (var output = new MemoryStream())
+            using var output = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var sheet = wb.Worksheets.Add("test");
+                sheet.Column(1).AddConditionalFormat().ColorScale().LowestValue(XLColor.Red)
+                    .HighestValue(XLColor.Green);
+
+                sheet.Column(2).AddConditionalFormat().ColorScale().LowestValue(XLColor.Alizarin)
+                    .HighestValue(XLColor.Blue);
+
+                wb.SaveAs(output);
+            }
+
+            using (var wb = new XLWorkbook(output))
+            {
+                var sheet = wb.Worksheets.First();
+                var cf = sheet.ConditionalFormats
+                    .OrderBy(x => x.Range.RangeAddress.FirstAddress.ColumnNumber)
+                    .ToArray();
+                Assert.That(cf.Length, Is.EqualTo(2));
+                Assert.Multiple(() =>
                 {
-                    var sheet = wb.Worksheets.Add("test");
-                    sheet.Column(1).AddConditionalFormat().ColorScale().LowestValue(XLColor.Red)
-                        .HighestValue(XLColor.Green);
-
-                    sheet.Column(2).AddConditionalFormat().ColorScale().LowestValue(XLColor.Alizarin)
-                        .HighestValue(XLColor.Blue);
-
-                    wb.SaveAs(output);
-                }
-
-                using (var wb = new XLWorkbook(output))
-                {
-                    var sheet = wb.Worksheets.First();
-                    var cf = sheet.ConditionalFormats
-                        .OrderBy(x => x.Range.RangeAddress.FirstAddress.ColumnNumber)
-                        .ToArray();
-                    Assert.AreEqual(2, cf.Length);
-                    Assert.AreEqual(XLConditionalFormatType.ColorScale, cf[0].ConditionalFormatType);
-                    Assert.AreEqual(XLColor.Red, cf[0].Colors[1]);
-                    Assert.AreEqual(XLCFContentType.Minimum, cf[0].ContentTypes[1]);
-                    Assert.AreEqual(XLColor.Green, cf[0].Colors[2]);
-                    Assert.AreEqual(XLCFContentType.Maximum, cf[0].ContentTypes[2]);
-                    Assert.AreEqual(XLConditionalFormatType.ColorScale, cf[1].ConditionalFormatType);
-                    Assert.AreEqual(XLColor.Alizarin, cf[1].Colors[1]);
-                    Assert.AreEqual(XLCFContentType.Minimum, cf[1].ContentTypes[1]);
-                    Assert.AreEqual(XLColor.Blue, cf[1].Colors[2]);
-                    Assert.AreEqual(XLCFContentType.Maximum, cf[1].ContentTypes[2]);
-                }
+                    Assert.That(cf[0].ConditionalFormatType, Is.EqualTo(XLConditionalFormatType.ColorScale));
+                    Assert.That(cf[0].Colors[1], Is.EqualTo(XLColor.Red));
+                    Assert.That(cf[0].ContentTypes[1], Is.EqualTo(XLCFContentType.Minimum));
+                    Assert.That(cf[0].Colors[2], Is.EqualTo(XLColor.Green));
+                    Assert.That(cf[0].ContentTypes[2], Is.EqualTo(XLCFContentType.Maximum));
+                    Assert.That(cf[1].ConditionalFormatType, Is.EqualTo(XLConditionalFormatType.ColorScale));
+                    Assert.That(cf[1].Colors[1], Is.EqualTo(XLColor.Alizarin));
+                    Assert.That(cf[1].ContentTypes[1], Is.EqualTo(XLCFContentType.Minimum));
+                    Assert.That(cf[1].Colors[2], Is.EqualTo(XLColor.Blue));
+                    Assert.That(cf[1].ContentTypes[2], Is.EqualTo(XLCFContentType.Maximum));
+                });
             }
         }
 
         [Test]
         public void RemoveExistingInlineStringsIfRequired()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlineStrings\inputfile.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\InlineStrings\inputfile.xlsx"));
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
+                var wb = new XLWorkbook(stream);
+                var ws = wb.Worksheet(1);
+
+                var numericCells = ws.CellsUsed(c => double.TryParse(c.GetString(), out double _));
+                var textCells = ws.CellsUsed(c => !double.TryParse(c.GetString(), out double _));
+
+                foreach (var cell in numericCells)
                 {
-                    var wb = new XLWorkbook(stream);
-                    var ws = wb.Worksheet(1);
+                    cell.Clear(XLClearOptions.AllFormats);
+                    Assert.That(cell.Value.TryConvert(out double val, CultureInfo.CurrentCulture), Is.True);
+                    cell.Value = val;
+                }
 
-                    var numericCells = ws.CellsUsed(c => double.TryParse(c.GetString(), out double _));
-                    var textCells = ws.CellsUsed(c => !double.TryParse(c.GetString(), out double _));
+                foreach (var cell in textCells)
+                {
+                    cell.ShareString = true;
+                }
 
-                    foreach (var cell in numericCells)
-                    {
-                        cell.Clear(XLClearOptions.AllFormats);
-                        Assert.True(cell.Value.TryConvert(out double val, CultureInfo.CurrentCulture));
-                        cell.Value = val;
-                    }
+                wb.SaveAs(ms);
 
-                    foreach (var cell in textCells)
-                    {
-                        cell.ShareString = true;
-                    }
-
-                    wb.SaveAs(ms);
-
-                    return wb;
-                }, @"Other\InlineStrings\outputfile.xlsx");
-            }
+                return wb;
+            }, @"Other\InlineStrings\outputfile.xlsx");
         }
 
         [Test]
         public void CanSaveFileWithEmptyFill()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyFill.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            using (var ms = new MemoryStream())
-            {
-                Assert.DoesNotThrow(() => wb.SaveAs(ms, false));
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\EmptyFill.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            using var ms = new MemoryStream();
+            Assert.DoesNotThrow(() => wb.SaveAs(ms, false));
         }
 
         [Test]
         public void CanSaveSingleRowAutoFilter()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SingleRowAutoFilter.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            using (var ms = new MemoryStream())
-            {
-                Assert.DoesNotThrow(() => wb.SaveAs(ms, false));
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\SingleRowAutoFilter.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            using var ms = new MemoryStream();
+            Assert.DoesNotThrow(() => wb.SaveAs(ms, false));
         }
 
         [Test]
@@ -666,12 +636,10 @@ namespace ClosedXML.Tests.Excel.Saving
         public void CanSaveFileWithVml_NoComments()
         {
             //See #1285
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FileWithButton.xlsm")))
-            using (var wb = new XLWorkbook(stream))
-            using (var ms = new MemoryStream())
-            {
-                Assert.DoesNotThrow(() => wb.SaveAs(ms));
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FileWithButton.xlsm"));
+            using var wb = new XLWorkbook(stream);
+            using var ms = new MemoryStream();
+            Assert.DoesNotThrow(() => wb.SaveAs(ms));
         }
 
         [Test]
@@ -689,7 +657,7 @@ namespace ClosedXML.Tests.Excel.Saving
 
             using (var wb = SpreadsheetDocument.Open(ms, false))
             {
-                Assert.IsTrue(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy);
+                Assert.That((bool)wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy, Is.True);
             }
         }
 
@@ -708,43 +676,39 @@ namespace ClosedXML.Tests.Excel.Saving
 
             using (var wb = SpreadsheetDocument.Open(ms, false))
             {
-                Assert.IsNull(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy);
+                Assert.That(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy, Is.Null);
             }
         }
 
         [Test]
         public void WorkbookFilterPrivacyIsReadCorrectly()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FilterPrivacyEnabledWorkbook.xlsx")))
-            using (var wb = SpreadsheetDocument.Open(stream, false))
-            {
-                Assert.IsTrue(wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy);
-            }
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"TryToLoad\FilterPrivacyEnabledWorkbook.xlsx"));
+            using var wb = SpreadsheetDocument.Open(stream, false);
+            Assert.That((bool)wb.WorkbookPart.Workbook.WorkbookProperties.FilterPrivacy, Is.True);
         }
 
         [Test]
         public void CanSaveAsWithDataValidationAfterInsertFirstRowsAboveAndInsertFirstColumnsBefore()
         {
-            using (var wb = new XLWorkbook())
-            using (var ms = new MemoryStream())
-            {
-                var ws = wb.AddWorksheet("WithDataValidation");
-                ws.Range("B4:B4").CreateDataValidation().WholeNumber.Between(0, 1);
+            using var wb = new XLWorkbook();
+            using var ms = new MemoryStream();
+            var ws = wb.AddWorksheet("WithDataValidation");
+            ws.Range("B4:B4").CreateDataValidation().WholeNumber.Between(0, 1);
 
-                ws.Row(1).InsertRowsAbove(1);
-                var dv = ws.DataValidations.ToArray();
-                Assert.AreEqual(1, dv.Length);
-                Assert.AreEqual("B5:B5", dv[0].Ranges.Single().RangeAddress.ToString());
+            ws.Row(1).InsertRowsAbove(1);
+            var dv = ws.DataValidations.ToArray();
+            Assert.That(dv.Length, Is.EqualTo(1));
+            Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("B5:B5"));
 
-                Assert.DoesNotThrow(() => wb.SaveAs(ms));
+            Assert.DoesNotThrow(() => wb.SaveAs(ms));
 
-                ws.Column(1).InsertColumnsBefore(1);
-                dv = ws.DataValidations.ToArray();
-                Assert.AreEqual(1, dv.Length);
-                Assert.AreEqual("C5:C5", dv[0].Ranges.Single().RangeAddress.ToString());
+            ws.Column(1).InsertColumnsBefore(1);
+            dv = ws.DataValidations.ToArray();
+            Assert.That(dv.Length, Is.EqualTo(1));
+            Assert.That(dv[0].Ranges.Single().RangeAddress.ToString(), Is.EqualTo("C5:C5"));
 
-                Assert.DoesNotThrow(() => wb.SaveAs(ms));
-            }
+            Assert.DoesNotThrow(() => wb.SaveAs(ms));
         }
 
         // https://github.com/ClosedXML/ClosedXML/issues/1606
@@ -828,11 +792,17 @@ namespace ClosedXML.Tests.Excel.Saving
                 using var workbook2 = new XLWorkbook(filename2);
                 var ws = workbook2.Worksheet("UI Sheet");
                 var B2 = ws.Cell("B2");
-                Assert.AreEqual(XLAllowedValues.List, B2.GetDataValidation().AllowedValues);
-                Assert.AreEqual("$E$1:$E$4", B2.GetDataValidation().Value);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(B2.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                    Assert.That(B2.GetDataValidation().Value, Is.EqualTo("$E$1:$E$4"));
+                });
                 var A2 = ws.Cell("A2");
-                Assert.AreEqual(XLAllowedValues.List, A2.GetDataValidation().AllowedValues);
-                Assert.AreEqual("ValuesSheet!$A$1:$A$4", A2.GetDataValidation().Value);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(A2.GetDataValidation().AllowedValues, Is.EqualTo(XLAllowedValues.List));
+                    Assert.That(A2.GetDataValidation().Value, Is.EqualTo("ValuesSheet!$A$1:$A$4"));
+                });
             }
             finally
             {

--- a/ClosedXML.Tests/Excel/Sparklines/SparklineShiftTests.cs
+++ b/ClosedXML.Tests/Excel/Sparklines/SparklineShiftTests.cs
@@ -54,7 +54,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             insertAction(ws);
             Assert.That(sparklineGroup.SingleOrDefault()?.Location.Address.ToString(), Is.EqualTo(expectedAddress));
             if (expectedAddress is null)
-                Assert.IsEmpty(sparklineGroup);
+                Assert.That(sparklineGroup, Is.Empty);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Sparklines/SparklineShiftTests.cs
+++ b/ClosedXML.Tests/Excel/Sparklines/SparklineShiftTests.cs
@@ -52,7 +52,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.Cell("C2").Value = 2;
             var sparklineGroup = ws.SparklineGroups.Add(sparklineAddress, "B2:C2");
             insertAction(ws);
-            Assert.AreEqual(expectedAddress, sparklineGroup.SingleOrDefault()?.Location.Address.ToString());
+            Assert.That(sparklineGroup.SingleOrDefault()?.Location.Address.ToString(), Is.EqualTo(expectedAddress));
             if (expectedAddress is null)
                 Assert.IsEmpty(sparklineGroup);
         }

--- a/ClosedXML.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/ClosedXML.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -49,7 +49,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             var ws = new XLWorkbook().AddWorksheet("Sheet1");
             var group = new XLSparklineGroup(ws);
             var sparkline = new XLSparkline(group, ws.FirstCell(), null);
-            Assert.IsFalse(sparkline.IsValid);
+            Assert.That(sparkline.IsValid, Is.False);
         }
 
         [Test]
@@ -61,17 +61,19 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A2", "B2:E2");
             ws.SparklineGroups.Add(ws.Cell("A3"), ws.Range("B3:E3"));
 
-            Assert.AreEqual(3, ws.SparklineGroups.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(3));
 
-            Assert.AreEqual("A1", ws.SparklineGroups.ElementAt(0).Single().Location.Address.ToString());
-            Assert.AreEqual("A2", ws.SparklineGroups.ElementAt(1).Single().Location.Address.ToString());
-            Assert.AreEqual("A3", ws.SparklineGroups.ElementAt(2).Single().Location.Address.ToString());
+                Assert.That(ws.SparklineGroups.ElementAt(0).Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.ElementAt(1).Single().Location.Address.ToString(), Is.EqualTo("A2"));
+            Assert.That(ws.SparklineGroups.ElementAt(2).Single().Location.Address.ToString(), Is.EqualTo("A3"));
 
-            Assert.AreEqual("B1:E1", ws.SparklineGroups.ElementAt(0).Single().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B2:E2", ws.SparklineGroups.ElementAt(1).Single().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B3:E3", ws.SparklineGroups.ElementAt(2).Single().SourceData.RangeAddress.ToString());
-
-            Assert.IsTrue(ws.SparklineGroups.All(g => g.Worksheet == ws));
+            Assert.That(ws.SparklineGroups.ElementAt(0).Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:E1"));
+            Assert.That(ws.SparklineGroups.ElementAt(1).Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
+            Assert.That(ws.SparklineGroups.ElementAt(2).Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B3:E3"));
+            Assert.That(ws.SparklineGroups.All(g => g.Worksheet == ws), Is.True);
         }
 
         [Test]
@@ -81,15 +83,18 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.SparklineGroups.Add(ws.Range("A1:A3"), ws.Range("B1:E3"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
 
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().ElementAt(0).Location.Address.ToString());
-            Assert.AreEqual("A2", ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString());
-            Assert.AreEqual("A3", ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString());
+                Assert.That(ws.SparklineGroups.Single().ElementAt(0).Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString(), Is.EqualTo("A2"));
+            Assert.That(ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString(), Is.EqualTo("A3"));
 
-            Assert.AreEqual("B1:E1", ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B2:E2", ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B3:E3", ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString());
+            Assert.That(ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("B1:E1"));
+            Assert.That(ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
+            Assert.That(ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("B3:E3"));
         }
 
         [Test]
@@ -99,15 +104,18 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.SparklineGroups.Add(ws.Range("A1:C1"), ws.Range("A2:C4"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
 
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().ElementAt(0).Location.Address.ToString());
-            Assert.AreEqual("B1", ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString());
-            Assert.AreEqual("C1", ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString());
+                Assert.That(ws.SparklineGroups.Single().ElementAt(0).Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString(), Is.EqualTo("B1"));
+            Assert.That(ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString(), Is.EqualTo("C1"));
 
-            Assert.AreEqual("A2:A4", ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B2:B4", ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString());
-            Assert.AreEqual("C2:C4", ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString());
+            Assert.That(ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("A2:A4"));
+            Assert.That(ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B4"));
+            Assert.That(ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("C2:C4"));
         }
 
         [Test]
@@ -118,7 +126,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => ws.SparklineGroups.Add(ws.Range("A1:C2"), ws.Range("A3:C4"));
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("locationRange must have either a single row or a single column", message);
+            Assert.That(message, Is.EqualTo("locationRange must have either a single row or a single column"));
         }
 
         [Test]
@@ -129,7 +137,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => ws.SparklineGroups.Add(ws.Range("A1:C1"), ws.Range("A3:D4"));
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("locationRange and sourceDataRange must have the same width", message);
+            Assert.That(message, Is.EqualTo("locationRange and sourceDataRange must have the same width"));
         }
 
         [Test]
@@ -140,7 +148,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => ws.SparklineGroups.Add(ws.Range("A1:A3"), ws.Range("B1:B4"));
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("locationRange and sourceDataRange must have the same height", message);
+            Assert.That(message, Is.EqualTo("locationRange and sourceDataRange must have the same height"));
         }
 
         [Test]
@@ -151,7 +159,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => ws.SparklineGroups.Add(ws.Range("A1:A1"), ws.Range("B1:C4"));
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("SourceData range must have either a single row or a single column", message);
+            Assert.That(message, Is.EqualTo("SourceData range must have either a single row or a single column"));
         }
 
         [Test]
@@ -164,13 +172,16 @@ namespace ClosedXML.Tests.Excel.Sparklines
             group.Add("A2", "B2:E2");
             group.Add(ws.Cell("A3"), ws.Range("B3:E3"));
 
-            Assert.AreEqual(0, ws.SparklineGroups.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(0));
 
-            Assert.AreEqual("A2", group.ElementAt(0).Location.Address.ToString());
-            Assert.AreEqual("A3", group.ElementAt(1).Location.Address.ToString());
+                Assert.That(group.ElementAt(0).Location.Address.ToString(), Is.EqualTo("A2"));
+            });
+            Assert.That(group.ElementAt(1).Location.Address.ToString(), Is.EqualTo("A3"));
 
-            Assert.AreEqual("B2:E2", group.ElementAt(0).SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B3:E3", group.ElementAt(1).SourceData.RangeAddress.ToString());
+            Assert.That(group.ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
+            Assert.That(group.ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B3:E3"));
         }
 
         [Test]
@@ -185,7 +196,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => ws2.SparklineGroups.Add(group);
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("The specified sparkline group belongs to the different worksheet", message);
+            Assert.That(message, Is.EqualTo("The specified sparkline group belongs to the different worksheet"));
         }
 
         [Test]
@@ -200,7 +211,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => group.Add(ws2.Cell("A3"), ws1.Range("B3:E3"));
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("The specified sparkline belongs to the different worksheet", message);
+            Assert.That(message, Is.EqualTo("The specified sparkline belongs to the different worksheet"));
         }
 
         [Test]
@@ -211,10 +222,13 @@ namespace ClosedXML.Tests.Excel.Sparklines
             var group = ws.SparklineGroups.Add("A1", "B1:E1");
             group.Add("A1", "B2:E2");
 
-            Assert.AreEqual(1, group.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Count(), Is.EqualTo(1));
 
-            Assert.AreEqual("A1", group.Single().Location.Address.ToString());
-            Assert.AreEqual("B2:E2", group.Single().SourceData.RangeAddress.ToString());
+                Assert.That(group.Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(group.Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
         }
 
         [Test]
@@ -225,10 +239,13 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1", "B1:E1");
             ws.SparklineGroups.Add("A1", "B2:E2");
 
-            Assert.AreEqual(2, ws.SparklineGroups.Count());
-            Assert.IsFalse(ws.SparklineGroups.First().Any());
-            Assert.AreEqual("A1", ws.SparklineGroups.Last().Single().Location.Address.ToString());
-            Assert.AreEqual("B2:E2", ws.SparklineGroups.Last().Single().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.First().Any(), Is.False);
+                Assert.That(ws.SparklineGroups.Last().Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Last().Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
         }
 
         [Test]
@@ -240,7 +257,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             var group = ws1.SparklineGroups.Add("A1", "'Sheet 3'!B1:F1");
 
-            Assert.AreSame(ws3, group.Single().SourceData.Worksheet);
+            Assert.That(group.Single().SourceData.Worksheet, Is.SameAs(ws3));
         }
 
         #endregion Add sparklines
@@ -262,8 +279,11 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             var sp = ws.SparklineGroups.GetSparkline(ws.Cell(cellAddress));
             Assert.IsNotNull(sp);
-            Assert.AreEqual(cellAddress, sp.Location.Address.ToString());
-            Assert.AreEqual(expectedSourceDataRange, sp.SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(sp.Location.Address.ToString(), Is.EqualTo(cellAddress));
+                Assert.That(sp.SourceData.RangeAddress.ToString(), Is.EqualTo(expectedSourceDataRange));
+            });
         }
 
         [TestCase("A1")]
@@ -278,7 +298,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("B1:Z1", "B2:Z100");
 
             var sp = ws.SparklineGroups.GetSparkline(ws.Cell(cellAddress));
-            Assert.IsNull(sp);
+            Assert.That(sp, Is.Null);
         }
 
         [Test]
@@ -295,16 +315,19 @@ namespace ClosedXML.Tests.Excel.Sparklines
             var sparklines4 = ws.SparklineGroups.GetSparklines(ws.Range("A:A"));
             var sparklines5 = ws.SparklineGroups.GetSparklines(ws.Range("1:1"));
 
-            Assert.AreEqual(2, sparklines1.Count());
-            Assert.AreEqual(0, sparklines2.Count());
-            Assert.AreEqual(99 + 25, sparklines3.Count());
-            Assert.AreEqual(99, sparklines4.Count());
-            Assert.AreEqual(25, sparklines5.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(sparklines1.Count(), Is.EqualTo(2));
+                Assert.That(sparklines2.Count(), Is.EqualTo(0));
+                Assert.That(sparklines3.Count(), Is.EqualTo(99 + 25));
+                Assert.That(sparklines4.Count(), Is.EqualTo(99));
+                Assert.That(sparklines5.Count(), Is.EqualTo(25));
 
-            Assert.AreEqual("A2", sparklines1.First().Location.Address.ToString());
-            Assert.AreEqual("B1", sparklines1.Last().Location.Address.ToString());
-            Assert.AreEqual("B2:Z2", sparklines1.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B2:B100", sparklines1.Last().SourceData.RangeAddress.ToString());
+                Assert.That(sparklines1.First().Location.Address.ToString(), Is.EqualTo("A2"));
+            });
+            Assert.That(sparklines1.Last().Location.Address.ToString(), Is.EqualTo("B1"));
+            Assert.That(sparklines1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
+            Assert.That(sparklines1.Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B100"));
         }
 
         #endregion Get sparklines
@@ -319,12 +342,15 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1:A3", "B1:Z3");
             ws.SparklineGroups.Remove(ws.Cell("A2"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.AreEqual(2, ws.SparklineGroups.Single().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().First().Location.Address.ToString());
-            Assert.AreEqual("A3", ws.SparklineGroups.Single().Last().Location.Address.ToString());
-            Assert.AreEqual("B1:Z1", ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B3:Z3", ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.Single().First().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("A3"));
+            Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+            Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B3:Z3"));
         }
 
         [Test]
@@ -335,12 +361,15 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1:A5", "B1:Z5");
             ws.SparklineGroups.Remove(ws.Range("A2:D4"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.AreEqual(2, ws.SparklineGroups.Single().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().First().Location.Address.ToString());
-            Assert.AreEqual("A5", ws.SparklineGroups.Single().Last().Location.Address.ToString());
-            Assert.AreEqual("B1:Z1", ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B5:Z5", ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.Single().First().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("A5"));
+            Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+            Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B5:Z5"));
         }
 
         [Test]
@@ -351,12 +380,15 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1:A2", "B1:Z2");
             ws.SparklineGroups.Remove(ws.Cell("F2"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.AreEqual(2, ws.SparklineGroups.Single().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().First().Location.Address.ToString());
-            Assert.AreEqual("A2", ws.SparklineGroups.Single().Last().Location.Address.ToString());
-            Assert.AreEqual("B1:Z1", ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B2:Z2", ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.Single().First().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("A2"));
+            Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+            Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
         }
 
         #endregion Remove sparklines
@@ -371,15 +403,21 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1:A2", "B1:Z2");
             ws.SparklineGroups.Single().Last().SetLocation(ws.Cell("F2"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.AreEqual(2, ws.SparklineGroups.Single().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().First().Location.Address.ToString());
-            Assert.AreEqual("F2", ws.SparklineGroups.Single().Last().Location.Address.ToString());
-            Assert.AreEqual("B1:Z1", ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B2:Z2", ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString());
-            Assert.IsTrue(ws.Cell("A1").HasSparkline);
-            Assert.IsFalse(ws.Cell("A2").HasSparkline);
-            Assert.IsTrue(ws.Cell("F2").HasSparkline);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.Single().First().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("F2"));
+            Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
+                Assert.That(ws.Cell("A1").HasSparkline, Is.True);
+                Assert.That(ws.Cell("A2").HasSparkline, Is.False);
+                Assert.That(ws.Cell("F2").HasSparkline, Is.True);
+            });
         }
 
         [Test]
@@ -390,10 +428,13 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1:A2", "B1:Z2");
             ws.SparklineGroups.Single().Last().SetLocation(ws.Cell("A1"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.AreEqual(1, ws.SparklineGroups.Single().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().Single().Location.Address.ToString());
-            Assert.AreEqual("B2:Z2", ws.SparklineGroups.Single().Single().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
         }
 
         [Test]
@@ -405,13 +446,16 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A3", "B3:Z3");
             ws.SparklineGroups.Last().Single().SetLocation(ws.Cell("A2"));
 
-            Assert.AreEqual(2, ws.SparklineGroups.Count());
-            Assert.AreEqual(1, ws.SparklineGroups.First().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.First().Single().Location.Address.ToString());
-            Assert.AreEqual("B1:Z1", ws.SparklineGroups.First().Single().SourceData.RangeAddress.ToString());
-            Assert.AreEqual(1, ws.SparklineGroups.Last().Count());
-            Assert.AreEqual("A2", ws.SparklineGroups.Last().Single().Location.Address.ToString());
-            Assert.AreEqual("B3:Z3", ws.SparklineGroups.Last().Single().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.First().Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.First().Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.First().Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+            Assert.That(ws.SparklineGroups.Last().Count(), Is.EqualTo(1));
+            Assert.That(ws.SparklineGroups.Last().Single().Location.Address.ToString(), Is.EqualTo("A2"));
+            Assert.That(ws.SparklineGroups.Last().Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B3:Z3"));
         }
 
         [Test]
@@ -426,7 +470,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => group.First().SetLocation(ws2.FirstCell());
 
             var message = Assert.Throws<InvalidOperationException>(action).Message;
-            Assert.AreEqual("Cannot move the sparkline to a different worksheet", message);
+            Assert.That(message, Is.EqualTo("Cannot move the sparkline to a different worksheet"));
         }
 
         [Test]
@@ -437,12 +481,15 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("A1:A2", "B1:Z2");
             ws.SparklineGroups.Single().Last().SetSourceData(ws.Range("D4:D50"));
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.AreEqual(2, ws.SparklineGroups.Single().Count());
-            Assert.AreEqual("A1", ws.SparklineGroups.Single().First().Location.Address.ToString());
-            Assert.AreEqual("A2", ws.SparklineGroups.Single().Last().Location.Address.ToString());
-            Assert.AreEqual("B1:Z1", ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("D4:D50", ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.Single().First().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("A2"));
+            Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+            Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D50"));
         }
 
         [Test]
@@ -455,7 +502,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             TestDelegate action = () => sparkline.SetSourceData(ws.Range("B1:Z2"));
 
             var message = Assert.Throws<ArgumentException>(action).Message;
-            Assert.AreEqual("SourceData range must have either a single row or a single column", message);
+            Assert.That(message, Is.EqualTo("SourceData range must have either a single row or a single column"));
         }
 
         [Test]
@@ -466,13 +513,16 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             group.Style = XLSparklineTheme.Colorful1;
 
-            Assert.AreEqual(XLColor.FromHtml("FF5F5F5F"), group.Style.SeriesColor);
-            Assert.AreEqual(XLColor.FromHtml("FFFFB620"), group.Style.NegativeColor);
-            Assert.AreEqual(XLColor.FromHtml("FFD70077"), group.Style.MarkersColor);
-            Assert.AreEqual(XLColor.FromHtml("FF56BE79"), group.Style.HighMarkerColor);
-            Assert.AreEqual(XLColor.FromHtml("FFFF5055"), group.Style.LowMarkerColor);
-            Assert.AreEqual(XLColor.FromHtml("FF5687C2"), group.Style.FirstMarkerColor);
-            Assert.AreEqual(XLColor.FromHtml("FF359CEB"), group.Style.LastMarkerColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Style.SeriesColor, Is.EqualTo(XLColor.FromHtml("FF5F5F5F")));
+                Assert.That(group.Style.NegativeColor, Is.EqualTo(XLColor.FromHtml("FFFFB620")));
+                Assert.That(group.Style.MarkersColor, Is.EqualTo(XLColor.FromHtml("FFD70077")));
+                Assert.That(group.Style.HighMarkerColor, Is.EqualTo(XLColor.FromHtml("FF56BE79")));
+                Assert.That(group.Style.LowMarkerColor, Is.EqualTo(XLColor.FromHtml("FFFF5055")));
+                Assert.That(group.Style.FirstMarkerColor, Is.EqualTo(XLColor.FromHtml("FF5687C2")));
+                Assert.That(group.Style.LastMarkerColor, Is.EqualTo(XLColor.FromHtml("FF359CEB")));
+            });
         }
 
         [Test]
@@ -484,8 +534,11 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             group.Style.NegativeColor = XLColor.Red;
 
-            Assert.AreEqual(XLColor.Red, group.Style.NegativeColor);
-            Assert.AreNotEqual(XLColor.Red, XLSparklineTheme.Colorful1.NegativeColor);
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Style.NegativeColor, Is.EqualTo(XLColor.Red));
+                Assert.That(XLSparklineTheme.Colorful1.NegativeColor, Is.Not.EqualTo(XLColor.Red));
+            });
         }
 
         [Test]
@@ -509,12 +562,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Row(2).InsertRowsBelow(3);
 
-            Assert.AreEqual("B2", group1.First().Location.Address.ToString());
-            Assert.AreEqual("D7:F7", group1.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B6", group2.First().Location.Address.ToString());
-            Assert.AreEqual("D7:D11", group2.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B7", group3.First().Location.Address.ToString());
-            Assert.AreEqual("E1:E11", group3.First().SourceData.RangeAddress.ToString());
+            Assert.That(group1.First().Location.Address.ToString(), Is.EqualTo("B2"));
+            Assert.That(group1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D7:F7"));
+            Assert.That(group2.First().Location.Address.ToString(), Is.EqualTo("B6"));
+            Assert.That(group2.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D7:D11"));
+            Assert.That(group3.First().Location.Address.ToString(), Is.EqualTo("B7"));
+            Assert.That(group3.First().SourceData.RangeAddress.ToString(), Is.EqualTo("E1:E11"));
         }
 
         [Test]
@@ -527,12 +580,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Rows(3, 5).Delete();
 
-            Assert.AreEqual("B2", group1.First().Location.Address.ToString());
-            Assert.AreEqual("D4:F4", group1.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B3", group2.First().Location.Address.ToString());
-            Assert.AreEqual("D4:D8", group2.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B4", group3.First().Location.Address.ToString());
-            Assert.AreEqual("E1:E8", group3.First().SourceData.RangeAddress.ToString());
+            Assert.That(group1.First().Location.Address.ToString(), Is.EqualTo("B2"));
+            Assert.That(group1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:F4"));
+            Assert.That(group2.First().Location.Address.ToString(), Is.EqualTo("B3"));
+            Assert.That(group2.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D8"));
+            Assert.That(group3.First().Location.Address.ToString(), Is.EqualTo("B4"));
+            Assert.That(group3.First().SourceData.RangeAddress.ToString(), Is.EqualTo("E1:E8"));
         }
 
         [Test]
@@ -545,12 +598,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Column(2).InsertColumnsAfter(3);
 
-            Assert.AreEqual("B2", group1.First().Location.Address.ToString());
-            Assert.AreEqual("G4:I4", group1.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("F3", group2.First().Location.Address.ToString());
-            Assert.AreEqual("G4:G8", group2.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("G4", group3.First().Location.Address.ToString());
-            Assert.AreEqual("A4:H4", group3.First().SourceData.RangeAddress.ToString());
+            Assert.That(group1.First().Location.Address.ToString(), Is.EqualTo("B2"));
+            Assert.That(group1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("G4:I4"));
+            Assert.That(group2.First().Location.Address.ToString(), Is.EqualTo("F3"));
+            Assert.That(group2.First().SourceData.RangeAddress.ToString(), Is.EqualTo("G4:G8"));
+            Assert.That(group3.First().Location.Address.ToString(), Is.EqualTo("G4"));
+            Assert.That(group3.First().SourceData.RangeAddress.ToString(), Is.EqualTo("A4:H4"));
         }
 
         [Test]
@@ -563,12 +616,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Columns(3, 5).Delete();
 
-            Assert.AreEqual("B2", group1.First().Location.Address.ToString());
-            Assert.AreEqual("D4:F4", group1.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("C3", group2.First().Location.Address.ToString());
-            Assert.AreEqual("D4:D8", group2.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("D4", group3.First().Location.Address.ToString());
-            Assert.AreEqual("A4:E4", group3.First().SourceData.RangeAddress.ToString());
+            Assert.That(group1.First().Location.Address.ToString(), Is.EqualTo("B2"));
+            Assert.That(group1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:F4"));
+            Assert.That(group2.First().Location.Address.ToString(), Is.EqualTo("C3"));
+            Assert.That(group2.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D8"));
+            Assert.That(group3.First().Location.Address.ToString(), Is.EqualTo("D4"));
+            Assert.That(group3.First().SourceData.RangeAddress.ToString(), Is.EqualTo("A4:E4"));
         }
 
         [Test]
@@ -579,9 +632,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Column(2).Delete();
 
-            Assert.AreEqual(1, group.Count());
-            Assert.AreEqual("A1", group.Single().Location.Address.ToString());
-            Assert.AreEqual("B2:B6", group.Single().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Count(), Is.EqualTo(1));
+                Assert.That(group.Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(group.Single().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B6"));
         }
 
         [Test]
@@ -592,9 +648,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Row(2).Delete();
 
-            Assert.AreEqual(1, group.Count());
-            Assert.AreEqual("A1", group.Single().Location.Address.ToString());
-            Assert.AreEqual("C2:F2", group.Single().SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Count(), Is.EqualTo(1));
+                Assert.That(group.Single().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(group.Single().SourceData.RangeAddress.ToString(), Is.EqualTo("C2:F2"));
         }
 
         [Test]
@@ -605,7 +664,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Column(1).InsertColumnsBefore(1);
 
-            Assert.AreEqual(0, group.Count());
+            Assert.That(group.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -616,7 +675,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Row(1).InsertRowsAbove(1);
 
-            Assert.AreEqual(0, group.Count());
+            Assert.That(group.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -627,11 +686,17 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Column(4).Delete();
 
-            Assert.AreEqual(2, group.Count());
-            Assert.AreEqual("A1", group.First().Location.Address.ToString());
-            Assert.AreEqual("C2:C6", group.First().SourceData.RangeAddress.ToString());
-            Assert.AreEqual("B1", group.Last().Location.Address.ToString());
-            Assert.IsFalse(group.Last().SourceData.RangeAddress.IsValid);
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Count(), Is.EqualTo(2));
+                Assert.That(group.First().Location.Address.ToString(), Is.EqualTo("A1"));
+            });
+            Assert.That(group.First().SourceData.RangeAddress.ToString(), Is.EqualTo("C2:C6"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.Last().Location.Address.ToString(), Is.EqualTo("B1"));
+                Assert.That(group.Last().SourceData.RangeAddress.IsValid, Is.False);
+            });
         }
 
         #endregion Change sparklines
@@ -641,107 +706,109 @@ namespace ClosedXML.Tests.Excel.Sparklines
         [Test]
         public void CanChangeSaveAndLoadSparklineGroup()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.AddWorksheet("Sheet 1");
-                    var originalGroup = ws.SparklineGroups.Add("A1:A3", "B1:Z3")
-                        .SetDateRange(ws.Range("B4:Z4"))
-                        .SetLineWeight(5.5)
-                        .SetDisplayHidden(true)
-                        .SetShowMarkers(XLSparklineMarkers.FirstPoint | XLSparklineMarkers.LastPoint |
-                                        XLSparklineMarkers.HighPoint | XLSparklineMarkers.LowPoint |
-                                        XLSparklineMarkers.NegativePoints | XLSparklineMarkers.Markers)
-                        .SetDisplayEmptyCellsAs(XLDisplayBlanksAsValues.Zero)
-                        .SetType(XLSparklineType.Stacked);
+                var ws = wb.AddWorksheet("Sheet 1");
+                var originalGroup = ws.SparklineGroups.Add("A1:A3", "B1:Z3")
+                    .SetDateRange(ws.Range("B4:Z4"))
+                    .SetLineWeight(5.5)
+                    .SetDisplayHidden(true)
+                    .SetShowMarkers(XLSparklineMarkers.FirstPoint | XLSparklineMarkers.LastPoint |
+                                    XLSparklineMarkers.HighPoint | XLSparklineMarkers.LowPoint |
+                                    XLSparklineMarkers.NegativePoints | XLSparklineMarkers.Markers)
+                    .SetDisplayEmptyCellsAs(XLDisplayBlanksAsValues.Zero)
+                    .SetType(XLSparklineType.Stacked);
 
-                    originalGroup.HorizontalAxis
-                        .SetColor(XLColor.AirForceBlue)
-                        .SetVisible(true)
-                        .SetRightToLeft(true);
+                originalGroup.HorizontalAxis
+                    .SetColor(XLColor.AirForceBlue)
+                    .SetVisible(true)
+                    .SetRightToLeft(true);
 
-                    originalGroup.VerticalAxis
-                        .SetManualMax(6.6)
-                        .SetManualMin(1.2)
-                        .SetMaxAxisType(XLSparklineAxisMinMax.Custom)
-                        .SetMinAxisType(XLSparklineAxisMinMax.Custom);
+                originalGroup.VerticalAxis
+                    .SetManualMax(6.6)
+                    .SetManualMin(1.2)
+                    .SetMaxAxisType(XLSparklineAxisMinMax.Custom)
+                    .SetMinAxisType(XLSparklineAxisMinMax.Custom);
 
-                    originalGroup.Style
-                        .SetFirstMarkerColor(XLColor.AliceBlue)
-                        .SetHighMarkerColor(XLColor.Alizarin)
-                        .SetLastMarkerColor(XLColor.Almond)
-                        .SetLowMarkerColor(XLColor.Amaranth)
-                        .SetMarkersColor(XLColor.Amber)
-                        .SetNegativeColor(XLColor.AmberSaeEce)
-                        .SetSeriesColor(XLColor.AmericanRose);
+                originalGroup.Style
+                    .SetFirstMarkerColor(XLColor.AliceBlue)
+                    .SetHighMarkerColor(XLColor.Alizarin)
+                    .SetLastMarkerColor(XLColor.Almond)
+                    .SetLowMarkerColor(XLColor.Amaranth)
+                    .SetMarkersColor(XLColor.Amber)
+                    .SetNegativeColor(XLColor.AmberSaeEce)
+                    .SetSeriesColor(XLColor.AmericanRose);
 
-                    AssertGroupIsValid(originalGroup);
-                    wb.SaveAs(ms);
-                }
+                AssertGroupIsValid(originalGroup);
+                wb.SaveAs(ms);
+            }
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
 
-                    Assert.AreEqual(1, ws.SparklineGroups.Count());
-                    AssertGroupIsValid(ws.SparklineGroups.Single());
-                }
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                AssertGroupIsValid(ws.SparklineGroups.Single());
             }
 
             void AssertGroupIsValid(IXLSparklineGroup group)
             {
-                Assert.AreEqual(3, group.Count());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(group.Count(), Is.EqualTo(3));
 
-                Assert.AreEqual("A1", group.ElementAt(0).Location.Address.ToString());
-                Assert.AreEqual("A2", group.ElementAt(1).Location.Address.ToString());
-                Assert.AreEqual("A3", group.ElementAt(2).Location.Address.ToString());
+                    Assert.That(group.ElementAt(0).Location.Address.ToString(), Is.EqualTo("A1"));
+                });
+                Assert.That(group.ElementAt(1).Location.Address.ToString(), Is.EqualTo("A2"));
+                Assert.That(group.ElementAt(2).Location.Address.ToString(), Is.EqualTo("A3"));
 
-                Assert.AreEqual("B1:Z1", group.ElementAt(0).SourceData.RangeAddress.ToString());
-                Assert.AreEqual("B2:Z2", group.ElementAt(1).SourceData.RangeAddress.ToString());
-                Assert.AreEqual("B3:Z3", group.ElementAt(2).SourceData.RangeAddress.ToString());
+                Assert.That(group.ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+                Assert.That(group.ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
+                Assert.That(group.ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("B3:Z3"));
 
-                Assert.AreEqual("B4:Z4", group.DateRange.RangeAddress.ToString());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(group.DateRange.RangeAddress.ToString(), Is.EqualTo("B4:Z4"));
 
-                Assert.AreEqual(XLColor.AliceBlue, group.Style.FirstMarkerColor);
-                Assert.AreEqual(XLColor.Alizarin, group.Style.HighMarkerColor);
-                Assert.AreEqual(XLColor.Almond, group.Style.LastMarkerColor);
-                Assert.AreEqual(XLColor.Amaranth, group.Style.LowMarkerColor);
-                Assert.AreEqual(XLColor.Amber, group.Style.MarkersColor);
-                Assert.AreEqual(XLColor.AmberSaeEce, group.Style.NegativeColor);
-                Assert.AreEqual(XLColor.AmericanRose, group.Style.SeriesColor);
-                Assert.IsTrue(group.DisplayHidden);
-                Assert.AreEqual(5.5, group.LineWeight, XLHelper.Epsilon);
-                Assert.AreEqual(XLDisplayBlanksAsValues.Zero, group.DisplayEmptyCellsAs);
-                Assert.AreEqual(XLSparklineType.Stacked, group.Type);
+                    Assert.That(group.Style.FirstMarkerColor, Is.EqualTo(XLColor.AliceBlue));
+                    Assert.That(group.Style.HighMarkerColor, Is.EqualTo(XLColor.Alizarin));
+                    Assert.That(group.Style.LastMarkerColor, Is.EqualTo(XLColor.Almond));
+                    Assert.That(group.Style.LowMarkerColor, Is.EqualTo(XLColor.Amaranth));
+                    Assert.That(group.Style.MarkersColor, Is.EqualTo(XLColor.Amber));
+                    Assert.That(group.Style.NegativeColor, Is.EqualTo(XLColor.AmberSaeEce));
+                    Assert.That(group.Style.SeriesColor, Is.EqualTo(XLColor.AmericanRose));
+                    Assert.That(group.DisplayHidden, Is.True);
+                    Assert.That(group.LineWeight, Is.EqualTo(5.5).Within(XLHelper.Epsilon));
+                    Assert.That(group.DisplayEmptyCellsAs, Is.EqualTo(XLDisplayBlanksAsValues.Zero));
+                    Assert.That(group.Type, Is.EqualTo(XLSparklineType.Stacked));
 
-                Assert.IsTrue(group.ShowMarkers.HasFlag(XLSparklineMarkers.FirstPoint));
-                Assert.IsTrue(group.ShowMarkers.HasFlag(XLSparklineMarkers.LastPoint));
-                Assert.IsTrue(group.ShowMarkers.HasFlag(XLSparklineMarkers.HighPoint));
-                Assert.IsTrue(group.ShowMarkers.HasFlag(XLSparklineMarkers.LowPoint));
-                Assert.IsTrue(group.ShowMarkers.HasFlag(XLSparklineMarkers.NegativePoints));
-                Assert.IsTrue(group.ShowMarkers.HasFlag(XLSparklineMarkers.Markers));
+                    Assert.That(group.ShowMarkers.HasFlag(XLSparklineMarkers.FirstPoint), Is.True);
+                    Assert.That(group.ShowMarkers.HasFlag(XLSparklineMarkers.LastPoint), Is.True);
+                    Assert.That(group.ShowMarkers.HasFlag(XLSparklineMarkers.HighPoint), Is.True);
+                    Assert.That(group.ShowMarkers.HasFlag(XLSparklineMarkers.LowPoint), Is.True);
+                    Assert.That(group.ShowMarkers.HasFlag(XLSparklineMarkers.NegativePoints), Is.True);
+                    Assert.That(group.ShowMarkers.HasFlag(XLSparklineMarkers.Markers), Is.True);
 
-                Assert.AreEqual(XLColor.AirForceBlue, group.HorizontalAxis.Color);
-                Assert.IsTrue(group.HorizontalAxis.IsVisible);
-                Assert.IsTrue(group.HorizontalAxis.RightToLeft);
-                Assert.IsTrue(group.HorizontalAxis.DateAxis);
+                    Assert.That(group.HorizontalAxis.Color, Is.EqualTo(XLColor.AirForceBlue));
+                    Assert.That(group.HorizontalAxis.IsVisible, Is.True);
+                    Assert.That(group.HorizontalAxis.RightToLeft, Is.True);
+                    Assert.That(group.HorizontalAxis.DateAxis, Is.True);
 
-                Assert.AreEqual(6.6, group.VerticalAxis.ManualMax, XLHelper.Epsilon);
-                Assert.AreEqual(1.2, group.VerticalAxis.ManualMin, XLHelper.Epsilon);
-                Assert.AreEqual(XLSparklineAxisMinMax.Custom, group.VerticalAxis.MaxAxisType);
-                Assert.AreEqual(XLSparklineAxisMinMax.Custom, group.VerticalAxis.MinAxisType);
+                    Assert.That(group.VerticalAxis.ManualMax, Is.EqualTo(6.6).Within(XLHelper.Epsilon));
+                    Assert.That(group.VerticalAxis.ManualMin, Is.EqualTo(1.2).Within(XLHelper.Epsilon));
+                    Assert.That(group.VerticalAxis.MaxAxisType, Is.EqualTo(XLSparklineAxisMinMax.Custom));
+                    Assert.That(group.VerticalAxis.MinAxisType, Is.EqualTo(XLSparklineAxisMinMax.Custom));
+                });
             }
         }
 
         [Test]
         public void CanLoadSparklines()
         {
-            using (var ms = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx")))
-            using (var wb = new XLWorkbook(ms))
-            {
-                Assert.IsTrue(wb.Worksheets.All(ws => ws.SparklineGroups.Count() == 6));
-            }
+            using var ms = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx"));
+            using var wb = new XLWorkbook(ms);
+            Assert.That(wb.Worksheets.All(ws => ws.SparklineGroups.Count() == 6), Is.True);
         }
 
         [TestCase("Accent!B1", nameof(XLSparklineTheme.Accent1))]
@@ -782,14 +849,12 @@ namespace ClosedXML.Tests.Excel.Sparklines
         [TestCase("Colorful!B6", nameof(XLSparklineTheme.Colorful6))]
         public void SparklineThemesAreIdenticalToExcel(string cellAddress, string expectedThemeName)
         {
-            using (var ms = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx")))
-            using (var wb = new XLWorkbook(ms))
-            {
-                var expectedStyle = GetThemeByName(expectedThemeName);
-                var actualStyle = wb.Cell(cellAddress).Sparkline.SparklineGroup.Style;
+            using var ms = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx"));
+            using var wb = new XLWorkbook(ms);
+            var expectedStyle = GetThemeByName(expectedThemeName);
+            var actualStyle = wb.Cell(cellAddress).Sparkline.SparklineGroup.Style;
 
-                Assert.AreEqual(expectedStyle, actualStyle);
-            }
+            Assert.That(actualStyle, Is.EqualTo(expectedStyle));
 
             IXLSparklineStyle GetThemeByName(string themeName)
             {
@@ -802,80 +867,77 @@ namespace ClosedXML.Tests.Excel.Sparklines
         [Test]
         public void DeletedSparklinesRemovedFromFile()
         {
-            using (var input = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx")))
-            using (var output = new MemoryStream())
+            using var input = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\Sparklines\SparklineThemes\inputfile.xlsx"));
+            using var output = new MemoryStream();
+            using (var wb = new XLWorkbook(input))
             {
-                using (var wb = new XLWorkbook(input))
-                {
-                    wb.Worksheet(1).SparklineGroups.RemoveAll();
-                    wb.Worksheet(2).SparklineGroups.Remove(wb.Worksheet(2).Cell("B1"));
-                    wb.Worksheet(3).SparklineGroups.Remove(wb.Worksheet(3).Range("B2:B6"));
-                    wb.Worksheet(4).SparklineGroups.Remove(wb.Worksheet(4).SparklineGroups.First());
+                wb.Worksheet(1).SparklineGroups.RemoveAll();
+                wb.Worksheet(2).SparklineGroups.Remove(wb.Worksheet(2).Cell("B1"));
+                wb.Worksheet(3).SparklineGroups.Remove(wb.Worksheet(3).Range("B2:B6"));
+                wb.Worksheet(4).SparklineGroups.Remove(wb.Worksheet(4).SparklineGroups.First());
 
-                    wb.SaveAs(output);
-                }
+                wb.SaveAs(output);
+            }
 
-                using (var wb = new XLWorkbook(output))
-                {
-                    Assert.AreEqual(0, wb.Worksheet(1).SparklineGroups.Count());
-                    Assert.AreEqual(5, wb.Worksheet(2).SparklineGroups.Count());
-                    Assert.AreEqual(1, wb.Worksheet(3).SparklineGroups.Count());
-                    Assert.AreEqual(5, wb.Worksheet(4).SparklineGroups.Count());
-                    Assert.AreEqual(6, wb.Worksheet(5).SparklineGroups.Count());
-                    Assert.AreEqual(6, wb.Worksheet(6).SparklineGroups.Count());
-                }
+            using (var wb = new XLWorkbook(output))
+            {
+                Assert.That(wb.Worksheet(1).SparklineGroups.Count(), Is.EqualTo(0));
+                Assert.That(wb.Worksheet(2).SparklineGroups.Count(), Is.EqualTo(5));
+                Assert.That(wb.Worksheet(3).SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(wb.Worksheet(4).SparklineGroups.Count(), Is.EqualTo(5));
+                Assert.That(wb.Worksheet(5).SparklineGroups.Count(), Is.EqualTo(6));
+                Assert.That(wb.Worksheet(6).SparklineGroups.Count(), Is.EqualTo(6));
             }
         }
 
         [Test]
         public void EmptySparklineGroupsSkippedOnSaving()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.AddWorksheet("Sheet 1");
-                    var group = ws.SparklineGroups.Add("A1:A2", "B1:Z2");
+                var ws = wb.AddWorksheet("Sheet 1");
+                var group = ws.SparklineGroups.Add("A1:A2", "B1:Z2");
 
-                    group.RemoveAll();
+                group.RemoveAll();
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.AreEqual(0, wb.Worksheets.First().SparklineGroups.Count());
-                }
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.That(wb.Worksheets.First().SparklineGroups.Count(), Is.EqualTo(0));
             }
         }
 
         [Test]
         public void CanSaveAndLoadSparklineWithInvalidRange()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws1 = wb.AddWorksheet("Sheet 1");
+                var ws2 = wb.AddWorksheet("Sheet 2");
+
+                ws1.SparklineGroups.Add("A1:A3", "'Sheet 2'!B1:F3");
+                ws1.SparklineGroups.Add("A4:A6", "B4:F6")
+                    .SetDateRange(ws2.Range("A1:E1"));
+
+                ws2.Delete();
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.Single();
+
+                Assert.Multiple(() =>
                 {
-                    var ws1 = wb.AddWorksheet("Sheet 1");
-                    var ws2 = wb.AddWorksheet("Sheet 2");
-
-                    ws1.SparklineGroups.Add("A1:A3", "'Sheet 2'!B1:F3");
-                    ws1.SparklineGroups.Add("A4:A6", "B4:F6")
-                        .SetDateRange(ws2.Range("A1:E1"));
-
-                    ws2.Delete();
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.Single();
-
-                    Assert.AreEqual(2, ws.SparklineGroups.Count());
-                    Assert.IsFalse(ws.Cell("A2").Sparkline.IsValid);
-                    Assert.AreEqual("B5:F5", ws.Cell("A5").Sparkline.SourceData.RangeAddress.ToString());
-                    Assert.IsNull(ws.Cell("A5").Sparkline.SparklineGroup.DateRange);
-                }
+                    Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(2));
+                    Assert.That(ws.Cell("A2").Sparkline.IsValid, Is.False);
+                    Assert.That(ws.Cell("A5").Sparkline.SourceData.RangeAddress.ToString(), Is.EqualTo("B5:F5"));
+                });
+                Assert.That(ws.Cell("A5").Sparkline.SparklineGroup.DateRange, Is.Null);
             }
         }
 
@@ -893,8 +955,11 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             axis.ManualMin = 100;
 
-            Assert.AreEqual(100, axis.ManualMin, XLHelper.Epsilon);
-            Assert.AreEqual(XLSparklineAxisMinMax.Custom, axis.MinAxisType);
+            Assert.Multiple(() =>
+            {
+                Assert.That(axis.ManualMin, Is.EqualTo(100).Within(XLHelper.Epsilon));
+                Assert.That(axis.MinAxisType, Is.EqualTo(XLSparklineAxisMinMax.Custom));
+            });
         }
 
         [Test]
@@ -907,8 +972,11 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             axis.ManualMax = 100;
 
-            Assert.AreEqual(100, axis.ManualMax, XLHelper.Epsilon);
-            Assert.AreEqual(XLSparklineAxisMinMax.Custom, axis.MaxAxisType);
+            Assert.Multiple(() =>
+            {
+                Assert.That(axis.ManualMax, Is.EqualTo(100).Within(XLHelper.Epsilon));
+                Assert.That(axis.MaxAxisType, Is.EqualTo(XLSparklineAxisMinMax.Custom));
+            });
         }
 
         [TestCase(XLSparklineAxisMinMax.Custom, 100)]
@@ -924,9 +992,9 @@ namespace ClosedXML.Tests.Excel.Sparklines
             axis.MinAxisType = axisType;
 
             if (expectedManualMin.HasValue)
-                Assert.AreEqual(expectedManualMin.Value, axis.ManualMin.Value, XLHelper.Epsilon);
+                Assert.That(axis.ManualMin.Value, Is.EqualTo(expectedManualMin.Value).Within(XLHelper.Epsilon));
             else
-                Assert.IsNull(axis.ManualMin);
+                Assert.That(axis.ManualMin, Is.Null);
         }
 
         [TestCase(XLSparklineAxisMinMax.Custom, 100)]
@@ -942,9 +1010,9 @@ namespace ClosedXML.Tests.Excel.Sparklines
             axis.MaxAxisType = axisType;
 
             if (expectedManualMax.HasValue)
-                Assert.AreEqual(expectedManualMax.Value, axis.ManualMax.Value, XLHelper.Epsilon);
+                Assert.That(axis.ManualMax.Value, Is.EqualTo(expectedManualMax.Value).Within(XLHelper.Epsilon));
             else
-                Assert.IsNull(axis.ManualMax);
+                Assert.That(axis.ManualMax, Is.Null);
         }
 
         [Test]
@@ -955,7 +1023,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             group.DateRange = ws.Range("B3:Z3");
 
-            Assert.IsTrue(group.HorizontalAxis.DateAxis);
+            Assert.That(group.HorizontalAxis.DateAxis, Is.True);
         }
 
         [Test]
@@ -967,7 +1035,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             group.DateRange = null;
 
-            Assert.IsFalse(group.HorizontalAxis.DateAxis);
+            Assert.That(group.HorizontalAxis.DateAxis, Is.False);
         }
 
         [Test]
@@ -994,10 +1062,16 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Cell("A2").CopyTo(target);
 
-            Assert.AreEqual(1, ws.SparklineGroups.Count());
-            Assert.IsTrue(target.HasSparkline);
-            Assert.AreSame(ws.Cell("A2").Sparkline.SparklineGroup, target.Sparkline.SparklineGroup);
-            Assert.AreEqual("E4:I4", target.Sparkline.SourceData.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(target.HasSparkline, Is.True);
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(target.Sparkline.SparklineGroup, Is.SameAs(ws.Cell("A2").Sparkline.SparklineGroup));
+                Assert.That(target.Sparkline.SourceData.RangeAddress.ToString(), Is.EqualTo("E4:I4"));
+            });
         }
 
         [Test]
@@ -1015,12 +1089,15 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws1.Cell("A2").CopyTo(target1);
             ws1.Cell("A5").CopyTo(target2);
 
-            Assert.AreEqual(2, ws1.SparklineGroups.Count());
-            Assert.AreEqual(2, ws2.SparklineGroups.Count());
-            Assert.IsTrue(target1.HasSparkline);
-            Assert.IsTrue(target2.HasSparkline);
-            Assert.AreEqual("'Sheet 2'!E4:I4", target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("'Sheet 3'!E5:I5", target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.SparklineGroups.Count(), Is.EqualTo(2));
+                Assert.That(ws2.SparklineGroups.Count(), Is.EqualTo(2));
+                Assert.That(target1.HasSparkline, Is.True);
+                Assert.That(target2.HasSparkline, Is.True);
+                Assert.That(target1.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 2'!E4:I4"));
+                Assert.That(target2.Sparkline.SourceData.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 3'!E5:I5"));
+            });
         }
 
         [Test]
@@ -1035,10 +1112,13 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws1.Cell("A2").CopyTo(target);
 
-            Assert.AreEqual(1, ws1.SparklineGroups.Count());
-            Assert.AreEqual(1, ws2.SparklineGroups.Count());
-            Assert.IsTrue(target.HasSparkline);
-            Assert.AreEqual("'Sheet 2'!D6:H6", target.Sparkline.SparklineGroup.DateRange.RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws2.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(target.HasSparkline, Is.True);
+                Assert.That(target.Sparkline.SparklineGroup.DateRange.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 2'!D6:H6"));
+            });
         }
 
         [Test]
@@ -1054,10 +1134,13 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws1.Cell("A2").CopyTo(target);
 
-            Assert.AreEqual(1, ws1.SparklineGroups.Count());
-            Assert.AreEqual(1, ws2.SparklineGroups.Count());
-            Assert.IsTrue(target.HasSparkline);
-            Assert.AreEqual("'Sheet 3'!D6:H6", target.Sparkline.SparklineGroup.DateRange.RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(ws2.SparklineGroups.Count(), Is.EqualTo(1));
+                Assert.That(target.HasSparkline, Is.True);
+                Assert.That(target.Sparkline.SparklineGroup.DateRange.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("'Sheet 3'!D6:H6"));
+            });
         }
 
         #endregion Copy sparkline groups

--- a/ClosedXML.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/ClosedXML.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -89,12 +89,14 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
                 Assert.That(ws.SparklineGroups.Single().ElementAt(0).Location.Address.ToString(), Is.EqualTo("A1"));
             });
-            Assert.That(ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString(), Is.EqualTo("A2"));
-            Assert.That(ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString(), Is.EqualTo("A3"));
-
-            Assert.That(ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("B1:E1"));
-            Assert.That(ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
-            Assert.That(ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("B3:E3"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString(), Is.EqualTo("A2"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString(), Is.EqualTo("A3"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("B1:E1"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:E2"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("B3:E3"));
+            });
         }
 
         [Test]
@@ -107,15 +109,14 @@ namespace ClosedXML.Tests.Excel.Sparklines
             Assert.Multiple(() =>
             {
                 Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
-
                 Assert.That(ws.SparklineGroups.Single().ElementAt(0).Location.Address.ToString(), Is.EqualTo("A1"));
-            });
-            Assert.That(ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString(), Is.EqualTo("B1"));
-            Assert.That(ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString(), Is.EqualTo("C1"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(1).Location.Address.ToString(), Is.EqualTo("B1"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(2).Location.Address.ToString(), Is.EqualTo("C1"));
 
-            Assert.That(ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("A2:A4"));
-            Assert.That(ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B4"));
-            Assert.That(ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("C2:C4"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(0).SourceData.RangeAddress.ToString(), Is.EqualTo("A2:A4"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(1).SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B4"));
+                Assert.That(ws.SparklineGroups.Single().ElementAt(2).SourceData.RangeAddress.ToString(), Is.EqualTo("C2:C4"));
+            });
         }
 
         [Test]
@@ -278,7 +279,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
             ws.SparklineGroups.Add("B1:Z1", "B2:Z100");
 
             var sp = ws.SparklineGroups.GetSparkline(ws.Cell(cellAddress));
-            Assert.IsNotNull(sp);
+            Assert.That(sp, Is.Not.Null);
             Assert.Multiple(() =>
             {
                 Assert.That(sp.Location.Address.ToString(), Is.EqualTo(cellAddress));
@@ -324,10 +325,10 @@ namespace ClosedXML.Tests.Excel.Sparklines
                 Assert.That(sparklines5.Count(), Is.EqualTo(25));
 
                 Assert.That(sparklines1.First().Location.Address.ToString(), Is.EqualTo("A2"));
+                Assert.That(sparklines1.Last().Location.Address.ToString(), Is.EqualTo("B1"));
+                Assert.That(sparklines1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
+                Assert.That(sparklines1.Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B100"));
             });
-            Assert.That(sparklines1.Last().Location.Address.ToString(), Is.EqualTo("B1"));
-            Assert.That(sparklines1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:Z2"));
-            Assert.That(sparklines1.Last().SourceData.RangeAddress.ToString(), Is.EqualTo("B2:B100"));
         }
 
         #endregion Get sparklines
@@ -485,11 +486,11 @@ namespace ClosedXML.Tests.Excel.Sparklines
             {
                 Assert.That(ws.SparklineGroups.Count(), Is.EqualTo(1));
                 Assert.That(ws.SparklineGroups.Single().Count(), Is.EqualTo(2));
+                Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("A2"));
+                Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
+                Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D50"));
                 Assert.That(ws.SparklineGroups.Single().First().Location.Address.ToString(), Is.EqualTo("A1"));
             });
-            Assert.That(ws.SparklineGroups.Single().Last().Location.Address.ToString(), Is.EqualTo("A2"));
-            Assert.That(ws.SparklineGroups.Single().First().SourceData.RangeAddress.ToString(), Is.EqualTo("B1:Z1"));
-            Assert.That(ws.SparklineGroups.Single().Last().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D50"));
         }
 
         [Test]
@@ -616,12 +617,15 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             ws.Columns(3, 5).Delete();
 
-            Assert.That(group1.First().Location.Address.ToString(), Is.EqualTo("B2"));
-            Assert.That(group1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:F4"));
-            Assert.That(group2.First().Location.Address.ToString(), Is.EqualTo("C3"));
-            Assert.That(group2.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D8"));
-            Assert.That(group3.First().Location.Address.ToString(), Is.EqualTo("D4"));
-            Assert.That(group3.First().SourceData.RangeAddress.ToString(), Is.EqualTo("A4:E4"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(group1.First().Location.Address.ToString(), Is.EqualTo("B2"));
+                Assert.That(group1.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:F4"));
+                Assert.That(group2.First().Location.Address.ToString(), Is.EqualTo("C3"));
+                Assert.That(group2.First().SourceData.RangeAddress.ToString(), Is.EqualTo("D4:D8"));
+                Assert.That(group3.First().Location.Address.ToString(), Is.EqualTo("D4"));
+                Assert.That(group3.First().SourceData.RangeAddress.ToString(), Is.EqualTo("A4:E4"));
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Styles/AlignmentTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/AlignmentTests.cs
@@ -35,11 +35,11 @@ namespace ClosedXML.Tests.Excel.Styles
             TestHelper.LoadAndAssert(wb =>
             {
                 var ws = wb.Worksheets.Single();
-                Assert.AreEqual(255, ws.Cell(1,1).Style.Alignment.TextRotation);
+                Assert.That(ws.Cell(1, 1).Style.Alignment.TextRotation, Is.EqualTo(255));
                 for (var column = 2; column < 21; ++column)
                 {
                     var expectedAngle = (column - 2) * 10 - 90;
-                    Assert.AreEqual(expectedAngle, ws.Cell(1, column).Style.Alignment.TextRotation);
+                    Assert.That(ws.Cell(1, column).Style.Alignment.TextRotation, Is.EqualTo(expectedAngle));
                 }
             }, @"Other\Styles\Alignment\TextRotation.xlsx");
         }

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -8,29 +8,33 @@ namespace ClosedXML.Tests.Excel.Styles
         [Test]
         public void SetInsideBorderPreservesOutsideBorders()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Cells("B2:C2").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetOutsideBorderColor(XLColor.FromTheme(XLThemeColor.Accent1, 0.5));
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet();
-
-                ws.Cells("B2:C2").Style
-                    .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
-                    .Border.SetOutsideBorderColor(XLColor.FromTheme(XLThemeColor.Accent1, 0.5));
-
                 //Check pre-conditions
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("B2").Style.Border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("B2").Style.Border.RightBorder);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.RightBorderColor.ThemeColor);
+                Assert.That(ws.Cell("B2").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+                Assert.That(ws.Cell("B2").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+                Assert.That(ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(ws.Cell("B2").Style.Border.RightBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+            });
 
-                ws.Range("B2:C2").Style.Border.SetInsideBorder(XLBorderStyleValues.None);
+            ws.Range("B2:C2").Style.Border.SetInsideBorder(XLBorderStyleValues.None);
 
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("B2").Style.Border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B2").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C2").Style.Border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("C2").Style.Border.RightBorder);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("C2").Style.Border.RightBorderColor.ThemeColor);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("B2").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+                Assert.That(ws.Cell("B2").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C2").Style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.None));
+                Assert.That(ws.Cell("C2").Style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thin));
+                Assert.That(ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(ws.Cell("C2").Style.Border.RightBorderColor.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/ColorTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/ColorTests.cs
@@ -15,19 +15,19 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void ColorEqualOperatorInPlace()
         {
-            Assert.IsTrue(XLColor.Black == XLColor.Black);
+            Assert.That(XLColor.Black == XLColor.Black, Is.True);
         }
 
         [Test]
         public void ColorNotEqualOperatorInPlace()
         {
-            Assert.IsFalse(XLColor.Black != XLColor.Black);
+            Assert.That(XLColor.Black != XLColor.Black, Is.False);
         }
 
         [Test]
         public void ColorNamedVsHTML()
         {
-            Assert.IsTrue(XLColor.Black == XLColor.FromHtml("#000000"));
+            Assert.That(XLColor.Black == XLColor.FromHtml("#000000"), Is.True);
         }
 
         [Test]
@@ -36,9 +36,12 @@ namespace ClosedXML.Tests.Excel
             var wb = new XLWorkbook();
             IXLWorksheet ws = wb.AddWorksheet("Sheet1");
             XLColor color = ws.FirstCell().Style.Fill.BackgroundColor;
-            Assert.AreEqual(XLColorType.Indexed, color.ColorType);
-            Assert.AreEqual(64, color.Indexed);
-            Assert.AreEqual(Color.Transparent, color.Color);
+            Assert.Multiple(() =>
+            {
+                Assert.That(color.ColorType, Is.EqualTo(XLColorType.Indexed));
+                Assert.That(color.Indexed, Is.EqualTo(64));
+                Assert.That(color.Color, Is.EqualTo(Color.Transparent));
+            });
         }
 
         [Test]
@@ -54,25 +57,28 @@ namespace ClosedXML.Tests.Excel
             var color3 = new BackgroundColor().FromClosedXMLColor<BackgroundColor>(xlColor3);
             var color4 = new BackgroundColor().FromClosedXMLColor<BackgroundColor>(xlColor4);
 
-            Assert.AreEqual("FFFF0000", color1.Rgb.Value);
-            Assert.IsNull(color1.Indexed);
-            Assert.IsNull(color1.Theme);
-            Assert.IsNull(color1.Tint);
+            Assert.That(color1.Rgb.Value, Is.EqualTo("FFFF0000"));
+            Assert.That(color1.Indexed, Is.Null);
+            Assert.That(color1.Theme, Is.Null);
+            Assert.That(color1.Tint, Is.Null);
 
-            Assert.IsNull(color2.Rgb);
-            Assert.AreEqual(20, color2.Indexed.Value);
-            Assert.IsNull(color2.Theme);
-            Assert.IsNull(color2.Tint);
+            Assert.That(color2.Rgb, Is.Null);
+            Assert.That(color2.Indexed.Value, Is.EqualTo(20));
+            Assert.That(color2.Theme, Is.Null);
+            Assert.That(color2.Tint, Is.Null);
 
-            Assert.IsNull(color3.Rgb);
-            Assert.IsNull(color3.Indexed);
-            Assert.AreEqual(4, color3.Theme.Value);
-            Assert.IsNull(color3.Tint);
+            Assert.That(color3.Rgb, Is.Null);
+            Assert.That(color3.Indexed, Is.Null);
+            Assert.That(color3.Theme.Value, Is.EqualTo(4));
+            Assert.That(color3.Tint, Is.Null);
 
-            Assert.IsNull(color4.Rgb);
-            Assert.IsNull(color4.Indexed);
-            Assert.AreEqual(5, color4.Theme.Value);
-            Assert.AreEqual(0.4, color4.Tint.Value);
+            Assert.That(color4.Rgb, Is.Null);
+            Assert.That(color4.Indexed, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(color4.Theme.Value, Is.EqualTo(5));
+                Assert.That(color4.Tint.Value, Is.EqualTo(0.4));
+            });
         }
 
         [Test]
@@ -88,25 +94,28 @@ namespace ClosedXML.Tests.Excel
             var color3 = new X14.FillColor().FromClosedXMLColor<X14.FillColor>(xlColor3);
             var color4 = new X14.HighMarkerColor().FromClosedXMLColor<X14.HighMarkerColor>(xlColor4);
 
-            Assert.AreEqual("FFFF0000", color1.Rgb.Value);
-            Assert.IsNull(color1.Indexed);
-            Assert.IsNull(color1.Theme);
-            Assert.IsNull(color1.Tint);
+            Assert.That(color1.Rgb.Value, Is.EqualTo("FFFF0000"));
+            Assert.That(color1.Indexed, Is.Null);
+            Assert.That(color1.Theme, Is.Null);
+            Assert.That(color1.Tint, Is.Null);
 
-            Assert.IsNull(color2.Rgb);
-            Assert.AreEqual(20, color2.Indexed.Value);
-            Assert.IsNull(color2.Theme);
-            Assert.IsNull(color2.Tint);
+            Assert.That(color2.Rgb, Is.Null);
+            Assert.That(color2.Indexed.Value, Is.EqualTo(20));
+            Assert.That(color2.Theme, Is.Null);
+            Assert.That(color2.Tint, Is.Null);
 
-            Assert.IsNull(color3.Rgb);
-            Assert.IsNull(color3.Indexed);
-            Assert.AreEqual(4, color3.Theme.Value);
-            Assert.IsNull(color3.Tint);
+            Assert.That(color3.Rgb, Is.Null);
+            Assert.That(color3.Indexed, Is.Null);
+            Assert.That(color3.Theme.Value, Is.EqualTo(4));
+            Assert.That(color3.Tint, Is.Null);
 
-            Assert.IsNull(color4.Rgb);
-            Assert.IsNull(color4.Indexed);
-            Assert.AreEqual(5, color4.Theme.Value);
-            Assert.AreEqual(0.4, color4.Tint.Value);
+            Assert.That(color4.Rgb, Is.Null);
+            Assert.That(color4.Indexed, Is.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(color4.Theme.Value, Is.EqualTo(5));
+                Assert.That(color4.Tint.Value, Is.EqualTo(0.4));
+            });
         }
 
         [Test]
@@ -126,19 +135,22 @@ namespace ClosedXML.Tests.Excel
             var xlColor3 = color3.ToClosedXMLColor();
             var xlColor4 = color4.ToClosedXMLColor();
 
-            Assert.AreEqual(XLColorType.Color, xlColor1.ColorType);
-            Assert.AreEqual(XLColor.Red.Color, xlColor1.Color);
+            Assert.Multiple(() =>
+            {
+                Assert.That(xlColor1.ColorType, Is.EqualTo(XLColorType.Color));
+                Assert.That(xlColor1.Color, Is.EqualTo(XLColor.Red.Color));
 
-            Assert.AreEqual(XLColorType.Indexed, xlColor2.ColorType);
-            Assert.AreEqual(20, xlColor2.Indexed);
+                Assert.That(xlColor2.ColorType, Is.EqualTo(XLColorType.Indexed));
+                Assert.That(xlColor2.Indexed, Is.EqualTo(20));
 
-            Assert.AreEqual(XLColorType.Theme, xlColor3.ColorType);
-            Assert.AreEqual(XLThemeColor.Accent1, xlColor3.ThemeColor);
-            Assert.AreEqual(0, xlColor3.ThemeTint, XLHelper.Epsilon);
+                Assert.That(xlColor3.ColorType, Is.EqualTo(XLColorType.Theme));
+                Assert.That(xlColor3.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(xlColor3.ThemeTint, Is.EqualTo(0).Within(XLHelper.Epsilon));
 
-            Assert.AreEqual(XLColorType.Theme, xlColor4.ColorType);
-            Assert.AreEqual(XLThemeColor.Accent1, xlColor4.ThemeColor);
-            Assert.AreEqual(0.4, xlColor4.ThemeTint, XLHelper.Epsilon);
+                Assert.That(xlColor4.ColorType, Is.EqualTo(XLColorType.Theme));
+                Assert.That(xlColor4.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(xlColor4.ThemeTint, Is.EqualTo(0.4).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -158,19 +170,22 @@ namespace ClosedXML.Tests.Excel
             var xlColor3 = color3.ToClosedXMLColor();
             var xlColor4 = color4.ToClosedXMLColor();
 
-            Assert.AreEqual(XLColorType.Color, xlColor1.ColorType);
-            Assert.AreEqual(XLColor.Red.Color, xlColor1.Color);
+            Assert.Multiple(() =>
+            {
+                Assert.That(xlColor1.ColorType, Is.EqualTo(XLColorType.Color));
+                Assert.That(xlColor1.Color, Is.EqualTo(XLColor.Red.Color));
 
-            Assert.AreEqual(XLColorType.Indexed, xlColor2.ColorType);
-            Assert.AreEqual(20, xlColor2.Indexed);
+                Assert.That(xlColor2.ColorType, Is.EqualTo(XLColorType.Indexed));
+                Assert.That(xlColor2.Indexed, Is.EqualTo(20));
 
-            Assert.AreEqual(XLColorType.Theme, xlColor3.ColorType);
-            Assert.AreEqual(XLThemeColor.Accent1, xlColor3.ThemeColor);
-            Assert.AreEqual(0, xlColor3.ThemeTint, XLHelper.Epsilon);
+                Assert.That(xlColor3.ColorType, Is.EqualTo(XLColorType.Theme));
+                Assert.That(xlColor3.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(xlColor3.ThemeTint, Is.EqualTo(0).Within(XLHelper.Epsilon));
 
-            Assert.AreEqual(XLColorType.Theme, xlColor4.ColorType);
-            Assert.AreEqual(XLThemeColor.Accent1, xlColor4.ThemeColor);
-            Assert.AreEqual(0.4, xlColor4.ThemeTint, XLHelper.Epsilon);
+                Assert.That(xlColor4.ColorType, Is.EqualTo(XLColorType.Theme));
+                Assert.That(xlColor4.ThemeColor, Is.EqualTo(XLThemeColor.Accent1));
+                Assert.That(xlColor4.ThemeTint, Is.EqualTo(0.4).Within(XLHelper.Epsilon));
+            });
         }
 
         [Test]
@@ -181,7 +196,7 @@ namespace ClosedXML.Tests.Excel
             culture.TextInfo.ListSeparator = "#";
             Thread.CurrentThread.CurrentCulture = culture;
             var color = XLColor.FromHtml("#FF008000");
-            Assert.AreEqual(XLColor.Green, color);
+            Assert.That(color, Is.EqualTo(XLColor.Green));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -14,8 +14,11 @@ namespace ClosedXML.Tests.Excel.Styles
             var fontKey2 = _defaultKey with { FontName = "Times New Roman" };
             var fontKey3 = _defaultKey with { FontName = "TIMES NEW ROMAN" };
 
-            Assert.AreNotEqual(fontKey1.GetHashCode(), fontKey2.GetHashCode());
-            Assert.AreEqual(fontKey2.GetHashCode(), fontKey3.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(fontKey2.GetHashCode(), Is.Not.EqualTo(fontKey1.GetHashCode()));
+                Assert.That(fontKey3.GetHashCode(), Is.EqualTo(fontKey2.GetHashCode()));
+            });
         }
 
         [Test]
@@ -25,8 +28,11 @@ namespace ClosedXML.Tests.Excel.Styles
             var fontKey2 = _defaultKey with { FontName = "Times New Roman" };
             var fontKey3 = _defaultKey with { FontName = "TIMES NEW ROMAN" };
 
-            Assert.IsFalse(fontKey1.Equals(fontKey2));
-            Assert.IsTrue(fontKey2.Equals(fontKey3));
+            Assert.Multiple(() =>
+            {
+                Assert.That(fontKey1.Equals(fontKey2), Is.False);
+                Assert.That(fontKey2.Equals(fontKey3), Is.True);
+            });
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -30,8 +30,8 @@ namespace ClosedXML.Tests.Excel.Styles
 
             Assert.Multiple(() =>
             {
-                Assert.That(fontKey1.Equals(fontKey2), Is.False);
-                Assert.That(fontKey2.Equals(fontKey3), Is.True);
+                Assert.That(fontKey1, Is.Not.EqualTo(fontKey2));
+                Assert.That(fontKey2, Is.EqualTo(fontKey3));
             });
         }
     }

--- a/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
@@ -13,41 +13,37 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void PreserveCellFormat()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            var table = new DataTable();
+            table.Columns.Add("Date", typeof(DateTime));
+
+            for (int i = 0; i < 10; i++)
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                var table = new DataTable();
-                table.Columns.Add("Date", typeof(DateTime));
-
-                for (int i = 0; i < 10; i++)
-                {
-                    table.Rows.Add(new DateTime(2017, 1, 1).AddMonths(i));
-                }
-
-                ws.Column(1).Style.NumberFormat.Format = "yy-MM-dd";
-                ws.Cell("A1").InsertData(table);
-                Assert.AreEqual("yy-MM-dd", ws.Cell("A5").Style.DateFormat.Format);
-
-                ws.Row(1).Style.NumberFormat.Format = "yy-MM-dd";
-                ws.Cell("A1").InsertData(table.Rows, true);
-                Assert.AreEqual("yy-MM-dd", ws.Cell("E1").Style.DateFormat.Format);
+                table.Rows.Add(new DateTime(2017, 1, 1).AddMonths(i));
             }
+
+            ws.Column(1).Style.NumberFormat.Format = "yy-MM-dd";
+            ws.Cell("A1").InsertData(table);
+            Assert.That(ws.Cell("A5").Style.DateFormat.Format, Is.EqualTo("yy-MM-dd"));
+
+            ws.Row(1).Style.NumberFormat.Format = "yy-MM-dd";
+            ws.Cell("A1").InsertData(table.Rows, true);
+            Assert.That(ws.Cell("E1").Style.DateFormat.Format, Is.EqualTo("yy-MM-dd"));
         }
 
         [Test]
         public void TestExcelNumberFormats()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                var c = ws.FirstCell()
-                    .SetValue((41573.875));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var c = ws.FirstCell()
+                .SetValue((41573.875));
 
-                c.Style.NumberFormat.SetFormat("m/d/yy\\ h:mm;@");
+            c.Style.NumberFormat.SetFormat("m/d/yy\\ h:mm;@");
 
-                Assert.AreEqual("10/26/13 21:00", c.GetFormattedString());
-            }
+            Assert.That(c.GetFormattedString(), Is.EqualTo("10/26/13 21:00"));
         }
 
         [Test]
@@ -59,32 +55,30 @@ namespace ClosedXML.Tests.Excel
             var cell = ws.Cell("A1").SetValue(10000.5);
 
             var currentCultureFormat = cell.GetFormattedString();
-            Assert.AreEqual("10000.5", currentCultureFormat);
+            Assert.That(currentCultureFormat, Is.EqualTo("10000.5"));
 
             var czechCultureFormat = cell.GetFormattedString(CultureInfo.GetCultureInfo("cs-CZ"));
-            Assert.AreEqual("10000,5", czechCultureFormat);
+            Assert.That(czechCultureFormat, Is.EqualTo("10000,5"));
         }
 
         [Test]
         public void ReadAndWriteColumnNumberFormat()
         {
-            using (var memoryStream = new MemoryStream())
+            using var memoryStream = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.AddWorksheet();
-                    var sourceColumn = ws.Column(1);
-                    sourceColumn.Style.NumberFormat.Format = "0.000";
-                    wb.SaveAs(memoryStream);
-                }
+                var ws = wb.AddWorksheet();
+                var sourceColumn = ws.Column(1);
+                sourceColumn.Style.NumberFormat.Format = "0.000";
+                wb.SaveAs(memoryStream);
+            }
 
-                memoryStream.Position = 0;
+            memoryStream.Position = 0;
 
-                using (var wb = new XLWorkbook(memoryStream))
-                {
-                    var column = wb.Worksheets.Single().Column(1);
-                    Assert.AreEqual("0.000", column.Style.NumberFormat.Format);
-                }
+            using (var wb = new XLWorkbook(memoryStream))
+            {
+                var column = wb.Worksheets.Single().Column(1);
+                Assert.That(column.Style.NumberFormat.Format, Is.EqualTo("0.000"));
             }
         }
 
@@ -94,7 +88,7 @@ namespace ClosedXML.Tests.Excel
             var numberFormatKey1 = XLNumberFormatKey.ForFormat("MM");
             var numberFormatKey2 = XLNumberFormatKey.ForFormat("mm");
 
-            Assert.AreNotEqual(numberFormatKey1.GetHashCode(), numberFormatKey2.GetHashCode());
+            Assert.That(numberFormatKey2.GetHashCode(), Is.Not.EqualTo(numberFormatKey1.GetHashCode()));
         }
 
         [Test]
@@ -103,29 +97,27 @@ namespace ClosedXML.Tests.Excel
             var numberFormatKey1 = XLNumberFormatKey.ForFormat("MM");
             var numberFormatKey2 = XLNumberFormatKey.ForFormat("mm");
 
-            Assert.IsFalse(numberFormatKey1.Equals(numberFormatKey2));
+            Assert.That(numberFormatKey1.Equals(numberFormatKey2), Is.False);
         }
 
         [Test]
         public void AddCustomNumberFormatsToFileWithNonSequentialNumberFormatIds()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\NumberFormats\NonSequentialNumberFormatsIds-Input.xlsx")))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\NumberFormats\NonSequentialNumberFormatsIds-Input.xlsx"));
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
-                {
-                    var wb = new XLWorkbook(stream);
+                var wb = new XLWorkbook(stream);
 
-                    var ws = wb.Worksheet("Sheet1");
+                var ws = wb.Worksheet("Sheet1");
 
-                    var format = "\"P\" #,##0.00; \"N\" #,##0.00;0;@";
-                    ws.Cell(5, 1).Value = 1.2;
-                    ws.Cell(5, 1).Style.NumberFormat.Format = format;
-                    ws.Cell(5, 2).Value = -1.2;
-                    ws.Cell(5, 2).Style.NumberFormat.Format = format;
+                var format = "\"P\" #,##0.00; \"N\" #,##0.00;0;@";
+                ws.Cell(5, 1).Value = 1.2;
+                ws.Cell(5, 1).Style.NumberFormat.Format = format;
+                ws.Cell(5, 2).Value = -1.2;
+                ws.Cell(5, 2).Style.NumberFormat.Format = format;
 
-                    return wb;
-                }, @"Other\NumberFormats\NonSequentialNumberFormatsIds-Output.xlsx");
-            }
+                return wb;
+            }, @"Other\NumberFormats\NonSequentialNumberFormatsIds-Output.xlsx");
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
@@ -97,7 +97,7 @@ namespace ClosedXML.Tests.Excel
             var numberFormatKey1 = XLNumberFormatKey.ForFormat("MM");
             var numberFormatKey2 = XLNumberFormatKey.ForFormat("mm");
 
-            Assert.That(numberFormatKey1.Equals(numberFormatKey2), Is.False);
+            Assert.That(numberFormatKey1, Is.Not.EqualTo(numberFormatKey2));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Styles/StyleChangeTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/StyleChangeTests.cs
@@ -9,46 +9,47 @@ namespace ClosedXML.Tests.Excel.Styles
         [Test]
         public void ChangeFontColorDoesNotAffectOtherProperties()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            // Arrange
+            var ws = wb.AddWorksheet("Sheet1");
+            var a1 = ws.Cell("A1");
+            var a2 = ws.Cell("A2");
+            var b1 = ws.Cell("B1");
+            var b2 = ws.Cell("B2");
+
+            ws.Range("A1:B2").Value = "Test";
+
+            a1.Style.Fill.BackgroundColor = XLColor.Red;
+            a2.Style.Fill.BackgroundColor = XLColor.Green;
+            b1.Style.Fill.BackgroundColor = XLColor.Blue;
+            b2.Style.Fill.BackgroundColor = XLColor.Pink;
+
+            a1.Style.Font.FontName = "Arial";
+            a2.Style.Font.FontName = "Times New Roman";
+            b1.Style.Font.FontName = "Calibri";
+            b2.Style.Font.FontName = "Cambria";
+
+            // Act
+            ws.Range("A1:B2").Style.Font.FontColor = XLColor.PowderBlue;
+
+            Assert.Multiple(() =>
             {
-                // Arrange
-                var ws = wb.AddWorksheet("Sheet1");
-                var a1 = ws.Cell("A1");
-                var a2 = ws.Cell("A2");
-                var b1 = ws.Cell("B1");
-                var b2 = ws.Cell("B2");
-
-                ws.Range("A1:B2").Value = "Test";
-
-                a1.Style.Fill.BackgroundColor = XLColor.Red;
-                a2.Style.Fill.BackgroundColor = XLColor.Green;
-                b1.Style.Fill.BackgroundColor = XLColor.Blue;
-                b2.Style.Fill.BackgroundColor = XLColor.Pink;
-
-                a1.Style.Font.FontName = "Arial";
-                a2.Style.Font.FontName = "Times New Roman";
-                b1.Style.Font.FontName = "Calibri";
-                b2.Style.Font.FontName = "Cambria";
-
-                // Act
-                ws.Range("A1:B2").Style.Font.FontColor = XLColor.PowderBlue;
-
                 //Assert
-                Assert.AreEqual(XLColor.Red, ws.Cell("A1").Style.Fill.BackgroundColor);
-                Assert.AreEqual(XLColor.Green, ws.Cell("A2").Style.Fill.BackgroundColor);
-                Assert.AreEqual(XLColor.Blue, ws.Cell("B1").Style.Fill.BackgroundColor);
-                Assert.AreEqual(XLColor.Pink, ws.Cell("B2").Style.Fill.BackgroundColor);
+                Assert.That(ws.Cell("A1").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
+                Assert.That(ws.Cell("A2").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Green));
+                Assert.That(ws.Cell("B1").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Blue));
+                Assert.That(ws.Cell("B2").Style.Fill.BackgroundColor, Is.EqualTo(XLColor.Pink));
 
-                Assert.AreEqual("Arial", ws.Cell("A1").Style.Font.FontName);
-                Assert.AreEqual("Times New Roman", ws.Cell("A2").Style.Font.FontName);
-                Assert.AreEqual("Calibri", ws.Cell("B1").Style.Font.FontName);
-                Assert.AreEqual("Cambria", ws.Cell("B2").Style.Font.FontName);
+                Assert.That(ws.Cell("A1").Style.Font.FontName, Is.EqualTo("Arial"));
+                Assert.That(ws.Cell("A2").Style.Font.FontName, Is.EqualTo("Times New Roman"));
+                Assert.That(ws.Cell("B1").Style.Font.FontName, Is.EqualTo("Calibri"));
+                Assert.That(ws.Cell("B2").Style.Font.FontName, Is.EqualTo("Cambria"));
 
-                Assert.AreEqual(XLColor.PowderBlue, ws.Cell("A1").Style.Font.FontColor);
-                Assert.AreEqual(XLColor.PowderBlue, ws.Cell("A2").Style.Font.FontColor);
-                Assert.AreEqual(XLColor.PowderBlue, ws.Cell("B1").Style.Font.FontColor);
-                Assert.AreEqual(XLColor.PowderBlue, ws.Cell("B2").Style.Font.FontColor);
-            }
+                Assert.That(ws.Cell("A1").Style.Font.FontColor, Is.EqualTo(XLColor.PowderBlue));
+                Assert.That(ws.Cell("A2").Style.Font.FontColor, Is.EqualTo(XLColor.PowderBlue));
+                Assert.That(ws.Cell("B1").Style.Font.FontColor, Is.EqualTo(XLColor.PowderBlue));
+                Assert.That(ws.Cell("B2").Style.Font.FontColor, Is.EqualTo(XLColor.PowderBlue));
+            });
         }
 
         [Test]
@@ -58,7 +59,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
             style.Alignment.Horizontal = XLAlignmentHorizontalValues.Justify;
 
-            Assert.AreEqual(XLAlignmentHorizontalValues.Justify, style.Alignment.Horizontal);
+            Assert.That(style.Alignment.Horizontal, Is.EqualTo(XLAlignmentHorizontalValues.Justify));
         }
 
         [Test]
@@ -68,7 +69,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
             style.Border.DiagonalBorder = XLBorderStyleValues.Double;
 
-            Assert.AreEqual(XLBorderStyleValues.Double, style.Border.DiagonalBorder);
+            Assert.That(style.Border.DiagonalBorder, Is.EqualTo(XLBorderStyleValues.Double));
         }
 
         [Test]
@@ -78,7 +79,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
             style.Fill.BackgroundColor = XLColor.Red;
 
-            Assert.AreEqual(XLColor.Red, style.Fill.BackgroundColor);
+            Assert.That(style.Fill.BackgroundColor, Is.EqualTo(XLColor.Red));
         }
 
         [Test]
@@ -88,7 +89,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
             style.Font.FontSize = 50;
 
-            Assert.AreEqual(50, style.Font.FontSize);
+            Assert.That(style.Font.FontSize, Is.EqualTo(50));
         }
 
         [Test]
@@ -98,7 +99,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
             style.NumberFormat.Format = "YYYY";
 
-            Assert.AreEqual("YYYY", style.NumberFormat.Format);
+            Assert.That(style.NumberFormat.Format, Is.EqualTo("YYYY"));
         }
 
         [Test]
@@ -108,21 +109,19 @@ namespace ClosedXML.Tests.Excel.Styles
 
             style.Protection.Hidden = true;
 
-            Assert.AreEqual(true, style.Protection.Hidden);
+            Assert.That(style.Protection.Hidden, Is.True);
         }
 
         [Test]
         public void ChangeAttachedStyleAlignment()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                var a1 = ws.Cell("A1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var a1 = ws.Cell("A1");
 
-                a1.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Justify;
+            a1.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Justify;
 
-                Assert.AreEqual(XLAlignmentHorizontalValues.Justify, a1.Style.Alignment.Horizontal);
-            }
+            Assert.That(a1.Style.Alignment.Horizontal, Is.EqualTo(XLAlignmentHorizontalValues.Justify));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/StyleTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/StyleTests.cs
@@ -13,35 +13,39 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void EmptyCellWithQuotePrefixNotTreatedAsEmpty()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.FirstCell().SetValue("Empty cell with quote prefix:");
+                var cell = ws.FirstCell().CellRight() as XLCell;
+
+                Assert.That(cell.IsEmpty(), Is.True);
+                cell.Value = string.Empty;
+                cell.Style.IncludeQuotePrefix = true;
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    ws.FirstCell().SetValue("Empty cell with quote prefix:");
-                    var cell = ws.FirstCell().CellRight() as XLCell;
+                    Assert.That(cell.IsEmpty(), Is.True);
+                    Assert.That(cell.IsEmpty(XLCellsUsedOptions.All), Is.False);
+                });
 
-                    Assert.IsTrue(cell.IsEmpty());
-                    cell.Value = String.Empty;
-                    cell.Style.IncludeQuotePrefix = true;
+                wb.SaveAs(ms);
+            }
 
-                    Assert.IsTrue(cell.IsEmpty());
-                    Assert.IsFalse(cell.IsEmpty(XLCellsUsedOptions.All));
+            ms.Seek(0, SeekOrigin.Begin);
 
-                    wb.SaveAs(ms);
-                }
-
-                ms.Seek(0, SeekOrigin.Begin);
-
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                var cell = (XLCell)ws.Cell("B1");
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var cell = (XLCell)ws.Cell("B1");
-                    Assert.AreEqual(1, cell.MemorySstId);
+                    Assert.That(cell.MemorySstId, Is.EqualTo(1));
 
-                    Assert.IsTrue(cell.IsEmpty());
-                    Assert.IsFalse(cell.IsEmpty(XLCellsUsedOptions.All));
-                }
+                    Assert.That(cell.IsEmpty(), Is.True);
+                    Assert.That(cell.IsEmpty(XLCellsUsedOptions.All), Is.False);
+                });
             }
         }
 
@@ -52,34 +56,33 @@ namespace ClosedXML.Tests.Excel
         [TestCase("F6", TestName = "Non-initialized cell")]
         public void CellTakesWorksheetStyle(string cellAddress)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Column(2);
-                ws.Row(2);
-                ws.Cell("D4").Value = "Non empty";
-                ws.Style.Font.SetFontName("Arial");
-                ws.Style.Font.SetFontSize(9);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Column(2);
+            ws.Row(2);
+            ws.Cell("D4").Value = "Non empty";
+            ws.Style.Font.SetFontName("Arial");
+            ws.Style.Font.SetFontSize(9);
 
-                var cell = ws.Cell(cellAddress);
-                Assert.AreEqual("Arial", cell.Style.Font.FontName);
-                Assert.AreEqual(9, cell.Style.Font.FontSize);
-            }
+            var cell = ws.Cell(cellAddress);
+            Assert.Multiple(() =>
+            {
+                Assert.That(cell.Style.Font.FontName, Is.EqualTo("Arial"));
+                Assert.That(cell.Style.Font.FontSize, Is.EqualTo(9));
+            });
         }
 
         [TestCaseSource(nameof(StylizedEntities))]
         public void WorksheetStyleAffectsAllNestedEntities(Func<IXLWorksheet, IXLStyle> getEntityStyle)
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
 
-                ws.Style.Font.FontSize = 8;
+            ws.Style.Font.FontSize = 8;
 
-                var style = getEntityStyle(ws);
+            var style = getEntityStyle(ws);
 
-                Assert.AreEqual(8, style.Font.FontSize);
-            }
+            Assert.That(style.Font.FontSize, Is.EqualTo(8));
         }
 
         // https://github.com/ClosedXML/ClosedXML/issues/1813
@@ -157,18 +160,21 @@ namespace ClosedXML.Tests.Excel
                 .NumberFormat.SetNumberFormatId((int)XLPredefinedFormat.Number.Precision2);
 
             var crossCellStyle = ws.Cell(4, 2).Style;
-            Assert.AreEqual(XLAlignmentHorizontalValues.Center, crossCellStyle.Alignment.Horizontal);
-            Assert.AreEqual(XLBorderStyleValues.Double, crossCellStyle.Border.BottomBorder);
-            Assert.AreEqual(XLColor.Blue, crossCellStyle.Fill.BackgroundColor);
-            Assert.AreEqual(true, crossCellStyle.IncludeQuotePrefix);
-            Assert.AreEqual((int)XLPredefinedFormat.Number.Precision2, crossCellStyle.NumberFormat.NumberFormatId);
-            Assert.AreEqual(true, crossCellStyle.Protection.Locked);
+            Assert.Multiple(() =>
+            {
+                Assert.That(crossCellStyle.Alignment.Horizontal, Is.EqualTo(XLAlignmentHorizontalValues.Center));
+                Assert.That(crossCellStyle.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Double));
+                Assert.That(crossCellStyle.Fill.BackgroundColor, Is.EqualTo(XLColor.Blue));
+                Assert.That(crossCellStyle.IncludeQuotePrefix, Is.True);
+                Assert.That(crossCellStyle.NumberFormat.NumberFormatId, Is.EqualTo((int)XLPredefinedFormat.Number.Precision2));
+                Assert.That(crossCellStyle.Protection.Locked, Is.True);
+            });
 
             var rowCellStyle = ws.Cell(4, 3).Style;
-            Assert.AreEqual(rowStyle, rowCellStyle);
+            Assert.That(rowCellStyle, Is.EqualTo(rowStyle));
 
             var colCellStyle = ws.Cell(5, 2).Style;
-            Assert.AreEqual(colStyle, colCellStyle);
+            Assert.That(colCellStyle, Is.EqualTo(colStyle));
         }
 
         private static IEnumerable<TestCaseData> StylizedEntities

--- a/ClosedXML.Tests/Excel/Styles/XLFillTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/XLFillTests.cs
@@ -11,14 +11,14 @@ namespace ClosedXML.Tests.Excel
         public void BackgroundColorSetsPattern()
         {
             var fill = new XLFill { BackgroundColor = XLColor.Blue };
-            Assert.AreEqual(XLFillPatternValues.Solid, fill.PatternType);
+            Assert.That(fill.PatternType, Is.EqualTo(XLFillPatternValues.Solid));
         }
 
         [Test]
         public void BackgroundNoColorSetsPatternNone()
         {
             var fill = new XLFill { BackgroundColor = XLColor.NoColor };
-            Assert.AreEqual(XLFillPatternValues.None, fill.PatternType);
+            Assert.That(fill.PatternType, Is.EqualTo(XLFillPatternValues.None));
         }
 
         [Test]
@@ -26,8 +26,11 @@ namespace ClosedXML.Tests.Excel
         {
             var fill1 = new XLFill { BackgroundColor = XLColor.Blue };
             var fill2 = new XLFill { BackgroundColor = XLColor.Blue };
-            Assert.IsTrue(fill1.Equals(fill2));
-            Assert.AreEqual(fill1.GetHashCode(), fill2.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(fill1.Equals(fill2), Is.True);
+                Assert.That(fill2.GetHashCode(), Is.EqualTo(fill1.GetHashCode()));
+            });
         }
 
         [Test]
@@ -35,8 +38,11 @@ namespace ClosedXML.Tests.Excel
         {
             var fill1 = new XLFill { PatternType = XLFillPatternValues.Solid, BackgroundColor = XLColor.Blue };
             var fill2 = new XLFill { PatternType = XLFillPatternValues.Solid, BackgroundColor = XLColor.Red };
-            Assert.IsFalse(fill1.Equals(fill2));
-            Assert.AreNotEqual(fill1.GetHashCode(), fill2.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(fill1.Equals(fill2), Is.False);
+                Assert.That(fill2.GetHashCode(), Is.Not.EqualTo(fill1.GetHashCode()));
+            });
         }
 
         [Test]
@@ -47,12 +53,15 @@ namespace ClosedXML.Tests.Excel
             var fill3 = new XLFill { BackgroundColor = XLColor.FromIndex(64) };
             var fill4 = new XLFill { BackgroundColor = XLColor.NoColor };
 
-            Assert.IsTrue(fill1.Equals(fill2));
-            Assert.IsTrue(fill1.Equals(fill3));
-            Assert.IsTrue(fill1.Equals(fill4));
-            Assert.AreEqual(fill1.GetHashCode(), fill2.GetHashCode());
-            Assert.AreEqual(fill1.GetHashCode(), fill3.GetHashCode());
-            Assert.AreEqual(fill1.GetHashCode(), fill4.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(fill1.Equals(fill2), Is.True);
+                Assert.That(fill1.Equals(fill3), Is.True);
+                Assert.That(fill1.Equals(fill4), Is.True);
+                Assert.That(fill2.GetHashCode(), Is.EqualTo(fill1.GetHashCode()));
+                Assert.That(fill3.GetHashCode(), Is.EqualTo(fill1.GetHashCode()));
+                Assert.That(fill4.GetHashCode(), Is.EqualTo(fill1.GetHashCode()));
+            });
         }
 
         [Test]
@@ -72,8 +81,11 @@ namespace ClosedXML.Tests.Excel
                 PatternColor = XLColor.Green
             };
 
-            Assert.IsTrue(fill1.Equals(fill2));
-            Assert.AreEqual(fill1.GetHashCode(), fill2.GetHashCode());
+            Assert.Multiple(() =>
+            {
+                Assert.That(fill1.Equals(fill2), Is.True);
+                Assert.That(fill2.GetHashCode(), Is.EqualTo(fill1.GetHashCode()));
+            });
         }
 
         [Test]
@@ -88,30 +100,31 @@ namespace ClosedXML.Tests.Excel
                 .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
                 .Border.SetOutsideBorderColor(XLColor.Blue);
 
-            Assert.AreEqual(style.Border.BottomBorder, XLBorderStyleValues.Thick);
-            Assert.AreEqual(style.Border.TopBorder, XLBorderStyleValues.Thick);
-            Assert.AreEqual(style.Border.LeftBorder, XLBorderStyleValues.Thick);
-            Assert.AreEqual(style.Border.RightBorder, XLBorderStyleValues.Thick);
+            Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.BottomBorder));
+            Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.TopBorder));
+            Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.LeftBorder));
+            Assert.Multiple(() =>
+            {
+                Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.RightBorder));
 
-            Assert.AreEqual(style.Border.BottomBorderColor, XLColor.Blue);
-            Assert.AreEqual(style.Border.TopBorderColor, XLColor.Blue);
-            Assert.AreEqual(style.Border.LeftBorderColor, XLColor.Blue);
-            Assert.AreEqual(style.Border.RightBorderColor, XLColor.Blue);
+                Assert.That(XLColor.Blue, Is.EqualTo(style.Border.BottomBorderColor));
+            });
+            Assert.That(XLColor.Blue, Is.EqualTo(style.Border.TopBorderColor));
+            Assert.That(XLColor.Blue, Is.EqualTo(style.Border.LeftBorderColor));
+            Assert.That(XLColor.Blue, Is.EqualTo(style.Border.RightBorderColor));
         }
 
         [Test]
         public void LoadAndSaveTransparentBackgroundFill()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\TransparentBackgroundFill\inputfile.xlsx")))
-            using (var ms = new MemoryStream())
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\StyleReferenceFiles\TransparentBackgroundFill\inputfile.xlsx"));
+            using var ms = new MemoryStream();
+            TestHelper.CreateAndCompare(() =>
             {
-                TestHelper.CreateAndCompare(() =>
-                {
-                    var wb = new XLWorkbook(stream);
-                    wb.SaveAs(ms);
-                    return wb;
-                }, @"Other\StyleReferenceFiles\TransparentBackgroundFill\TransparentBackgroundFill.xlsx");
-            }
+                var wb = new XLWorkbook(stream);
+                wb.SaveAs(ms);
+                return wb;
+            }, @"Other\StyleReferenceFiles\TransparentBackgroundFill\TransparentBackgroundFill.xlsx");
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Styles/XLFillTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/XLFillTests.cs
@@ -100,18 +100,17 @@ namespace ClosedXML.Tests.Excel
                 .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
                 .Border.SetOutsideBorderColor(XLColor.Blue);
 
-            Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.BottomBorder));
-            Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.TopBorder));
-            Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.LeftBorder));
             Assert.Multiple(() =>
             {
-                Assert.That(XLBorderStyleValues.Thick, Is.EqualTo(style.Border.RightBorder));
-
+                Assert.That(style.Border.BottomBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(style.Border.TopBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(style.Border.LeftBorder, Is.EqualTo(XLBorderStyleValues.Thick));
+                Assert.That(style.Border.RightBorder, Is.EqualTo(XLBorderStyleValues.Thick));
                 Assert.That(XLColor.Blue, Is.EqualTo(style.Border.BottomBorderColor));
+                Assert.That(XLColor.Blue, Is.EqualTo(style.Border.TopBorderColor));
+                Assert.That(XLColor.Blue, Is.EqualTo(style.Border.LeftBorderColor));
+                Assert.That(XLColor.Blue, Is.EqualTo(style.Border.RightBorderColor));
             });
-            Assert.That(XLColor.Blue, Is.EqualTo(style.Border.TopBorderColor));
-            Assert.That(XLColor.Blue, Is.EqualTo(style.Border.LeftBorderColor));
-            Assert.That(XLColor.Blue, Is.EqualTo(style.Border.RightBorderColor));
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -14,8 +14,8 @@ namespace ClosedXML.Tests.Excel.Tables
     {
         public class TestObjectWithoutAttributes
         {
-            public String Column1 { get; set; }
-            public String Column2 { get; set; }
+            public string Column1 { get; set; }
+            public string Column2 { get; set; }
         }
 
         public class Person
@@ -23,13 +23,13 @@ namespace ClosedXML.Tests.Excel.Tables
             public int Age { get; set; }
 
             [XLColumn(Header = "Last name", Order = 2)]
-            public String LastName { get; set; }
+            public string LastName { get; set; }
 
             [XLColumn(Header = "First name", Order = 1)]
-            public String FirstName { get; set; }
+            public string FirstName { get; set; }
 
             [XLColumn(Header = "Full name", Order = 0)]
-            public String FullName { get => string.Concat(FirstName, " ", LastName); }
+            public string FullName { get => string.Concat(FirstName, " ", LastName); }
 
             [XLColumn(Order = 3)]
             public DateTime DateOfBirth { get; set; }
@@ -92,479 +92,487 @@ namespace ClosedXML.Tests.Excel.Tables
         [Test]
         public void AddingEmptyEnumerables()
         {
-            using (var wb = PrepareWorkbook())
-            {
-                var ws = wb.Worksheets.First();
+            using var wb = PrepareWorkbook();
+            var ws = wb.Worksheets.First();
 
-                var table = ws.Tables.First();
+            var table = ws.Tables.First();
 
-                IEnumerable<Person> personEnumerable = null;
-                Assert.AreEqual(null, table.AppendData(personEnumerable));
+            IEnumerable<Person> personEnumerable = null;
+            Assert.That(table.AppendData(personEnumerable), Is.Null);
 
-                personEnumerable = new Person[] { };
-                Assert.AreEqual(null, table.AppendData(personEnumerable));
+            personEnumerable = new Person[] { };
+            Assert.That(table.AppendData(personEnumerable), Is.Null);
 
-                IEnumerable enumerable = null;
-                Assert.AreEqual(null, table.AppendData(enumerable));
+            IEnumerable enumerable = null;
+            Assert.That(table.AppendData(enumerable), Is.Null);
 
-                enumerable = new Person[] { };
-                Assert.AreEqual(null, table.AppendData(enumerable));
-            }
+            enumerable = new Person[] { };
+            Assert.That(table.AppendData(enumerable), Is.Null);
         }
 
         [Test]
         public void ReplaceWithEmptyEnumerables()
         {
+            using var wb = PrepareWorkbook();
+            var ws = wb.Worksheets.First();
+
+            var table = ws.Tables.First();
+
+            IEnumerable<Person> personEnumerable = null;
+            Assert.Throws<InvalidOperationException>(() => table.ReplaceData(personEnumerable));
+
+            personEnumerable = new Person[] { };
+            Assert.Throws<InvalidOperationException>(() => table.ReplaceData(personEnumerable));
+
+            IEnumerable enumerable = null;
+            Assert.Throws<InvalidOperationException>(() => table.ReplaceData(enumerable));
+
+            enumerable = new Person[] { };
+            Assert.Throws<InvalidOperationException>(() => table.ReplaceData(enumerable));
+        }
+
+        [Test]
+        public void CanAppendTypedEnumerable()
+        {
+            using var ms = new MemoryStream();
             using (var wb = PrepareWorkbook())
             {
                 var ws = wb.Worksheets.First();
 
                 var table = ws.Tables.First();
 
-                IEnumerable<Person> personEnumerable = null;
-                Assert.Throws<InvalidOperationException>(() => table.ReplaceData(personEnumerable));
+                IEnumerable<Person> personEnumerable = NewData;
+                var addedRange = table.AppendData(personEnumerable);
 
-                personEnumerable = new Person[] { };
-                Assert.Throws<InvalidOperationException>(() => table.ReplaceData(personEnumerable));
+                Assert.That(addedRange.RangeAddress.ToString(), Is.EqualTo("B6:G7"));
+                ws.Columns().AdjustToContents();
 
-                IEnumerable enumerable = null;
-                Assert.Throws<InvalidOperationException>(() => table.ReplaceData(enumerable));
-
-                enumerable = new Person[] { };
-                Assert.Throws<InvalidOperationException>(() => table.ReplaceData(enumerable));
+                wb.SaveAs(ms);
             }
-        }
 
-        [Test]
-        public void CanAppendTypedEnumerable()
-        {
-            using (var ms = new MemoryStream())
+            using (var wb = new XLWorkbook(ms))
             {
-                using (var wb = PrepareWorkbook())
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    IEnumerable<Person> personEnumerable = NewData;
-                    var addedRange = table.AppendData(personEnumerable);
-
-                    Assert.AreEqual("B6:G7", addedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(5, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(5));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanAppendToTableWithTotalsRow()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+                table.SetShowTotalsRow(true);
+                table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Average;
+
+                IEnumerable<Person> personEnumerable = NewData;
+                var addedRange = table.AppendData(personEnumerable);
+
+                Assert.That(addedRange.RangeAddress.ToString(), Is.EqualTo("B6:G7"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-                    table.SetShowTotalsRow(true);
-                    table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Average;
-
-                    IEnumerable<Person> personEnumerable = NewData;
-                    var addedRange = table.AppendData(personEnumerable);
-
-                    Assert.AreEqual("B6:G7", addedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(5, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(5));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanAppendTypedEnumerableAndPushDownCellsBelowTable()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            var value = "Some value that will be overwritten";
+            IXLAddress address;
+            using (var wb = PrepareWorkbook())
             {
-                var value = "Some value that will be overwritten";
-                IXLAddress address;
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                var cell = table.LastRow().FirstCell().CellRight(2).CellBelow(1);
+                address = cell.Address;
+                cell.Value = value;
+
+                IEnumerable<Person> personEnumerable = NewData;
+                var addedRange = table.AppendData(personEnumerable);
+
+                Assert.That(addedRange.RangeAddress.ToString(), Is.EqualTo("B6:G7"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                var cell = ws.Cell(address);
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
+                    Assert.That(cell.Value, Is.EqualTo("de Beer"));
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(5));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
 
-                    var table = ws.Tables.First();
-
-                    var cell = table.LastRow().FirstCell().CellRight(2).CellBelow(1);
-                    address = cell.Address;
-                    cell.Value = value;
-
-                    IEnumerable<Person> personEnumerable = NewData;
-                    var addedRange = table.AppendData(personEnumerable);
-
-                    Assert.AreEqual("B6:G7", addedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    var cell = ws.Cell(address);
-                    Assert.AreEqual("de Beer", cell.Value);
-                    Assert.AreEqual(5, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-
-                    Assert.AreEqual(value, cell.CellBelow(NewData.Count()).Value);
-                }
+                    Assert.That(cell.CellBelow(NewData.Length).Value, Is.EqualTo(value));
+                });
             }
         }
 
         [Test]
         public void CanAppendUntypedEnumerable()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                var list = new ArrayList();
+                list.AddRange(NewData);
+
+                var addedRange = table.AppendData(list);
+
+                Assert.That(addedRange.RangeAddress.ToString(), Is.EqualTo("B6:G7"));
+
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    var list = new ArrayList();
-                    list.AddRange(NewData);
-
-                    var addedRange = table.AppendData(list);
-
-                    Assert.AreEqual("B6:G7", addedRange.RangeAddress.ToString());
-
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(5, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(5));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanAppendDataTable()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                IEnumerable<Person> personEnumerable = NewData;
+
+                var ws2 = wb.AddWorksheet("temp");
+                var dataTable = ws2.FirstCell().InsertTable(personEnumerable).AsNativeDataTable();
+
+                var addedRange = table.AppendData(dataTable);
+
+                Assert.That(addedRange.RangeAddress.ToString(), Is.EqualTo("B6:G7"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    IEnumerable<Person> personEnumerable = NewData;
-
-                    var ws2 = wb.AddWorksheet("temp");
-                    var dataTable = ws2.FirstCell().InsertTable(personEnumerable).AsNativeDataTable();
-
-                    var addedRange = table.AppendData(dataTable);
-
-                    Assert.AreEqual("B6:G7", addedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(5, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(5));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanReplaceWithTypedEnumerable()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                IEnumerable<Person> personEnumerable = NewData;
+                var replacedRange = table.ReplaceData(personEnumerable);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G4"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    IEnumerable<Person> personEnumerable = NewData;
-                    var replacedRange = table.ReplaceData(personEnumerable);
-
-                    Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(2, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(2));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanReplaceWithUntypedEnumerable()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                var list = new ArrayList();
+                list.AddRange(NewData);
+
+                var replacedRange = table.ReplaceData(list);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G4"));
+
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    var list = new ArrayList();
-                    list.AddRange(NewData);
-
-                    var replacedRange = table.ReplaceData(list);
-
-                    Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
-
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(2, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(2));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanReplaceWithDataTable()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                IEnumerable<Person> personEnumerable = NewData;
+
+                var ws2 = wb.AddWorksheet("temp");
+                var dataTable = ws2.FirstCell().InsertTable(personEnumerable).AsNativeDataTable();
+
+                var replacedRange = table.ReplaceData(dataTable);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G4"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-
-                    IEnumerable<Person> personEnumerable = NewData;
-
-                    var ws2 = wb.AddWorksheet("temp");
-                    var dataTable = ws2.FirstCell().InsertTable(personEnumerable).AsNativeDataTable();
-
-                    var replacedRange = table.ReplaceData(dataTable);
-
-                    Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(2, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(2));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanReplaceToTableWithTablesRow1()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+                table.SetShowTotalsRow(true);
+                table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Average;
+
+                // Will cause table to overflow
+                IEnumerable<Person> personEnumerable = NewData.Union(NewData).Union(NewData);
+                var replacedRange = table.ReplaceData(personEnumerable);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G8"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-                    table.SetShowTotalsRow(true);
-                    table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Average;
-
-                    // Will cause table to overflow
-                    IEnumerable<Person> personEnumerable = NewData.Union(NewData).Union(NewData);
-                    var replacedRange = table.ReplaceData(personEnumerable);
-
-                    Assert.AreEqual("B3:G8", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(6, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(6));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanReplaceToTableWithTablesRow2()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+                table.SetShowTotalsRow(true);
+                table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Average;
+
+                // Will cause table to shrink
+                IEnumerable<Person> personEnumerable = NewData.Take(1);
+                var replacedRange = table.ReplaceData(personEnumerable);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G3"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    var table = ws.Tables.First();
-                    table.SetShowTotalsRow(true);
-                    table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Average;
-
-                    // Will cause table to shrink
-                    IEnumerable<Person> personEnumerable = NewData.Take(1);
-                    var replacedRange = table.ReplaceData(personEnumerable);
-
-                    Assert.AreEqual("B3:G3", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(1, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(1));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanReplaceWithUntypedEnumerableAndPropagateExtraColumns()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbookWithAdditionalColumns())
             {
-                using (var wb = PrepareWorkbookWithAdditionalColumns())
+                var ws = wb.Worksheets.First();
+                var table = ws.Tables.First();
+
+                var list = new ArrayList();
+                list.AddRange(NewData);
+                list.AddRange(NewData);
+
+                var replacedRange = table.ReplaceData(list, propagateExtraColumns: true);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G6"));
+
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var table = ws.Tables.First();
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(4));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(10));
 
-                    var list = new ArrayList();
-                    list.AddRange(NewData);
-                    list.AddRange(NewData);
+                    Assert.That(table.Worksheet.Cell("H5").FormulaA1, Is.EqualTo("SUM($G$3:G5)"));
+                    Assert.That(table.Worksheet.Cell("H6").FormulaA1, Is.EqualTo("SUM($G$3:G6)"));
+                    Assert.That(table.Worksheet.Cell("H5").Value, Is.EqualTo(100));
+                    Assert.That(table.Worksheet.Cell("H6").Value, Is.EqualTo(130));
 
-                    var replacedRange = table.ReplaceData(list, propagateExtraColumns: true);
+                    Assert.That(table.Worksheet.Cell("I5").FormulaA1, Is.EqualTo("LEN(B5)"));
+                    Assert.That(table.Worksheet.Cell("I6").FormulaA1, Is.EqualTo("LEN(B6)"));
+                    Assert.That(table.Worksheet.Cell("I5").Value, Is.EqualTo(16));
+                    Assert.That(table.Worksheet.Cell("I6").Value, Is.EqualTo(21));
 
-                    Assert.AreEqual("B3:G6", replacedRange.RangeAddress.ToString());
+                    Assert.That(table.Worksheet.Cell("J5").FormulaA1, Is.EqualTo("G5>=40"));
+                    Assert.That(table.Worksheet.Cell("J6").FormulaA1, Is.EqualTo("G6>=40"));
+                    Assert.That(table.Worksheet.Cell("J5").Value, Is.EqualTo(false));
+                    Assert.That(table.Worksheet.Cell("J6").Value, Is.EqualTo(false));
 
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(4, table.DataRange.RowCount());
-                    Assert.AreEqual(10, table.DataRange.ColumnCount());
-
-                    Assert.AreEqual("SUM($G$3:G5)", table.Worksheet.Cell("H5").FormulaA1);
-                    Assert.AreEqual("SUM($G$3:G6)", table.Worksheet.Cell("H6").FormulaA1);
-                    Assert.AreEqual(100, table.Worksheet.Cell("H5").Value);
-                    Assert.AreEqual(130, table.Worksheet.Cell("H6").Value);
-
-                    Assert.AreEqual("LEN(B5)", table.Worksheet.Cell("I5").FormulaA1);
-                    Assert.AreEqual("LEN(B6)", table.Worksheet.Cell("I6").FormulaA1);
-                    Assert.AreEqual(16, table.Worksheet.Cell("I5").Value);
-                    Assert.AreEqual(21, table.Worksheet.Cell("I6").Value);
-
-                    Assert.AreEqual("G5>=40", table.Worksheet.Cell("J5").FormulaA1);
-                    Assert.AreEqual("G6>=40", table.Worksheet.Cell("J6").FormulaA1);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J5").Value);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J6").Value);
-
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K5").Value);
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K6").Value);
-                }
+                    Assert.That(table.Worksheet.Cell("K5").Value, Is.EqualTo("40 is not old!"));
+                    Assert.That(table.Worksheet.Cell("K6").Value, Is.EqualTo("40 is not old!"));
+                });
             }
         }
 
         [Test]
         public void CanReplaceWithTypedEnumerableAndPropagateExtraColumns()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbookWithAdditionalColumns())
             {
-                using (var wb = PrepareWorkbookWithAdditionalColumns())
+                var ws = wb.Worksheets.First();
+
+                var table = ws.Tables.First();
+
+                IEnumerable<Person> personEnumerable = NewData.Concat(NewData).OrderBy(p => p.Age);
+                var replacedRange = table.ReplaceData(personEnumerable, propagateExtraColumns: true);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G6"));
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(4));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(10));
 
-                    var table = ws.Tables.First();
+                    Assert.That(table.Worksheet.Cell("H5").FormulaA1, Is.EqualTo("SUM($G$3:G5)"));
+                    Assert.That(table.Worksheet.Cell("H6").FormulaA1, Is.EqualTo("SUM($G$3:G6)"));
+                    Assert.That(table.Worksheet.Cell("H5").Value, Is.EqualTo(95));
+                    Assert.That(table.Worksheet.Cell("H6").Value, Is.EqualTo(130));
 
-                    IEnumerable<Person> personEnumerable = NewData.Concat(NewData).OrderBy(p => p.Age);
-                    var replacedRange = table.ReplaceData(personEnumerable, propagateExtraColumns: true);
+                    Assert.That(table.Worksheet.Cell("I5").FormulaA1, Is.EqualTo("LEN(B5)"));
+                    Assert.That(table.Worksheet.Cell("I6").FormulaA1, Is.EqualTo("LEN(B6)"));
+                    Assert.That(table.Worksheet.Cell("I5").Value, Is.EqualTo(16));
+                    Assert.That(table.Worksheet.Cell("I6").Value, Is.EqualTo(16));
 
-                    Assert.AreEqual("B3:G6", replacedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
+                    Assert.That(table.Worksheet.Cell("J5").FormulaA1, Is.EqualTo("G5>=40"));
+                    Assert.That(table.Worksheet.Cell("J6").FormulaA1, Is.EqualTo("G6>=40"));
+                    Assert.That(table.Worksheet.Cell("J5").Value, Is.EqualTo(false));
+                    Assert.That(table.Worksheet.Cell("J6").Value, Is.EqualTo(false));
 
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(4, table.DataRange.RowCount());
-                    Assert.AreEqual(10, table.DataRange.ColumnCount());
-
-                    Assert.AreEqual("SUM($G$3:G5)", table.Worksheet.Cell("H5").FormulaA1);
-                    Assert.AreEqual("SUM($G$3:G6)", table.Worksheet.Cell("H6").FormulaA1);
-                    Assert.AreEqual(95, table.Worksheet.Cell("H5").Value);
-                    Assert.AreEqual(130, table.Worksheet.Cell("H6").Value);
-
-                    Assert.AreEqual("LEN(B5)", table.Worksheet.Cell("I5").FormulaA1);
-                    Assert.AreEqual("LEN(B6)", table.Worksheet.Cell("I6").FormulaA1);
-                    Assert.AreEqual(16, table.Worksheet.Cell("I5").Value);
-                    Assert.AreEqual(16, table.Worksheet.Cell("I6").Value);
-
-                    Assert.AreEqual("G5>=40", table.Worksheet.Cell("J5").FormulaA1);
-                    Assert.AreEqual("G6>=40", table.Worksheet.Cell("J6").FormulaA1);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J5").Value);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J6").Value);
-
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K5").Value);
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K6").Value);
-                }
+                    Assert.That(table.Worksheet.Cell("K5").Value, Is.EqualTo("40 is not old!"));
+                    Assert.That(table.Worksheet.Cell("K6").Value, Is.EqualTo("40 is not old!"));
+                });
             }
         }
 
@@ -576,135 +584,138 @@ namespace ClosedXML.Tests.Excel.Tables
             // means rows below it are shifted up/down and defined names should be
             // adjusted.
             // TODO: add assert for name shift when formulas are properly shifted. Originally, it threw even on defined name with A1 reference
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbook())
             {
-                using (var wb = PrepareWorkbook())
+                var ws = wb.Worksheets.First();
+
+                ws.DefinedNames.Add("ListOfPeople_Age", nameFormula);
+
+                var table = ws.Tables.First();
+
+                IEnumerable<Person> personEnumerable = NewData;
+                var replacedRange = table.ReplaceData(personEnumerable);
+
+                Assert.That(replacedRange.RangeAddress.ToString(), Is.EqualTo("B3:G4"));
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-
-                    ws.DefinedNames.Add("ListOfPeople_Age", nameFormula);
-
-                    var table = ws.Tables.First();
-
-                    IEnumerable<Person> personEnumerable = NewData;
-                    var replacedRange = table.ReplaceData(personEnumerable);
-
-                    Assert.AreEqual("B3:G4", replacedRange.RangeAddress.ToString());
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(2, table.DataRange.RowCount());
-                    Assert.AreEqual(6, table.DataRange.ColumnCount());
-                }
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(2));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(6));
+                });
             }
         }
 
         [Test]
         public void CanAppendWithUntypedEnumerableAndPropagateExtraColumns()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbookWithAdditionalColumns())
             {
-                using (var wb = PrepareWorkbookWithAdditionalColumns())
+                var ws = wb.Worksheets.First();
+                var table = ws.Tables.First();
+
+                var list = new ArrayList();
+                list.AddRange(NewData);
+                list.AddRange(NewData);
+
+                var appendedRange = table.AppendData(list, propagateExtraColumns: true);
+
+                Assert.That(appendedRange.RangeAddress.ToString(), Is.EqualTo("B6:G9"));
+
+                ws.Columns().AdjustToContents();
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.First();
-                    var table = ws.Tables.First();
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(7));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(10));
 
-                    var list = new ArrayList();
-                    list.AddRange(NewData);
-                    list.AddRange(NewData);
+                    Assert.That(table.Worksheet.Cell("H8").FormulaA1, Is.EqualTo("SUM($G$3:G8)"));
+                    Assert.That(table.Worksheet.Cell("H9").FormulaA1, Is.EqualTo("SUM($G$3:G9)"));
+                    Assert.That(table.Worksheet.Cell("H8").Value, Is.EqualTo(220));
+                    Assert.That(table.Worksheet.Cell("H9").Value, Is.EqualTo(250));
 
-                    var appendedRange = table.AppendData(list, propagateExtraColumns: true);
+                    Assert.That(table.Worksheet.Cell("I8").FormulaA1, Is.EqualTo("LEN(B8)"));
+                    Assert.That(table.Worksheet.Cell("I9").FormulaA1, Is.EqualTo("LEN(B9)"));
+                    Assert.That(table.Worksheet.Cell("I8").Value, Is.EqualTo(16));
+                    Assert.That(table.Worksheet.Cell("I9").Value, Is.EqualTo(21));
 
-                    Assert.AreEqual("B6:G9", appendedRange.RangeAddress.ToString());
+                    Assert.That(table.Worksheet.Cell("J8").FormulaA1, Is.EqualTo("G8>=40"));
+                    Assert.That(table.Worksheet.Cell("J9").FormulaA1, Is.EqualTo("G9>=40"));
+                    Assert.That(table.Worksheet.Cell("J8").Value, Is.EqualTo(false));
+                    Assert.That(table.Worksheet.Cell("J9").Value, Is.EqualTo(false));
 
-                    ws.Columns().AdjustToContents();
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
-
-                    Assert.AreEqual(7, table.DataRange.RowCount());
-                    Assert.AreEqual(10, table.DataRange.ColumnCount());
-
-                    Assert.AreEqual("SUM($G$3:G8)", table.Worksheet.Cell("H8").FormulaA1);
-                    Assert.AreEqual("SUM($G$3:G9)", table.Worksheet.Cell("H9").FormulaA1);
-                    Assert.AreEqual(220, table.Worksheet.Cell("H8").Value);
-                    Assert.AreEqual(250, table.Worksheet.Cell("H9").Value);
-
-                    Assert.AreEqual("LEN(B8)", table.Worksheet.Cell("I8").FormulaA1);
-                    Assert.AreEqual("LEN(B9)", table.Worksheet.Cell("I9").FormulaA1);
-                    Assert.AreEqual(16, table.Worksheet.Cell("I8").Value);
-                    Assert.AreEqual(21, table.Worksheet.Cell("I9").Value);
-
-                    Assert.AreEqual("G8>=40", table.Worksheet.Cell("J8").FormulaA1);
-                    Assert.AreEqual("G9>=40", table.Worksheet.Cell("J9").FormulaA1);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J8").Value);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J9").Value);
-
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K8").Value);
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K9").Value);
-                }
+                    Assert.That(table.Worksheet.Cell("K8").Value, Is.EqualTo("40 is not old!"));
+                    Assert.That(table.Worksheet.Cell("K9").Value, Is.EqualTo("40 is not old!"));
+                });
             }
         }
 
         [Test]
         public void CanAppendTypedEnumerableAndPropagateExtraColumns()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = PrepareWorkbookWithAdditionalColumns())
             {
-                using (var wb = PrepareWorkbookWithAdditionalColumns())
-                {
-                    var ws = wb.Worksheets.First();
+                var ws = wb.Worksheets.First();
 
-                    var table = ws.Tables.First();
+                var table = ws.Tables.First();
 
-                    IEnumerable<Person> personEnumerable =
-                        NewData
+                IEnumerable<Person> personEnumerable =
+                    NewData
                         .Concat(NewData)
                         .Concat(NewData)
                         .OrderBy(p => p.FirstName);
 
-                    var addedRange = table.AppendData(personEnumerable);
+                var addedRange = table.AppendData(personEnumerable);
 
-                    Assert.AreEqual("B6:G11", addedRange.RangeAddress.ToString());
-                    ws.Columns().AdjustToContents();
+                Assert.That(addedRange.RangeAddress.ToString(), Is.EqualTo("B6:G11"));
+                ws.Columns().AdjustToContents();
 
-                    wb.SaveAs(ms);
-                }
+                wb.SaveAs(ms);
+            }
 
-                using (var wb = new XLWorkbook(ms))
+            using (var wb = new XLWorkbook(ms))
+            {
+                var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+
+                Assert.Multiple(() =>
                 {
-                    var table = wb.Worksheets.SelectMany(ws => ws.Tables).First();
+                    Assert.That(table.DataRange.RowCount(), Is.EqualTo(9));
+                    Assert.That(table.DataRange.ColumnCount(), Is.EqualTo(10));
 
-                    Assert.AreEqual(9, table.DataRange.RowCount());
-                    Assert.AreEqual(10, table.DataRange.ColumnCount());
+                    Assert.That(table.Worksheet.Cell("H10").FormulaA1, Is.EqualTo("SUM($G$3:G10)"));
+                    Assert.That(table.Worksheet.Cell("H11").FormulaA1, Is.EqualTo("SUM($G$3:G11)"));
+                    Assert.That(table.Worksheet.Cell("H10").Value, Is.EqualTo(280));
+                    Assert.That(table.Worksheet.Cell("H11").Value, Is.EqualTo(315));
 
-                    Assert.AreEqual("SUM($G$3:G10)", table.Worksheet.Cell("H10").FormulaA1);
-                    Assert.AreEqual("SUM($G$3:G11)", table.Worksheet.Cell("H11").FormulaA1);
-                    Assert.AreEqual(280, table.Worksheet.Cell("H10").Value);
-                    Assert.AreEqual(315, table.Worksheet.Cell("H11").Value);
+                    Assert.That(table.Worksheet.Cell("I10").FormulaA1, Is.EqualTo("LEN(B10)"));
+                    Assert.That(table.Worksheet.Cell("I11").FormulaA1, Is.EqualTo("LEN(B11)"));
+                    Assert.That(table.Worksheet.Cell("I10").Value, Is.EqualTo(16));
+                    Assert.That(table.Worksheet.Cell("I11").Value, Is.EqualTo(16));
 
-                    Assert.AreEqual("LEN(B10)", table.Worksheet.Cell("I10").FormulaA1);
-                    Assert.AreEqual("LEN(B11)", table.Worksheet.Cell("I11").FormulaA1);
-                    Assert.AreEqual(16, table.Worksheet.Cell("I10").Value);
-                    Assert.AreEqual(16, table.Worksheet.Cell("I11").Value);
+                    Assert.That(table.Worksheet.Cell("J10").FormulaA1, Is.EqualTo("G10>=40"));
+                    Assert.That(table.Worksheet.Cell("J11").FormulaA1, Is.EqualTo("G11>=40"));
+                    Assert.That(table.Worksheet.Cell("J10").Value, Is.EqualTo(false));
+                    Assert.That(table.Worksheet.Cell("J11").Value, Is.EqualTo(false));
 
-                    Assert.AreEqual("G10>=40", table.Worksheet.Cell("J10").FormulaA1);
-                    Assert.AreEqual("G11>=40", table.Worksheet.Cell("J11").FormulaA1);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J10").Value);
-                    Assert.AreEqual(false, table.Worksheet.Cell("J11").Value);
-
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K10").Value);
-                    Assert.AreEqual("40 is not old!", table.Worksheet.Cell("K11").Value);
-                }
+                    Assert.That(table.Worksheet.Cell("K10").Value, Is.EqualTo("40 is not old!"));
+                    Assert.That(table.Worksheet.Cell("K11").Value, Is.EqualTo("40 is not old!"));
+                });
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/AddingAndReplacingTableDataTests.cs
@@ -100,13 +100,13 @@ namespace ClosedXML.Tests.Excel.Tables
             IEnumerable<Person> personEnumerable = null;
             Assert.That(table.AppendData(personEnumerable), Is.Null);
 
-            personEnumerable = new Person[] { };
+            personEnumerable = Array.Empty<Person>();
             Assert.That(table.AppendData(personEnumerable), Is.Null);
 
             IEnumerable enumerable = null;
             Assert.That(table.AppendData(enumerable), Is.Null);
 
-            enumerable = new Person[] { };
+            enumerable = Array.Empty<Person>();
             Assert.That(table.AppendData(enumerable), Is.Null);
         }
 
@@ -121,13 +121,13 @@ namespace ClosedXML.Tests.Excel.Tables
             IEnumerable<Person> personEnumerable = null;
             Assert.Throws<InvalidOperationException>(() => table.ReplaceData(personEnumerable));
 
-            personEnumerable = new Person[] { };
+            personEnumerable = Array.Empty<Person>();
             Assert.Throws<InvalidOperationException>(() => table.ReplaceData(personEnumerable));
 
             IEnumerable enumerable = null;
             Assert.Throws<InvalidOperationException>(() => table.ReplaceData(enumerable));
 
-            enumerable = new Person[] { };
+            enumerable = Array.Empty<Person>();
             Assert.Throws<InvalidOperationException>(() => table.ReplaceData(enumerable));
         }
 

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -950,7 +950,7 @@ namespace ClosedXML.Tests.Excel
             ws.Cell("D1").Value = "Normal";
 
             var table = ws.RangeUsed().CreateTable();
-            Assert.IsNotNull(table);
+            Assert.That(table, Is.Not.Null);
 
             table.ShowTotalsRow = true;
             table.Field(0).TotalsRowFunction = XLTotalsRowFunction.Count;
@@ -1131,7 +1131,7 @@ namespace ClosedXML.Tests.Excel
                 var ws = wb.Worksheets.Add("Sheet2");
                 var original = wb.Worksheets.First().Tables.First();
 
-                Assert.IsNotNull((original as XLTable).RelId);
+                Assert.That((original as XLTable).RelId, Is.Not.Null);
 
                 var copy = original.CopyTo(ws);
 

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -1062,7 +1062,7 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(ws2.Cell("C1").Value, Is.EqualTo("Custom column 3"));
                 Assert.That(ws2.Cell("A2").Value, Is.EqualTo("Value 1"));
                 Assert.That((double)ws2.Cell("B2").Value, Is.EqualTo(123.45).Within(XLHelper.Epsilon));
-                Assert.That(ws2.Cell("C2").Value, Is.EqualTo(new DateTime(2018, 5, 10)));
+                Assert.That(ws2.Cell("C2").Value.GetDateTime(), Is.EqualTo(new DateTime(2018, 5, 10)));
             });
         }
 
@@ -1101,7 +1101,7 @@ namespace ClosedXML.Tests.Excel
                 Assert.That(ws2.Cell("C1").Value, Is.EqualTo("Custom column 3"));
                 Assert.That(ws2.Cell("A2").Value, Is.EqualTo("Value 1"));
                 Assert.That((double)ws2.Cell("B2").Value, Is.EqualTo(123.45).Within(XLHelper.Epsilon));
-                Assert.That(ws2.Cell("C2").Value, Is.EqualTo(new DateTime(2018, 5, 10)));
+                Assert.That(ws2.Cell("C2").Value.GetDateTime(), Is.EqualTo(new DateTime(2018, 5, 10)));
             });
         }
 
@@ -1148,7 +1148,7 @@ namespace ClosedXML.Tests.Excel
                     Assert.That(ws.Cell("C1").Value, Is.EqualTo("Custom column 3"));
                     Assert.That(ws.Cell("A2").Value, Is.EqualTo("Value 1"));
                     Assert.That((double)ws.Cell("B2").Value, Is.EqualTo(123.45).Within(XLHelper.Epsilon));
-                    Assert.That(ws.Cell("C2").Value, Is.EqualTo(new DateTime(2018, 5, 10)));
+                    Assert.That(ws.Cell("C2").Value.GetDateTime(), Is.EqualTo(new DateTime(2018, 5, 10)));
                 });
             }
         }

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -15,8 +15,8 @@ namespace ClosedXML.Tests.Excel
     {
         public class TestObjectWithoutAttributes
         {
-            public String Column1 { get; set; }
-            public String Column2 { get; set; }
+            public string Column1 { get; set; }
+            public string Column2 { get; set; }
         }
 
         public class TestObjectWithAttributes
@@ -24,10 +24,10 @@ namespace ClosedXML.Tests.Excel
             public int UnOrderedColumn { get; set; }
 
             [XLColumn(Header = "SecondColumn", Order = 1)]
-            public String Column1 { get; set; }
+            public string Column1 { get; set; }
 
             [XLColumn(Header = "FirstColumn", Order = 0)]
-            public String Column2 { get; set; }
+            public string Column2 { get; set; }
 
             [XLColumn(Header = "SomeFieldNotProperty", Order = 2)]
             public int MyField;
@@ -40,146 +40,129 @@ namespace ClosedXML.Tests.Excel
             dt.Columns.Add("col1", typeof(string));
             dt.Columns.Add("col2", typeof(double));
 
-            using (var wb = new XLWorkbook())
-            {
-                wb.AddWorksheet(dt);
+            using var wb = new XLWorkbook();
+            wb.AddWorksheet(dt);
 
-                using (var ms = new MemoryStream())
-                    wb.SaveAs(ms, true);
-            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
         }
 
         [Test]
         public void PreventAddingOfEmptyDataTable()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                var dt = new DataTable();
-                var table = ws.FirstCell().InsertTable(dt);
+            var dt = new DataTable();
+            var table = ws.FirstCell().InsertTable(dt);
 
-                Assert.AreEqual(null, table);
-            }
+            Assert.That(table, Is.Null);
         }
 
         [Test]
         public void CanSaveTableCreatedFromSingleRow()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Title");
-                ws.Range("A1").CreateTable();
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Title");
+            ws.Range("A1").CreateTable();
 
-                using (var ms = new MemoryStream())
-                    wb.SaveAs(ms, true);
-            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
         }
 
         [Test]
         public void CreatingATableFromHeadersPushCellsBelow()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Title")
-                    .CellBelow().SetValue("X");
-                ws.Range("A1").CreateTable();
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Title")
+                .CellBelow().SetValue("X");
+            ws.Range("A1").CreateTable();
 
-                Assert.AreEqual(Blank.Value, ws.Cell("A2").Value);
-                Assert.AreEqual("X", ws.Cell("A3").GetText());
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(Blank.Value));
+                Assert.That(ws.Cell("A3").GetText(), Is.EqualTo("X"));
+            });
         }
 
         [Test]
         public void Inserting_Column_Sets_Header()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Categories")
-                    .CellBelow().SetValue("A")
-                    .CellBelow().SetValue("B")
-                    .CellBelow().SetValue("C");
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Categories")
+                .CellBelow().SetValue("A")
+                .CellBelow().SetValue("B")
+                .CellBelow().SetValue("C");
 
-                IXLTable table = ws.RangeUsed().CreateTable();
-                table.InsertColumnsAfter(1);
-                Assert.AreEqual("Column2", table.HeadersRow().LastCell().GetText());
-            }
+            IXLTable table = ws.RangeUsed().CreateTable();
+            table.InsertColumnsAfter(1);
+            Assert.That(table.HeadersRow().LastCell().GetText(), Is.EqualTo("Column2"));
         }
 
         [Test]
         public void DataRange_returns_null_if_empty()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Categories")
-                    .CellBelow().SetValue("A")
-                    .CellBelow().SetValue("B")
-                    .CellBelow().SetValue("C");
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Categories")
+                .CellBelow().SetValue("A")
+                .CellBelow().SetValue("B")
+                .CellBelow().SetValue("C");
 
-                IXLTable table = ws.RangeUsed().CreateTable();
+            IXLTable table = ws.RangeUsed().CreateTable();
 
-                ws.Rows("2:4").Delete();
+            ws.Rows("2:4").Delete();
 
-                Assert.IsNull(table.DataRange);
-            }
+            Assert.That(table.DataRange, Is.Null);
         }
 
         [Test]
         public void SavingLoadingTableWithNewLineInHeader()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                string columnName = "Line1" + Environment.NewLine + "Line2";
-                ws.FirstCell().SetValue(columnName)
-                    .CellBelow().SetValue("A");
-                ws.RangeUsed().CreateTable();
-                using (var ms = new MemoryStream())
-                {
-                    wb.SaveAs(ms, true);
-                    var wb2 = new XLWorkbook(ms);
-                    IXLWorksheet ws2 = wb2.Worksheet(1);
-                    IXLTable table2 = ws2.Table(0);
-                    string fieldName = table2.Field(0).Name;
-                    Assert.AreEqual("Line1\nLine2", fieldName);
-                }
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            string columnName = "Line1" + Environment.NewLine + "Line2";
+            ws.FirstCell().SetValue(columnName)
+                .CellBelow().SetValue("A");
+            ws.RangeUsed().CreateTable();
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
+            var wb2 = new XLWorkbook(ms);
+            IXLWorksheet ws2 = wb2.Worksheet(1);
+            IXLTable table2 = ws2.Table(0);
+            string fieldName = table2.Field(0).Name;
+            Assert.That(fieldName, Is.EqualTo("Line1\nLine2"));
         }
 
         [Test]
         public void SavingLoadingTableWithNewLineInHeader2()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.Worksheets.Add("Test");
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.Worksheets.Add("Test");
 
-                var dt = new DataTable();
-                string columnName = "Line1" + Environment.NewLine + "Line2";
-                dt.Columns.Add(columnName);
+            var dt = new DataTable();
+            string columnName = "Line1" + Environment.NewLine + "Line2";
+            dt.Columns.Add(columnName);
 
-                DataRow dr = dt.NewRow();
-                dr[columnName] = "some text";
-                dt.Rows.Add(dr);
-                ws.Cell(1, 1).InsertTable(dt);
+            DataRow dr = dt.NewRow();
+            dr[columnName] = "some text";
+            dt.Rows.Add(dr);
+            ws.Cell(1, 1).InsertTable(dt);
 
-                IXLTable table1 = ws.Table(0);
-                string fieldName1 = table1.Field(0).Name;
-                Assert.AreEqual(columnName, fieldName1);
+            IXLTable table1 = ws.Table(0);
+            string fieldName1 = table1.Field(0).Name;
+            Assert.That(fieldName1, Is.EqualTo(columnName));
 
-                using (var ms = new MemoryStream())
-                {
-                    wb.SaveAs(ms, true);
-                    var wb2 = new XLWorkbook(ms);
-                    IXLWorksheet ws2 = wb2.Worksheet(1);
-                    IXLTable table2 = ws2.Table(0);
-                    string fieldName2 = table2.Field(0).Name;
-                    Assert.AreEqual("Line1\nLine2", fieldName2);
-                }
-            }
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms, true);
+            var wb2 = new XLWorkbook(ms);
+            IXLWorksheet ws2 = wb2.Worksheet(1);
+            IXLTable table2 = ws2.Table(0);
+            string fieldName2 = table2.Field(0).Name;
+            Assert.That(fieldName2, Is.EqualTo("Line1\nLine2"));
         }
 
         [Test]
@@ -189,25 +172,21 @@ namespace ClosedXML.Tests.Excel
             dt.Columns.Add("col1", typeof(string));
             dt.Columns.Add("col2", typeof(double));
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(dt);
-                Assert.AreEqual(2, ws.Tables.First().ColumnCount());
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(dt);
+            Assert.That(ws.Tables.First().ColumnCount(), Is.EqualTo(2));
         }
 
         [Test]
         public void TableCreatedFromEmptyListOfInt()
         {
-            var l = new List<Int32>();
+            var l = new List<int>();
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(l);
-                Assert.AreEqual(1, ws.Tables.First().ColumnCount());
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(l);
+            Assert.That(ws.Tables.First().ColumnCount(), Is.EqualTo(1));
         }
 
         [Test]
@@ -215,12 +194,10 @@ namespace ClosedXML.Tests.Excel
         {
             var l = new List<TestObjectWithoutAttributes>();
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(l);
-                Assert.AreEqual(2, ws.Tables.First().ColumnCount());
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(l);
+            Assert.That(ws.Tables.First().ColumnCount(), Is.EqualTo(2));
         }
 
         [Test]
@@ -232,16 +209,17 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(l);
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(l);
-                Assert.AreEqual(4, ws.Tables.First().ColumnCount());
-                Assert.AreEqual("FirstColumn", ws.FirstCell().Value);
-                Assert.AreEqual("SecondColumn", ws.FirstCell().CellRight().Value);
-                Assert.AreEqual("SomeFieldNotProperty", ws.FirstCell().CellRight().CellRight().Value);
-                Assert.AreEqual("UnOrderedColumn", ws.FirstCell().CellRight().CellRight().CellRight().Value);
-            }
+                Assert.That(ws.Tables.First().ColumnCount(), Is.EqualTo(4));
+                Assert.That(ws.FirstCell().Value, Is.EqualTo("FirstColumn"));
+                Assert.That(ws.FirstCell().CellRight().Value, Is.EqualTo("SecondColumn"));
+                Assert.That(ws.FirstCell().CellRight().CellRight().Value, Is.EqualTo("SomeFieldNotProperty"));
+                Assert.That(ws.FirstCell().CellRight().CellRight().CellRight().Value, Is.EqualTo("UnOrderedColumn"));
+            });
         }
 
         [Test]
@@ -249,163 +227,175 @@ namespace ClosedXML.Tests.Excel
         {
             var l = new List<TestObjectWithAttributes>();
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(l);
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(l);
-                Assert.AreEqual(4, ws.Tables.First().ColumnCount());
-                Assert.AreEqual("FirstColumn", ws.FirstCell().Value);
-                Assert.AreEqual("SecondColumn", ws.FirstCell().CellRight().Value);
-                Assert.AreEqual("SomeFieldNotProperty", ws.FirstCell().CellRight().CellRight().Value);
-                Assert.AreEqual("UnOrderedColumn", ws.FirstCell().CellRight().CellRight().CellRight().Value);
-            }
+                Assert.That(ws.Tables.First().ColumnCount(), Is.EqualTo(4));
+                Assert.That(ws.FirstCell().Value, Is.EqualTo("FirstColumn"));
+                Assert.That(ws.FirstCell().CellRight().Value, Is.EqualTo("SecondColumn"));
+                Assert.That(ws.FirstCell().CellRight().CellRight().Value, Is.EqualTo("SomeFieldNotProperty"));
+                Assert.That(ws.FirstCell().CellRight().CellRight().CellRight().Value, Is.EqualTo("UnOrderedColumn"));
+            });
         }
 
         [Test]
         public void TableInsertAboveFromData()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Value");
+
+            IXLTable table = ws.Range("A1:A2").CreateTable();
+            table.SetShowTotalsRow()
+                .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+            IXLTableRow row = table.DataRange.FirstRow();
+            row.Field("Value").Value = 3;
+            row = table.DataRange.InsertRowsAbove(1).First();
+            row.Field("Value").Value = 2;
+            row = table.DataRange.InsertRowsAbove(1).First();
+            row.Field("Value").Value = 1;
+
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Value");
-
-                IXLTable table = ws.Range("A1:A2").CreateTable();
-                table.SetShowTotalsRow()
-                    .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
-
-                IXLTableRow row = table.DataRange.FirstRow();
-                row.Field("Value").Value = 3;
-                row = table.DataRange.InsertRowsAbove(1).First();
-                row.Field("Value").Value = 2;
-                row = table.DataRange.InsertRowsAbove(1).First();
-                row.Field("Value").Value = 1;
-
-                Assert.AreEqual(1, ws.Cell(2, 1).GetDouble());
-                Assert.AreEqual(2, ws.Cell(3, 1).GetDouble());
-                Assert.AreEqual(3, ws.Cell(4, 1).GetDouble());
-            }
+                Assert.That(ws.Cell(2, 1).GetDouble(), Is.EqualTo(1));
+                Assert.That(ws.Cell(3, 1).GetDouble(), Is.EqualTo(2));
+                Assert.That(ws.Cell(4, 1).GetDouble(), Is.EqualTo(3));
+            });
         }
 
         [Test]
         public void TableInsertAboveFromRows()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Value");
+
+            IXLTable table = ws.Range("A1:A2").CreateTable();
+            table.SetShowTotalsRow()
+                .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+            IXLTableRow row = table.DataRange.FirstRow();
+            row.Field("Value").Value = 3;
+            row = row.InsertRowsAbove(1).First();
+            row.Field("Value").Value = 2;
+            row = row.InsertRowsAbove(1).First();
+            row.Field("Value").Value = 1;
+
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Value");
-
-                IXLTable table = ws.Range("A1:A2").CreateTable();
-                table.SetShowTotalsRow()
-                    .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
-
-                IXLTableRow row = table.DataRange.FirstRow();
-                row.Field("Value").Value = 3;
-                row = row.InsertRowsAbove(1).First();
-                row.Field("Value").Value = 2;
-                row = row.InsertRowsAbove(1).First();
-                row.Field("Value").Value = 1;
-
-                Assert.AreEqual(1, ws.Cell(2, 1).GetDouble());
-                Assert.AreEqual(2, ws.Cell(3, 1).GetDouble());
-                Assert.AreEqual(3, ws.Cell(4, 1).GetDouble());
-            }
+                Assert.That(ws.Cell(2, 1).GetDouble(), Is.EqualTo(1));
+                Assert.That(ws.Cell(3, 1).GetDouble(), Is.EqualTo(2));
+                Assert.That(ws.Cell(4, 1).GetDouble(), Is.EqualTo(3));
+            });
         }
 
         [Test]
         public void TableInsertBelowFromData()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Value");
+
+            IXLTable table = ws.Range("A1:A2").CreateTable();
+            table.SetShowTotalsRow()
+                .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+            IXLTableRow row = table.DataRange.FirstRow();
+            row.Field("Value").Value = 1;
+            row = table.DataRange.InsertRowsBelow(1).First();
+            row.Field("Value").Value = 2;
+            row = table.DataRange.InsertRowsBelow(1).First();
+            row.Field("Value").Value = 3;
+
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Value");
-
-                IXLTable table = ws.Range("A1:A2").CreateTable();
-                table.SetShowTotalsRow()
-                    .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
-
-                IXLTableRow row = table.DataRange.FirstRow();
-                row.Field("Value").Value = 1;
-                row = table.DataRange.InsertRowsBelow(1).First();
-                row.Field("Value").Value = 2;
-                row = table.DataRange.InsertRowsBelow(1).First();
-                row.Field("Value").Value = 3;
-
-                Assert.AreEqual(1, ws.Cell(2, 1).GetDouble());
-                Assert.AreEqual(2, ws.Cell(3, 1).GetDouble());
-                Assert.AreEqual(3, ws.Cell(4, 1).GetDouble());
-            }
+                Assert.That(ws.Cell(2, 1).GetDouble(), Is.EqualTo(1));
+                Assert.That(ws.Cell(3, 1).GetDouble(), Is.EqualTo(2));
+                Assert.That(ws.Cell(4, 1).GetDouble(), Is.EqualTo(3));
+            });
         }
 
         [Test]
         public void TableInsertBelowFromRows()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Value");
+
+            IXLTable table = ws.Range("A1:A2").CreateTable();
+            table.SetShowTotalsRow()
+                .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+            IXLTableRow row = table.DataRange.FirstRow();
+            row.Field("Value").Value = 1;
+            row = row.InsertRowsBelow(1).First();
+            row.Field("Value").Value = 2;
+            row = row.InsertRowsBelow(1).First();
+            row.Field("Value").Value = 3;
+
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Value");
-
-                IXLTable table = ws.Range("A1:A2").CreateTable();
-                table.SetShowTotalsRow()
-                    .Field(0).TotalsRowFunction = XLTotalsRowFunction.Sum;
-
-                IXLTableRow row = table.DataRange.FirstRow();
-                row.Field("Value").Value = 1;
-                row = row.InsertRowsBelow(1).First();
-                row.Field("Value").Value = 2;
-                row = row.InsertRowsBelow(1).First();
-                row.Field("Value").Value = 3;
-
-                Assert.AreEqual(1, ws.Cell(2, 1).GetDouble());
-                Assert.AreEqual(2, ws.Cell(3, 1).GetDouble());
-                Assert.AreEqual(3, ws.Cell(4, 1).GetDouble());
-            }
+                Assert.That(ws.Cell(2, 1).GetDouble(), Is.EqualTo(1));
+                Assert.That(ws.Cell(3, 1).GetDouble(), Is.EqualTo(2));
+                Assert.That(ws.Cell(4, 1).GetDouble(), Is.EqualTo(3));
+            });
         }
 
         [Test]
         public void TableShowHeader()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().SetValue("Categories")
+                .CellBelow().SetValue("A")
+                .CellBelow().SetValue("B")
+                .CellBelow().SetValue("C");
+
+            IXLTable table = ws.RangeUsed().CreateTable();
+
+            Assert.That(table.Fields.First().Name, Is.EqualTo("Categories"));
+
+            table.SetShowHeaderRow(false);
+
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().SetValue("Categories")
-                    .CellBelow().SetValue("A")
-                    .CellBelow().SetValue("B")
-                    .CellBelow().SetValue("C");
+                Assert.That(table.Fields.First().Name, Is.EqualTo("Categories"));
 
-                IXLTable table = ws.RangeUsed().CreateTable();
+                Assert.That(ws.Cell(1, 1).IsEmpty(XLCellsUsedOptions.All), Is.True);
+                Assert.That(table.HeadersRow(), Is.Null);
+                Assert.That(table.DataRange.FirstRow().Field("Categories").GetText(), Is.EqualTo("A"));
+                Assert.That(table.DataRange.LastRow().Field("Categories").GetText(), Is.EqualTo("C"));
+                Assert.That(table.DataRange.FirstCell().GetText(), Is.EqualTo("A"));
+                Assert.That(table.DataRange.LastCell().GetText(), Is.EqualTo("C"));
+            });
 
-                Assert.AreEqual("Categories", table.Fields.First().Name);
+            table.SetShowHeaderRow();
+            IXLRangeRow headerRow = table.HeadersRow();
+            Assert.That(headerRow, Is.Not.Null);
+            Assert.That(headerRow.Cell(1).GetText(), Is.EqualTo("Categories"));
 
-                table.SetShowHeaderRow(false);
+            table.SetShowHeaderRow(false);
 
-                Assert.AreEqual("Categories", table.Fields.First().Name);
+            ws.FirstCell().SetValue("x");
 
-                Assert.IsTrue(ws.Cell(1, 1).IsEmpty(XLCellsUsedOptions.All));
-                Assert.AreEqual(null, table.HeadersRow());
-                Assert.AreEqual("A", table.DataRange.FirstRow().Field("Categories").GetText());
-                Assert.AreEqual("C", table.DataRange.LastRow().Field("Categories").GetText());
-                Assert.AreEqual("A", table.DataRange.FirstCell().GetText());
-                Assert.AreEqual("C", table.DataRange.LastCell().GetText());
+            table.SetShowHeaderRow();
 
-                table.SetShowHeaderRow();
-                IXLRangeRow headerRow = table.HeadersRow();
-                Assert.AreNotEqual(null, headerRow);
-                Assert.AreEqual("Categories", headerRow.Cell(1).GetText());
-
-                table.SetShowHeaderRow(false);
-
-                ws.FirstCell().SetValue("x");
-
-                table.SetShowHeaderRow();
-
-                Assert.AreEqual("x", ws.FirstCell().GetText());
-                Assert.AreEqual("Categories", ws.Cell("A2").GetText());
-                Assert.AreNotEqual(null, headerRow);
-                Assert.AreEqual("A", table.DataRange.FirstRow().Field("Categories").GetText());
-                Assert.AreEqual("C", table.DataRange.LastRow().Field("Categories").GetText());
-                Assert.AreEqual("A", table.DataRange.FirstCell().GetText());
-                Assert.AreEqual("C", table.DataRange.LastCell().GetText());
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.FirstCell().GetText(), Is.EqualTo("x"));
+                Assert.That(ws.Cell("A2").GetText(), Is.EqualTo("Categories"));
+            });
+            Assert.That(headerRow, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(table.DataRange.FirstRow().Field("Categories").GetText(), Is.EqualTo("A"));
+                Assert.That(table.DataRange.LastRow().Field("Categories").GetText(), Is.EqualTo("C"));
+                Assert.That(table.DataRange.FirstCell().GetText(), Is.EqualTo("A"));
+                Assert.That(table.DataRange.LastCell().GetText(), Is.EqualTo("C"));
+            });
         }
 
         [TestCase("Amount")]
@@ -418,47 +408,48 @@ namespace ClosedXML.Tests.Excel
             var table = ws.Cell("A1").InsertTable(new[] { new { Amount = 1 } });
 
             var expectedField = table.Field(0);
-            Assert.AreSame(expectedField, table.Field(fieldName));
+            Assert.That(table.Field(fieldName), Is.SameAs(expectedField));
         }
 
         [Test]
         public void ChangeFieldName()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet");
+            ws.Cell("A1").SetValue("FName")
+                .CellBelow().SetValue("John");
+
+            ws.Cell("B1").SetValue("LName")
+                .CellBelow().SetValue("Doe");
+
+            var tbl = ws.RangeUsed().CreateTable();
+            var nameBefore = tbl.Field(tbl.Fields.Last().Index).Name;
+            tbl.Field(tbl.Fields.Last().Index).Name = "LastName";
+            var nameAfter = tbl.Field(tbl.Fields.Last().Index).Name;
+
+            var cellValue = ws.Cell("B1").GetText();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet");
-                ws.Cell("A1").SetValue("FName")
-                    .CellBelow().SetValue("John");
+                Assert.That(nameBefore, Is.EqualTo("LName"));
+                Assert.That(nameAfter, Is.EqualTo("LastName"));
+                Assert.That(cellValue, Is.EqualTo("LastName"));
+            });
 
-                ws.Cell("B1").SetValue("LName")
-                    .CellBelow().SetValue("Doe");
+            tbl.ShowHeaderRow = false;
+            tbl.Field(tbl.Fields.Last().Index).Name = "LastNameChanged";
+            nameAfter = tbl.Field(tbl.Fields.Last().Index).Name;
+            Assert.That(nameAfter, Is.EqualTo("LastNameChanged"));
 
-                var tbl = ws.RangeUsed().CreateTable();
-                var nameBefore = tbl.Field(tbl.Fields.Last().Index).Name;
-                tbl.Field(tbl.Fields.Last().Index).Name = "LastName";
-                var nameAfter = tbl.Field(tbl.Fields.Last().Index).Name;
+            tbl.SetShowHeaderRow(true);
+            nameAfter = (string)tbl.Cell("B1").Value;
+            Assert.That(nameAfter, Is.EqualTo("LastNameChanged"));
 
-                var cellValue = ws.Cell("B1").GetText();
+            var field = tbl.Field("LastNameChanged");
+            Assert.That(field.Name, Is.EqualTo("LastNameChanged"));
 
-                Assert.AreEqual("LName", nameBefore);
-                Assert.AreEqual("LastName", nameAfter);
-                Assert.AreEqual("LastName", cellValue);
-
-                tbl.ShowHeaderRow = false;
-                tbl.Field(tbl.Fields.Last().Index).Name = "LastNameChanged";
-                nameAfter = tbl.Field(tbl.Fields.Last().Index).Name;
-                Assert.AreEqual("LastNameChanged", nameAfter);
-
-                tbl.SetShowHeaderRow(true);
-                nameAfter = (String)tbl.Cell("B1").Value;
-                Assert.AreEqual("LastNameChanged", nameAfter);
-
-                var field = tbl.Field("LastNameChanged");
-                Assert.AreEqual("LastNameChanged", field.Name);
-
-                tbl.Cell(1, 1).Value = "FirstName";
-                Assert.AreEqual("FirstName", tbl.Field(0).Name);
-            }
+            tbl.Cell(1, 1).Value = "FirstName";
+            Assert.That(tbl.Field(0).Name, Is.EqualTo("FirstName"));
         }
 
         [Test]
@@ -470,21 +461,22 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var table = ws.FirstCell().InsertTable(l);
+
+            table.Column("C").Delete();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                var table = ws.FirstCell().InsertTable(l);
+                Assert.That(table.Fields.Count(), Is.EqualTo(3));
 
-                table.Column("C").Delete();
+                Assert.That(table.Fields.First().Name, Is.EqualTo("FirstColumn"));
+                Assert.That(table.Fields.First().Index, Is.EqualTo(0));
 
-                Assert.AreEqual(3, table.Fields.Count());
-
-                Assert.AreEqual("FirstColumn", table.Fields.First().Name);
-                Assert.AreEqual(0, table.Fields.First().Index);
-
-                Assert.AreEqual("UnOrderedColumn", table.Fields.Last().Name);
-                Assert.AreEqual(2, table.Fields.Last().Index);
-            }
+                Assert.That(table.Fields.Last().Name, Is.EqualTo("UnOrderedColumn"));
+                Assert.That(table.Fields.Last().Index, Is.EqualTo(2));
+            });
         }
 
         [Test]
@@ -496,36 +488,42 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var table = ws.Cell("B2").InsertTable(l);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                var table = ws.Cell("B2").InsertTable(l);
+                Assert.That(table.Fields.Count(), Is.EqualTo(4));
+                Assert.That(table.Field(0).HeaderCell.Address.ToString(), Is.EqualTo("B2"));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(table.Field(1).HeaderCell.Address.ToString(), Is.EqualTo("C2"));
+                Assert.That(table.Field(2).HeaderCell.Address.ToString(), Is.EqualTo("D2"));
+                Assert.That(table.Field(3).HeaderCell.Address.ToString(), Is.EqualTo("E2"));
 
-                Assert.AreEqual(4, table.Fields.Count());
+                Assert.That(table.Field(0).TotalsCell, Is.Null);
+                Assert.That(table.Field(1).TotalsCell, Is.Null);
+                Assert.That(table.Field(2).TotalsCell, Is.Null);
+                Assert.That(table.Field(3).TotalsCell, Is.Null);
+            });
 
-                Assert.AreEqual("B2", table.Field(0).HeaderCell.Address.ToString());
-                Assert.AreEqual("C2", table.Field(1).HeaderCell.Address.ToString());
-                Assert.AreEqual("D2", table.Field(2).HeaderCell.Address.ToString());
-                Assert.AreEqual("E2", table.Field(3).HeaderCell.Address.ToString());
+            table.SetShowTotalsRow();
 
-                Assert.IsNull(table.Field(0).TotalsCell);
-                Assert.IsNull(table.Field(1).TotalsCell);
-                Assert.IsNull(table.Field(2).TotalsCell);
-                Assert.IsNull(table.Field(3).TotalsCell);
+            Assert.That(table.Field(0).TotalsCell.Address.ToString(), Is.EqualTo("B5"));
+            Assert.That(table.Field(1).TotalsCell.Address.ToString(), Is.EqualTo("C5"));
+            Assert.That(table.Field(2).TotalsCell.Address.ToString(), Is.EqualTo("D5"));
+            Assert.That(table.Field(3).TotalsCell.Address.ToString(), Is.EqualTo("E5"));
 
-                table.SetShowTotalsRow();
+            var field = table.Fields.Last();
 
-                Assert.AreEqual("B5", table.Field(0).TotalsCell.Address.ToString());
-                Assert.AreEqual("C5", table.Field(1).TotalsCell.Address.ToString());
-                Assert.AreEqual("D5", table.Field(2).TotalsCell.Address.ToString());
-                Assert.AreEqual("E5", table.Field(3).TotalsCell.Address.ToString());
-
-                var field = table.Fields.Last();
-
-                Assert.AreEqual("E2:E5", field.Column.RangeAddress.ToString());
-                Assert.AreEqual("E3", field.DataCells.First().Address.ToString());
-                Assert.AreEqual("E4", field.DataCells.Last().Address.ToString());
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(field.Column.RangeAddress.ToString(), Is.EqualTo("E2:E5"));
+                Assert.That(field.DataCells.First().Address.ToString(), Is.EqualTo("E3"));
+                Assert.That(field.DataCells.Last().Address.ToString(), Is.EqualTo("E4"));
+            });
         }
 
         [Test]
@@ -533,30 +531,28 @@ namespace ClosedXML.Tests.Excel
         {
             var l = new List<TestObjectWithAttributes>()
             {
-                new TestObjectWithAttributes() { Column1 = "a", Column2 = "b", MyField = 4, UnOrderedColumn = 999 },
-                new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
+                new() { Column1 = "a", Column2 = "b", MyField = 4, UnOrderedColumn = 999 },
+                new() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws = wb.AddWorksheet("Sheet1");
-                    ws.FirstCell().InsertTable(l);
-                    wb.SaveAs(ms);
-                }
+                var ws = wb.AddWorksheet("Sheet1");
+                ws.FirstCell().InsertTable(l);
+                wb.SaveAs(ms);
+            }
 
-                ms.Seek(0, SeekOrigin.Begin);
+            ms.Seek(0, SeekOrigin.Begin);
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.First();
-                    var table = ws.Tables.First();
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.First();
+                var table = ws.Tables.First();
 
-                    ws.Tables.Remove(table.Name);
-                    Assert.AreEqual(0, ws.Tables.Count());
-                    wb.Save();
-                }
+                ws.Tables.Remove(table.Name);
+                Assert.That(ws.Tables.Count(), Is.EqualTo(0));
+                wb.Save();
             }
         }
 
@@ -567,16 +563,14 @@ namespace ClosedXML.Tests.Excel
             dt.Columns.Add("Patient", typeof(string));
             dt.Rows.Add("David");
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "May2019"));
-                Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "A1"));
-                Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "R1C2"));
-                Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "r3c2"));
-                Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "R2C33333"));
-                Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "RC"));
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "May2019"));
+            Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "A1"));
+            Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "R1C2"));
+            Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "r3c2"));
+            Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "R2C33333"));
+            Assert.Throws<InvalidOperationException>(() => ws.Cell(1, 1).InsertTable(dt, "RC"));
         }
 
         [Test]
@@ -597,8 +591,11 @@ namespace ClosedXML.Tests.Excel
                 // Should pass because t1 is a valid sheet name, and is not used for the tableName
                 Assert.DoesNotThrow(() => wb.AddWorksheet(dt, "t1", "table1"));
 
-                Assert.AreEqual(1, wb.Worksheets.Count);
-                Assert.AreEqual(1, wb.Worksheet(1).Tables.Count());
+                Assert.Multiple(() =>
+                {
+                    Assert.That(wb.Worksheets, Has.Count.EqualTo(1));
+                    Assert.That(wb.Worksheet(1).Tables.Count(), Is.EqualTo(1));
+                });
             }
 
         }
@@ -612,25 +609,26 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var table = ws.Cell("B2").InsertTable(l);
+
+            Assert.That(table.RangeAddress.ToString(), Is.EqualTo("B2:E4"));
+
+            table.Field("SomeFieldNotProperty").Delete();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                var table = ws.Cell("B2").InsertTable(l);
+                Assert.That(table.Fields.Count(), Is.EqualTo(3));
 
-                Assert.AreEqual("B2:E4", table.RangeAddress.ToString());
+                Assert.That(table.Fields.First().Name, Is.EqualTo("FirstColumn"));
+                Assert.That(table.Fields.First().Index, Is.EqualTo(0));
 
-                table.Field("SomeFieldNotProperty").Delete();
+                Assert.That(table.Fields.Last().Name, Is.EqualTo("UnOrderedColumn"));
+                Assert.That(table.Fields.Last().Index, Is.EqualTo(2));
 
-                Assert.AreEqual(3, table.Fields.Count());
-
-                Assert.AreEqual("FirstColumn", table.Fields.First().Name);
-                Assert.AreEqual(0, table.Fields.First().Index);
-
-                Assert.AreEqual("UnOrderedColumn", table.Fields.Last().Name);
-                Assert.AreEqual(2, table.Fields.Last().Index);
-
-                Assert.AreEqual("B2:D4", table.RangeAddress.ToString());
-            }
+                Assert.That(table.RangeAddress.ToString(), Is.EqualTo("B2:D4"));
+            });
         }
 
         [Test]
@@ -644,22 +642,23 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "g", Column2 = "h", MyField = 7, UnOrderedColumn = 333 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var table = ws.Cell("B2").InsertTable(l);
+
+            Assert.That(table.RangeAddress.ToString(), Is.EqualTo("B2:E6"));
+
+            table.DataRange.Rows(3, 4).Delete();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                var table = ws.Cell("B2").InsertTable(l);
+                Assert.That(table.DataRange.Rows().Count(), Is.EqualTo(2));
 
-                Assert.AreEqual("B2:E6", table.RangeAddress.ToString());
+                Assert.That(table.DataRange.FirstCell().Value, Is.EqualTo("b"));
+                Assert.That(table.DataRange.LastCell().Value, Is.EqualTo(777));
 
-                table.DataRange.Rows(3, 4).Delete();
-
-                Assert.AreEqual(2, table.DataRange.Rows().Count());
-
-                Assert.AreEqual("b", table.DataRange.FirstCell().Value);
-                Assert.AreEqual(777, table.DataRange.LastCell().Value);
-
-                Assert.AreEqual("B2:E4", table.RangeAddress.ToString());
-            }
+                Assert.That(table.RangeAddress.ToString(), Is.EqualTo("B2:E4"));
+            });
         }
 
         [Test]
@@ -669,12 +668,10 @@ namespace ClosedXML.Tests.Excel
             dt.Columns.Add("col1", typeof(string));
             dt.Columns.Add("col2", typeof(double));
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(dt, true);
-                Assert.Throws<InvalidOperationException>(() => ws.FirstCell().CellRight().InsertTable(dt, true));
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(dt, true);
+            Assert.Throws<InvalidOperationException>(() => ws.FirstCell().CellRight().InsertTable(dt, true));
         }
 
         [Test]
@@ -694,52 +691,56 @@ namespace ClosedXML.Tests.Excel
                 (XLError.IncompatibleValue, 7)
             });
 
-            // The non-string data inserted to headers were converted to strings and used as a field names.
-            Assert.AreEqual("#VALUE!", table.Field(0).Name);
-            Assert.AreEqual("#VALUE!", ws.Cell("A1").Value);
-            Assert.AreEqual("7", table.Field(1).Name);
-            Assert.AreEqual("7", ws.Cell("B1").Value);
+            Assert.Multiple(() =>
+            {
+                // The non-string data inserted to headers were converted to strings and used as a field names.
+                Assert.That(table.Field(0).Name, Is.EqualTo("#VALUE!"));
+                Assert.That(ws.Cell("A1").Value, Is.EqualTo("#VALUE!"));
+                Assert.That(table.Field(1).Name, Is.EqualTo("7"));
+                Assert.That(ws.Cell("B1").Value, Is.EqualTo("7"));
+            });
         }
 
         [Test]
         public void OverwritingTableTotalsRow()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                var data1 = Enumerable.Range(1, 10)
-                    .Select(i =>
+            var data1 = Enumerable.Range(1, 10)
+                .Select(i =>
                     new
                     {
                         Index = i,
                         Character = Convert.ToChar(64 + i),
-                        String = new String('a', i)
+                        String = new string('a', i)
                     });
 
-                var table = ws.FirstCell().InsertTable(data1, true)
-                    .SetShowHeaderRow()
-                    .SetShowTotalsRow();
-                table.Fields.First().TotalsRowFunction = XLTotalsRowFunction.Sum;
+            var table = ws.FirstCell().InsertTable(data1, true)
+                .SetShowHeaderRow()
+                .SetShowTotalsRow();
+            table.Fields.First().TotalsRowFunction = XLTotalsRowFunction.Sum;
 
-                var data2 = Enumerable.Range(1, 20)
-                    .Select(i =>
+            var data2 = Enumerable.Range(1, 20)
+                .Select(i =>
                     new
                     {
                         Index = i,
                         Character = Convert.ToChar(64 + i),
-                        String = new String('b', i),
+                        String = new string('b', i),
                         Int = 64 + i
                     });
 
-                ws.FirstCell().CellBelow().InsertData(data2);
+            ws.FirstCell().CellBelow().InsertData(data2);
 
-                table.Fields.ForEach(f => Assert.AreEqual(XLTotalsRowFunction.None, f.TotalsRowFunction));
+            table.Fields.ForEach(f => Assert.That(f.TotalsRowFunction, Is.EqualTo(XLTotalsRowFunction.None)));
 
-                Assert.AreEqual("11", table.Field(0).TotalsRowLabel);
-                Assert.AreEqual("K", table.Field(1).TotalsRowLabel);
-                Assert.AreEqual("bbbbbbbbbbb", table.Field(2).TotalsRowLabel);
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(table.Field(0).TotalsRowLabel, Is.EqualTo("11"));
+                Assert.That(table.Field(1).TotalsRowLabel, Is.EqualTo("K"));
+                Assert.That(table.Field(2).TotalsRowLabel, Is.EqualTo("bbbbbbbbbbb"));
+            });
         }
 
         [Test]
@@ -751,79 +752,81 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            var table1 = ws.FirstCell().InsertTable(l);
+            var table2 = ws.Cell("A10").InsertTable(l);
+
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                var table1 = ws.FirstCell().InsertTable(l);
-                var table2 = ws.Cell("A10").InsertTable(l);
+                Assert.That(table1.Name, Is.EqualTo("Table1"));
+                Assert.That(table2.Name, Is.EqualTo("Table2"));
+            });
 
-                Assert.AreEqual("Table1", table1.Name);
-                Assert.AreEqual("Table2", table2.Name);
+            table1.Name = "table1";
+            Assert.That(table1.Name, Is.EqualTo("table1"));
 
-                table1.Name = "table1";
-                Assert.AreEqual("table1", table1.Name);
+            table1.Name = "_table1";
+            Assert.That(table1.Name, Is.EqualTo("_table1"));
 
-                table1.Name = "_table1";
-                Assert.AreEqual("_table1", table1.Name);
+            table1.Name = "\\table1";
+            Assert.That(table1.Name, Is.EqualTo("\\table1"));
 
-                table1.Name = "\\table1";
-                Assert.AreEqual("\\table1", table1.Name);
+            Assert.Throws<ArgumentException>(() => table1.Name = "");
+            Assert.Throws<ArgumentException>(() => table1.Name = "R");
+            Assert.Throws<ArgumentException>(() => table1.Name = "C");
+            Assert.Throws<ArgumentException>(() => table1.Name = "r");
+            Assert.Throws<ArgumentException>(() => table1.Name = "c");
 
-                Assert.Throws<ArgumentException>(() => table1.Name = "");
-                Assert.Throws<ArgumentException>(() => table1.Name = "R");
-                Assert.Throws<ArgumentException>(() => table1.Name = "C");
-                Assert.Throws<ArgumentException>(() => table1.Name = "r");
-                Assert.Throws<ArgumentException>(() => table1.Name = "c");
+            Assert.Throws<ArgumentException>(() => table1.Name = "123");
+            Assert.Throws<ArgumentException>(() => table1.Name = new string('A', 256));
 
-                Assert.Throws<ArgumentException>(() => table1.Name = "123");
-                Assert.Throws<ArgumentException>(() => table1.Name = new String('A', 256));
-
-                Assert.Throws<ArgumentException>(() => table1.Name = "Table2");
-                Assert.Throws<ArgumentException>(() => table1.Name = "TABLE2");
-            }
+            Assert.Throws<ArgumentException>(() => table1.Name = "Table2");
+            Assert.Throws<ArgumentException>(() => table1.Name = "TABLE2");
         }
 
         [Test]
         public void CanResizeTable()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                var data1 = Enumerable.Range(1, 10)
-                    .Select(i =>
+            var data1 = Enumerable.Range(1, 10)
+                .Select(i =>
                     new
                     {
                         Index = i,
                         Character = Convert.ToChar(64 + i),
-                        String = new String('a', i)
+                        String = new string('a', i)
                     });
 
-                var table = ws.FirstCell().InsertTable(data1, true)
-                    .SetShowHeaderRow()
-                    .SetShowTotalsRow();
-                table.Fields.First().TotalsRowFunction = XLTotalsRowFunction.Sum;
+            var table = ws.FirstCell().InsertTable(data1, true)
+                .SetShowHeaderRow()
+                .SetShowTotalsRow();
+            table.Fields.First().TotalsRowFunction = XLTotalsRowFunction.Sum;
 
-                var data2 = Enumerable.Range(1, 10)
-                    .Select(i =>
+            var data2 = Enumerable.Range(1, 10)
+                .Select(i =>
                     new
                     {
                         Index = i,
                         Character = Convert.ToChar(64 + i),
-                        String = new String('b', i),
+                        String = new string('b', i),
                         Integer = 64 + i
                     });
 
-                ws.FirstCell().CellBelow().InsertData(data2);
-                table.Resize(table.FirstCell().Address, table.AsRange().LastCell().CellRight().Address);
+            ws.FirstCell().CellBelow().InsertData(data2);
+            table.Resize(table.FirstCell().Address, table.AsRange().LastCell().CellRight().Address);
 
-                Assert.AreEqual(4, table.Fields.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(table.Fields.Count(), Is.EqualTo(4));
 
-                Assert.AreEqual("Column4", table.Field(3).Name);
+                Assert.That(table.Field(3).Name, Is.EqualTo("Column4"));
+            });
 
-                ws.Cell("D1").Value = "Integer";
-                Assert.AreEqual("Integer", table.Field(3).Name);
-            }
+            ws.Cell("D1").Value = "Integer";
+            Assert.That(table.Field(3).Name, Is.EqualTo("Integer"));
         }
 
         [Test]
@@ -835,22 +838,20 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                var table = ws.FirstCell().InsertTable(l);
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            var table = ws.FirstCell().InsertTable(l);
 
-                foreach (var d in table.AsDynamicEnumerable())
+            foreach (var d in table.AsDynamicEnumerable())
+            {
+                Assert.DoesNotThrow(() =>
                 {
-                    Assert.DoesNotThrow(() =>
-                    {
-                        object value;
-                        value = d.FirstColumn;
-                        value = d.SecondColumn;
-                        value = d.UnOrderedColumn;
-                        value = d.SomeFieldNotProperty;
-                    });
-                }
+                    object value;
+                    value = d.FirstColumn;
+                    value = d.SecondColumn;
+                    value = d.UnOrderedColumn;
+                    value = d.SomeFieldNotProperty;
+                });
             }
         }
 
@@ -863,62 +864,70 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            var table = ws.FirstCell().InsertTable(l).AsNativeDataTable();
+
+            Assert.That(table.Columns, Has.Count.EqualTo(4));
+            Assert.Multiple(() =>
             {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                var table = ws.FirstCell().InsertTable(l).AsNativeDataTable();
+                Assert.That(table.Columns[0].ColumnName, Is.EqualTo("FirstColumn"));
+                Assert.That(table.Columns[1].ColumnName, Is.EqualTo("SecondColumn"));
+                Assert.That(table.Columns[2].ColumnName, Is.EqualTo("SomeFieldNotProperty"));
+                Assert.That(table.Columns[3].ColumnName, Is.EqualTo("UnOrderedColumn"));
 
-                Assert.AreEqual(4, table.Columns.Count);
-                Assert.AreEqual("FirstColumn", table.Columns[0].ColumnName);
-                Assert.AreEqual("SecondColumn", table.Columns[1].ColumnName);
-                Assert.AreEqual("SomeFieldNotProperty", table.Columns[2].ColumnName);
-                Assert.AreEqual("UnOrderedColumn", table.Columns[3].ColumnName);
+                Assert.That(table.Columns[0].DataType, Is.EqualTo(typeof(string)));
+                Assert.That(table.Columns[1].DataType, Is.EqualTo(typeof(string)));
+                Assert.That(table.Columns[2].DataType, Is.EqualTo(typeof(double)));
+                Assert.That(table.Columns[3].DataType, Is.EqualTo(typeof(double)));
+            });
 
-                Assert.AreEqual(typeof(String), table.Columns[0].DataType);
-                Assert.AreEqual(typeof(String), table.Columns[1].DataType);
-                Assert.AreEqual(typeof(Double), table.Columns[2].DataType);
-                Assert.AreEqual(typeof(Double), table.Columns[3].DataType);
+            var dr = table.Rows[0];
+            Assert.Multiple(() =>
+            {
+                Assert.That(dr["FirstColumn"], Is.EqualTo("b"));
+                Assert.That(dr["SecondColumn"], Is.EqualTo("a"));
+                Assert.That(dr["SomeFieldNotProperty"], Is.EqualTo(4));
+                Assert.That(dr["UnOrderedColumn"], Is.EqualTo(999));
+            });
 
-                var dr = table.Rows[0];
-                Assert.AreEqual("b", dr["FirstColumn"]);
-                Assert.AreEqual("a", dr["SecondColumn"]);
-                Assert.AreEqual(4, dr["SomeFieldNotProperty"]);
-                Assert.AreEqual(999, dr["UnOrderedColumn"]);
-
-                dr = table.Rows[1];
-                Assert.AreEqual("d", dr["FirstColumn"]);
-                Assert.AreEqual("c", dr["SecondColumn"]);
-                Assert.AreEqual(5, dr["SomeFieldNotProperty"]);
-                Assert.AreEqual(777, dr["UnOrderedColumn"]);
-            }
+            dr = table.Rows[1];
+            Assert.Multiple(() =>
+            {
+                Assert.That(dr["FirstColumn"], Is.EqualTo("d"));
+                Assert.That(dr["SecondColumn"], Is.EqualTo("c"));
+                Assert.That(dr["SomeFieldNotProperty"], Is.EqualTo(5));
+                Assert.That(dr["UnOrderedColumn"], Is.EqualTo(777));
+            });
         }
 
         [Test]
         public void TestTableCellTypes()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                var data1 = Enumerable.Range(1, 10)
-                    .Select(i =>
+            var data1 = Enumerable.Range(1, 10)
+                .Select(i =>
                     new
                     {
                         Index = i,
                         Character = Convert.ToChar(64 + i),
-                        String = new String('a', i)
+                        String = new string('a', i)
                     });
 
-                var table = ws.FirstCell().InsertTable(data1, true)
-                    .SetShowHeaderRow()
-                    .SetShowTotalsRow();
-                table.Fields.First().TotalsRowFunction = XLTotalsRowFunction.Sum;
+            var table = ws.FirstCell().InsertTable(data1, true)
+                .SetShowHeaderRow()
+                .SetShowTotalsRow();
+            table.Fields.First().TotalsRowFunction = XLTotalsRowFunction.Sum;
 
-                Assert.AreEqual(XLTableCellType.Header, table.HeadersRow().Cell(1).TableCellType());
-                Assert.AreEqual(XLTableCellType.Data, table.HeadersRow().Cell(1).CellBelow().TableCellType());
-                Assert.AreEqual(XLTableCellType.Total, table.TotalsRow().Cell(1).TableCellType());
-                Assert.AreEqual(XLTableCellType.None, ws.Cell("Z100").TableCellType());
-            }
+            Assert.Multiple(() =>
+            {
+                Assert.That(table.HeadersRow().Cell(1).TableCellType(), Is.EqualTo(XLTableCellType.Header));
+                Assert.That(table.HeadersRow().Cell(1).CellBelow().TableCellType(), Is.EqualTo(XLTableCellType.Data));
+                Assert.That(table.TotalsRow().Cell(1).TableCellType(), Is.EqualTo(XLTableCellType.Total));
+                Assert.That(ws.Cell("Z100").TableCellType(), Is.EqualTo(XLTableCellType.None));
+            });
         }
 
         [Test]
@@ -930,31 +939,32 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(l, false);
+
+            // Give the headings weird names (i.e. spaces, hashes, single quotes
+            ws.Cell("A1").Value = "ABCD    ";
+            ws.Cell("B1").Value = "   #BCD";
+            ws.Cell("C1").Value = "   as'df   ";
+            ws.Cell("D1").Value = "Normal";
+
+            var table = ws.RangeUsed().CreateTable();
+            Assert.IsNotNull(table);
+
+            table.ShowTotalsRow = true;
+            table.Field(0).TotalsRowFunction = XLTotalsRowFunction.Count;
+            table.Field(1).TotalsRowFunction = XLTotalsRowFunction.Count;
+            table.Field(2).TotalsRowFunction = XLTotalsRowFunction.Sum;
+            table.Field(3).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(l, false);
-
-                // Give the headings weird names (i.e. spaces, hashes, single quotes
-                ws.Cell("A1").Value = "ABCD    ";
-                ws.Cell("B1").Value = "   #BCD";
-                ws.Cell("C1").Value = "   as'df   ";
-                ws.Cell("D1").Value = "Normal";
-
-                var table = ws.RangeUsed().CreateTable();
-                Assert.IsNotNull(table);
-
-                table.ShowTotalsRow = true;
-                table.Field(0).TotalsRowFunction = XLTotalsRowFunction.Count;
-                table.Field(1).TotalsRowFunction = XLTotalsRowFunction.Count;
-                table.Field(2).TotalsRowFunction = XLTotalsRowFunction.Sum;
-                table.Field(3).TotalsRowFunction = XLTotalsRowFunction.Sum;
-
-                Assert.AreEqual("SUBTOTAL(103,Table1[[ABCD    ]])", table.Field(0).TotalsRowFormulaA1);
-                Assert.AreEqual("SUBTOTAL(103,Table1[[   '#BCD]])", table.Field(1).TotalsRowFormulaA1);
-                Assert.AreEqual("SUBTOTAL(109,Table1[[   as''df   ]])", table.Field(2).TotalsRowFormulaA1);
-                Assert.AreEqual("SUBTOTAL(109,[Normal])", table.Field(3).TotalsRowFormulaA1);
-            }
+                Assert.That(table.Field(0).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(103,Table1[[ABCD    ]])"));
+                Assert.That(table.Field(1).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(103,Table1[[   '#BCD]])"));
+                Assert.That(table.Field(2).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(109,Table1[[   as''df   ]])"));
+                Assert.That(table.Field(3).TotalsRowFormulaA1, Is.EqualTo("SUBTOTAL(109,[Normal])"));
+            });
         }
 
         [Test]
@@ -966,12 +976,10 @@ namespace ClosedXML.Tests.Excel
                 new TestObjectWithAttributes() { Column1 = "c", Column2 = "d", MyField = 5, UnOrderedColumn = 777 }
             };
 
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-                ws.FirstCell().InsertTable(l);
-                Assert.Throws<InvalidOperationException>(() => ws.RangeUsed().CreateTable());
-            }
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+            ws.FirstCell().InsertTable(l);
+            Assert.Throws<InvalidOperationException>(() => ws.RangeUsed().CreateTable());
         }
 
         [Test]
@@ -1019,7 +1027,7 @@ namespace ClosedXML.Tests.Excel
 
             var actual = ws1.Cell("A2").GetDateTime().ToString(format);
             var expected = now.DateTime.ToString(format);
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
 
         [Test]
@@ -1038,18 +1046,24 @@ namespace ClosedXML.Tests.Excel
 
             var copy = original.CopyTo(ws2);
 
-            Assert.AreEqual(0, ws1.Tables.Count()); // We did not add it
-            Assert.AreEqual(1, ws2.Tables.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.Tables.Count(), Is.EqualTo(0)); // We did not add it
+                Assert.That(ws2.Tables.Count(), Is.EqualTo(1));
+            });
 
             AssertTablesAreEqual(original, copy);
 
-            Assert.AreEqual("Sheet2!A1:C2", copy.RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Custom column 1", ws2.Cell("A1").Value);
-            Assert.AreEqual("Custom column 2", ws2.Cell("B1").Value);
-            Assert.AreEqual("Custom column 3", ws2.Cell("C1").Value);
-            Assert.AreEqual("Value 1", ws2.Cell("A2").Value);
-            Assert.AreEqual(123.45, (double)ws2.Cell("B2").Value, XLHelper.Epsilon);
-            Assert.AreEqual(new DateTime(2018, 5, 10), ws2.Cell("C2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!A1:C2"));
+                Assert.That(ws2.Cell("A1").Value, Is.EqualTo("Custom column 1"));
+                Assert.That(ws2.Cell("B1").Value, Is.EqualTo("Custom column 2"));
+                Assert.That(ws2.Cell("C1").Value, Is.EqualTo("Custom column 3"));
+                Assert.That(ws2.Cell("A2").Value, Is.EqualTo("Value 1"));
+                Assert.That((double)ws2.Cell("B2").Value, Is.EqualTo(123.45).Within(XLHelper.Epsilon));
+                Assert.That(ws2.Cell("C2").Value, Is.EqualTo(new DateTime(2018, 5, 10)));
+            });
         }
 
         [Test]
@@ -1069,66 +1083,73 @@ namespace ClosedXML.Tests.Excel
 
             original.CopyTo(ws2);
 
-            Assert.AreEqual(1, ws1.Tables.Count());
-            Assert.AreEqual(1, ws2.Tables.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.Tables.Count(), Is.EqualTo(1));
+                Assert.That(ws2.Tables.Count(), Is.EqualTo(1));
+            });
 
             var copy = ws2.Tables.First();
 
             AssertTablesAreEqual(original, copy);
 
-            Assert.AreEqual("Sheet2!A1:C2", copy.RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Custom column 1", ws2.Cell("A1").Value);
-            Assert.AreEqual("Custom column 2", ws2.Cell("B1").Value);
-            Assert.AreEqual("Custom column 3", ws2.Cell("C1").Value);
-            Assert.AreEqual("Value 1", ws2.Cell("A2").Value);
-            Assert.AreEqual(123.45, (double)ws2.Cell("B2").Value, XLHelper.Epsilon);
-            Assert.AreEqual(new DateTime(2018, 5, 10), ws2.Cell("C2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!A1:C2"));
+                Assert.That(ws2.Cell("A1").Value, Is.EqualTo("Custom column 1"));
+                Assert.That(ws2.Cell("B1").Value, Is.EqualTo("Custom column 2"));
+                Assert.That(ws2.Cell("C1").Value, Is.EqualTo("Custom column 3"));
+                Assert.That(ws2.Cell("A2").Value, Is.EqualTo("Value 1"));
+                Assert.That((double)ws2.Cell("B2").Value, Is.EqualTo(123.45).Within(XLHelper.Epsilon));
+                Assert.That(ws2.Cell("C2").Value, Is.EqualTo(new DateTime(2018, 5, 10)));
+            });
         }
 
         [Test]
         public void NewTableHasNullRelId()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                var ws = wb.Worksheets.Add("Sheet1");
+                ws.Cell("A1").Value = "Custom column 1";
+                ws.Cell("B1").Value = "Custom column 2";
+                ws.Cell("C1").Value = "Custom column 3";
+                ws.Cell("A2").Value = "Value 1";
+                ws.Cell("B2").Value = 123.45;
+                ws.Cell("C2").Value = new DateTime(2018, 5, 10);
+                var original = ws.Range("A1:C2").CreateTable("Attached table");
+
+                Assert.That(ws.Tables.Count(), Is.EqualTo(1));
+                Assert.That((original as XLTable).RelId, Is.Null);
+
+                wb.SaveAs(ms);
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws = wb.Worksheets.Add("Sheet2");
+                var original = wb.Worksheets.First().Tables.First();
+
+                Assert.IsNotNull((original as XLTable).RelId);
+
+                var copy = original.CopyTo(ws);
+
+                Assert.That(ws.Tables.Count(), Is.EqualTo(1));
+                Assert.That((copy as XLTable).RelId, Is.Null);
+
+                AssertTablesAreEqual(original, copy);
+
+                Assert.Multiple(() =>
                 {
-                    var ws = wb.Worksheets.Add("Sheet1");
-                    ws.Cell("A1").Value = "Custom column 1";
-                    ws.Cell("B1").Value = "Custom column 2";
-                    ws.Cell("C1").Value = "Custom column 3";
-                    ws.Cell("A2").Value = "Value 1";
-                    ws.Cell("B2").Value = 123.45;
-                    ws.Cell("C2").Value = new DateTime(2018, 5, 10);
-                    var original = ws.Range("A1:C2").CreateTable("Attached table");
-
-                    Assert.AreEqual(1, ws.Tables.Count());
-                    Assert.IsNull((original as XLTable).RelId);
-
-                    wb.SaveAs(ms);
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws = wb.Worksheets.Add("Sheet2");
-                    var original = wb.Worksheets.First().Tables.First();
-
-                    Assert.IsNotNull((original as XLTable).RelId);
-
-                    var copy = original.CopyTo(ws);
-
-                    Assert.AreEqual(1, ws.Tables.Count());
-                    Assert.IsNull((copy as XLTable).RelId);
-
-                    AssertTablesAreEqual(original, copy);
-
-                    Assert.AreEqual("Sheet2!A1:C2", copy.RangeAddress.ToString(XLReferenceStyle.A1, true));
-                    Assert.AreEqual("Custom column 1", ws.Cell("A1").Value);
-                    Assert.AreEqual("Custom column 2", ws.Cell("B1").Value);
-                    Assert.AreEqual("Custom column 3", ws.Cell("C1").Value);
-                    Assert.AreEqual("Value 1", ws.Cell("A2").Value);
-                    Assert.AreEqual(123.45, (double)ws.Cell("B2").Value, XLHelper.Epsilon);
-                    Assert.AreEqual(new DateTime(2018, 5, 10), ws.Cell("C2").Value);
-                }
+                    Assert.That(copy.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!A1:C2"));
+                    Assert.That(ws.Cell("A1").Value, Is.EqualTo("Custom column 1"));
+                    Assert.That(ws.Cell("B1").Value, Is.EqualTo("Custom column 2"));
+                    Assert.That(ws.Cell("C1").Value, Is.EqualTo("Custom column 3"));
+                    Assert.That(ws.Cell("A2").Value, Is.EqualTo("Value 1"));
+                    Assert.That((double)ws.Cell("B2").Value, Is.EqualTo(123.45).Within(XLHelper.Epsilon));
+                    Assert.That(ws.Cell("C2").Value, Is.EqualTo(new DateTime(2018, 5, 10)));
+                });
             }
         }
 
@@ -1151,44 +1172,45 @@ namespace ClosedXML.Tests.Excel
 
             AssertTablesAreEqual(original, copy);
 
-            Assert.AreEqual("Sheet2!A1:C2", copy.RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Custom column 1", ws2.Cell("A1").Value);
-            Assert.AreEqual("Custom column 2", ws2.Cell("B1").Value);
-            Assert.AreEqual("Custom column 3", ws2.Cell("C1").Value);
-            Assert.AreEqual(Blank.Value, ws2.Cell("A2").Value);
-            Assert.AreEqual(Blank.Value, ws2.Cell("B2").Value);
-            Assert.AreEqual(Blank.Value, ws2.Cell("C2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.RangeAddress.ToString(XLReferenceStyle.A1, true), Is.EqualTo("Sheet2!A1:C2"));
+                Assert.That(ws2.Cell("A1").Value, Is.EqualTo("Custom column 1"));
+                Assert.That(ws2.Cell("B1").Value, Is.EqualTo("Custom column 2"));
+                Assert.That(ws2.Cell("C1").Value, Is.EqualTo("Custom column 3"));
+                Assert.That(ws2.Cell("A2").Value, Is.EqualTo(Blank.Value));
+                Assert.That(ws2.Cell("B2").Value, Is.EqualTo(Blank.Value));
+                Assert.That(ws2.Cell("C2").Value, Is.EqualTo(Blank.Value));
+            });
         }
 
         [Test]
         public void SavingTableWithNullDataRangeThrowsException()
         {
-            using (var ms = new MemoryStream())
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
+            using var ms = new MemoryStream();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
 
-                var data = Enumerable.Range(1, 10)
-                    .Select(i => new
-                    {
-                        Number = i,
-                        NumberString = String.Concat("Number", i.ToString())
-                    });
+            var data = Enumerable.Range(1, 10)
+                .Select(i => new
+                {
+                    Number = i,
+                    NumberString = string.Concat("Number", i.ToString())
+                });
 
-                var table = ws.FirstCell()
-                    .InsertTable(data)
-                    .SetShowTotalsRow();
+            var table = ws.FirstCell()
+                .InsertTable(data)
+                .SetShowTotalsRow();
 
-                table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Count;
+            table.Fields.Last().TotalsRowFunction = XLTotalsRowFunction.Count;
 
-                table.DataRange.Rows()
-                    .OrderByDescending(r => r.RowNumber())
-                    .ToList()
-                    .ForEach(r => r.WorksheetRow().Delete());
+            table.DataRange.Rows()
+                .OrderByDescending(r => r.RowNumber())
+                .ToList()
+                .ForEach(r => r.WorksheetRow().Delete());
 
-                Assert.IsNull(table.DataRange);
-                Assert.Throws<EmptyTableException>(() => wb.SaveAs(ms));
-            }
+            Assert.That(table.DataRange, Is.Null);
+            Assert.Throws<EmptyTableException>(() => wb.SaveAs(ms));
         }
 
         [Test]
@@ -1215,75 +1237,81 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void CanCreateTableWithWhiteSpaceColumnHeaders()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            ws.Cell("A1").SetValue("Header");
+            ws.Cell("B1").SetValue(new string(' ', 1));
+            ws.Cell("C1").SetValue(new string(' ', 2));
+            ws.Cell("D1").SetValue(new string(' ', 3));
+
+            var table = ws.Range("A1:E3").CreateTable("Table1");
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-
-                ws.Cell("A1").SetValue("Header");
-                ws.Cell("B1").SetValue(new string(' ', 1));
-                ws.Cell("C1").SetValue(new string(' ', 2));
-                ws.Cell("D1").SetValue(new string(' ', 3));
-
-                var table = ws.Range("A1:E3").CreateTable("Table1");
-
-                Assert.AreEqual("Header", table.Field(0).Name);
-                Assert.AreEqual(new string(' ', 1), table.Field(1).Name);
-                Assert.AreEqual(new string(' ', 2), table.Field(2).Name);
-                Assert.AreEqual(new string(' ', 3), table.Field(3).Name);
-                Assert.AreEqual("Column5", table.Field(4).Name);
-            }
+                Assert.That(table.Field(0).Name, Is.EqualTo("Header"));
+                Assert.That(table.Field(1).Name, Is.EqualTo(new string(' ', 1)));
+                Assert.That(table.Field(2).Name, Is.EqualTo(new string(' ', 2)));
+                Assert.That(table.Field(3).Name, Is.EqualTo(new string(' ', 3)));
+                Assert.That(table.Field(4).Name, Is.EqualTo("Column5"));
+            });
         }
 
         [Test]
         public void TableNotFound()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Table("dummy"));
-                Assert.Throws<ArgumentOutOfRangeException>(() => wb.Table("dummy"));
-            }
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Table("dummy"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => wb.Table("dummy"));
         }
 
         [Test]
         public void SecondTableOnNewSheetHasUniqueName()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws1 = wb.AddWorksheet();
-                var t1 = ws1.FirstCell().InsertTable(Enumerable.Range(1, 10).Select(i => new { Number = i }));
-                Assert.AreEqual("Table1", t1.Name);
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            var t1 = ws1.FirstCell().InsertTable(Enumerable.Range(1, 10).Select(i => new { Number = i }));
+            Assert.That(t1.Name, Is.EqualTo("Table1"));
 
-                var ws2 = wb.AddWorksheet();
-                var t2 = ws2.FirstCell().InsertTable(Enumerable.Range(1, 10).Select(i => new { Number = i }));
-                Assert.AreEqual("Table2", t2.Name);
-            }
+            var ws2 = wb.AddWorksheet();
+            var t2 = ws2.FirstCell().InsertTable(Enumerable.Range(1, 10).Select(i => new { Number = i }));
+            Assert.That(t2.Name, Is.EqualTo("Table2"));
         }
 
         private void AssertTablesAreEqual(IXLTable table1, IXLTable table2)
         {
-            Assert.AreEqual(table1.RangeAddress.ToString(XLReferenceStyle.A1, false), table2.RangeAddress.ToString(XLReferenceStyle.A1, false));
-            Assert.AreEqual(table1.Fields.Count(), table2.Fields.Count());
+            Assert.Multiple(() =>
+            {
+                Assert.That(table2.RangeAddress.ToString(XLReferenceStyle.A1, false), Is.EqualTo(table1.RangeAddress.ToString(XLReferenceStyle.A1, false)));
+                Assert.That(table2.Fields.Count(), Is.EqualTo(table1.Fields.Count()));
+            });
             for (int j = 0; j < table1.Fields.Count(); j++)
             {
                 var originalField = table1.Fields.ElementAt(j);
                 var copyField = table2.Fields.ElementAt(j);
-                Assert.AreEqual(originalField.Name, copyField.Name);
+                Assert.That(copyField.Name, Is.EqualTo(originalField.Name));
                 if (table1.ShowTotalsRow)
                 {
-                    Assert.AreEqual(originalField.TotalsRowFormulaA1, copyField.TotalsRowFormulaA1);
-                    Assert.AreEqual(originalField.TotalsRowFunction, copyField.TotalsRowFunction);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(copyField.TotalsRowFormulaA1, Is.EqualTo(originalField.TotalsRowFormulaA1));
+                        Assert.That(copyField.TotalsRowFunction, Is.EqualTo(originalField.TotalsRowFunction));
+                    });
                 }
             }
 
-            Assert.AreEqual(table1.Name, table2.Name);
-            Assert.AreEqual(table1.ShowAutoFilter, table2.ShowAutoFilter);
-            Assert.AreEqual(table1.ShowColumnStripes, table2.ShowColumnStripes);
-            Assert.AreEqual(table1.ShowHeaderRow, table2.ShowHeaderRow);
-            Assert.AreEqual(table1.ShowRowStripes, table2.ShowRowStripes);
-            Assert.AreEqual(table1.ShowTotalsRow, table2.ShowTotalsRow);
-            Assert.AreEqual((table1.Style as XLStyle).Value, (table2.Style as XLStyle).Value);
-            Assert.AreEqual(table1.Theme, table2.Theme);
+            Assert.Multiple(() =>
+            {
+                Assert.That(table2.Name, Is.EqualTo(table1.Name));
+                Assert.That(table2.ShowAutoFilter, Is.EqualTo(table1.ShowAutoFilter));
+                Assert.That(table2.ShowColumnStripes, Is.EqualTo(table1.ShowColumnStripes));
+                Assert.That(table2.ShowHeaderRow, Is.EqualTo(table1.ShowHeaderRow));
+                Assert.That(table2.ShowRowStripes, Is.EqualTo(table1.ShowRowStripes));
+                Assert.That(table2.ShowTotalsRow, Is.EqualTo(table1.ShowTotalsRow));
+                Assert.That((table2.Style as XLStyle).Value, Is.EqualTo((table1.Style as XLStyle).Value));
+                Assert.That(table2.Theme, Is.EqualTo(table1.Theme));
+            });
         }
 
         //TODO: Delete table (not underlying range)

--- a/ClosedXML.Tests/Excel/Worksheets/XLSheetViewTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLSheetViewTests.cs
@@ -21,8 +21,11 @@ namespace ClosedXML.Tests.Excel.Worksheets
 
             var ws2 = ws1.CopyTo(wb2, "WS2");
 
-            Assert.AreEqual(ws2, ws2.SheetView.Worksheet);
-            Assert.AreEqual("AZ2000", ws2.SheetView.TopLeftCellAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws2.SheetView.Worksheet, Is.EqualTo(ws2));
+                Assert.That(ws2.SheetView.TopLeftCellAddress.ToString(), Is.EqualTo("AZ2000"));
+            });
         }
 
         [Test]
@@ -51,7 +54,7 @@ namespace ClosedXML.Tests.Excel.Worksheets
             using (var wb = new XLWorkbook(ms))
             {
                 var ws = wb.Worksheets.First();
-                Assert.AreEqual("AZ2000", ws.SheetView.TopLeftCellAddress.ToString());
+                Assert.That(ws.SheetView.TopLeftCellAddress.ToString(), Is.EqualTo("AZ2000"));
 
                 ws.SheetView.TopLeftCellAddress = ws.Cell("AZ2000")
                     .CellBelow()
@@ -66,7 +69,7 @@ namespace ClosedXML.Tests.Excel.Worksheets
             using (var wb = new XLWorkbook(ms))
             {
                 var ws = wb.Worksheets.First();
-                Assert.AreEqual("BA2001", ws.SheetView.TopLeftCellAddress.ToString());
+                Assert.That(ws.SheetView.TopLeftCellAddress.ToString(), Is.EqualTo("BA2001"));
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1323,7 +1323,7 @@ namespace ClosedXML.Tests
             Assert.That(sut.Cell("A1").NeedsRecalculation, Is.False);
             Assert.That(sut.Cell("A1").CachedValue, Is.EqualTo(15.0));
 
-            Assert.False(sut.Cell("A2").NeedsRecalculation);
+            Assert.That(sut.Cell("A2").NeedsRecalculation, Is.False);
             Assert.That(sut.Cell("A2").CachedValue, Is.EqualTo(3.0));
         }
 

--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -185,13 +185,16 @@ namespace ClosedXML.Tests
             ws.Range("D2:E2").Merge();
 
             Assert.That(ws.MergedRanges, Has.Count.EqualTo(2));
-            Assert.That(ws.MergedRanges.First().RangeAddress.ToStringRelative(), Is.EqualTo("A1:B2"));
-            Assert.That(ws.MergedRanges.Last().RangeAddress.ToStringRelative(), Is.EqualTo("D2:E2"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.MergedRanges.First().RangeAddress.ToStringRelative(), Is.EqualTo("A1:B2"));
+                Assert.That(ws.MergedRanges.Last().RangeAddress.ToStringRelative(), Is.EqualTo("D2:E2"));
 
-            Assert.That(ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative(), Is.EqualTo("A1:B2"));
-            Assert.That(ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative(), Is.EqualTo("D2:E2"));
+                Assert.That(ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative(), Is.EqualTo("A1:B2"));
+                Assert.That(ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative(), Is.EqualTo("D2:E2"));
 
-            Assert.That(ws.Cell("Z10").MergedRange(), Is.Null);
+                Assert.That(ws.Cell("Z10").MergedRange(), Is.Null);
+            });
         }
 
         [Test]
@@ -533,14 +536,14 @@ namespace ClosedXML.Tests
             {
                 var nr1 = ws1.DefinedNames.ElementAt(i);
                 var nr2 = ws2.DefinedNames.ElementAt(i);
-
-                
-                Assert.That((int)nr2.Scope, Is.EqualTo((int)XLScope.Worksheet));
-
-                Assert.That(nr2.Ranges.ToString(), Is.EqualTo(nr1.Ranges.ToString()));
-                Assert.That(nr2.Name, Is.EqualTo(nr1.Name));
-                Assert.That(nr2.Visible, Is.EqualTo(nr1.Visible));
-                Assert.That(nr2.Comment, Is.EqualTo(nr1.Comment));
+                Assert.Multiple(() =>
+                {
+                    Assert.That((int)nr2.Scope, Is.EqualTo((int)XLScope.Worksheet));
+                    Assert.That(nr2.Ranges.ToString(), Is.EqualTo(nr1.Ranges.ToString()));
+                    Assert.That(nr2.Name, Is.EqualTo(nr1.Name));
+                    Assert.That(nr2.Visible, Is.EqualTo(nr1.Visible));
+                    Assert.That(nr2.Comment, Is.EqualTo(nr1.Comment));
+                });
             }
         }
         [Test]
@@ -757,7 +760,7 @@ namespace ClosedXML.Tests
 
             void AssertPicturesAreEqual(IXLWorksheet ws1, IXLWorksheet ws2)
             {
-                Assert.That(ws2.Pictures, Has.Count.EqualTo(ws1.Pictures.Count()));
+                Assert.That(ws2.Pictures, Has.Count.EqualTo(ws1.Pictures.Count));
 
                 for (var i = 0; i < ws1.Pictures.Count; i++)
                 {
@@ -1317,7 +1320,7 @@ namespace ClosedXML.Tests
             });
 
             // Formulas in test sheet were recalculated - they are affected by recalculation of a sut sheet.
-            Assert.False(sut.Cell("A1").NeedsRecalculation);
+            Assert.That(sut.Cell("A1").NeedsRecalculation, Is.False);
             Assert.That(sut.Cell("A1").CachedValue, Is.EqualTo(15.0));
 
             Assert.False(sut.Cell("A2").NeedsRecalculation);

--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -21,7 +21,7 @@ namespace ClosedXML.Tests
             DateTime start = DateTime.Now;
             ws.ColumnCount();
             DateTime end = DateTime.Now;
-            Assert.IsTrue((end - start).TotalMilliseconds < 500);
+            Assert.That((end - start).TotalMilliseconds, Is.LessThan(500));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace ClosedXML.Tests
             ws.Range("A1:C3").AddConditionalFormat().WhenContains("1").Fill.SetBackgroundColor(XLColor.Blue);
             ws.Range("A1:C3").Value = 1;
             IXLWorksheet ws2 = ws.CopyTo("Sheet2");
-            Assert.AreEqual(1, ws2.ConditionalFormats.Count());
+            Assert.That(ws2.ConditionalFormats.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace ClosedXML.Tests
             var ws = wb.AddWorksheet("Sheet1");
             ws.Columns(10, 20).Hide();
             ws.CopyTo("Sheet2");
-            Assert.IsTrue(wb.Worksheet("Sheet2").Column(10).IsHidden);
+            Assert.That(wb.Worksheet("Sheet2").Column(10).IsHidden, Is.True);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace ClosedXML.Tests
             var ws = wb.AddWorksheet("Sheet1");
             ws.Rows(2, 5).Hide();
             ws.CopyTo("Sheet2");
-            Assert.IsTrue(wb.Worksheet("Sheet2").Row(4).IsHidden);
+            Assert.That(wb.Worksheet("Sheet2").Row(4).IsHidden, Is.True);
         }
 
         [Test]
@@ -65,9 +65,12 @@ namespace ClosedXML.Tests
 
             wb.Worksheet("Sheet3").Delete();
 
-            Assert.AreEqual("Sheet1", wb.Worksheet(1).Name);
-            Assert.AreEqual("Sheet2", wb.Worksheet(2).Name);
-            Assert.AreEqual(2, wb.Worksheets.Count);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Worksheet(1).Name, Is.EqualTo("Sheet1"));
+                Assert.That(wb.Worksheet(2).Name, Is.EqualTo("Sheet2"));
+                Assert.That(wb.Worksheets, Has.Count.EqualTo(2));
+            });
         }
 
         [Test]
@@ -78,9 +81,12 @@ namespace ClosedXML.Tests
             wb.Worksheets.Add("Sheet2");
             wb.Worksheets.Add("Sheet3");
 
-            Assert.AreEqual("Sheet1", wb.Worksheet(1).Name);
-            Assert.AreEqual("Sheet2", wb.Worksheet(2).Name);
-            Assert.AreEqual("Sheet3", wb.Worksheet(3).Name);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Worksheet(1).Name, Is.EqualTo("Sheet1"));
+                Assert.That(wb.Worksheet(2).Name, Is.EqualTo("Sheet2"));
+                Assert.That(wb.Worksheet(3).Name, Is.EqualTo("Sheet3"));
+            });
         }
 
         [Test]
@@ -91,9 +97,12 @@ namespace ClosedXML.Tests
             wb.Worksheets.Add("Sheet1", 1);
             wb.Worksheets.Add("Sheet3");
 
-            Assert.AreEqual("Sheet1", wb.Worksheet(1).Name);
-            Assert.AreEqual("Sheet2", wb.Worksheet(2).Name);
-            Assert.AreEqual("Sheet3", wb.Worksheet(3).Name);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Worksheet(1).Name, Is.EqualTo("Sheet1"));
+                Assert.That(wb.Worksheet(2).Name, Is.EqualTo("Sheet2"));
+                Assert.That(wb.Worksheet(3).Name, Is.EqualTo("Sheet3"));
+            });
         }
 
         [Test]
@@ -104,9 +113,12 @@ namespace ClosedXML.Tests
             wb.Worksheets.Add("Sheet2", 1);
             wb.Worksheets.Add("Sheet1", 1);
 
-            Assert.AreEqual("Sheet1", wb.Worksheet(1).Name);
-            Assert.AreEqual("Sheet2", wb.Worksheet(2).Name);
-            Assert.AreEqual("Sheet3", wb.Worksheet(3).Name);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wb.Worksheet(1).Name, Is.EqualTo("Sheet1"));
+                Assert.That(wb.Worksheet(2).Name, Is.EqualTo("Sheet2"));
+                Assert.That(wb.Worksheet(3).Name, Is.EqualTo("Sheet3"));
+            });
         }
 
         [Test]
@@ -115,20 +127,20 @@ namespace ClosedXML.Tests
             var wb = new XLWorkbook();
             var ws1 = wb.Worksheets.Add();
 
-            Assert.AreEqual("Sheet1", ws1.Name);
+            Assert.That(ws1.Name, Is.EqualTo("Sheet1"));
             ws1.Name = "shEEt1";
 
             var ws2 = wb.Worksheets.Add();
-            Assert.AreEqual("Sheet2", ws2.Name);
+            Assert.That(ws2.Name, Is.EqualTo("Sheet2"));
 
             wb.Worksheets.Add("SHEET4");
 
-            Assert.AreEqual("Sheet5", wb.Worksheets.Add().Name);
-            Assert.AreEqual("Sheet6", wb.Worksheets.Add().Name);
+            Assert.That(wb.Worksheets.Add().Name, Is.EqualTo("Sheet5"));
+            Assert.That(wb.Worksheets.Add().Name, Is.EqualTo("Sheet6"));
 
             wb.Worksheets.Add(1);
 
-            Assert.AreEqual("Sheet7", wb.Worksheet(1).Name);
+            Assert.That(wb.Worksheet(1).Name, Is.EqualTo("Sheet7"));
         }
 
         [Test]
@@ -139,28 +151,29 @@ namespace ClosedXML.Tests
             var ws2 = (XLWorksheet)wb.AddWorksheet();
             var ws3 = (XLWorksheet)wb.AddWorksheet();
 
-            Assert.AreEqual(1, ws1.SheetId);
-            Assert.AreEqual(2, ws2.SheetId);
-            Assert.AreEqual(3, ws3.SheetId);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws1.SheetId, Is.EqualTo(1));
+                Assert.That(ws2.SheetId, Is.EqualTo(2));
+                Assert.That(ws3.SheetId, Is.EqualTo(3));
+            });
 
             ws3.Delete();
             var ws4 = (XLWorksheet)wb.AddWorksheet();
-            Assert.AreEqual(4, ws4.SheetId);
+            Assert.That(ws4.SheetId, Is.EqualTo(4));
         }
 
         [Test]
         public void AddingDuplicateSheetNameThrowsException()
         {
-            using (var wb = new XLWorkbook())
-            {
-                IXLWorksheet ws;
-                ws = wb.AddWorksheet("Sheet1");
+            using var wb = new XLWorkbook();
+            IXLWorksheet ws;
+            ws = wb.AddWorksheet("Sheet1");
 
-                Assert.Throws<ArgumentException>(() => wb.AddWorksheet("Sheet1"));
+            Assert.Throws<ArgumentException>(() => wb.AddWorksheet("Sheet1"));
 
-                //Sheet names are case insensitive
-                Assert.Throws<ArgumentException>(() => wb.AddWorksheet("sheet1"));
-            }
+            //Sheet names are case insensitive
+            Assert.Throws<ArgumentException>(() => wb.AddWorksheet("sheet1"));
         }
 
         [Test]
@@ -171,14 +184,14 @@ namespace ClosedXML.Tests
             ws.Range("C1:D3").Merge();
             ws.Range("D2:E2").Merge();
 
-            Assert.AreEqual(2, ws.MergedRanges.Count);
-            Assert.AreEqual("A1:B2", ws.MergedRanges.First().RangeAddress.ToStringRelative());
-            Assert.AreEqual("D2:E2", ws.MergedRanges.Last().RangeAddress.ToStringRelative());
+            Assert.That(ws.MergedRanges, Has.Count.EqualTo(2));
+            Assert.That(ws.MergedRanges.First().RangeAddress.ToStringRelative(), Is.EqualTo("A1:B2"));
+            Assert.That(ws.MergedRanges.Last().RangeAddress.ToStringRelative(), Is.EqualTo("D2:E2"));
 
-            Assert.AreEqual("A1:B2", ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative());
-            Assert.AreEqual("D2:E2", ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative());
+            Assert.That(ws.Cell("A2").MergedRange().RangeAddress.ToStringRelative(), Is.EqualTo("A1:B2"));
+            Assert.That(ws.Cell("D2").MergedRange().RangeAddress.ToStringRelative(), Is.EqualTo("D2:E2"));
 
-            Assert.AreEqual(null, ws.Cell("Z10").MergedRange());
+            Assert.That(ws.Cell("Z10").MergedRange(), Is.Null);
         }
 
         [Test]
@@ -189,132 +202,129 @@ namespace ClosedXML.Tests
             DateTime start = DateTime.Now;
             ws.RowCount();
             DateTime end = DateTime.Now;
-            Assert.IsTrue((end - start).TotalMilliseconds < 500);
+            Assert.That((end - start).TotalMilliseconds, Is.LessThan(500));
         }
 
         [Test]
         public void SheetsWithCommas()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var sourceSheetName = "Sheet1, Sheet3";
-                var ws = wb.Worksheets.Add(sourceSheetName);
-                ws.Cell("A1").Value = 1;
-                ws.Cell("A2").Value = 2;
-                ws.Cell("B2").Value = 3;
+            using var wb = new XLWorkbook();
+            var sourceSheetName = "Sheet1, Sheet3";
+            var ws = wb.Worksheets.Add(sourceSheetName);
+            ws.Cell("A1").Value = 1;
+            ws.Cell("A2").Value = 2;
+            ws.Cell("B2").Value = 3;
 
-                ws = wb.Worksheets.Add("Formula");
-                ws.FirstCell().FormulaA1 = string.Format("=SUM('{0}'!A1:A2,'{0}'!B1:B2)", sourceSheetName);
+            ws = wb.Worksheets.Add("Formula");
+            ws.FirstCell().FormulaA1 = string.Format("=SUM('{0}'!A1:A2,'{0}'!B1:B2)", sourceSheetName);
 
-                var value = ws.FirstCell().Value;
-                Assert.AreEqual(6, value);
-            }
+            var value = ws.FirstCell().Value;
+            Assert.That(value, Is.EqualTo(6));
         }
 
         [Test]
         public void CanRenameWorksheet()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws1 = wb.AddWorksheet("Sheet1");
-                var ws2 = wb.AddWorksheet("Sheet2");
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet("Sheet1");
+            var ws2 = wb.AddWorksheet("Sheet2");
 
-                ws1.Name = "New sheet name";
-                Assert.AreEqual("New sheet name", ws1.Name);
+            ws1.Name = "New sheet name";
+            Assert.That(ws1.Name, Is.EqualTo("New sheet name"));
 
-                ws2.Name = "sheet2";
-                Assert.AreEqual("sheet2", ws2.Name);
+            ws2.Name = "sheet2";
+            Assert.That(ws2.Name, Is.EqualTo("sheet2"));
 
-                Assert.Throws<ArgumentException>(() => ws1.Name = "SHEET2");
-            }
+            Assert.Throws<ArgumentException>(() => ws1.Name = "SHEET2");
         }
 
         [Test]
         public void TryGetWorksheet()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            wb.AddWorksheet("Sheet1");
+            wb.AddWorksheet("Sheet2");
+
+            IXLWorksheet ws;
+            Assert.Multiple(() =>
             {
-                wb.AddWorksheet("Sheet1");
-                wb.AddWorksheet("Sheet2");
+                Assert.That(wb.Worksheets.TryGetWorksheet("Sheet1", out ws), Is.True);
+                Assert.That(wb.Worksheets.TryGetWorksheet("sheet1", out ws), Is.True);
+                Assert.That(wb.Worksheets.TryGetWorksheet("sHEeT1", out ws), Is.True);
+                Assert.That(wb.Worksheets.TryGetWorksheet("Sheeeet2", out ws), Is.False);
 
-                IXLWorksheet ws;
-                Assert.IsTrue(wb.Worksheets.TryGetWorksheet("Sheet1", out ws));
-                Assert.IsTrue(wb.Worksheets.TryGetWorksheet("sheet1", out ws));
-                Assert.IsTrue(wb.Worksheets.TryGetWorksheet("sHEeT1", out ws));
-                Assert.IsFalse(wb.Worksheets.TryGetWorksheet("Sheeeet2", out ws));
-
-                Assert.IsTrue(wb.TryGetWorksheet("Sheet1", out ws));
-                Assert.IsTrue(wb.TryGetWorksheet("sheet1", out ws));
-                Assert.IsTrue(wb.TryGetWorksheet("sHEeT1", out ws));
-                Assert.IsFalse(wb.TryGetWorksheet("Sheeeet2", out ws));
-            }
+                Assert.That(wb.TryGetWorksheet("Sheet1", out ws), Is.True);
+                Assert.That(wb.TryGetWorksheet("sheet1", out ws), Is.True);
+                Assert.That(wb.TryGetWorksheet("sHEeT1", out ws), Is.True);
+                Assert.That(wb.TryGetWorksheet("Sheeeet2", out ws), Is.False);
+            });
         }
 
         [Test]
         public void HideWorksheet()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
+                wb.Worksheets.Add("VisibleSheet");
+                wb.Worksheets.Add("HiddenSheet").Hide();
+                wb.SaveAs(ms);
+            }
+
+            // unhide the hidden sheet
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    wb.Worksheets.Add("VisibleSheet");
-                    wb.Worksheets.Add("HiddenSheet").Hide();
-                    wb.SaveAs(ms);
-                }
+                    Assert.That(wb.Worksheet("VisibleSheet").Visibility, Is.EqualTo(XLWorksheetVisibility.Visible));
+                    Assert.That(wb.Worksheet("HiddenSheet").Visibility, Is.EqualTo(XLWorksheetVisibility.Hidden));
+                });
 
-                // unhide the hidden sheet
-                using (var wb = new XLWorkbook(ms))
+                var ws = wb.Worksheet("HiddenSheet");
+                ws.Unhide().Name = "NoAlsoVisible";
+
+                Assert.That(ws.Visibility, Is.EqualTo(XLWorksheetVisibility.Visible));
+
+                wb.Save();
+            }
+
+            using (var wb = new XLWorkbook(ms))
+            {
+                Assert.Multiple(() =>
                 {
-                    Assert.AreEqual(XLWorksheetVisibility.Visible, wb.Worksheet("VisibleSheet").Visibility);
-                    Assert.AreEqual(XLWorksheetVisibility.Hidden, wb.Worksheet("HiddenSheet").Visibility);
-
-                    var ws = wb.Worksheet("HiddenSheet");
-                    ws.Unhide().Name = "NoAlsoVisible";
-
-                    Assert.AreEqual(XLWorksheetVisibility.Visible, ws.Visibility);
-
-                    wb.Save();
-                }
-
-                using (var wb = new XLWorkbook(ms))
-                {
-                    Assert.AreEqual(XLWorksheetVisibility.Visible, wb.Worksheet("VisibleSheet").Visibility);
-                    Assert.AreEqual(XLWorksheetVisibility.Visible, wb.Worksheet("NoAlsoVisible").Visibility);
-                }
+                    Assert.That(wb.Worksheet("VisibleSheet").Visibility, Is.EqualTo(XLWorksheetVisibility.Visible));
+                    Assert.That(wb.Worksheet("NoAlsoVisible").Visibility, Is.EqualTo(XLWorksheetVisibility.Visible));
+                });
             }
         }
 
         [Test]
         public void CanCopySheetsWithAllAnchorTypes()
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx")))
-            using (var wb = new XLWorkbook(stream))
-            {
-                var ws = wb.Worksheets.First();
-                ws.CopyTo("Copy1");
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\ImageHandling\ImageAnchors.xlsx"));
+            using var wb = new XLWorkbook(stream);
+            var ws = wb.Worksheets.First();
+            ws.CopyTo("Copy1");
 
-                var ws2 = wb.Worksheets.Skip(1).First();
-                ws2.CopyTo("Copy2");
+            var ws2 = wb.Worksheets.Skip(1).First();
+            ws2.CopyTo("Copy2");
 
-                var ws3 = wb.Worksheets.Skip(2).First();
-                ws3.CopyTo("Copy3");
+            var ws3 = wb.Worksheets.Skip(2).First();
+            ws3.CopyTo("Copy3");
 
-                var ws4 = wb.Worksheets.Skip(3).First();
-                ws3.CopyTo("Copy4");
-            }
+            var ws4 = wb.Worksheets.Skip(3).First();
+            ws3.CopyTo("Copy4");
         }
 
         [Test]
         public void CannotCopyDeletedWorksheet()
         {
-            using (var wb = new XLWorkbook())
-            {
-                wb.AddWorksheet("Sheet1");
-                var ws = wb.AddWorksheet("Sheet2");
+            using var wb = new XLWorkbook();
+            wb.AddWorksheet("Sheet1");
+            var ws = wb.AddWorksheet("Sheet2");
 
-                ws.Delete();
-                Assert.Throws<InvalidOperationException>(() => ws.CopyTo("Copy of Sheet2"));
-            }
+            ws.Delete();
+            Assert.Throws<InvalidOperationException>(() => ws.CopyTo("Copy of Sheet2"));
         }
 
         [Test]
@@ -323,10 +333,8 @@ namespace ClosedXML.Tests
             var title = "'StartsWithApostrophe";
             TestDelegate addWorksheet = () =>
             {
-                using (var wb = new XLWorkbook())
-                {
-                    wb.Worksheets.Add(title);
-                }
+                using var wb = new XLWorkbook();
+                wb.Worksheets.Add(title);
             };
 
             Assert.Throws(typeof(ArgumentException), addWorksheet);
@@ -338,10 +346,8 @@ namespace ClosedXML.Tests
             var title = "EndsWithApostrophe'";
             TestDelegate addWorksheet = () =>
             {
-                using (var wb = new XLWorkbook())
-                {
-                    wb.Worksheets.Add(title);
-                }
+                using var wb = new XLWorkbook();
+                wb.Worksheets.Add(title);
             };
 
             Assert.Throws(typeof(ArgumentException), addWorksheet);
@@ -367,192 +373,181 @@ namespace ClosedXML.Tests
             var savedTitle = "";
             TestDelegate saveAndOpenWorkbook = () =>
             {
-                using (var ms = new MemoryStream())
+                using var ms = new MemoryStream();
+                using (var wb = new XLWorkbook())
                 {
-                    using (var wb = new XLWorkbook())
-                    {
-                        wb.Worksheets.Add(title);
-                        wb.Worksheets.First().Cell(1, 1).FormulaA1 = $"{title}!A2";
-                        wb.SaveAs(ms);
-                    }
+                    wb.Worksheets.Add(title);
+                    wb.Worksheets.First().Cell(1, 1).FormulaA1 = $"{title}!A2";
+                    wb.SaveAs(ms);
+                }
 
-                    using (var wb = new XLWorkbook(ms))
-                    {
-                        savedTitle = wb.Worksheets.First().Name;
-                    }
+                using (var wb = new XLWorkbook(ms))
+                {
+                    savedTitle = wb.Worksheets.First().Name;
                 }
             };
 
             Assert.DoesNotThrow(saveAndOpenWorkbook);
-            Assert.AreEqual(title, savedTitle);
+            Assert.That(savedTitle, Is.EqualTo(title));
         }
 
         [Test]
         public void CopyWorksheetPreservesContents()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Cell("A1").Value = "A1 value";
+            ws1.Cell("A2").Value = 100;
+            ws1.Cell("D4").Value = new DateTime(2018, 5, 1);
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.Cell("A1").Value = "A1 value";
-                ws1.Cell("A2").Value = 100;
-                ws1.Cell("D4").Value = new DateTime(2018, 5, 1);
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual("A1 value", ws2.Cell("A1").Value);
-                Assert.AreEqual(100, ws2.Cell("A2").Value);
-                Assert.AreEqual(new DateTime(2018, 5, 1), ws2.Cell("D4").Value);
-            }
+                Assert.That(ws2.Cell("A1").Value, Is.EqualTo("A1 value"));
+                Assert.That(ws2.Cell("A2").Value, Is.EqualTo(100));
+                Assert.That(ws2.Cell("D4").Value, Is.EqualTo(new DateTime(2018, 5, 1)));
+            });
         }
 
         [Test]
         public void CopyWorksheetPreservesFormulae()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Cell("A1").FormulaA1 = "10*10";
+            ws1.Cell("A2").FormulaA1 = "A1 * 2";
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.Cell("A1").FormulaA1 = "10*10";
-                ws1.Cell("A2").FormulaA1 = "A1 * 2";
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual("10*10", ws2.Cell("A1").FormulaA1);
-                Assert.AreEqual("A1 * 2", ws2.Cell("A2").FormulaA1);
-            }
+                Assert.That(ws2.Cell("A1").FormulaA1, Is.EqualTo("10*10"));
+                Assert.That(ws2.Cell("A2").FormulaA1, Is.EqualTo("A1 * 2"));
+            });
         }
 
         [Test]
         public void CopyWorksheetPreservesRowHeights()
         {
-            using (var wb1 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+            using var wb2 = new XLWorkbook();
+            ws1.RowHeight = 55;
+            ws1.Row(2).Height = 0;
+            ws1.Row(3).Height = 20;
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.RowHeight, Is.EqualTo(ws1.RowHeight));
+            for (int i = 1; i <= 3; i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-                using (var wb2 = new XLWorkbook())
-                {
-                    ws1.RowHeight = 55;
-                    ws1.Row(2).Height = 0;
-                    ws1.Row(3).Height = 20;
-
-                    var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                    Assert.AreEqual(ws1.RowHeight, ws2.RowHeight);
-                    for (int i = 1; i <= 3; i++)
-                    {
-                        Assert.AreEqual(ws1.Row(i).Height, ws2.Row(i).Height);
-                    }
-                }
+                Assert.That(ws2.Row(i).Height, Is.EqualTo(ws1.Row(i).Height));
             }
         }
 
         [Test]
         public void CopyWorksheetPreservesColumnWidths()
         {
-            using (var wb1 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+            using var wb2 = new XLWorkbook();
+            ws1.ColumnWidth = 160;
+            ws1.Column(2).Width = 0;
+            ws1.Column(3).Width = 240;
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.ColumnWidth, Is.EqualTo(ws1.ColumnWidth));
+            for (int i = 1; i <= 3; i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-                using (var wb2 = new XLWorkbook())
-                {
-                    ws1.ColumnWidth = 160;
-                    ws1.Column(2).Width = 0;
-                    ws1.Column(3).Width = 240;
-
-                    var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                    Assert.AreEqual(ws1.ColumnWidth, ws2.ColumnWidth);
-                    for (int i = 1; i <= 3; i++)
-                    {
-                        Assert.AreEqual(ws1.Column(i).Width, ws2.Column(i).Width);
-                    }
-                }
+                Assert.That(ws2.Column(i).Width, Is.EqualTo(ws1.Column(i).Width));
             }
         }
 
         [Test]
         public void CopyWorksheetPreservesMergedCells()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Range("A:A").Merge();
+            ws1.Range("B1:C2").Merge();
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.MergedRanges, Has.Count.EqualTo(ws1.MergedRanges.Count));
+            for (int i = 0; i < ws1.MergedRanges.Count; i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.Range("A:A").Merge();
-                ws1.Range("B1:C2").Merge();
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.MergedRanges.Count, ws2.MergedRanges.Count);
-                for (int i = 0; i < ws1.MergedRanges.Count; i++)
-                {
-                    Assert.AreEqual(ws1.MergedRanges.ElementAt(i).RangeAddress.ToString(),
-                                    ws2.MergedRanges.ElementAt(i).RangeAddress.ToString());
-                }
+                Assert.That(ws2.MergedRanges.ElementAt(i).RangeAddress.ToString(),
+                    Is.EqualTo(ws1.MergedRanges.ElementAt(i).RangeAddress.ToString()));
             }
         }
 
         [Test]
         public void Copy_sheet_across_workbooks_preserves_defined_names()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Range("A1:A2").AddToNamed("GLOBAL", XLScope.Workbook);
+            ws1.Ranges("B1:B2,D1:D2").AddToNamed("LOCAL", XLScope.Worksheet);
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.DefinedNames.Count(), Is.EqualTo(ws1.DefinedNames.Count()));
+            for (int i = 0; i < ws1.DefinedNames.Count(); i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.Range("A1:A2").AddToNamed("GLOBAL", XLScope.Workbook);
-                ws1.Ranges("B1:B2,D1:D2").AddToNamed("LOCAL", XLScope.Worksheet);
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.DefinedNames.Count(), ws2.DefinedNames.Count());
-                for (int i = 0; i < ws1.DefinedNames.Count(); i++)
+                var nr1 = ws1.DefinedNames.ElementAt(i);
+                var nr2 = ws2.DefinedNames.ElementAt(i);
+                Assert.Multiple(() =>
                 {
-                    var nr1 = ws1.DefinedNames.ElementAt(i);
-                    var nr2 = ws2.DefinedNames.ElementAt(i);
-                    Assert.AreEqual(nr1.Ranges.ToString(), nr2.Ranges.ToString());
-                    Assert.AreEqual(nr1.Scope, nr2.Scope);
-                    Assert.AreEqual(nr1.Name, nr2.Name);
-                    Assert.AreEqual(nr1.Visible, nr2.Visible);
-                    Assert.AreEqual(nr1.Comment, nr2.Comment);
-                }
+                    Assert.That(nr2.Ranges.ToString(), Is.EqualTo(nr1.Ranges.ToString()));
+                    Assert.That(nr2.Scope, Is.EqualTo(nr1.Scope));
+                    Assert.That(nr2.Name, Is.EqualTo(nr1.Name));
+                    Assert.That(nr2.Visible, Is.EqualTo(nr1.Visible));
+                    Assert.That(nr2.Comment, Is.EqualTo(nr1.Comment));
+                });
             }
         }
 
         [Test]
         public void Copying_sheet_inside_workbook_makes_copies_of_sheet_scoped_defined_names()
         {
-            using (var wb1 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Range("A1:A2").AddToNamed("GLOBAL", XLScope.Workbook);
+            ws1.Ranges("B1:B2,D1:D2").AddToNamed("LOCAL", XLScope.Worksheet);
+
+            var ws2 = ws1.CopyTo("Copy");
+
+            Assert.That(ws2.DefinedNames.Count(), Is.EqualTo(ws1.DefinedNames.Count()));
+            for (int i = 0; i < ws1.DefinedNames.Count(); i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
+                var nr1 = ws1.DefinedNames.ElementAt(i);
+                var nr2 = ws2.DefinedNames.ElementAt(i);
 
-                ws1.Range("A1:A2").AddToNamed("GLOBAL", XLScope.Workbook);
-                ws1.Ranges("B1:B2,D1:D2").AddToNamed("LOCAL", XLScope.Worksheet);
+                
+                Assert.That((int)nr2.Scope, Is.EqualTo((int)XLScope.Worksheet));
 
-                var ws2 = ws1.CopyTo("Copy");
-
-                Assert.AreEqual(ws1.DefinedNames.Count(), ws2.DefinedNames.Count());
-                for (int i = 0; i < ws1.DefinedNames.Count(); i++)
-                {
-                    var nr1 = ws1.DefinedNames.ElementAt(i);
-                    var nr2 = ws2.DefinedNames.ElementAt(i);
-
-                    Assert.AreEqual(XLScope.Worksheet, nr2.Scope);
-
-                    Assert.AreEqual(nr1.Ranges.ToString(), nr2.Ranges.ToString());
-                    Assert.AreEqual(nr1.Name, nr2.Name);
-                    Assert.AreEqual(nr1.Visible, nr2.Visible);
-                    Assert.AreEqual(nr1.Comment, nr2.Comment);
-                }
+                Assert.That(nr2.Ranges.ToString(), Is.EqualTo(nr1.Ranges.ToString()));
+                Assert.That(nr2.Name, Is.EqualTo(nr1.Name));
+                Assert.That(nr2.Visible, Is.EqualTo(nr1.Visible));
+                Assert.That(nr2.Comment, Is.EqualTo(nr1.Comment));
             }
         }
-
         [Test]
         public void CopyWorksheetPreservesStyles()
         {
-            using (var ms = new MemoryStream())
-            using (var wb1 = new XLWorkbook())
+            using var ms = new MemoryStream();
+            using var wb1 = new XLWorkbook();
             {
                 var ws1 = wb1.Worksheets.Add("Original");
 
@@ -578,14 +573,14 @@ namespace ClosedXML.Tests
 
             void AssertStylesAreEqual(IXLWorksheet ws1, IXLWorksheet ws2)
             {
-                Assert.AreEqual((ws1.Style as XLStyle).Value, (ws2.Style as XLStyle).Value,
+                Assert.That((ws2.Style as XLStyle).Value, Is.EqualTo((ws1.Style as XLStyle).Value),
                     "Worksheet styles differ");
                 var cellsUsed = ws1.Range(ws1.FirstCell(), ws1.LastCellUsed()).Cells();
                 foreach (var cell in cellsUsed)
                 {
                     var style1 = (cell.Style as XLStyle).Value;
                     var style2 = (ws2.Cell(cell.Address.ToString()).Style as XLStyle).Value;
-                    Assert.AreEqual(style1, style2, $"Cell {cell.Address} styles differ");
+                    Assert.That(style2, Is.EqualTo(style1), $"Cell {cell.Address} styles differ");
                 }
             }
         }
@@ -593,145 +588,151 @@ namespace ClosedXML.Tests
         [Test]
         public void CopyWorksheetPreservesConditionalFormats()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Range("A:A").AddConditionalFormat()
+                .WhenContains("0").Fill.SetBackgroundColor(XLColor.Red);
+            var cf = ws1.Range("B1:C2").AddConditionalFormat();
+            cf.Ranges.Add(ws1.Range("D4:D5"));
+            cf.WhenEqualOrGreaterThan(100).Font.SetBold();
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.ConditionalFormats.Count(), Is.EqualTo(ws1.ConditionalFormats.Count()));
+            for (int i = 0; i < ws1.ConditionalFormats.Count(); i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.Range("A:A").AddConditionalFormat()
-                    .WhenContains("0").Fill.SetBackgroundColor(XLColor.Red);
-                var cf = ws1.Range("B1:C2").AddConditionalFormat();
-                cf.Ranges.Add(ws1.Range("D4:D5"));
-                cf.WhenEqualOrGreaterThan(100).Font.SetBold();
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.ConditionalFormats.Count(), ws2.ConditionalFormats.Count());
-                for (int i = 0; i < ws1.ConditionalFormats.Count(); i++)
+                var original = ws1.ConditionalFormats.ElementAt(i);
+                var copy = ws2.ConditionalFormats.ElementAt(i);
+                Assert.That(copy.Ranges, Has.Count.EqualTo(original.Ranges.Count));
+                for (int j = 0; j < original.Ranges.Count; j++)
                 {
-                    var original = ws1.ConditionalFormats.ElementAt(i);
-                    var copy = ws2.ConditionalFormats.ElementAt(i);
-                    Assert.AreEqual(original.Ranges.Count, copy.Ranges.Count);
-                    for (int j = 0; j < original.Ranges.Count; j++)
-                    {
-                        Assert.AreEqual(original.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false),
-                            copy.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false));
-                    }
-
-                    Assert.AreEqual((original.Style as XLStyle).Value, (copy.Style as XLStyle).Value);
-                    Assert.AreEqual(original.Values.Single().Value.Value, copy.Values.Single().Value.Value);
+                    Assert.That(copy.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false),
+                        Is.EqualTo(original.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false)));
                 }
+
+                Assert.That((copy.Style as XLStyle).Value, Is.EqualTo((original.Style as XLStyle).Value));
+                Assert.That(copy.Values.Single().Value.Value, Is.EqualTo(original.Values.Single().Value.Value));
             }
         }
 
         [Test]
         public void CopyWorksheetPreservesTables()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.Cell("A2").Value = "Name";
+            ws1.Cell("B2").Value = "Count";
+            ws1.Cell("A3").Value = "John Smith";
+            ws1.Cell("B3").Value = 50;
+            ws1.Cell("A4").Value = "Ivan Ivanov";
+            ws1.Cell("B4").Value = 40;
+            var table1 = ws1.Range("A2:B4").CreateTable("Test table 1");
+            table1
+                .SetShowAutoFilter(true)
+                .SetShowTotalsRow(true)
+                .SetEmphasizeFirstColumn(true)
+                .SetShowColumnStripes(true)
+                .SetShowRowStripes(true);
+            table1.Theme = XLTableTheme.TableStyleDark8;
+            table1.Field(1).TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.Tables.Count(), Is.EqualTo(ws1.Tables.Count()));
+            for (int i = 0; i < ws1.Tables.Count(); i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.Cell("A2").Value = "Name";
-                ws1.Cell("B2").Value = "Count";
-                ws1.Cell("A3").Value = "John Smith";
-                ws1.Cell("B3").Value = 50;
-                ws1.Cell("A4").Value = "Ivan Ivanov";
-                ws1.Cell("B4").Value = 40;
-                var table1 = ws1.Range("A2:B4").CreateTable("Test table 1");
-                table1
-                    .SetShowAutoFilter(true)
-                    .SetShowTotalsRow(true)
-                    .SetEmphasizeFirstColumn(true)
-                    .SetShowColumnStripes(true)
-                    .SetShowRowStripes(true);
-                table1.Theme = XLTableTheme.TableStyleDark8;
-                table1.Field(1).TotalsRowFunction = XLTotalsRowFunction.Sum;
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.Tables.Count(), ws2.Tables.Count());
-                for (int i = 0; i < ws1.Tables.Count(); i++)
+                var original = ws1.Tables.ElementAt(i);
+                var copy = ws2.Tables.ElementAt(i);
+                Assert.Multiple(() =>
                 {
-                    var original = ws1.Tables.ElementAt(i);
-                    var copy = ws2.Tables.ElementAt(i);
-                    Assert.AreEqual(original.RangeAddress.ToString(XLReferenceStyle.A1, false), copy.RangeAddress.ToString(XLReferenceStyle.A1, false));
-                    Assert.AreEqual(original.Fields.Count(), copy.Fields.Count());
-                    for (int j = 0; j < original.Fields.Count(); j++)
+                    Assert.That(copy.RangeAddress.ToString(XLReferenceStyle.A1, false), Is.EqualTo(original.RangeAddress.ToString(XLReferenceStyle.A1, false)));
+                    Assert.That(copy.Fields.Count(), Is.EqualTo(original.Fields.Count()));
+                });
+                for (int j = 0; j < original.Fields.Count(); j++)
+                {
+                    var originalField = original.Fields.ElementAt(j);
+                    var copyField = copy.Fields.ElementAt(j);
+                    Assert.Multiple(() =>
                     {
-                        var originalField = original.Fields.ElementAt(j);
-                        var copyField = copy.Fields.ElementAt(j);
-                        Assert.AreEqual(originalField.Name, copyField.Name);
-                        Assert.AreEqual(originalField.TotalsRowFormulaA1, copyField.TotalsRowFormulaA1);
-                        Assert.AreEqual(originalField.TotalsRowFunction, copyField.TotalsRowFunction);
-                    }
-
-                    Assert.AreEqual(original.Name, copy.Name);
-                    Assert.AreEqual(original.ShowAutoFilter, copy.ShowAutoFilter);
-                    Assert.AreEqual(original.ShowColumnStripes, copy.ShowColumnStripes);
-                    Assert.AreEqual(original.ShowHeaderRow, copy.ShowHeaderRow);
-                    Assert.AreEqual(original.ShowRowStripes, copy.ShowRowStripes);
-                    Assert.AreEqual(original.ShowTotalsRow, copy.ShowTotalsRow);
-                    Assert.AreEqual((original.Style as XLStyle).Value, (copy.Style as XLStyle).Value);
-                    Assert.AreEqual(original.Theme, copy.Theme);
+                        Assert.That(copyField.Name, Is.EqualTo(originalField.Name));
+                        Assert.That(copyField.TotalsRowFormulaA1, Is.EqualTo(originalField.TotalsRowFormulaA1));
+                        Assert.That(copyField.TotalsRowFunction, Is.EqualTo(originalField.TotalsRowFunction));
+                    });
                 }
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(copy.Name, Is.EqualTo(original.Name));
+                    Assert.That(copy.ShowAutoFilter, Is.EqualTo(original.ShowAutoFilter));
+                    Assert.That(copy.ShowColumnStripes, Is.EqualTo(original.ShowColumnStripes));
+                    Assert.That(copy.ShowHeaderRow, Is.EqualTo(original.ShowHeaderRow));
+                    Assert.That(copy.ShowRowStripes, Is.EqualTo(original.ShowRowStripes));
+                    Assert.That(copy.ShowTotalsRow, Is.EqualTo(original.ShowTotalsRow));
+                    Assert.That((copy.Style as XLStyle).Value, Is.EqualTo((original.Style as XLStyle).Value));
+                    Assert.That(copy.Theme, Is.EqualTo(original.Theme));
+                });
             }
         }
 
         [Test]
         public void CopyWorksheetPreservesDataValidation()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            var dv1 = ws1.Range("A:A").CreateDataValidation();
+            dv1.WholeNumber.EqualTo(2);
+            dv1.ErrorStyle = XLErrorStyle.Warning;
+            dv1.ErrorTitle = "Number out of range";
+            dv1.ErrorMessage = "This cell only allows the number 2.";
+
+            var dv2 = ws1.Ranges("B2:C3,D4:E5").CreateDataValidation();
+            dv2.Decimal.GreaterThan(5);
+            dv2.ErrorStyle = XLErrorStyle.Stop;
+            dv2.ErrorTitle = "Decimal number out of range";
+            dv2.ErrorMessage = "This cell only allows decimals greater than 5.";
+
+            var dv3 = ws1.Cell("D1").CreateDataValidation();
+            dv3.TextLength.EqualOrLessThan(10);
+            dv3.ErrorStyle = XLErrorStyle.Information;
+            dv3.ErrorTitle = "Text length out of range";
+            dv3.ErrorMessage = "You entered more than 10 characters.";
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.DataValidations.Count(), Is.EqualTo(ws1.DataValidations.Count()));
+            for (int i = 0; i < ws1.DataValidations.Count(); i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
+                var original = ws1.DataValidations.ElementAt(i);
+                var copy = ws2.DataValidations.ElementAt(i);
 
-                var dv1 = ws1.Range("A:A").CreateDataValidation();
-                dv1.WholeNumber.EqualTo(2);
-                dv1.ErrorStyle = XLErrorStyle.Warning;
-                dv1.ErrorTitle = "Number out of range";
-                dv1.ErrorMessage = "This cell only allows the number 2.";
+                var originalRanges = string.Join(",", original.Ranges.Select(r => r.RangeAddress.ToString()));
+                var copyRanges = string.Join(",", original.Ranges.Select(r => r.RangeAddress.ToString()));
 
-                var dv2 = ws1.Ranges("B2:C3,D4:E5").CreateDataValidation();
-                dv2.Decimal.GreaterThan(5);
-                dv2.ErrorStyle = XLErrorStyle.Stop;
-                dv2.ErrorTitle = "Decimal number out of range";
-                dv2.ErrorMessage = "This cell only allows decimals greater than 5.";
-
-                var dv3 = ws1.Cell("D1").CreateDataValidation();
-                dv3.TextLength.EqualOrLessThan(10);
-                dv3.ErrorStyle = XLErrorStyle.Information;
-                dv3.ErrorTitle = "Text length out of range";
-                dv3.ErrorMessage = "You entered more than 10 characters.";
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.DataValidations.Count(), ws2.DataValidations.Count());
-                for (int i = 0; i < ws1.DataValidations.Count(); i++)
+                Assert.Multiple(() =>
                 {
-                    var original = ws1.DataValidations.ElementAt(i);
-                    var copy = ws2.DataValidations.ElementAt(i);
-
-                    var originalRanges = string.Join(",", original.Ranges.Select(r => r.RangeAddress.ToString()));
-                    var copyRanges = string.Join(",", original.Ranges.Select(r => r.RangeAddress.ToString()));
-
-                    Assert.AreEqual(originalRanges, copyRanges);
-                    Assert.AreEqual(original.AllowedValues, copy.AllowedValues);
-                    Assert.AreEqual(original.Operator, copy.Operator);
-                    Assert.AreEqual(original.ErrorStyle, copy.ErrorStyle);
-                    Assert.AreEqual(original.ErrorTitle, copy.ErrorTitle);
-                    Assert.AreEqual(original.ErrorMessage, copy.ErrorMessage);
-                }
+                    Assert.That(copyRanges, Is.EqualTo(originalRanges));
+                    Assert.That(copy.AllowedValues, Is.EqualTo(original.AllowedValues));
+                    Assert.That(copy.Operator, Is.EqualTo(original.Operator));
+                    Assert.That(copy.ErrorStyle, Is.EqualTo(original.ErrorStyle));
+                    Assert.That(copy.ErrorTitle, Is.EqualTo(original.ErrorTitle));
+                    Assert.That(copy.ErrorMessage, Is.EqualTo(original.ErrorMessage));
+                });
             }
         }
 
         [Test]
         public void CopyWorksheetPreservesPictures()
         {
-            using (var ms = new MemoryStream())
-            using (var imageStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable))
-                       .GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg"))
-            using (var wb1 = new XLWorkbook())
+            using var ms = new MemoryStream();
+            using var imageStream = Assembly.GetAssembly(typeof(ClosedXML.Examples.BasicTable))
+                .GetManifestResourceStream("ClosedXML.Examples.Resources.SampleImage.jpg");
+            using var wb1 = new XLWorkbook();
             {
                 var ws1 = wb1.Worksheets.Add("Original");
 
@@ -756,24 +757,27 @@ namespace ClosedXML.Tests
 
             void AssertPicturesAreEqual(IXLWorksheet ws1, IXLWorksheet ws2)
             {
-                Assert.AreEqual(ws1.Pictures.Count(), ws2.Pictures.Count());
+                Assert.That(ws2.Pictures, Has.Count.EqualTo(ws1.Pictures.Count()));
 
-                for (int i = 0; i < ws1.Pictures.Count(); i++)
+                for (var i = 0; i < ws1.Pictures.Count; i++)
                 {
                     var original = ws1.Pictures.ElementAt(i);
                     var copy = ws2.Pictures.ElementAt(i);
-                    Assert.AreEqual(ws2, copy.Worksheet);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(copy.Worksheet, Is.EqualTo(ws2));
 
-                    Assert.AreEqual(original.Format, copy.Format);
-                    Assert.AreEqual(original.Height, copy.Height);
-                    Assert.AreEqual(original.Id, copy.Id);
-                    Assert.AreEqual(original.Left, copy.Left);
-                    Assert.AreEqual(original.Name, copy.Name);
-                    Assert.AreEqual(original.Placement, copy.Placement);
-                    Assert.AreEqual(original.Top, copy.Top);
-                    Assert.AreEqual(original.TopLeftCell.Address.ToString(), copy.TopLeftCell.Address.ToString());
-                    Assert.AreEqual(original.Width, copy.Width);
-                    Assert.AreEqual(original.ImageStream.ToArray(), copy.ImageStream.ToArray(), "Image streams differ");
+                        Assert.That(copy.Format, Is.EqualTo(original.Format));
+                        Assert.That(copy.Height, Is.EqualTo(original.Height));
+                        Assert.That(copy.Id, Is.EqualTo(original.Id));
+                        Assert.That(copy.Left, Is.EqualTo(original.Left));
+                        Assert.That(copy.Name, Is.EqualTo(original.Name));
+                        Assert.That(copy.Placement, Is.EqualTo(original.Placement));
+                        Assert.That(copy.Top, Is.EqualTo(original.Top));
+                        Assert.That(copy.TopLeftCell.Address.ToString(), Is.EqualTo(original.TopLeftCell.Address.ToString()));
+                        Assert.That(copy.Width, Is.EqualTo(original.Width));
+                        Assert.That(copy.ImageStream.ToArray(), Is.EqualTo(original.ImageStream.ToArray()), "Image streams differ");
+                    });
                 }
             }
         }
@@ -781,9 +785,9 @@ namespace ClosedXML.Tests
         [Test]
         public void CopyWorksheetPreservesPivotTables()
         {
-            using (var ms = new MemoryStream())
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
-            using (var wb = new XLWorkbook(stream))
+            using var ms = new MemoryStream();
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
+            using var wb = new XLWorkbook(stream);
             {
                 var ws1 = wb.Worksheet("pvt1");
                 var copyOfws1 = ws1.CopyTo("CopyOfPvt1");
@@ -808,7 +812,7 @@ namespace ClosedXML.Tests
 
             void AssertPivotTablesAreEqual(IXLWorksheet ws1, IXLWorksheet ws2)
             {
-                Assert.AreEqual(ws1.PivotTables.Count(), ws2.PivotTables.Count());
+                Assert.That(ws2.PivotTables.Count(), Is.EqualTo(ws1.PivotTables.Count()));
 
                 var comparer = new PivotTableComparer();
 
@@ -817,9 +821,12 @@ namespace ClosedXML.Tests
                     var original = ws1.PivotTables.ElementAt(i).CastTo<XLPivotTable>();
                     var copy = ws2.PivotTables.ElementAt(i).CastTo<XLPivotTable>();
 
-                    Assert.AreEqual(ws2, copy.Worksheet);
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(copy.Worksheet, Is.EqualTo(ws2));
 
-                    Assert.IsTrue(comparer.Equals(original, copy));
+                        Assert.That(comparer.Equals(original, copy), Is.True);
+                    });
                 }
             }
         }
@@ -827,173 +834,180 @@ namespace ClosedXML.Tests
         [Test]
         public void CopyWorksheetPreservesSelectedRanges()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.SelectedRanges.RemoveAll();
+            ws1.SelectedRanges.Add(ws1.Range("E12:H20"));
+            ws1.SelectedRanges.Add(ws1.Range("B:B"));
+            ws1.SelectedRanges.Add(ws1.Range("3:6"));
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.SelectedRanges, Has.Count.EqualTo(ws1.SelectedRanges.Count));
+            for (int i = 0; i < ws1.SelectedRanges.Count; i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-
-                ws1.SelectedRanges.RemoveAll();
-                ws1.SelectedRanges.Add(ws1.Range("E12:H20"));
-                ws1.SelectedRanges.Add(ws1.Range("B:B"));
-                ws1.SelectedRanges.Add(ws1.Range("3:6"));
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.SelectedRanges.Count, ws2.SelectedRanges.Count);
-                for (int i = 0; i < ws1.SelectedRanges.Count; i++)
-                {
-                    Assert.AreEqual(ws1.SelectedRanges.ElementAt(i).RangeAddress.ToString(),
-                                    ws2.SelectedRanges.ElementAt(i).RangeAddress.ToString());
-                }
+                Assert.That(ws2.SelectedRanges.ElementAt(i).RangeAddress.ToString(),
+                    Is.EqualTo(ws1.SelectedRanges.ElementAt(i).RangeAddress.ToString()));
             }
         }
 
         [Test]
         public void CopyWorksheetPreservesPageSetup()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+
+            ws1.PageSetup.AddHorizontalPageBreak(15);
+            ws1.PageSetup.AddVerticalPageBreak(5);
+            ws1.PageSetup
+                .SetBlackAndWhite()
+                .SetCenterHorizontally()
+                .SetCenterVertically()
+                .SetFirstPageNumber(200)
+                .SetPageOrientation(XLPageOrientation.Landscape)
+                .SetPaperSize(XLPaperSize.A5Paper)
+                .SetScale(89)
+                .SetShowGridlines()
+                .SetHorizontalDpi(200)
+                .SetVerticalDpi(300)
+                .SetPagesTall(5)
+                .SetPagesWide(2)
+                .SetColumnsToRepeatAtLeft(1, 3);
+            ws1.PageSetup.PrintAreas.Clear();
+            ws1.PageSetup.PrintAreas.Add("A1:Z200");
+            ws1.PageSetup.Margins.SetBottom(5).SetTop(6).SetLeft(7).SetRight(8).SetFooter(9).SetHeader(10);
+            ws1.PageSetup.Header.Left.AddText(XLHFPredefinedText.FullPath, XLHFOccurrence.AllPages);
+            ws1.PageSetup.Footer.Right.AddText(XLHFPredefinedText.PageNumber, XLHFOccurrence.OddPages);
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.Multiple(() =>
             {
-                var ws1 = wb1.Worksheets.Add("Original");
+                Assert.That(ws2.PageSetup.FirstRowToRepeatAtTop, Is.EqualTo(ws1.PageSetup.FirstRowToRepeatAtTop));
+                Assert.That(ws2.PageSetup.LastRowToRepeatAtTop, Is.EqualTo(ws1.PageSetup.LastRowToRepeatAtTop));
+                Assert.That(ws2.PageSetup.FirstColumnToRepeatAtLeft, Is.EqualTo(ws1.PageSetup.FirstColumnToRepeatAtLeft));
+                Assert.That(ws2.PageSetup.LastColumnToRepeatAtLeft, Is.EqualTo(ws1.PageSetup.LastColumnToRepeatAtLeft));
+                Assert.That(ws2.PageSetup.PageOrientation, Is.EqualTo(ws1.PageSetup.PageOrientation));
+                Assert.That(ws2.PageSetup.PagesWide, Is.EqualTo(ws1.PageSetup.PagesWide));
+                Assert.That(ws2.PageSetup.PagesTall, Is.EqualTo(ws1.PageSetup.PagesTall));
+                Assert.That(ws2.PageSetup.Scale, Is.EqualTo(ws1.PageSetup.Scale));
+                Assert.That(ws2.PageSetup.HorizontalDpi, Is.EqualTo(ws1.PageSetup.HorizontalDpi));
+                Assert.That(ws2.PageSetup.VerticalDpi, Is.EqualTo(ws1.PageSetup.VerticalDpi));
+                Assert.That(ws2.PageSetup.FirstPageNumber, Is.EqualTo(ws1.PageSetup.FirstPageNumber));
+                Assert.That(ws2.PageSetup.CenterHorizontally, Is.EqualTo(ws1.PageSetup.CenterHorizontally));
+                Assert.That(ws2.PageSetup.CenterVertically, Is.EqualTo(ws1.PageSetup.CenterVertically));
+                Assert.That(ws2.PageSetup.PaperSize, Is.EqualTo(ws1.PageSetup.PaperSize));
+                Assert.That(ws2.PageSetup.Margins.Bottom, Is.EqualTo(ws1.PageSetup.Margins.Bottom));
+                Assert.That(ws2.PageSetup.Margins.Top, Is.EqualTo(ws1.PageSetup.Margins.Top));
+                Assert.That(ws2.PageSetup.Margins.Left, Is.EqualTo(ws1.PageSetup.Margins.Left));
+                Assert.That(ws2.PageSetup.Margins.Right, Is.EqualTo(ws1.PageSetup.Margins.Right));
+                Assert.That(ws2.PageSetup.Margins.Footer, Is.EqualTo(ws1.PageSetup.Margins.Footer));
+                Assert.That(ws2.PageSetup.Margins.Header, Is.EqualTo(ws1.PageSetup.Margins.Header));
+                Assert.That(ws2.PageSetup.ScaleHFWithDocument, Is.EqualTo(ws1.PageSetup.ScaleHFWithDocument));
+                Assert.That(ws2.PageSetup.AlignHFWithMargins, Is.EqualTo(ws1.PageSetup.AlignHFWithMargins));
+                Assert.That(ws2.PageSetup.ShowGridlines, Is.EqualTo(ws1.PageSetup.ShowGridlines));
+                Assert.That(ws2.PageSetup.ShowRowAndColumnHeadings, Is.EqualTo(ws1.PageSetup.ShowRowAndColumnHeadings));
+                Assert.That(ws2.PageSetup.BlackAndWhite, Is.EqualTo(ws1.PageSetup.BlackAndWhite));
+                Assert.That(ws2.PageSetup.DraftQuality, Is.EqualTo(ws1.PageSetup.DraftQuality));
+                Assert.That(ws2.PageSetup.PageOrder, Is.EqualTo(ws1.PageSetup.PageOrder));
+                Assert.That(ws2.PageSetup.ShowComments, Is.EqualTo(ws1.PageSetup.ShowComments));
+                Assert.That(ws2.PageSetup.PrintErrorValue, Is.EqualTo(ws1.PageSetup.PrintErrorValue));
 
-                ws1.PageSetup.AddHorizontalPageBreak(15);
-                ws1.PageSetup.AddVerticalPageBreak(5);
-                ws1.PageSetup
-                    .SetBlackAndWhite()
-                    .SetCenterHorizontally()
-                    .SetCenterVertically()
-                    .SetFirstPageNumber(200)
-                    .SetPageOrientation(XLPageOrientation.Landscape)
-                    .SetPaperSize(XLPaperSize.A5Paper)
-                    .SetScale(89)
-                    .SetShowGridlines()
-                    .SetHorizontalDpi(200)
-                    .SetVerticalDpi(300)
-                    .SetPagesTall(5)
-                    .SetPagesWide(2)
-                    .SetColumnsToRepeatAtLeft(1, 3);
-                ws1.PageSetup.PrintAreas.Clear();
-                ws1.PageSetup.PrintAreas.Add("A1:Z200");
-                ws1.PageSetup.Margins.SetBottom(5).SetTop(6).SetLeft(7).SetRight(8).SetFooter(9).SetHeader(10);
-                ws1.PageSetup.Header.Left.AddText(XLHFPredefinedText.FullPath, XLHFOccurrence.AllPages);
-                ws1.PageSetup.Footer.Right.AddText(XLHFPredefinedText.PageNumber, XLHFOccurrence.OddPages);
+                Assert.That(ws2.PageSetup.PrintAreas.Count(), Is.EqualTo(ws1.PageSetup.PrintAreas.Count()));
 
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(ws1.PageSetup.FirstRowToRepeatAtTop, ws2.PageSetup.FirstRowToRepeatAtTop);
-                Assert.AreEqual(ws1.PageSetup.LastRowToRepeatAtTop, ws2.PageSetup.LastRowToRepeatAtTop);
-                Assert.AreEqual(ws1.PageSetup.FirstColumnToRepeatAtLeft, ws2.PageSetup.FirstColumnToRepeatAtLeft);
-                Assert.AreEqual(ws1.PageSetup.LastColumnToRepeatAtLeft, ws2.PageSetup.LastColumnToRepeatAtLeft);
-                Assert.AreEqual(ws1.PageSetup.PageOrientation, ws2.PageSetup.PageOrientation);
-                Assert.AreEqual(ws1.PageSetup.PagesWide, ws2.PageSetup.PagesWide);
-                Assert.AreEqual(ws1.PageSetup.PagesTall, ws2.PageSetup.PagesTall);
-                Assert.AreEqual(ws1.PageSetup.Scale, ws2.PageSetup.Scale);
-                Assert.AreEqual(ws1.PageSetup.HorizontalDpi, ws2.PageSetup.HorizontalDpi);
-                Assert.AreEqual(ws1.PageSetup.VerticalDpi, ws2.PageSetup.VerticalDpi);
-                Assert.AreEqual(ws1.PageSetup.FirstPageNumber, ws2.PageSetup.FirstPageNumber);
-                Assert.AreEqual(ws1.PageSetup.CenterHorizontally, ws2.PageSetup.CenterHorizontally);
-                Assert.AreEqual(ws1.PageSetup.CenterVertically, ws2.PageSetup.CenterVertically);
-                Assert.AreEqual(ws1.PageSetup.PaperSize, ws2.PageSetup.PaperSize);
-                Assert.AreEqual(ws1.PageSetup.Margins.Bottom, ws2.PageSetup.Margins.Bottom);
-                Assert.AreEqual(ws1.PageSetup.Margins.Top, ws2.PageSetup.Margins.Top);
-                Assert.AreEqual(ws1.PageSetup.Margins.Left, ws2.PageSetup.Margins.Left);
-                Assert.AreEqual(ws1.PageSetup.Margins.Right, ws2.PageSetup.Margins.Right);
-                Assert.AreEqual(ws1.PageSetup.Margins.Footer, ws2.PageSetup.Margins.Footer);
-                Assert.AreEqual(ws1.PageSetup.Margins.Header, ws2.PageSetup.Margins.Header);
-                Assert.AreEqual(ws1.PageSetup.ScaleHFWithDocument, ws2.PageSetup.ScaleHFWithDocument);
-                Assert.AreEqual(ws1.PageSetup.AlignHFWithMargins, ws2.PageSetup.AlignHFWithMargins);
-                Assert.AreEqual(ws1.PageSetup.ShowGridlines, ws2.PageSetup.ShowGridlines);
-                Assert.AreEqual(ws1.PageSetup.ShowRowAndColumnHeadings, ws2.PageSetup.ShowRowAndColumnHeadings);
-                Assert.AreEqual(ws1.PageSetup.BlackAndWhite, ws2.PageSetup.BlackAndWhite);
-                Assert.AreEqual(ws1.PageSetup.DraftQuality, ws2.PageSetup.DraftQuality);
-                Assert.AreEqual(ws1.PageSetup.PageOrder, ws2.PageSetup.PageOrder);
-                Assert.AreEqual(ws1.PageSetup.ShowComments, ws2.PageSetup.ShowComments);
-                Assert.AreEqual(ws1.PageSetup.PrintErrorValue, ws2.PageSetup.PrintErrorValue);
-
-                Assert.AreEqual(ws1.PageSetup.PrintAreas.Count(), ws2.PageSetup.PrintAreas.Count());
-
-                Assert.AreEqual(ws1.PageSetup.Header.Left.GetText(XLHFOccurrence.AllPages), ws2.PageSetup.Header.Left.GetText(XLHFOccurrence.AllPages));
-                Assert.AreEqual(ws1.PageSetup.Footer.Right.GetText(XLHFOccurrence.OddPages), ws2.PageSetup.Footer.Right.GetText(XLHFOccurrence.OddPages));
-            }
+                Assert.That(ws2.PageSetup.Header.Left.GetText(XLHFOccurrence.AllPages), Is.EqualTo(ws1.PageSetup.Header.Left.GetText(XLHFOccurrence.AllPages)));
+                Assert.That(ws2.PageSetup.Footer.Right.GetText(XLHFOccurrence.OddPages), Is.EqualTo(ws1.PageSetup.Footer.Right.GetText(XLHFOccurrence.OddPages)));
+            });
         }
 
         [Test]
         public void CopyWorksheetPreservesSparklineGroups()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
+            var original = ws1.SparklineGroups.Add("A1:A10", "D1:Z10")
+                .SetDateRange(ws1.Range("D11:Z11"))
+                .SetDisplayEmptyCellsAs(XLDisplayBlanksAsValues.Zero)
+                .SetDisplayHidden(true)
+                .SetLineWeight(1.5)
+                .SetShowMarkers(XLSparklineMarkers.All)
+                .SetStyle(XLSparklineTheme.Colorful3)
+                .SetType(XLSparklineType.Column);
+
+            original.HorizontalAxis
+                .SetColor(XLColor.Blue)
+                .SetRightToLeft(true)
+                .SetVisible(true);
+
+            original.VerticalAxis
+                .SetManualMin(-100.0)
+                .SetManualMax(100.0);
+
+            var ws2 = ws1.CopyTo(wb2, "Copy");
+
+            Assert.That(ws2.SparklineGroups.Count(), Is.EqualTo(1));
+            var copy = ws2.SparklineGroups.Single();
+
+            Assert.That(copy.Count(), Is.EqualTo(original.Count()));
+            for (int i = 0; i < original.Count(); i++)
             {
-                var ws1 = wb1.Worksheets.Add("Original");
-                var original = ws1.SparklineGroups.Add("A1:A10", "D1:Z10")
-                    .SetDateRange(ws1.Range("D11:Z11"))
-                    .SetDisplayEmptyCellsAs(XLDisplayBlanksAsValues.Zero)
-                    .SetDisplayHidden(true)
-                    .SetLineWeight(1.5)
-                    .SetShowMarkers(XLSparklineMarkers.All)
-                    .SetStyle(XLSparklineTheme.Colorful3)
-                    .SetType(XLSparklineType.Column);
-
-                original.HorizontalAxis
-                    .SetColor(XLColor.Blue)
-                    .SetRightToLeft(true)
-                    .SetVisible(true);
-
-                original.VerticalAxis
-                    .SetManualMin(-100.0)
-                    .SetManualMax(100.0);
-
-                var ws2 = ws1.CopyTo(wb2, "Copy");
-
-                Assert.AreEqual(1, ws2.SparklineGroups.Count());
-                var copy = ws2.SparklineGroups.Single();
-
-                Assert.AreEqual(original.Count(), copy.Count());
-                for (int i = 0; i < original.Count(); i++)
+                Assert.Multiple(() =>
                 {
-                    Assert.AreSame(ws2, copy.ElementAt(i).Location.Worksheet);
-                    Assert.AreSame(ws2, copy.ElementAt(i).SourceData.Worksheet);
-                    Assert.AreEqual(original.ElementAt(i).Location.Address.ToString(), copy.ElementAt(i).Location.Address.ToString());
-                    Assert.AreEqual(original.ElementAt(i).SourceData.RangeAddress.ToString(), copy.ElementAt(i).SourceData.RangeAddress.ToString());
-                }
-
-                Assert.AreEqual(original.DateRange.RangeAddress.ToString(), copy.DateRange.RangeAddress.ToString());
-                Assert.AreSame(ws2, copy.DateRange.Worksheet);
-
-                Assert.AreEqual(original.DisplayEmptyCellsAs, copy.DisplayEmptyCellsAs);
-                Assert.AreEqual(original.DisplayHidden, copy.DisplayHidden);
-                Assert.AreEqual(original.LineWeight, copy.LineWeight, XLHelper.Epsilon);
-                Assert.AreEqual(original.ShowMarkers, copy.ShowMarkers);
-                Assert.AreEqual(original.Style, copy.Style);
-                Assert.AreNotSame(original.Style, copy.Style);
-                Assert.AreEqual(original.Type, copy.Type);
-
-                Assert.AreEqual(original.HorizontalAxis.Color, copy.HorizontalAxis.Color);
-                Assert.AreEqual(original.HorizontalAxis.DateAxis, copy.HorizontalAxis.DateAxis);
-                Assert.AreEqual(original.HorizontalAxis.IsVisible, copy.HorizontalAxis.IsVisible);
-                Assert.AreEqual(original.HorizontalAxis.RightToLeft, copy.HorizontalAxis.RightToLeft);
-
-                Assert.AreEqual(original.VerticalAxis.ManualMax, copy.VerticalAxis.ManualMax);
-                Assert.AreEqual(original.VerticalAxis.ManualMin, copy.VerticalAxis.ManualMin);
-                Assert.AreEqual(original.VerticalAxis.MaxAxisType, copy.VerticalAxis.MaxAxisType);
-                Assert.AreEqual(original.VerticalAxis.MinAxisType, copy.VerticalAxis.MinAxisType);
+                    Assert.That(copy.ElementAt(i).Location.Worksheet, Is.SameAs(ws2));
+                    Assert.That(copy.ElementAt(i).SourceData.Worksheet, Is.SameAs(ws2));
+                    Assert.That(copy.ElementAt(i).Location.Address.ToString(), Is.EqualTo(original.ElementAt(i).Location.Address.ToString()));
+                });
+                Assert.That(copy.ElementAt(i).SourceData.RangeAddress.ToString(), Is.EqualTo(original.ElementAt(i).SourceData.RangeAddress.ToString()));
             }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.DateRange.RangeAddress.ToString(), Is.EqualTo(original.DateRange.RangeAddress.ToString()));
+                Assert.That(copy.DateRange.Worksheet, Is.SameAs(ws2));
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.DisplayEmptyCellsAs, Is.EqualTo(original.DisplayEmptyCellsAs));
+                Assert.That(copy.DisplayHidden, Is.EqualTo(original.DisplayHidden));
+                Assert.That(copy.LineWeight, Is.EqualTo(original.LineWeight).Within(XLHelper.Epsilon));
+                Assert.That(copy.ShowMarkers, Is.EqualTo(original.ShowMarkers));
+                Assert.That(copy.Style, Is.EqualTo(original.Style));
+            });
+            Assert.Multiple(() =>
+            {
+                Assert.That(copy.Style, Is.Not.SameAs(original.Style));
+                Assert.That(copy.Type, Is.EqualTo(original.Type));
+
+                Assert.That(copy.HorizontalAxis.Color, Is.EqualTo(original.HorizontalAxis.Color));
+                Assert.That(copy.HorizontalAxis.DateAxis, Is.EqualTo(original.HorizontalAxis.DateAxis));
+                Assert.That(copy.HorizontalAxis.IsVisible, Is.EqualTo(original.HorizontalAxis.IsVisible));
+                Assert.That(copy.HorizontalAxis.RightToLeft, Is.EqualTo(original.HorizontalAxis.RightToLeft));
+
+                Assert.That(copy.VerticalAxis.ManualMax, Is.EqualTo(original.VerticalAxis.ManualMax));
+                Assert.That(copy.VerticalAxis.ManualMin, Is.EqualTo(original.VerticalAxis.ManualMin));
+                Assert.That(copy.VerticalAxis.MaxAxisType, Is.EqualTo(original.VerticalAxis.MaxAxisType));
+                Assert.That(copy.VerticalAxis.MinAxisType, Is.EqualTo(original.VerticalAxis.MinAxisType));
+            });
         }
 
         [Test, Ignore("Muted until #836 is fixed")]
         public void CopyWorksheetChangesAbsoluteReferencesInFormulae()
         {
-            using (var wb1 = new XLWorkbook())
-            using (var wb2 = new XLWorkbook())
-            {
-                var ws1 = wb1.Worksheets.Add("Original");
+            using var wb1 = new XLWorkbook();
+            using var wb2 = new XLWorkbook();
+            var ws1 = wb1.Worksheets.Add("Original");
 
-                ws1.Cell("A1").FormulaA1 = "10*10";
-                ws1.Cell("A2").FormulaA1 = "Original!A1 * 3";
+            ws1.Cell("A1").FormulaA1 = "10*10";
+            ws1.Cell("A2").FormulaA1 = "Original!A1 * 3";
 
-                var ws2 = ws1.CopyTo(wb2, "Copy");
+            var ws2 = ws1.CopyTo(wb2, "Copy");
 
-                Assert.AreEqual("Copy!A1 * 3", ws2.Cell("A2").FormulaA1);
-            }
+            Assert.That(ws2.Cell("A2").FormulaA1, Is.EqualTo("Copy!A1 * 3"));
         }
 
         [Test]
@@ -1008,243 +1022,230 @@ namespace ClosedXML.Tests
 
             ws.Name = "Renamed";
 
-            Assert.AreEqual("Renamed!A1 * 3", ws.Cell("A2").FormulaA1);
-            Assert.True(ws.Cell("A2").NeedsRecalculation);
-            Assert.AreEqual(300, ws.Cell("A2").Value);
+            Assert.Multiple(() =>
+            {
+                Assert.That(ws.Cell("A2").FormulaA1, Is.EqualTo("Renamed!A1 * 3"));
+                Assert.That(ws.Cell("A2").NeedsRecalculation, Is.True);
+                Assert.That(ws.Cell("A2").Value, Is.EqualTo(300));
+            });
         }
 
         [Test]
         public void RangesFromDeletedWorksheetContainREF()
         {
-            using (var wb1 = new XLWorkbook())
-            {
-                wb1.Worksheets.Add("Sheet1");
-                var ws2 = wb1.Worksheets.Add("Sheet2");
-                var range = ws2.Range("A1:B2");
+            using var wb1 = new XLWorkbook();
+            wb1.Worksheets.Add("Sheet1");
+            var ws2 = wb1.Worksheets.Add("Sheet2");
+            var range = ws2.Range("A1:B2");
 
-                ws2.Delete();
+            ws2.Delete();
 
-                Assert.AreEqual("#REF!A1:B2", range.RangeAddress.ToString());
-            }
+            Assert.That(range.RangeAddress.ToString(), Is.EqualTo("#REF!A1:B2"));
         }
 
         [Test]
         public void InvalidRowAndColumnIndices()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Row(-1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Row(XLHelper.MaxRowNumber + 1));
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Row(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Row(XLHelper.MaxRowNumber + 1));
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Column(-1));
-                Assert.Throws<ArgumentOutOfRangeException>(() => ws.Column(XLHelper.MaxColumnNumber + 1));
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Column(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Column(XLHelper.MaxColumnNumber + 1));
         }
 
         [Test]
         public void InvalidSelectedRangeExcluded()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            var range1 = ws.Range("B2:C2");
+            var range2 = ws.Range("B4:C4");
+            ws.SelectedRanges.Clear();
+
+            ws.SelectedRanges.Add(range1);
+            ws.SelectedRanges.Add(range2);
+
+            ws.Row(4).Delete();
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("Sheet1");
-                var range1 = ws.Range("B2:C2");
-                var range2 = ws.Range("B4:C4");
-                ws.SelectedRanges.Clear();
-
-                ws.SelectedRanges.Add(range1);
-                ws.SelectedRanges.Add(range2);
-
-                ws.Row(4).Delete();
-
-                Assert.IsFalse(range2.RangeAddress.IsValid);
-                Assert.AreEqual(range1, ws.SelectedRanges.Single());
-            }
+                Assert.That(range2.RangeAddress.IsValid, Is.False);
+                Assert.That(ws.SelectedRanges.Single(), Is.EqualTo(range1));
+            });
         }
 
         [Test]
         public void InsertColumnsDoesNotIncreaseCellsCount()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                ws.Cell("A1").SetValue(1);
-                ws.Cell("AAA50").SetValue(1);
-                var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").SetValue(1);
+            ws.Cell("AAA50").SetValue(1);
+            var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
 
-                ws.Column(1).InsertColumnsBefore(1);
+            ws.Column(1).InsertColumnsBefore(1);
 
-                Assert.AreEqual(originalCount, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(originalCount));
         }
 
         [Test]
         public void InsertRowsDoesNotIncreaseCellsCount()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                ws.Cell("A1").SetValue(1);
-                ws.Cell("AAA500").SetValue(1);
-                var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").SetValue(1);
+            ws.Cell("AAA500").SetValue(1);
+            var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
 
-                ws.Row(1).InsertRowsAbove(1);
+            ws.Row(1).InsertRowsAbove(1);
 
-                Assert.AreEqual(originalCount, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(originalCount));
         }
 
         [Test]
         public void InsertCellsBeforeDoesNotIncreaseCellsCount()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var a1 = ws.Cell("A1").SetValue(1);
-                ws.Cell("AAA50").SetValue(1);
-                var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var a1 = ws.Cell("A1").SetValue(1);
+            ws.Cell("AAA50").SetValue(1);
+            var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
 
-                a1.InsertCellsBefore(1);
+            a1.InsertCellsBefore(1);
 
-                Assert.AreEqual(originalCount, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(originalCount));
         }
 
         [Test]
         public void InsertCellsAboveDoesNotIncreaseCellsCount()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var a1 = ws.Cell("A1").SetValue(1);
-                ws.Cell("AAA500").SetValue(1);
-                var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var a1 = ws.Cell("A1").SetValue(1);
+            ws.Cell("AAA500").SetValue(1);
+            var originalCount = ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count();
 
-                a1.InsertCellsAbove(1);
+            a1.InsertCellsAbove(1);
 
-                Assert.AreEqual(originalCount, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(originalCount));
         }
 
         [Test]
         public void CellsShiftedTooFarRightArePurged()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var a1 = ws.Cell("A1").SetValue(1);
-                ws.Cell(1, XLHelper.MaxColumnNumber).SetValue(1);
-                ws.Cell(2, XLHelper.MaxColumnNumber).SetValue(1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var a1 = ws.Cell("A1").SetValue(1);
+            ws.Cell(1, XLHelper.MaxColumnNumber).SetValue(1);
+            ws.Cell(2, XLHelper.MaxColumnNumber).SetValue(1);
 
-                a1.InsertCellsBefore(1);
+            a1.InsertCellsBefore(1);
 
-                Assert.AreEqual(2, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                ws.Column(1).InsertColumnsBefore(1);
-                Assert.AreEqual(1, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(2));
+            ws.Column(1).InsertColumnsBefore(1);
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(1));
         }
 
         [Test]
         public void CellsShiftedTooFarDownArePurged()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var a1 = ws.Cell("A1").SetValue(1);
-                ws.Cell(XLHelper.MaxRowNumber, 1).SetValue(1);
-                ws.Cell(XLHelper.MaxRowNumber, 2).SetValue(1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var a1 = ws.Cell("A1").SetValue(1);
+            ws.Cell(XLHelper.MaxRowNumber, 1).SetValue(1);
+            ws.Cell(XLHelper.MaxRowNumber, 2).SetValue(1);
 
-                a1.InsertCellsAbove(1);
+            a1.InsertCellsAbove(1);
 
-                Assert.AreEqual(2, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-                ws.Row(1).InsertRowsAbove(1);
-                Assert.AreEqual(1, ((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count());
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(2));
+            ws.Row(1).InsertRowsAbove(1);
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.GetCells().Count(), Is.EqualTo(1));
         }
 
         [Test]
         public void MaxColumnUsedUpdatedWhenColumnDeleted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                ws.Cell("C1").SetValue(1);
-                ws.Cell(1, XLHelper.MaxColumnNumber).SetValue(1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("C1").SetValue(1);
+            ws.Cell(1, XLHelper.MaxColumnNumber).SetValue(1);
 
-                ws.Column(XLHelper.MaxColumnNumber).Delete();
+            ws.Column(XLHelper.MaxColumnNumber).Delete();
 
-                Assert.AreEqual(3, ((XLWorksheet)ws).Internals.CellsCollection.MaxColumnUsed);
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.MaxColumnUsed, Is.EqualTo(3));
         }
 
         [Test]
         public void MaxRowUsedUpdatedWhenRowDeleted()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                ws.Cell("A3").SetValue(1);
-                ws.Cell(XLHelper.MaxRowNumber, 1).SetValue(1);
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A3").SetValue(1);
+            ws.Cell(XLHelper.MaxRowNumber, 1).SetValue(1);
 
-                ws.Row(XLHelper.MaxRowNumber).Delete();
+            ws.Row(XLHelper.MaxRowNumber).Delete();
 
-                Assert.AreEqual(3, ((XLWorksheet)ws).Internals.CellsCollection.MaxRowUsed);
-            }
+            Assert.That(((XLWorksheet)ws).Internals.CellsCollection.MaxRowUsed, Is.EqualTo(3));
         }
 
         [Test]
         public void ChangeColumnStyleFirst()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("ColumnFirst");
+
+            ws.Column(2).Style.Font.SetBold(true);
+            ws.Row(2).Style.Font.SetItalic(true);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("ColumnFirst");
-
-                ws.Column(2).Style.Font.SetBold(true);
-                ws.Row(2).Style.Font.SetItalic(true);
-
-                Assert.IsTrue(ws.Cell("B2").Style.Font.Bold);
-                Assert.IsTrue(ws.Cell("B2").Style.Font.Italic);
-            }
+                Assert.That(ws.Cell("B2").Style.Font.Bold, Is.True);
+                Assert.That(ws.Cell("B2").Style.Font.Italic, Is.True);
+            });
         }
 
         [Test]
         public void ChangeRowStyleFirst()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("RowFirst");
+
+            ws.Row(2).Style.Font.SetItalic(true);
+            ws.Column(2).Style.Font.SetBold(true);
+
+            Assert.Multiple(() =>
             {
-                var ws = wb.AddWorksheet("RowFirst");
-
-                ws.Row(2).Style.Font.SetItalic(true);
-                ws.Column(2).Style.Font.SetBold(true);
-
-                Assert.IsTrue(ws.Cell("B2").Style.Font.Bold);
-                Assert.IsTrue(ws.Cell("B2").Style.Font.Italic);
-            }
+                Assert.That(ws.Cell("B2").Style.Font.Bold, Is.True);
+                Assert.That(ws.Cell("B2").Style.Font.Italic, Is.True);
+            });
         }
 
         [Test]
         public void SelectedTabIsActive_WhenInsertBefore()
         {
-            using (var ms = new MemoryStream())
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
             {
-                using (var wb = new XLWorkbook())
-                {
-                    var ws1 = wb.AddWorksheet();
-                    ws1.TabSelected = true;
-                    var ws2 = wb.Worksheets.Add(1);
-                    wb.SaveAs(ms);
-                }
+                var ws1 = wb.AddWorksheet();
+                ws1.TabSelected = true;
+                var ws2 = wb.Worksheets.Add(1);
+                wb.SaveAs(ms);
+            }
 
-                using (var wb = new XLWorkbook(ms))
-                {
-                    var ws1 = wb.Worksheets.First();
-                    var ws2 = wb.Worksheets.Last();
+            using (var wb = new XLWorkbook(ms))
+            {
+                var ws1 = wb.Worksheets.First();
+                var ws2 = wb.Worksheets.Last();
 
-                    Assert.IsFalse(ws1.TabActive);
-                    Assert.IsFalse(ws1.TabSelected);
-                    Assert.IsTrue(ws2.TabActive);
-                    Assert.IsTrue(ws2.TabSelected);
-                }
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ws1.TabActive, Is.False);
+                    Assert.That(ws1.TabSelected, Is.False);
+                    Assert.That(ws2.TabActive, Is.True);
+                    Assert.That(ws2.TabSelected, Is.True);
+                });
             }
         }
 
@@ -1253,12 +1254,13 @@ namespace ClosedXML.Tests
         [TestCase("noactive_negativeId.xlsx")]
         public void FirstSheetIsActive_WhenNotSpecified(string fileName)
         {
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\NoActiveSheet\" + fileName)))
-            using (var wb = new XLWorkbook(stream))
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Other\NoActiveSheet\" + fileName));
+            using var wb = new XLWorkbook(stream);
+            Assert.Multiple(() =>
             {
-                Assert.IsTrue(wb.Worksheets.First().TabActive);
-                Assert.AreEqual(XLWorksheetVisibility.Visible, wb.Worksheets.First().Visibility);
-            }
+                Assert.That(wb.Worksheets.First().TabActive, Is.True);
+                Assert.That(wb.Worksheets.First().Visibility, Is.EqualTo(XLWorksheetVisibility.Visible));
+            });
         }
 
         [TestCase(XLCellsUsedOptions.NormalFormats, 42)]
@@ -1271,7 +1273,7 @@ namespace ClosedXML.Tests
             ws.Cell(1, 100).SetValue(5);
 
             var column = ws.FirstColumnUsed(options);
-            Assert.AreEqual(expectedColumn, column.ColumnNumber());
+            Assert.That(column.ColumnNumber(), Is.EqualTo(expectedColumn));
         }
 
         [Test]
@@ -1283,34 +1285,43 @@ namespace ClosedXML.Tests
 
             other.Cell("A1").Value = 7;
             other.Cell("A2").FormulaA1 = "A1+3";
-            Assert.AreEqual(10.0, other.Cell("A2").Value);
+            Assert.That(other.Cell("A2").Value, Is.EqualTo(10.0));
 
             // Change the supporting value, but without recalculation of dependent
             // formula, thus the value stays the same.
             other.Cell("A1").Value = 5;
 
-            Assert.True(other.Cell("A2").NeedsRecalculation);
-            Assert.AreEqual(10.0, other.Cell("A2").CachedValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(other.Cell("A2").NeedsRecalculation, Is.True);
+                Assert.That(other.Cell("A2").CachedValue, Is.EqualTo(10.0));
+            });
 
             // Tested formula depends on a dirty formula from other sheet.
             sut.Cell("A1").FormulaA1 = "other!A2+5";
             sut.Cell("A2").FormulaA1 = "1+2";
 
-            Assert.AreEqual(Blank.Value, sut.Cell("A1").CachedValue);
-            Assert.AreEqual(Blank.Value, sut.Cell("A2").CachedValue);
+            Assert.Multiple(() =>
+            {
+                Assert.That(sut.Cell("A1").CachedValue, Is.EqualTo(Blank.Value));
+                Assert.That(sut.Cell("A2").CachedValue, Is.EqualTo(Blank.Value));
+            });
 
             sut.RecalculateAllFormulas();
 
-            // Formulas in other sheets kept the value - not affected by recalculation of a sut sheet.
-            Assert.True(other.Cell("A2").NeedsRecalculation);
-            Assert.AreEqual(10.0, other.Cell("A2").CachedValue);
+            Assert.Multiple(() =>
+            {
+                // Formulas in other sheets kept the value - not affected by recalculation of a sut sheet.
+                Assert.That(other.Cell("A2").NeedsRecalculation, Is.True);
+                Assert.That(other.Cell("A2").CachedValue, Is.EqualTo(10.0));
+            });
 
             // Formulas in test sheet were recalculated - they are affected by recalculation of a sut sheet.
             Assert.False(sut.Cell("A1").NeedsRecalculation);
-            Assert.AreEqual(15.0, sut.Cell("A1").CachedValue);
+            Assert.That(sut.Cell("A1").CachedValue, Is.EqualTo(15.0));
 
             Assert.False(sut.Cell("A2").NeedsRecalculation);
-            Assert.AreEqual(3.0, sut.Cell("A2").CachedValue);
+            Assert.That(sut.Cell("A2").CachedValue, Is.EqualTo(3.0));
         }
 
         [Test]
@@ -1323,8 +1334,11 @@ namespace ClosedXML.Tests
             var cellB4 = ws.Cell("B4");
             var firstCellOfRange = ws.Cell("test_range");
 
-            Assert.AreEqual("B4", cellB4.Address.ToString());
-            Assert.AreEqual("C2", firstCellOfRange.Address.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(cellB4.Address.ToString(), Is.EqualTo("B4"));
+                Assert.That(firstCellOfRange.Address.ToString(), Is.EqualTo("C2"));
+            });
         }
 
         [Test]
@@ -1350,10 +1364,13 @@ namespace ClosedXML.Tests
             var bookNamedRange = ws.Range("book_range");
             var sheetNamedRange = ws.Range("sheet_range");
 
-            Assert.AreEqual("B4:B4", singleCellRange.RangeAddress.ToString());
-            Assert.AreEqual("B4:D7", areaCellRange.RangeAddress.ToString());
-            Assert.AreEqual("$C$2:$G$5", bookNamedRange.RangeAddress.ToString());
-            Assert.AreEqual("$B$1:$D$3", sheetNamedRange.RangeAddress.ToString());
+            Assert.Multiple(() =>
+            {
+                Assert.That(singleCellRange.RangeAddress.ToString(), Is.EqualTo("B4:B4"));
+                Assert.That(areaCellRange.RangeAddress.ToString(), Is.EqualTo("B4:D7"));
+                Assert.That(bookNamedRange.RangeAddress.ToString(), Is.EqualTo("$C$2:$G$5"));
+                Assert.That(sheetNamedRange.RangeAddress.ToString(), Is.EqualTo("$B$1:$D$3"));
+            });
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -411,7 +411,7 @@ namespace ClosedXML.Tests
             {
                 Assert.That(ws2.Cell("A1").Value, Is.EqualTo("A1 value"));
                 Assert.That(ws2.Cell("A2").Value, Is.EqualTo(100));
-                Assert.That(ws2.Cell("D4").Value, Is.EqualTo(new DateTime(2018, 5, 1)));
+                Assert.That(ws2.Cell("D4").Value.GetDateTime(), Is.EqualTo(new DateTime(2018, 5, 1)));
             });
         }
 

--- a/ClosedXML.Tests/ExcelDocsComparerTests.cs
+++ b/ClosedXML.Tests/ExcelDocsComparerTests.cs
@@ -16,7 +16,7 @@ namespace ClosedXML.Tests
             {
                 new BasicTable().Create(left);
                 new BasicTable().Create(right);
-                Assert.IsTrue(ExcelDocsComparer.Compare(left, right, out string message));
+                Assert.That(ExcelDocsComparer.Compare(left, right, out string message), Is.True);
             }
             finally
             {
@@ -41,7 +41,7 @@ namespace ClosedXML.Tests
                 new BasicTable().Create(left);
                 new HelloWorld().Create(right);
 
-                Assert.IsFalse(ExcelDocsComparer.Compare(left, right, out string message));
+                Assert.That(ExcelDocsComparer.Compare(left, right, out string message), Is.False);
             }
             finally
             {

--- a/ClosedXML.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -13,21 +13,24 @@ namespace ClosedXML.Tests.Extensions
         [Test]
         public void CanGetItemType()
         {
-            var array = new int[0];
-            Assert.AreEqual(typeof(int), array.GetItemType());
+            var array = Array.Empty<int>();
+            Assert.That(array.GetItemType(), Is.EqualTo(typeof(int)));
 
             var list = new List<double>();
-            Assert.AreEqual(typeof(double), list.GetItemType());
-            Assert.AreEqual(typeof(double), list.AsEnumerable().GetItemType());
+            Assert.Multiple(() =>
+            {
+                Assert.That(list.GetItemType(), Is.EqualTo(typeof(double)));
+                Assert.That(list.AsEnumerable().GetItemType(), Is.EqualTo(typeof(double)));
+            });
 
             IEnumerable<IEnumerable> enumerable = new List<string>();
-            Assert.AreEqual(typeof(string), enumerable.GetItemType());
+            Assert.That(enumerable.GetItemType(), Is.EqualTo(typeof(string)));
 
             enumerable = new List<List<string>>();
-            Assert.AreEqual(typeof(List<string>), enumerable.GetItemType());
+            Assert.That(enumerable.GetItemType(), Is.EqualTo(typeof(List<string>)));
 
             enumerable = new List<int[]>();
-            Assert.AreEqual(typeof(int[]), enumerable.GetItemType());
+            Assert.That(enumerable.GetItemType(), Is.EqualTo(typeof(int[])));
 
             var anonymousIterator = new List<TablesTests.TestObjectWithoutAttributes>()
                 .Select(o => new { FirstName = o.Column1, LastName = o.Column2 });
@@ -38,26 +41,32 @@ namespace ClosedXML.Tests.Extensions
             var expectedTypeStart = "<>f__AnonymousType";
             var expectedTypeEnd = "`2[System.String,System.String]";
             var actualType = anonymousIterator.GetItemType().ToString();
-            Assert.True(actualType.StartsWith(expectedTypeStart));
-            Assert.True(actualType.EndsWith(expectedTypeEnd));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualType, Does.StartWith(expectedTypeStart));
+                Assert.That(actualType, Does.EndWith(expectedTypeEnd));
+            });
 
             IEnumerable<object> obj = anonymousIterator;
             actualType = obj.GetItemType().ToString();
-            Assert.True(actualType.StartsWith(expectedTypeStart));
-            Assert.True(actualType.EndsWith(expectedTypeEnd));
+            Assert.Multiple(() =>
+            {
+                Assert.That(actualType, Does.StartWith(expectedTypeStart));
+                Assert.That(actualType, Does.EndWith(expectedTypeEnd));
+            });
         }
 
         [Test]
         public void SkipLast_skips_last_element_of_enumerable()
         {
             var empty = Array.Empty<int>().SkipLast();
-            CollectionAssert.IsEmpty(empty);
+            Assert.That(empty, Is.Empty);
 
             var oneElement = new[] { 1 }.SkipLast();
-            CollectionAssert.IsEmpty(oneElement);
+            Assert.That(oneElement, Is.Empty);
 
             var twoElements = new[] { 1, 2 }.SkipLast();
-            CollectionAssert.AreEqual(new[] { 1 }, twoElements);
+            Assert.That(twoElements, Is.EqualTo(new[] { 1 }).AsCollection);
         }
 
         [Test]
@@ -67,7 +76,7 @@ namespace ClosedXML.Tests.Extensions
 
             var result = source.WhereNotNull(x => x);
 
-            CollectionAssert.AreEqual(new[] { 1, 2 }, result);
+            Assert.That(result, Is.EqualTo(new[] { 1, 2 }).AsCollection);
         }
     }
 }

--- a/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Tests.Extensions
             Assert.That(tokenArea.ToSheetRange(anchor), Is.EqualTo(expectedRange));
         }
 
-        public static IEnumerable<object[]> A1TestCases()
+        private static IEnumerable<object[]> A1TestCases()
         {
             // C5
             yield return new object[]
@@ -91,7 +91,7 @@ namespace ClosedXML.Tests.Extensions
             };
         }
 
-        public static IEnumerable<object[]> R1C1TestCases()
+        private static IEnumerable<object[]> R1C1TestCases()
         {
             // R2C4
             yield return new object[]

--- a/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
@@ -15,14 +15,14 @@ namespace ClosedXML.Tests.Extensions
         [TestCaseSource(nameof(A1TestCases))]
         public void ToSheetPoint_converts_a1_reference_to_sheet_range(ReferenceArea tokenArea, XLSheetRange expectedRange)
         {
-            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(default));
+            Assert.That(tokenArea.ToSheetRange(default), Is.EqualTo(expectedRange));
         }
 
         [Test]
         [TestCaseSource(nameof(R1C1TestCases))]
         public void ToSheetPoint_converts_r1c1_reference_to_sheet_range(XLSheetPoint anchor, ReferenceArea tokenArea, XLSheetRange expectedRange)
         {
-            Assert.AreEqual(expectedRange, tokenArea.ToSheetRange(anchor));
+            Assert.That(tokenArea.ToSheetRange(anchor), Is.EqualTo(expectedRange));
         }
 
         public static IEnumerable<object[]> A1TestCases()

--- a/ClosedXML.Tests/Extensions/ReflectionExtensionTests.cs
+++ b/ClosedXML.Tests/Extensions/ReflectionExtensionTests.cs
@@ -51,7 +51,7 @@ namespace ClosedXML.Tests.Extensions
         public void IsStatic(string memberName, bool expectedIsStatic)
         {
             var member = typeof(TestClass).GetMember(memberName).Single();
-            Assert.AreEqual(expectedIsStatic, member.IsStatic());
+            Assert.That(member.IsStatic(), Is.EqualTo(expectedIsStatic));
         }
 
         [TestCase(BindingFlags.Static | BindingFlags.NonPublic, true)]
@@ -59,7 +59,7 @@ namespace ClosedXML.Tests.Extensions
         public void ConstructorIsStatic(BindingFlags flag, bool expectedIsStatic)
         {
             var constructors = typeof(TestClass).GetConstructors(flag);
-            Assert.AreEqual(expectedIsStatic, constructors.Single().IsStatic());
+            Assert.That(constructors.Single().IsStatic(), Is.EqualTo(expectedIsStatic));
         }
     }
 }

--- a/ClosedXML.Tests/Graphics/FontTests.cs
+++ b/ClosedXML.Tests/Graphics/FontTests.cs
@@ -67,7 +67,7 @@ namespace ClosedXML.Tests.Graphics
             var box = engine.GetGlyphBox(text, nonExistentFont, new Dpi(96, 96));
 
             // Max digit width of CarlitoBare is 7, unlike MS Sans Serif which is 8
-            Assert.AreEqual(7, box.AdvanceWidth);
+            Assert.That(box.AdvanceWidth, Is.EqualTo(7));
         }
 
         [TestCase]
@@ -80,7 +80,7 @@ namespace ClosedXML.Tests.Graphics
             var widthOfLetterA = engine.GetTextWidth("A", nonExistentFont, 120);
 
             const double expectedWidthOfLetterA = 31.25d;
-            Assert.AreEqual(expectedWidthOfLetterA, widthOfLetterA, 0.0001);
+            Assert.That(widthOfLetterA, Is.EqualTo(expectedWidthOfLetterA).Within(0.0001));
         }
 
         [TestCase]
@@ -93,7 +93,7 @@ namespace ClosedXML.Tests.Graphics
             var widthOfLetterB = engine.GetTextWidth("B", new DummyFont("TestFontB", 30), 96);
 
             const double expectedWidthOfLetterB = 25d;
-            Assert.AreEqual(expectedWidthOfLetterB, widthOfLetterB, 0.0001);
+            Assert.That(widthOfLetterB, Is.EqualTo(expectedWidthOfLetterB).Within(0.0001));
         }
 
         [TestCase]

--- a/ClosedXML.Tests/Graphics/PictureInfoTests.cs
+++ b/ClosedXML.Tests/Graphics/PictureInfoTests.cs
@@ -124,13 +124,16 @@ namespace ClosedXML.Tests.Graphics
             using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"ClosedXML.Tests.Resource.Images.{imageName}");
             var info = DefaultGraphicEngine.Instance.Value.GetPictureInfo(stream, XLPictureFormat.Unknown);
 
-            Assert.AreEqual(expectedFormat, info.Format);
-            Assert.AreEqual(expectedPxSize, info.SizePx);
-            Assert.AreEqual(expectedHiMetricSize, info.SizePhys);
+            Assert.Multiple(() =>
+            {
+                Assert.That(info.Format, Is.EqualTo(expectedFormat));
+                Assert.That(info.SizePx, Is.EqualTo(expectedPxSize));
+                Assert.That(info.SizePhys, Is.EqualTo(expectedHiMetricSize));
 
-            // Some DPI is stored as pixels per meter, causing a rounding errors.
-            Assert.AreEqual(expectedDpiX, info.DpiX, 0.02);
-            Assert.AreEqual(expectedDpiY, info.DpiY, 0.02);
+                // Some DPI is stored as pixels per meter, causing a rounding errors.
+                Assert.That(info.DpiX, Is.EqualTo(expectedDpiX).Within(0.02));
+                Assert.That(info.DpiY, Is.EqualTo(expectedDpiY).Within(0.02));
+            });
         }
     }
 }

--- a/ClosedXML.Tests/IO/XStringConvertTests.cs
+++ b/ClosedXML.Tests/IO/XStringConvertTests.cs
@@ -19,7 +19,7 @@ internal class XStringConvertTests
     [TestCase("_x0001_ _x0002_ _x0003_ _x0004_", "\u0001 \u0002 \u0003 \u0004")]
     [TestCase("_x0005_ _x0006_ _x0007_ _x0008_", "\u0005 \u0006 \u0007 \u0008")]
     [TestCase("_xaaBB_ _xAAbb_", "\uAABB \uAABB")]
-    [TestCase(@"_Xceed_Something", @"_Xceed_Something")] // https://github.com/ClosedXML/ClosedXML/issues/1154
+    [TestCase("_Xceed_Something", "_Xceed_Something")] // https://github.com/ClosedXML/ClosedXML/issues/1154
     [TestCase("_xD83DDE43_", "_xD83DDE43_")] // 8 hex digit name, decoded by XmlConvert.DecodeName, but not by XString
     public void Decodes_encoded_unicode_characters(string sourceText, string expectedText)
     {

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -120,7 +120,7 @@ internal class XmlTreeReaderAttributesTests
         var mapper = new XmlToEnumMapper.Builder().Add(new Dictionary<string, BindingFlags>
         {
             { "def", BindingFlags.Default },
-            { "ci", BindingFlags.IgnoreCase },
+            { "ci", BindingFlags.IgnoreCase }
         }).Build();
 
         using var reader = CreateReader(xmlText, mapper);

--- a/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderExtensionsTests.cs
@@ -42,12 +42,12 @@ internal class XmlTreeReaderExtensionsTests
 
     [TestCase("00000000", 0u)]
     [TestCase("0G000000", null)]
-    [TestCase(@"FFFFFFFF", 0xFFFFFFFF)]
-    [TestCase(@"FFFFFFFF", 0xFFFFFFFF)]
+    [TestCase("FFFFFFFF", 0xFFFFFFFF)]
+    [TestCase("FFFFFFFF", 0xFFFFFFFF)]
     [TestCase("abcdef00", 0xABCDEF00)]
     [TestCase("0000000", null)]
-    [TestCase(@"", null)]
-    [TestCase(@"hello", null)]
+    [TestCase("", null)]
+    [TestCase("hello", null)]
     public void GetOptionalUIntHex_parses_8_hex_digits(string xmlText, uint? expectedValue)
     {
         using var reader = CreateReader(xmlText);

--- a/ClosedXML.Tests/OleDb/OleDbTests.cs
+++ b/ClosedXML.Tests/OleDb/OleDbTests.cs
@@ -17,103 +17,106 @@ namespace ClosedXML.Tests.OleDb
         [Test]
         public void TestOleDbValues()
         {
-            using (var tf = new TemporaryFile(CreateTestFile()))
+            using var tf = new TemporaryFile(CreateTestFile());
+            Console.Write("Using temporary file\t{0}", tf.Path);
+            var connectionString = string.Format(@"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties='Excel 12.0 Xml;HDR=YES;IMEX=1';", tf.Path);
+            using var connection = new OleDbConnection(connectionString);
+            // Install driver from https://www.microsoft.com/en-za/download/details.aspx?id=13255 if required
+            // Also check that test runner is running under correct architecture:
+            connection.Open();
+            using (var command = new OleDbCommand("select * from [Sheet1$]", connection))
+            using (var dataAdapter = new OleDbDataAdapter())
             {
-                Console.Write("Using temporary file\t{0}", tf.Path);
-                var connectionString = string.Format(@"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties='Excel 12.0 Xml;HDR=YES;IMEX=1';", tf.Path);
-                using (var connection = new OleDbConnection(connectionString))
+                dataAdapter.SelectCommand = command;
+                var dt = new DataTable();
+                dataAdapter.Fill(dt);
+
+                Assert.Multiple(() =>
                 {
-                    // Install driver from https://www.microsoft.com/en-za/download/details.aspx?id=13255 if required
-                    // Also check that test runner is running under correct architecture:
-                    connection.Open();
-                    using (var command = new OleDbCommand("select * from [Sheet1$]", connection))
-                    using (var dataAdapter = new OleDbDataAdapter())
-                    {
-                        dataAdapter.SelectCommand = command;
-                        var dt = new DataTable();
-                        dataAdapter.Fill(dt);
+                    Assert.That(dt.Columns[0].ColumnName, Is.EqualTo("Base"));
+                    Assert.That(dt.Columns[1].ColumnName, Is.EqualTo("Ref"));
 
-                        Assert.AreEqual("Base", dt.Columns[0].ColumnName);
-                        Assert.AreEqual("Ref", dt.Columns[1].ColumnName);
+                    Assert.That(dt.Rows.Count, Is.EqualTo(2));
+                });
 
-                        Assert.AreEqual(2, dt.Rows.Count);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(dt.Rows.Cast<DataRow>().First()[0], Is.EqualTo(42));
+                    Assert.That(dt.Rows.Cast<DataRow>().First()[1], Is.EqualTo(42));
 
-                        Assert.AreEqual(42, dt.Rows.Cast<DataRow>().First()[0]);
-                        Assert.AreEqual(42, dt.Rows.Cast<DataRow>().First()[1]);
-
-                        Assert.AreEqual(41, dt.Rows.Cast<DataRow>().Last()[0]);
-                        Assert.AreEqual(41, dt.Rows.Cast<DataRow>().Last()[1]);
-                    }
-
-                    using (var command = new OleDbCommand("select * from [Sheet2$]", connection))
-                    using (var dataAdapter = new OleDbDataAdapter())
-                    {
-                        dataAdapter.SelectCommand = command;
-                        var dt = new DataTable();
-                        dataAdapter.Fill(dt);
-
-                        Assert.AreEqual("Ref1", dt.Columns[0].ColumnName);
-                        Assert.AreEqual("Ref2", dt.Columns[1].ColumnName);
-                        Assert.AreEqual("Sum", dt.Columns[2].ColumnName);
-                        Assert.AreEqual("SumRef", dt.Columns[3].ColumnName);
-
-                        var expected = new Dictionary<string, double>()
-                        {
-                            {"Ref1", 42 },
-                            {"Ref2", 41 },
-                            {"Sum", 83 },
-                            {"SumRef", 83 },
-                        };
-
-                        foreach (var col in dt.Columns.Cast<DataColumn>())
-                            foreach (var row in dt.Rows.Cast<DataRow>())
-                            {
-                                Assert.AreEqual(expected[col.ColumnName], row[col]);
-                            }
-
-                        Assert.AreEqual(2, dt.Rows.Count);
-                    }
-
-                    connection.Close();
-                }
+                    Assert.That(dt.Rows.Cast<DataRow>().Last()[0], Is.EqualTo(41));
+                    Assert.That(dt.Rows.Cast<DataRow>().Last()[1], Is.EqualTo(41));
+                });
             }
+
+            using (var command = new OleDbCommand("select * from [Sheet2$]", connection))
+            using (var dataAdapter = new OleDbDataAdapter())
+            {
+                dataAdapter.SelectCommand = command;
+                var dt = new DataTable();
+                dataAdapter.Fill(dt);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(dt.Columns[0].ColumnName, Is.EqualTo("Ref1"));
+                    Assert.That(dt.Columns[1].ColumnName, Is.EqualTo("Ref2"));
+                    Assert.That(dt.Columns[2].ColumnName, Is.EqualTo("Sum"));
+                    Assert.That(dt.Columns[3].ColumnName, Is.EqualTo("SumRef"));
+                });
+
+                var expected = new Dictionary<string, double>()
+                {
+                    {"Ref1", 42 },
+                    {"Ref2", 41 },
+                    {"Sum", 83 },
+                    {"SumRef", 83 },
+                };
+
+                foreach (var col in dt.Columns.Cast<DataColumn>())
+                foreach (var row in dt.Rows.Cast<DataRow>())
+                {
+                    Assert.That(row[col], Is.EqualTo(expected[col.ColumnName]));
+                }
+
+                Assert.That(dt.Rows.Count, Is.EqualTo(2));
+            }
+
+            connection.Close();
         }
 
         private string CreateTestFile()
         {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("Sheet1");
-                ws.Cell("A1").Value = "Base";
-                ws.Cell("B1").Value = "Ref";
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Value = "Base";
+            ws.Cell("B1").Value = "Ref";
 
-                ws.Cell("A2").Value = 42;
-                ws.Cell("A3").Value = 41;
+            ws.Cell("A2").Value = 42;
+            ws.Cell("A3").Value = 41;
 
-                ws.Cell("B2").FormulaA1 = "=A2";
-                ws.Cell("B3").FormulaA1 = "=A3";
+            ws.Cell("B2").FormulaA1 = "=A2";
+            ws.Cell("B3").FormulaA1 = "=A3";
 
-                ws = wb.AddWorksheet("Sheet2");
-                ws.Cell("A1").Value = "Ref1";
-                ws.Cell("B1").Value = "Ref2";
-                ws.Cell("C1").Value = "Sum";
-                ws.Cell("D1").Value = "SumRef";
+            ws = wb.AddWorksheet("Sheet2");
+            ws.Cell("A1").Value = "Ref1";
+            ws.Cell("B1").Value = "Ref2";
+            ws.Cell("C1").Value = "Sum";
+            ws.Cell("D1").Value = "SumRef";
 
-                ws.Cell("A2").FormulaA1 = "=Sheet1!A2";
-                ws.Cell("B2").FormulaA1 = "=Sheet1!A3";
-                ws.Cell("C2").FormulaA1 = "=SUM(A2:B2)";
-                ws.Cell("D2").FormulaA1 = "=SUM(Sheet1!A2:Sheet1!A3)";
+            ws.Cell("A2").FormulaA1 = "=Sheet1!A2";
+            ws.Cell("B2").FormulaA1 = "=Sheet1!A3";
+            ws.Cell("C2").FormulaA1 = "=SUM(A2:B2)";
+            ws.Cell("D2").FormulaA1 = "=SUM(Sheet1!A2:Sheet1!A3)";
 
-                ws.Cell("A3").FormulaA1 = "=Sheet1!B2";
-                ws.Cell("B3").FormulaA1 = "=Sheet1!B3";
-                ws.Cell("C3").FormulaA1 = "=SUM(A3:B3)";
-                ws.Cell("D3").FormulaA1 = "=SUM(Sheet1!B2:Sheet1!B3)";
+            ws.Cell("A3").FormulaA1 = "=Sheet1!B2";
+            ws.Cell("B3").FormulaA1 = "=Sheet1!B3";
+            ws.Cell("C3").FormulaA1 = "=SUM(A3:B3)";
+            ws.Cell("D3").FormulaA1 = "=SUM(Sheet1!B2:Sheet1!B3)";
 
-                var path = Path.ChangeExtension(Path.GetTempFileName(), "xlsx");
-                wb.SaveAs(path, true, true);
+            var path = Path.ChangeExtension(Path.GetTempFileName(), "xlsx");
+            wb.SaveAs(path, true, true);
 
-                return path;
-            }
+            return path;
         }
     }
 }

--- a/ClosedXML.Tests/OpenXmlTests.cs
+++ b/ClosedXML.Tests/OpenXmlTests.cs
@@ -15,16 +15,12 @@ namespace ClosedXML.Tests
             // See:
             //      https://github.com/OfficeDev/Open-XML-SDK/issues/235
             //      https://github.com/dotnet/corefx/issues/23795
-            using (var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx")))
-            using (var ms = new MemoryStream())
-            {
-                stream.CopyTo(ms);
+            using var stream = TestHelper.GetStreamFromResource(TestHelper.GetResourcePath(@"Examples\PivotTables\PivotTables.xlsx"));
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
 
-                using (var document = SpreadsheetDocument.Open(ms, true))
-                {
-                    document.PackageProperties.Creator = null;
-                }
-            }
+            using var document = SpreadsheetDocument.Open(ms, true);
+            document.PackageProperties.Creator = null;
         }
     }
 }

--- a/ClosedXML.Tests/TestHelper.cs
+++ b/ClosedXML.Tests/TestHelper.cs
@@ -35,21 +35,21 @@ namespace ClosedXML.Tests
 
         public static void SaveWorkbook(XLWorkbook workbook, params string[] fileNameParts)
         {
-            workbook.SaveAs(Path.Combine(new string[] { TestsOutputDirectory }.Concat(fileNameParts).ToArray()), true);
+            workbook.SaveAs(Path.Combine(new[] { TestsOutputDirectory }.Concat(fileNameParts).ToArray()), true);
         }
 
         // Because different fonts are installed on Unix,
-        // the columns widths after AdjustToContents() will
+        // the column widths after AdjustToContents() will
         // cause the tests to fail.
-        // Therefore we ignore the width attribute when running on Unix
-        public static bool StripColumnWidths { get { return IsRunningOnUnix; } }
+        // Therefore, we ignore the width attribute when running on Unix
+        public static bool StripColumnWidths => IsRunningOnUnix;
 
         public static bool IsRunningOnUnix
         {
             get
             {
-                int p = (int)Environment.OSVersion.Platform;
-                return ((p == 4) || (p == 6) || (p == 128));
+                var p = (int)Environment.OSVersion.Platform;
+                return p is 4 or 6 or 128;
             }
         }
 
@@ -87,17 +87,15 @@ namespace ClosedXML.Tests
             if (CompareWithResources)
             {
                 string resourcePath = "Examples." + filePartName.Replace('\\', '.').TrimStart('.');
-                using (var streamExpected = _extractor.ReadFileFromResourceToStream(resourcePath))
-                using (var streamActual = File.OpenRead(filePath2))
-                {
-                    var success = ExcelDocsComparer.Compare(streamActual, streamExpected, out string message);
-                    var formattedMessage =
-                        String.Format(
-                            "Actual file '{0}' is different than the expected file '{1}'. The difference is: '{2}'",
-                            filePath2, resourcePath, message);
+                using var streamExpected = _extractor.ReadFileFromResourceToStream(resourcePath);
+                using var streamActual = File.OpenRead(filePath2);
+                var success = ExcelDocsComparer.Compare(streamActual, streamExpected, out string message);
+                var formattedMessage =
+                    string.Format(
+                        "Actual file '{0}' is different than the expected file '{1}'. The difference is: '{2}'",
+                        filePath2, resourcePath, message);
 
-                    Assert.IsTrue(success, formattedMessage);
-                }
+                Assert.That(success, Is.True, formattedMessage);
             }
         }
 
@@ -140,17 +138,15 @@ namespace ClosedXML.Tests
             if (CompareWithResources)
             {
                 string resourcePath = referenceResource.Replace('\\', '.').TrimStart('.');
-                using (var streamExpected = _extractor.ReadFileFromResourceToStream(resourcePath))
-                using (var streamActual = File.OpenRead(filePath2))
-                {
-                    var success = ExcelDocsComparer.Compare(streamActual, streamExpected, out string message);
-                    var formattedMessage =
-                        String.Format(
-                            "Actual file '{0}' is different than the expected file '{1}'. The difference is: '{2}'",
-                            filePath2, resourcePath, message);
+                using var streamExpected = _extractor.ReadFileFromResourceToStream(resourcePath);
+                using var streamActual = File.OpenRead(filePath2);
+                var success = ExcelDocsComparer.Compare(streamActual, streamExpected, out string message);
+                var formattedMessage =
+                    string.Format(
+                        "Actual file '{0}' is different than the expected file '{1}'. The difference is: '{2}'",
+                        filePath2, resourcePath, message);
 
-                    Assert.IsTrue(success, formattedMessage);
-                }
+                Assert.That(success, Is.True, formattedMessage);
             }
         }
 
@@ -219,13 +215,11 @@ namespace ClosedXML.Tests
         public static void LoadFile(string filePartName)
         {
             IXLWorkbook wb;
-            using (var stream = GetStreamFromResource(GetResourcePath(filePartName)))
-            {
-                Assert.DoesNotThrow(() => wb = new XLWorkbook(stream), "Unable to load resource {0}", filePartName);
-            }
+            using var stream = GetStreamFromResource(GetResourcePath(filePartName));
+            Assert.DoesNotThrow(() => wb = new XLWorkbook(stream), "Unable to load resource {0}", filePartName);
         }
 
-        public static IEnumerable<String> ListResourceFiles(Func<String, Boolean> predicate = null)
+        public static IEnumerable<string> ListResourceFiles(Func<string, bool> predicate = null)
         {
             return _extractor.GetFileNames(predicate);
         }

--- a/ClosedXML.Tests/Utils/ExcelDocsComparer.cs
+++ b/ClosedXML.Tests/Utils/ExcelDocsComparer.cs
@@ -8,20 +8,16 @@ namespace ClosedXML.Tests
     {
         public static bool Compare(string left, string right, out string message)
         {
-            using (FileStream leftStream = File.OpenRead(left))
-            using (FileStream rightStream = File.OpenRead(right))
-            {
-                return Compare(leftStream, rightStream, out message);
-            }
+            using FileStream leftStream = File.OpenRead(left);
+            using FileStream rightStream = File.OpenRead(right);
+            return Compare(leftStream, rightStream, out message);
         }
 
         public static bool Compare(Stream left, Stream right, out string message)
         {
-            using (Package leftPackage = Package.Open(left, FileMode.Open, FileAccess.Read))
-            using (Package rightPackage = Package.Open(right, FileMode.Open, FileAccess.Read))
-            {
-                return PackageHelper.Compare(leftPackage, rightPackage, false, ExcludeMethod, out message);
-            }
+            using Package leftPackage = Package.Open(left, FileMode.Open, FileAccess.Read);
+            using Package rightPackage = Package.Open(right, FileMode.Open, FileAccess.Read);
+            return PackageHelper.Compare(leftPackage, rightPackage, false, ExcludeMethod, out message);
         }
 
         private static bool ExcludeMethod(Uri uri)

--- a/ClosedXML.Tests/Utils/PackageHelper.cs
+++ b/ClosedXML.Tests/Utils/PackageHelper.cs
@@ -19,10 +19,8 @@ namespace ClosedXML.Tests
                 package.DeletePart(uri);
             }
             PackagePart part = package.CreatePart(uri, MediaTypeNames.Text.Xml, CompressionOption.Fast);
-            using (Stream stream = part.GetStream())
-            {
-                serializer.Serialize(stream, content);
-            }
+            using Stream stream = part.GetStream();
+            serializer.Serialize(stream, content);
         }
 
         public static object ReadXmlPart(Package package, Uri uri, XmlSerializer serializer)
@@ -32,10 +30,8 @@ namespace ClosedXML.Tests
                 throw new ApplicationException(string.Format("Package part '{0}' doesn't exists!", uri.OriginalString));
             }
             PackagePart part = package.GetPart(uri);
-            using (Stream stream = part.GetStream())
-            {
-                return serializer.Deserialize(stream);
-            }
+            using Stream stream = part.GetStream();
+            return serializer.Deserialize(stream);
         }
 
         public static void WriteBinaryPart(Package package, Uri uri, Stream content)
@@ -45,10 +41,8 @@ namespace ClosedXML.Tests
                 package.DeletePart(uri);
             }
             PackagePart part = package.CreatePart(uri, MediaTypeNames.Application.Octet, CompressionOption.Fast);
-            using (Stream stream = part.GetStream())
-            {
-                StreamHelper.StreamToStreamAppend(content, stream);
-            }
+            using Stream stream = part.GetStream();
+            StreamHelper.StreamToStreamAppend(content, stream);
         }
 
         /// <summary>
@@ -102,13 +96,9 @@ namespace ClosedXML.Tests
             PackagePart sourcePart = source.GetPart(uri);
             PackagePart destPart = dest.CreatePart(uri, sourcePart.ContentType, sourcePart.CompressionOption);
 
-            using (Stream sourceStream = sourcePart.GetStream())
-            {
-                using (Stream destStream = destPart.GetStream())
-                {
-                    StreamHelper.StreamToStreamAppend(sourceStream, destStream);
-                }
-            }
+            using Stream sourceStream = sourcePart.GetStream();
+            using Stream destStream = destPart.GetStream();
+            StreamHelper.StreamToStreamAppend(sourceStream, destStream);
         }
 
         public static void WritePart<T>(Package package, PackagePartDescriptor descriptor, T content,
@@ -136,10 +126,8 @@ namespace ClosedXML.Tests
                 package.DeletePart(descriptor.Uri);
             }
             PackagePart part = package.CreatePart(descriptor.Uri, descriptor.ContentType, descriptor.CompressOption);
-            using (Stream stream = part.GetStream())
-            {
-                serializeAction(stream, content);
-            }
+            using Stream stream = part.GetStream();
+            serializeAction(stream, content);
         }
 
         public static void WritePart(Package package, PackagePartDescriptor descriptor, Action<Stream> serializeAction)
@@ -166,10 +154,8 @@ namespace ClosedXML.Tests
                 package.DeletePart(descriptor.Uri);
             }
             PackagePart part = package.CreatePart(descriptor.Uri, descriptor.ContentType, descriptor.CompressOption);
-            using (Stream stream = part.GetStream())
-            {
-                serializeAction(stream);
-            }
+            using Stream stream = part.GetStream();
+            serializeAction(stream);
         }
 
         public static T ReadPart<T>(Package package, Uri uri, Func<Stream, T> deserializeFunc)
@@ -196,10 +182,8 @@ namespace ClosedXML.Tests
                 throw new ApplicationException(string.Format("Package part '{0}' doesn't exists!", uri.OriginalString));
             }
             PackagePart part = package.GetPart(uri);
-            using (Stream stream = part.GetStream())
-            {
-                return deserializeFunc(stream);
-            }
+            using Stream stream = part.GetStream();
+            return deserializeFunc(stream);
         }
 
         public static void ReadPart(Package package, Uri uri, Action<Stream> deserializeAction)
@@ -226,10 +210,8 @@ namespace ClosedXML.Tests
                 throw new ApplicationException(string.Format("Package part '{0}' doesn't exists!", uri.OriginalString));
             }
             PackagePart part = package.GetPart(uri);
-            using (Stream stream = part.GetStream())
-            {
-                deserializeAction(stream);
-            }
+            using Stream stream = part.GetStream();
+            deserializeAction(stream);
         }
 
         public static bool TryReadPart(Package package, Uri uri, Action<Stream> deserializeAction)
@@ -256,10 +238,8 @@ namespace ClosedXML.Tests
                 return false;
             }
             PackagePart part = package.GetPart(uri);
-            using (Stream stream = part.GetStream())
-            {
-                deserializeAction(stream);
-            }
+            using Stream stream = part.GetStream();
+            deserializeAction(stream);
             return true;
         }
 
@@ -291,11 +271,11 @@ namespace ClosedXML.Tests
 
             if (left == null)
             {
-                throw new ArgumentNullException("left");
+                throw new ArgumentNullException(nameof(left));
             }
             if (right == null)
             {
-                throw new ArgumentNullException("right");
+                throw new ArgumentNullException(nameof(right));
             }
 
             #endregion Check
@@ -342,31 +322,29 @@ namespace ClosedXML.Tests
                 }
                 var leftPart = left.GetPart(pair.Uri);
                 var rightPart = right.GetPart(pair.Uri);
-                using (Stream leftPackagePartStream = leftPart.GetStream(FileMode.Open, FileAccess.Read))
-                using (Stream rightPackagePartStream = rightPart.GetStream(FileMode.Open, FileAccess.Read))
-                using (var leftMemoryStream = new MemoryStream())
-                using (var rightMemoryStream = new MemoryStream())
+                using Stream leftPackagePartStream = leftPart.GetStream(FileMode.Open, FileAccess.Read);
+                using Stream rightPackagePartStream = rightPart.GetStream(FileMode.Open, FileAccess.Read);
+                using var leftMemoryStream = new MemoryStream();
+                using var rightMemoryStream = new MemoryStream();
+                leftPackagePartStream.CopyTo(leftMemoryStream);
+                rightPackagePartStream.CopyTo(rightMemoryStream);
+
+                leftMemoryStream.Seek(0, SeekOrigin.Begin);
+                rightMemoryStream.Seek(0, SeekOrigin.Begin);
+
+                bool stripColumnWidthsFromSheet = TestHelper.StripColumnWidths &&
+                                                  leftPart.ContentType == @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" &&
+                                                  rightPart.ContentType == @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
+
+                var tuple1 = (leftPart.ContentType, Stream: leftMemoryStream);
+                var tuple2 = (rightPart.ContentType, Stream: rightMemoryStream);
+
+                if (!StreamHelper.Compare(tuple1, tuple2, pair.Uri, stripColumnWidthsFromSheet))
                 {
-                    leftPackagePartStream.CopyTo(leftMemoryStream);
-                    rightPackagePartStream.CopyTo(rightMemoryStream);
-
-                    leftMemoryStream.Seek(0, SeekOrigin.Begin);
-                    rightMemoryStream.Seek(0, SeekOrigin.Begin);
-
-                    bool stripColumnWidthsFromSheet = TestHelper.StripColumnWidths &&
-                        leftPart.ContentType == @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml" &&
-                        rightPart.ContentType == @"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
-
-                    var tuple1 = (leftPart.ContentType, Stream: leftMemoryStream);
-                    var tuple2 = (rightPart.ContentType, Stream: rightMemoryStream);
-
-                    if (!StreamHelper.Compare(tuple1, tuple2, pair.Uri, stripColumnWidthsFromSheet))
+                    pair.Status = CompareStatus.NonEqual;
+                    if (compareToFirstDifference)
                     {
-                        pair.Status = CompareStatus.NonEqual;
-                        if (compareToFirstDifference)
-                        {
-                            goto EXIT;
-                        }
+                        goto EXIT;
                     }
                 }
             }

--- a/ClosedXML.Tests/Utils/PackageHelper.cs
+++ b/ClosedXML.Tests/Utils/PackageHelper.cs
@@ -18,6 +18,7 @@ namespace ClosedXML.Tests
             {
                 package.DeletePart(uri);
             }
+
             PackagePart part = package.CreatePart(uri, MediaTypeNames.Text.Xml, CompressionOption.Fast);
             using Stream stream = part.GetStream();
             serializer.Serialize(stream, content);
@@ -29,6 +30,7 @@ namespace ClosedXML.Tests
             {
                 throw new ApplicationException(string.Format("Package part '{0}' doesn't exists!", uri.OriginalString));
             }
+
             PackagePart part = package.GetPart(uri);
             using Stream stream = part.GetStream();
             return serializer.Deserialize(stream);
@@ -40,6 +42,7 @@ namespace ClosedXML.Tests
             {
                 package.DeletePart(uri);
             }
+
             PackagePart part = package.CreatePart(uri, MediaTypeNames.Application.Octet, CompressionOption.Fast);
             using Stream stream = part.GetStream();
             StreamHelper.StreamToStreamAppend(content, stream);
@@ -56,6 +59,7 @@ namespace ClosedXML.Tests
             {
                 throw new ApplicationException("Package part doesn't exists!");
             }
+
             PackagePart part = package.GetPart(uri);
             return part.GetStream();
         }
@@ -71,15 +75,17 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(uri, null))
             {
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
             }
+
             if (ReferenceEquals(source, null))
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
+
             if (ReferenceEquals(dest, null))
             {
-                throw new ArgumentNullException("dest");
+                throw new ArgumentNullException(nameof(dest));
             }
 
             #endregion Check
@@ -88,8 +94,9 @@ namespace ClosedXML.Tests
             {
                 if (!overwrite)
                 {
-                    throw new ArgumentException("Specified part already exists", "uri");
+                    throw new ArgumentException("Specified part already exists", nameof(uri));
                 }
+
                 dest.DeletePart(uri);
             }
 
@@ -108,15 +115,17 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(package, null))
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
+
             if (ReferenceEquals(descriptor, null))
             {
-                throw new ArgumentNullException("descriptor");
+                throw new ArgumentNullException(nameof(descriptor));
             }
+
             if (ReferenceEquals(serializeAction, null))
             {
-                throw new ArgumentNullException("serializeAction");
+                throw new ArgumentNullException(nameof(serializeAction));
             }
 
             #endregion Check
@@ -125,6 +134,7 @@ namespace ClosedXML.Tests
             {
                 package.DeletePart(descriptor.Uri);
             }
+
             PackagePart part = package.CreatePart(descriptor.Uri, descriptor.ContentType, descriptor.CompressOption);
             using Stream stream = part.GetStream();
             serializeAction(stream, content);
@@ -136,15 +146,17 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(package, null))
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
+
             if (ReferenceEquals(descriptor, null))
             {
-                throw new ArgumentNullException("descriptor");
+                throw new ArgumentNullException(nameof(descriptor));
             }
+
             if (ReferenceEquals(serializeAction, null))
             {
-                throw new ArgumentNullException("serializeAction");
+                throw new ArgumentNullException(nameof(serializeAction));
             }
 
             #endregion Check
@@ -153,6 +165,7 @@ namespace ClosedXML.Tests
             {
                 package.DeletePart(descriptor.Uri);
             }
+
             PackagePart part = package.CreatePart(descriptor.Uri, descriptor.ContentType, descriptor.CompressOption);
             using Stream stream = part.GetStream();
             serializeAction(stream);
@@ -164,15 +177,17 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(package, null))
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
+
             if (ReferenceEquals(uri, null))
             {
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
             }
+
             if (ReferenceEquals(deserializeFunc, null))
             {
-                throw new ArgumentNullException("deserializeFunc");
+                throw new ArgumentNullException(nameof(deserializeFunc));
             }
 
             #endregion Check
@@ -181,6 +196,7 @@ namespace ClosedXML.Tests
             {
                 throw new ApplicationException(string.Format("Package part '{0}' doesn't exists!", uri.OriginalString));
             }
+
             PackagePart part = package.GetPart(uri);
             using Stream stream = part.GetStream();
             return deserializeFunc(stream);
@@ -192,15 +208,17 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(package, null))
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
+
             if (ReferenceEquals(uri, null))
             {
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
             }
+
             if (ReferenceEquals(deserializeAction, null))
             {
-                throw new ArgumentNullException("deserializeAction");
+                throw new ArgumentNullException(nameof(deserializeAction));
             }
 
             #endregion Check
@@ -209,6 +227,7 @@ namespace ClosedXML.Tests
             {
                 throw new ApplicationException(string.Format("Package part '{0}' doesn't exists!", uri.OriginalString));
             }
+
             PackagePart part = package.GetPart(uri);
             using Stream stream = part.GetStream();
             deserializeAction(stream);
@@ -220,15 +239,17 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(package, null))
             {
-                throw new ArgumentNullException("package");
+                throw new ArgumentNullException(nameof(package));
             }
+
             if (ReferenceEquals(uri, null))
             {
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
             }
+
             if (ReferenceEquals(deserializeAction, null))
             {
-                throw new ArgumentNullException("deserializeAction");
+                throw new ArgumentNullException(nameof(deserializeAction));
             }
 
             #endregion Check
@@ -237,6 +258,7 @@ namespace ClosedXML.Tests
             {
                 return false;
             }
+
             PackagePart part = package.GetPart(uri);
             using Stream stream = part.GetStream();
             deserializeAction(stream);
@@ -273,6 +295,7 @@ namespace ClosedXML.Tests
             {
                 throw new ArgumentNullException(nameof(left));
             }
+
             if (right == null)
             {
                 throw new ArgumentNullException(nameof(right));
@@ -291,14 +314,17 @@ namespace ClosedXML.Tests
                 {
                     continue;
                 }
+
                 pairs.Add(part.Uri, new PartPair(part.Uri, CompareStatus.OnlyOnLeft));
             }
+
             foreach (PackagePart part in rightParts)
             {
                 if (excludeMethod(part.Uri))
                 {
                     continue;
                 }
+
                 if (pairs.TryGetValue(part.Uri, out PartPair pair))
                 {
                     pair.Status = CompareStatus.Equal;
@@ -320,6 +346,7 @@ namespace ClosedXML.Tests
                 {
                     continue;
                 }
+
                 var leftPart = left.GetPart(pair.Uri);
                 var rightPart = right.GetPart(pair.Uri);
                 using Stream leftPackagePartStream = leftPart.GetStream(FileMode.Open, FileAccess.Read);
@@ -349,7 +376,7 @@ namespace ClosedXML.Tests
                 }
             }
 
-        EXIT:
+            EXIT:
             List<PartPair> sortedPairs = pairs.Values.ToList();
             sortedPairs.Sort((one, other) => one.Uri.OriginalString.CompareTo(other.Uri.OriginalString));
             var sbuilder = new StringBuilder();
@@ -359,9 +386,11 @@ namespace ClosedXML.Tests
                 {
                     continue;
                 }
+
                 sbuilder.AppendFormat("{0} :{1}", pair.Uri, pair.Status);
                 sbuilder.AppendLine();
             }
+
             message = sbuilder.ToString();
             return message.Length == 0;
         }
@@ -397,11 +426,12 @@ namespace ClosedXML.Tests
 
                 if (ReferenceEquals(uri, null))
                 {
-                    throw new ArgumentNullException("uri");
+                    throw new ArgumentNullException(nameof(uri));
                 }
+
                 if (string.IsNullOrEmpty(contentType))
                 {
-                    throw new ArgumentNullException("contentType");
+                    throw new ArgumentNullException(nameof(contentType));
                 }
 
                 #endregion Check
@@ -417,20 +447,17 @@ namespace ClosedXML.Tests
 
             public Uri Uri
             {
-                [DebuggerStepThrough]
-                get { return _uri; }
+                [DebuggerStepThrough] get { return _uri; }
             }
 
             public string ContentType
             {
-                [DebuggerStepThrough]
-                get { return _contentType; }
+                [DebuggerStepThrough] get { return _contentType; }
             }
 
             public CompressionOption CompressOption
             {
-                [DebuggerStepThrough]
-                get { return _compressOption; }
+                [DebuggerStepThrough] get { return _compressOption; }
             }
 
             #endregion Public properties
@@ -487,16 +514,13 @@ namespace ClosedXML.Tests
 
             public Uri Uri
             {
-                [DebuggerStepThrough]
-                get { return _uri; }
+                [DebuggerStepThrough] get { return _uri; }
             }
 
             public CompareStatus Status
             {
-                [DebuggerStepThrough]
-                get { return _status; }
-                [DebuggerStepThrough]
-                set { _status = value; }
+                [DebuggerStepThrough] get { return _status; }
+                [DebuggerStepThrough] set { _status = value; }
             }
 
             #endregion Public properties

--- a/ClosedXML.Tests/Utils/ResourceFileExtractor.cs
+++ b/ClosedXML.Tests/Utils/ResourceFileExtractor.cs
@@ -135,7 +135,7 @@ namespace ClosedXML.Tests
 
             if (assembly is null)
             {
-                throw new ArgumentNullException("assembly");
+                throw new ArgumentNullException(nameof(assembly));
             }
 
             #endregion Check
@@ -164,7 +164,7 @@ namespace ClosedXML.Tests
 
         public bool IsStatic { get; set; }
 
-        public IEnumerable<string> GetFileNames(Func<String, Boolean> predicate = null)
+        public IEnumerable<string> GetFileNames(Func<string, bool> predicate = null)
         {
             predicate = predicate ?? (s => true);
 

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -40,19 +40,19 @@ namespace ClosedXML.Tests
 
             if (ReferenceEquals(streamIn, null))
             {
-                throw new ArgumentNullException("streamIn");
+                throw new ArgumentNullException(nameof(streamIn));
             }
             if (ReferenceEquals(streamToWrite, null))
             {
-                throw new ArgumentNullException("streamToWrite");
+                throw new ArgumentNullException(nameof(streamToWrite));
             }
             if (!streamIn.CanRead)
             {
-                throw new ArgumentException("Can't read from stream", "streamIn");
+                throw new ArgumentException("Can't read from stream", nameof(streamIn));
             }
             if (!streamToWrite.CanWrite)
             {
-                throw new ArgumentException("Can't write to stream", "streamToWrite");
+                throw new ArgumentException("Can't write to stream", nameof(streamToWrite));
             }
 
             #endregion Check params

--- a/ClosedXML.Tests/Utils/StreamHelper.cs
+++ b/ClosedXML.Tests/Utils/StreamHelper.cs
@@ -124,7 +124,7 @@ namespace ClosedXML.Tests
             return XNode.DeepEquals(leftXml, rightXml);
         }
 
-        private static void RemoveIgnoredParts(XDocument document, Uri partUri, Boolean stripColumnWidths)
+        private static void RemoveIgnoredParts(XDocument document, Uri partUri, bool stripColumnWidths)
         {
             foreach (var ignoredNode in ignoredNodes.Where(i => partUri.OriginalString.Contains(i.PartSubstring)))
                 document.Descendants(ignoredNode.NodeName).Remove();

--- a/ClosedXML.Tests/Utils/TemporaryFile.cs
+++ b/ClosedXML.Tests/Utils/TemporaryFile.cs
@@ -13,7 +13,7 @@ namespace ClosedXML.Tests.Utils
             : this(path, false)
         { }
 
-        internal TemporaryFile(String path, bool preserve)
+        internal TemporaryFile(string path, bool preserve)
         {
             this.Path = path;
             this.Preserve = preserve;

--- a/ClosedXML.Tests/XLHelperTests.cs
+++ b/ClosedXML.Tests/XLHelperTests.cs
@@ -2,160 +2,162 @@ using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 
-namespace ClosedXML.Tests
+namespace ClosedXML.Tests;
+
+[TestFixture]
+public class XLHelperTests
 {
-    [TestFixture]
-    public class XLHelperTests
+    [Test]
+    public void IsValidColumnTest()
     {
-        [Test]
-        public void IsValidColumnTest()
+        Assert.Multiple(() =>
         {
-            Assert.AreEqual(false, XLHelper.IsValidColumn(""));
-            Assert.AreEqual(false, XLHelper.IsValidColumn("1"));
-            Assert.AreEqual(false, XLHelper.IsValidColumn("A1"));
-            Assert.AreEqual(false, XLHelper.IsValidColumn("AA1"));
-            Assert.AreEqual(true, XLHelper.IsValidColumn("A"));
-            Assert.AreEqual(true, XLHelper.IsValidColumn("AA"));
-            Assert.AreEqual(true, XLHelper.IsValidColumn("AAA"));
-            Assert.AreEqual(true, XLHelper.IsValidColumn("Z"));
-            Assert.AreEqual(true, XLHelper.IsValidColumn("ZZ"));
-            Assert.AreEqual(true, XLHelper.IsValidColumn("XFD"));
-            Assert.AreEqual(false, XLHelper.IsValidColumn("ZAA"));
-            Assert.AreEqual(false, XLHelper.IsValidColumn("XZA"));
-            Assert.AreEqual(false, XLHelper.IsValidColumn("XFZ"));
-        }
+            Assert.That(XLHelper.IsValidColumn(""), Is.False);
+            Assert.That(XLHelper.IsValidColumn("1"), Is.False);
+            Assert.That(XLHelper.IsValidColumn("A1"), Is.False);
+            Assert.That(XLHelper.IsValidColumn("AA1"), Is.False);
+            Assert.That(XLHelper.IsValidColumn("A"), Is.True);
+            Assert.That(XLHelper.IsValidColumn("AA"), Is.True);
+            Assert.That(XLHelper.IsValidColumn("AAA"), Is.True);
+            Assert.That(XLHelper.IsValidColumn("Z"), Is.True);
+            Assert.That(XLHelper.IsValidColumn("ZZ"), Is.True);
+            Assert.That(XLHelper.IsValidColumn("XFD"), Is.True);
+            Assert.That(XLHelper.IsValidColumn("ZAA"), Is.False);
+            Assert.That(XLHelper.IsValidColumn("XZA"), Is.False);
+            Assert.That(XLHelper.IsValidColumn("XFZ"), Is.False);
+        });
+    }
 
-        [Test]
-        public void ReplaceRelative1()
-        {
-            string result = XLHelper.ReplaceRelative("A1", 2, "B");
-            Assert.AreEqual("B2", result);
-        }
+    [Test]
+    public void ReplaceRelative1()
+    {
+        var result = XLHelper.ReplaceRelative("A1", 2, "B");
+        Assert.That(result, Is.EqualTo("B2"));
+    }
 
-        [Test]
-        public void ReplaceRelative2()
-        {
-            string result = XLHelper.ReplaceRelative("$A1", 2, "B");
-            Assert.AreEqual("$A2", result);
-        }
+    [Test]
+    public void ReplaceRelative2()
+    {
+        var result = XLHelper.ReplaceRelative("$A1", 2, "B");
+        Assert.That(result, Is.EqualTo("$A2"));
+    }
 
-        [Test]
-        public void ReplaceRelative3()
-        {
-            string result = XLHelper.ReplaceRelative("A$1", 2, "B");
-            Assert.AreEqual("B$1", result);
-        }
+    [Test]
+    public void ReplaceRelative3()
+    {
+        var result = XLHelper.ReplaceRelative("A$1", 2, "B");
+        Assert.That(result, Is.EqualTo("B$1"));
+    }
 
-        [Test]
-        public void ReplaceRelative4()
-        {
-            string result = XLHelper.ReplaceRelative("$A$1", 2, "B");
-            Assert.AreEqual("$A$1", result);
-        }
+    [Test]
+    public void ReplaceRelative4()
+    {
+        var result = XLHelper.ReplaceRelative("$A$1", 2, "B");
+        Assert.That(result, Is.EqualTo("$A$1"));
+    }
 
-        [Test]
-        public void ReplaceRelative5()
-        {
-            string result = XLHelper.ReplaceRelative("1:1", 2, "B");
-            Assert.AreEqual("2:2", result);
-        }
+    [Test]
+    public void ReplaceRelative5()
+    {
+        var result = XLHelper.ReplaceRelative("1:1", 2, "B");
+        Assert.That(result, Is.EqualTo("2:2"));
+    }
 
-        [Test]
-        public void ReplaceRelative6()
-        {
-            string result = XLHelper.ReplaceRelative("$1:1", 2, "B");
-            Assert.AreEqual("$1:2", result);
-        }
+    [Test]
+    public void ReplaceRelative6()
+    {
+        var result = XLHelper.ReplaceRelative("$1:1", 2, "B");
+        Assert.That(result, Is.EqualTo("$1:2"));
+    }
 
-        [Test]
-        public void ReplaceRelative7()
-        {
-            string result = XLHelper.ReplaceRelative("1:$1", 2, "B");
-            Assert.AreEqual("2:$1", result);
-        }
+    [Test]
+    public void ReplaceRelative7()
+    {
+        var result = XLHelper.ReplaceRelative("1:$1", 2, "B");
+        Assert.That(result, Is.EqualTo("2:$1"));
+    }
 
-        [Test]
-        public void ReplaceRelative8()
-        {
-            string result = XLHelper.ReplaceRelative("$1:$1", 2, "B");
-            Assert.AreEqual("$1:$1", result);
-        }
+    [Test]
+    public void ReplaceRelative8()
+    {
+        var result = XLHelper.ReplaceRelative("$1:$1", 2, "B");
+        Assert.That(result, Is.EqualTo("$1:$1"));
+    }
 
-        [Test]
-        public void ReplaceRelative9()
-        {
-            string result = XLHelper.ReplaceRelative("A:A", 2, "B");
-            Assert.AreEqual("B:B", result);
-        }
+    [Test]
+    public void ReplaceRelative9()
+    {
+        var result = XLHelper.ReplaceRelative("A:A", 2, "B");
+        Assert.That(result, Is.EqualTo("B:B"));
+    }
 
-        [Test]
-        public void ReplaceRelativeA()
-        {
-            string result = XLHelper.ReplaceRelative("$A:A", 2, "B");
-            Assert.AreEqual("$A:B", result);
-        }
+    [Test]
+    public void ReplaceRelativeA()
+    {
+        var result = XLHelper.ReplaceRelative("$A:A", 2, "B");
+        Assert.That(result, Is.EqualTo("$A:B"));
+    }
 
-        [Test]
-        public void ReplaceRelativeB()
-        {
-            string result = XLHelper.ReplaceRelative("A:$A", 2, "B");
-            Assert.AreEqual("B:$A", result);
-        }
+    [Test]
+    public void ReplaceRelativeB()
+    {
+        var result = XLHelper.ReplaceRelative("A:$A", 2, "B");
+        Assert.That(result, Is.EqualTo("B:$A"));
+    }
 
-        [Test]
-        public void ReplaceRelativeC()
-        {
-            string result = XLHelper.ReplaceRelative("$A:$A", 2, "B");
-            Assert.AreEqual("$A:$A", result);
-        }
+    [Test]
+    public void ReplaceRelativeC()
+    {
+        var result = XLHelper.ReplaceRelative("$A:$A", 2, "B");
+        Assert.That(result, Is.EqualTo("$A:$A"));
+    }
 
-        [TestCase("Sheet1", "Sheet1")]
-        [TestCase("O'Brien's sales", "O'Brien's sales")]
-        [TestCase(" data # ", " data # ")]
-        [TestCase("data $1.00", "data $1.00")]
-        [TestCase("data ", "data?")]
-        [TestCase("abc def", "abc/def")]
-        [TestCase("data 0 ", "data[0]")]
-        [TestCase("data ", "data*")]
-        [TestCase("abc def", "abc\\def")]
-        [TestCase(" data", "'data")]
-        [TestCase("data ", "data'")]
-        [TestCase("d'at'a", "d'at'a")]
-        [TestCase("sheet a4", "sheet:a4")]
-        [TestCase("null", null)]
-        [TestCase("empty", "")]
-        [TestCase("1234567890123456789012345678901", "1234567890123456789012345678901TOOLONG")]
-        public void CreateSafeSheetNames(string expected, string input)
-        {
-            var actual = XLHelper.CreateSafeSheetName(input);
-            Assert.AreEqual(expected, actual);
-        }
+    [TestCase("Sheet1", "Sheet1")]
+    [TestCase("O'Brien's sales", "O'Brien's sales")]
+    [TestCase(" data # ", " data # ")]
+    [TestCase("data $1.00", "data $1.00")]
+    [TestCase("data ", "data?")]
+    [TestCase("abc def", "abc/def")]
+    [TestCase("data 0 ", "data[0]")]
+    [TestCase("data ", "data*")]
+    [TestCase("abc def", "abc\\def")]
+    [TestCase(" data", "'data")]
+    [TestCase("data ", "data'")]
+    [TestCase("d'at'a", "d'at'a")]
+    [TestCase("sheet a4", "sheet:a4")]
+    [TestCase("null", null)]
+    [TestCase("empty", "")]
+    [TestCase("1234567890123456789012345678901", "1234567890123456789012345678901TOOLONG")]
+    public void CreateSafeSheetNames(string expected, string input)
+    {
+        var actual = XLHelper.CreateSafeSheetName(input);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
 
-        [TestCase("Sheet1", ExpectedResult = "Sheet1")]
-        [TestCase("O'Brien's sales", ExpectedResult = "O'Brien's sales")]
-        [TestCase(" data # ", ExpectedResult = " data # ")]
-        [TestCase("data $1.00", ExpectedResult = "data $1.00")]
-        [TestCase("data?", ExpectedResult = "data_")]
-        [TestCase("abc/def", ExpectedResult = "abc_def")]
-        [TestCase("data[0]", ExpectedResult = "data_0_")]
-        [TestCase("data*", ExpectedResult = "data_")]
-        [TestCase("abc\\def", ExpectedResult = "abc_def")]
-        [TestCase("'data", ExpectedResult = "_data")]
-        [TestCase("data'", ExpectedResult = "data_")]
-        [TestCase("d'at'a", ExpectedResult = "d'at'a")]
-        [TestCase("sheet:a4", ExpectedResult = "sheet_a4")]
-        [TestCase(null, ExpectedResult = "null")]
-        [TestCase("", ExpectedResult = "empty")]
-        [TestCase("1234567890123456789012345678901TOOLONG", ExpectedResult = "1234567890123456789012345678901")]
-        public string CreateSafeSheetNamesWithUnderscore(string input)
-        {
-            return XLHelper.CreateSafeSheetName(input, replaceChar: '_');
-        }
+    [TestCase("Sheet1", ExpectedResult = "Sheet1")]
+    [TestCase("O'Brien's sales", ExpectedResult = "O'Brien's sales")]
+    [TestCase(" data # ", ExpectedResult = " data # ")]
+    [TestCase("data $1.00", ExpectedResult = "data $1.00")]
+    [TestCase("data?", ExpectedResult = "data_")]
+    [TestCase("abc/def", ExpectedResult = "abc_def")]
+    [TestCase("data[0]", ExpectedResult = "data_0_")]
+    [TestCase("data*", ExpectedResult = "data_")]
+    [TestCase("abc\\def", ExpectedResult = "abc_def")]
+    [TestCase("'data", ExpectedResult = "_data")]
+    [TestCase("data'", ExpectedResult = "data_")]
+    [TestCase("d'at'a", ExpectedResult = "d'at'a")]
+    [TestCase("sheet:a4", ExpectedResult = "sheet_a4")]
+    [TestCase(null, ExpectedResult = "null")]
+    [TestCase("", ExpectedResult = "empty")]
+    [TestCase("1234567890123456789012345678901TOOLONG", ExpectedResult = "1234567890123456789012345678901")]
+    public string CreateSafeSheetNamesWithUnderscore(string input)
+    {
+        return XLHelper.CreateSafeSheetName(input, replaceChar: '_');
+    }
 
-        [Test]
-        public void CreateSafeSheetNamesInvalidReplacementChar()
-        {
-            Assert.Throws<ArgumentException>(() => XLHelper.CreateSafeSheetName("abc\\def", replaceChar: ':'));
-        }
+    [Test]
+    public void CreateSafeSheetNamesInvalidReplacementChar()
+    {
+        Assert.Throws<ArgumentException>(() => XLHelper.CreateSafeSheetName("abc\\def", replaceChar: ':'));
     }
 }


### PR DESCRIPTION
Updated package reference to `NUnit4`

### Assertion Modernization:
* Replaced `Assert.AreEqual`, `Assert.IsTrue`, and similar methods with `Assert.That` across multiple test files for improved readability and consistency 

Resolves #2676 