### PR TITLE
Add enum mapping to Codegen

### DIFF
--- a/ClosedXML.IO.CodeGen/ParserGenerator.cs
+++ b/ClosedXML.IO.CodeGen/ParserGenerator.cs
@@ -5,18 +5,19 @@ using ClosedXML.IO.CodeGen.Model;
 
 namespace ClosedXML.IO.CodeGen;
 
-public class ParserGenerator
+internal class ParserGenerator
 {
     private readonly Schema _schema;
     private readonly string _readerName;
     private readonly string _namespaceField;
     private readonly List<string> _parseMethods = new();
-    private readonly SchemeTypeMap _typeMap = new();
+    private readonly SchemeTypeMap _typeMap;
     private string _targetNamespace = "ClosedXML.Excel.IO";
 
-    public ParserGenerator(Schema schema, string readerField, string nsVariable)
+    internal ParserGenerator(Schema schema, SchemeTypeMap typeMap, string readerField, string nsVariable)
     {
         _schema = schema;
+        _typeMap = typeMap;
         _readerName = readerField;
         _namespaceField = nsVariable;
     }
@@ -34,18 +35,6 @@ public class ParserGenerator
     public ParserGenerator AddParseMethod(string complexTypeName)
     {
         _parseMethods.Add(complexTypeName);
-        return this;
-    }
-
-    public ParserGenerator AddSimpleTypeRequired<CSharpType>(string typeName, string methodTemplate)
-    {
-        _typeMap.AddSimpleTypeTemplate<CSharpType>(typeName, true, methodTemplate);
-        return this;
-    }
-
-    public ParserGenerator AddSimpleTypeOptional<CSharpType>(string typeName, string methodTemplate)
-    {
-        _typeMap.AddSimpleTypeTemplate<CSharpType>(typeName, false, methodTemplate);
         return this;
     }
 

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -60,7 +60,7 @@ public class Program
     {
         var typeMap = new SchemeTypeMap()
             .AddPrimitiveTypes()
-            .AddSimpleTypeRequired<uint>("ST_NumFmtId", "_reader.GetUInt(\"{0}\")")
+            .AddSimpleTypeRequired("ST_NumFmtId", "_reader.GetUInt(\"{0}\")", "uint")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesPartReader1", "_ns");

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -55,17 +55,7 @@ public class Program
     private static void GenerateCacheRecords(Schema schema)
     {
         var typeMap = new SchemeTypeMap()
-            .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
-            .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
-            .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
-            .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
-            .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
-            .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
-            .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
-            .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
-            .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
-            .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
-            ;
+            .AddPrimitiveTypes();
 
         var cacheRecordsGenerator = new ParserGenerator(schema, typeMap, "PivotCacheRecordsReader", "_ns")
                 .WithNamespace("ClosedXML.Excel.IO")

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using ClosedXML.IO.CodeGen.Model;
 using ClosedXML.IO.CodeGen.XsdParser;
 
 namespace ClosedXML.IO.CodeGen;
@@ -36,46 +37,51 @@ public class Program
                 visitor.Visit(schema);
                 var outputFile = Path.ChangeExtension(schemaPath, "copy");
                 File.WriteAllText(outputFile, sb.ToString());
-
                 Console.WriteLine($"Wrote copy to {outputFile}");
                 break;
 
             case "cache-records":
-                var cacheRecordsGenerator = new ParserGenerator(schema, "PivotCacheRecordsReader", "_ns")
-                        .WithNamespace("ClosedXML.Excel.IO")
-                        .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
-                        .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
-                        .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
-                        .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
-                        .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
-                        .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
-                        .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
-                        .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
-                        .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
-                        .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
-
-                        // CT_PivotCacheRecords - hand-coded
-                        .AddParseMethod("CT_Record")
-                        .AddParseMethod("CT_Missing")
-                        .AddParseMethod("CT_Number")
-                        .AddParseMethod("CT_Boolean")
-                        .AddParseMethod("CT_Error")
-                        .AddParseMethod("CT_String")
-                        .AddParseMethod("CT_DateTime")
-                        .AddParseMethod("CT_Index")
-                        .AddParseMethod("CT_X")
-                        .AddParseMethod("CT_Tuples")
-                        .AddParseMethod("CT_Tuple")
-                    ;
-
-                var cacheRecordsSource = cacheRecordsGenerator.Generate();
-                Console.WriteLine(cacheRecordsSource);
+                GenerateCacheRecords(schema);
                 break;
+
             default:
                 Console.WriteLine($"Unknown command '{args[1]}'");
                 break;
         }
 
         Console.ReadKey();
+    }
+
+    private static void GenerateCacheRecords(Schema schema)
+    {
+        var cacheRecordsGenerator = new ParserGenerator(schema, "PivotCacheRecordsReader", "_ns")
+                .WithNamespace("ClosedXML.Excel.IO")
+                .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
+                .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
+                .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
+                .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
+                .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
+                .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
+                .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
+                .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
+                .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
+                .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
+
+                // CT_PivotCacheRecords - hand-coded
+                .AddParseMethod("CT_Record")
+                .AddParseMethod("CT_Missing")
+                .AddParseMethod("CT_Number")
+                .AddParseMethod("CT_Boolean")
+                .AddParseMethod("CT_Error")
+                .AddParseMethod("CT_String")
+                .AddParseMethod("CT_DateTime")
+                .AddParseMethod("CT_Index")
+                .AddParseMethod("CT_X")
+                .AddParseMethod("CT_Tuples")
+                .AddParseMethod("CT_Tuple")
+            ;
+
+        var cacheRecordsSource = cacheRecordsGenerator.Generate();
+        Console.WriteLine(cacheRecordsSource);
     }
 }

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -40,6 +40,10 @@ public class Program
                 Console.WriteLine($"Wrote copy to {outputFile}");
                 break;
 
+            case "styles":
+                GenerateStylesReader(schema);
+                break;
+
             case "cache-records":
                 GenerateCacheRecords(schema);
                 break;
@@ -50,6 +54,28 @@ public class Program
         }
 
         Console.ReadKey();
+    }
+
+    private static void GenerateStylesReader(Schema schema)
+    {
+        var typeMap = new SchemeTypeMap()
+            .AddPrimitiveTypes()
+            .AddSimpleTypeRequired<uint>("ST_NumFmtId", "_reader.GetUInt(\"{0}\")")
+            ;
+
+        var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesPartReader1", "_ns");
+
+        stylesReaderGenerator
+            .AddParseMethod("CT_Stylesheet")
+            .AddParseMethod("CT_NumFmts")
+            .AddParseMethod("CT_NumFmt")
+            .AddParseMethod("CT_Fonts")
+            .AddParseMethod("CT_Font")
+            .AddParseMethod("CT_FontName")
+            ;
+
+        var cacheRecordsSource = stylesReaderGenerator.Generate();
+        Console.WriteLine(cacheRecordsSource);
     }
 
     private static void GenerateCacheRecords(Schema schema)

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -49,7 +49,7 @@ public class Program
                 break;
 
             default:
-                Console.WriteLine($"Unknown command '{args[1]}'");
+                Console.WriteLine($"Unknown command '{command}'");
                 break;
         }
 
@@ -68,8 +68,8 @@ public class Program
             .AddParseMethod("CT_PatternFill")
             ;
 
-        var cacheRecordsSource = stylesReaderGenerator.Generate();
-        Console.WriteLine(cacheRecordsSource);
+        var stylesReaderSource = stylesReaderGenerator.Generate();
+        Console.WriteLine(stylesReaderSource);
     }
 
     private static void GenerateCacheRecords(Schema schema)
@@ -78,20 +78,20 @@ public class Program
             .AddPrimitiveTypes();
 
         var cacheRecordsGenerator = new ParserGenerator(schema, typeMap, "PivotCacheRecordsReader", "_ns")
-                .WithNamespace("ClosedXML.Excel.IO")
+            .WithNamespace("ClosedXML.Excel.IO")
 
-                // CT_PivotCacheRecords - hand-coded
-                .AddParseMethod("CT_Record")
-                .AddParseMethod("CT_Missing")
-                .AddParseMethod("CT_Number")
-                .AddParseMethod("CT_Boolean")
-                .AddParseMethod("CT_Error")
-                .AddParseMethod("CT_String")
-                .AddParseMethod("CT_DateTime")
-                .AddParseMethod("CT_Index")
-                .AddParseMethod("CT_X")
-                .AddParseMethod("CT_Tuples")
-                .AddParseMethod("CT_Tuple")
+            // CT_PivotCacheRecords - hand-coded
+            .AddParseMethod("CT_Record")
+            .AddParseMethod("CT_Missing")
+            .AddParseMethod("CT_Number")
+            .AddParseMethod("CT_Boolean")
+            .AddParseMethod("CT_Error")
+            .AddParseMethod("CT_String")
+            .AddParseMethod("CT_DateTime")
+            .AddParseMethod("CT_Index")
+            .AddParseMethod("CT_X")
+            .AddParseMethod("CT_Tuples")
+            .AddParseMethod("CT_Tuple")
             ;
 
         var cacheRecordsSource = cacheRecordsGenerator.Generate();

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -54,18 +54,21 @@ public class Program
 
     private static void GenerateCacheRecords(Schema schema)
     {
-        var cacheRecordsGenerator = new ParserGenerator(schema, "PivotCacheRecordsReader", "_ns")
+        var typeMap = new SchemeTypeMap()
+            .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
+            .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
+            .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
+            .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
+            .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
+            .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
+            .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
+            .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
+            .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
+            .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
+            ;
+
+        var cacheRecordsGenerator = new ParserGenerator(schema, typeMap, "PivotCacheRecordsReader", "_ns")
                 .WithNamespace("ClosedXML.Excel.IO")
-                .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
-                .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
-                .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
-                .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
-                .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
-                .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
-                .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
-                .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
-                .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
-                .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
 
                 // CT_PivotCacheRecords - hand-coded
                 .AddParseMethod("CT_Record")

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -13,56 +13,69 @@ public class Program
         if (args.Length != 2)
         {
             Console.Error.WriteLine("Usage:");
-            Console.Error.WriteLine($"    {Process.GetCurrentProcess().ProcessName}.exe name-of-ooxml.xsd output-path.xsd");
+            Console.Error.WriteLine($"    {Process.GetCurrentProcess().ProcessName}.exe name-of-ooxml.xsd command");
             Console.Error.WriteLine();
             return;
         }
 
-        using var fileStream = File.OpenRead(args[0]);
+        var schemaPath = args[0];
+        using var fileStream = File.OpenRead(schemaPath);
         using var reader = new XmlTreeReader(fileStream, new XsdEnumMapper(), false);
         var parser = new XsdSchemaParser();
 
         var schema = parser.ParseSchema(reader);
 
-        Console.Out.WriteLine($"File {args[0]} successfully parsed.");
+        Console.Out.WriteLine($"Schema {schemaPath} successfully parsed.");
 
-        var sb = new StringBuilder();
-        var visitor = new XsdCopyVisitor(sb);
-        visitor.Visit(schema);
+        var command = args[1];
+        switch (command)
+        {
+            case "copy":
+                var sb = new StringBuilder();
+                var visitor = new XsdCopyVisitor(sb);
+                visitor.Visit(schema);
+                var outputFile = Path.ChangeExtension(schemaPath, "copy");
+                File.WriteAllText(outputFile, sb.ToString());
 
-        File.WriteAllText(args[1], sb.ToString());
+                Console.WriteLine($"Wrote copy to {outputFile}");
+                break;
 
-        Console.WriteLine($"Wrote copy to {args[1]}");
+            case "cache-records":
+                var cacheRecordsGenerator = new ParserGenerator(schema, "PivotCacheRecordsReader", "_ns")
+                        .WithNamespace("ClosedXML.Excel.IO")
+                        .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
+                        .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
+                        .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
+                        .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
+                        .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
+                        .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
+                        .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
+                        .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
+                        .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
+                        .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
 
-        var cacheRecordsGenerator = new ParserGenerator(schema, "PivotCacheRecordsReader", "_ns")
-            .WithNamespace("ClosedXML.Excel.IO")
-            .AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")")
-            .AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")")
-            .AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")")
-            .AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")")
-            .AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")")
-            .AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")")
-            .AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")")
-            .AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")")
-            .AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")")
-            .AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")")
+                        // CT_PivotCacheRecords - hand-coded
+                        .AddParseMethod("CT_Record")
+                        .AddParseMethod("CT_Missing")
+                        .AddParseMethod("CT_Number")
+                        .AddParseMethod("CT_Boolean")
+                        .AddParseMethod("CT_Error")
+                        .AddParseMethod("CT_String")
+                        .AddParseMethod("CT_DateTime")
+                        .AddParseMethod("CT_Index")
+                        .AddParseMethod("CT_X")
+                        .AddParseMethod("CT_Tuples")
+                        .AddParseMethod("CT_Tuple")
+                    ;
 
-            // CT_PivotCacheRecords - hand-coded
-            .AddParseMethod("CT_Record")
-            .AddParseMethod("CT_Missing")
-            .AddParseMethod("CT_Number")
-            .AddParseMethod("CT_Boolean")
-            .AddParseMethod("CT_Error")
-            .AddParseMethod("CT_String")
-            .AddParseMethod("CT_DateTime")
-            .AddParseMethod("CT_Index")
-            .AddParseMethod("CT_X")
-            .AddParseMethod("CT_Tuples")
-            .AddParseMethod("CT_Tuple")
-            ;
+                var cacheRecordsSource = cacheRecordsGenerator.Generate();
+                Console.WriteLine(cacheRecordsSource);
+                break;
+            default:
+                Console.WriteLine($"Unknown command '{args[1]}'");
+                break;
+        }
 
-        var cacheRecordsSource = cacheRecordsGenerator.Generate();
-        Console.WriteLine(cacheRecordsSource);
         Console.ReadKey();
     }
 }

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -61,17 +61,11 @@ public class Program
         var typeMap = new SchemeTypeMap()
             .AddPrimitiveTypes()
             .AddSimpleTypeRequired("ST_NumFmtId", "_reader.GetUInt(\"{0}\")", "uint")
+            .AddSimpleTypeOptional("ST_PatternType", "_reader.GetOptionalEnum<XLFillPatternValues>(\"{0}\")", "XLFillPatternValues")
             ;
 
-        var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesPartReader1", "_ns");
-
-        stylesReaderGenerator
-            .AddParseMethod("CT_Stylesheet")
-            .AddParseMethod("CT_NumFmts")
-            .AddParseMethod("CT_NumFmt")
-            .AddParseMethod("CT_Fonts")
-            .AddParseMethod("CT_Font")
-            .AddParseMethod("CT_FontName")
+        var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesPartReader", "_ns")
+            .AddParseMethod("CT_PatternFill")
             ;
 
         var cacheRecordsSource = stylesReaderGenerator.Generate();

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -40,14 +40,15 @@ internal class SchemeTypeMap
 
     private void AddSimpleTypeTemplate(string typeName, bool isRequired, string methodTemplate, string cSharpTypeName)
     {
+        // Simple type can be added multiple types for optional and required templates
         if (!_simpleTypeMap.TryGetValue(typeName, out var existingCSharpType))
         {
-            _simpleTypeMap.TryAdd(typeName, cSharpTypeName);
+            _simpleTypeMap.Add(typeName, cSharpTypeName);
         }
         else
         {
             if (cSharpTypeName != existingCSharpType)
-                throw new InvalidOperationException($"Adding XML type {typeName} should be mapped to {cSharpTypeName}, but is already mapped to {existingCSharpType}.");
+                throw new InvalidOperationException($"The XML type {typeName} should be mapped to {cSharpTypeName}, but is already mapped to {existingCSharpType}.");
         }
 
         var typeTemplate = isRequired ? _requiredSimpleTypeTemplate : _optionalSimpleTypeTemplate;

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -7,10 +7,10 @@ namespace ClosedXML.IO.CodeGen;
 internal class SchemeTypeMap
 {
     /// <summary>
-    /// Simple type map. The key is a simple name, while value is C# type. The type is never
-    /// nullable, nullability is determined by other XML attributes.
+    /// Simple type map. The key is an XML simple name, the value is C# type name (including
+    /// namespace). The type is never nullable, nullability is determined by other XML attributes.
     /// </summary>
-    private readonly Dictionary<string, Type> _typeMap = new();
+    private readonly Dictionary<string, string> _simpleTypeMap = new();
 
     /// <summary>
     /// Templates for required attributes in XML. The key is XML simple type name, the value is a
@@ -26,60 +26,37 @@ internal class SchemeTypeMap
     /// </summary>
     private readonly Dictionary<string, string> _optionalSimpleTypeTemplate = new();
 
-    internal SchemeTypeMap AddSimpleTypeRequired<CSharpType>(string typeName, string methodTemplate)
+    internal SchemeTypeMap AddSimpleTypeRequired(string typeName, string methodTemplate, string cSharpTypeName)
     {
-        AddSimpleTypeTemplate<CSharpType>(typeName, true, methodTemplate);
+        AddSimpleTypeTemplate(typeName, true, methodTemplate, cSharpTypeName);
         return this;
     }
 
-    internal SchemeTypeMap AddSimpleTypeOptional<CSharpType>(string typeName, string methodTemplate)
+    internal SchemeTypeMap AddSimpleTypeOptional(string typeName, string methodTemplate, string cSharpTypeName)
     {
-        AddSimpleTypeTemplate<CSharpType>(typeName, false, methodTemplate);
+        AddSimpleTypeTemplate(typeName, false, methodTemplate, cSharpTypeName);
         return this;
     }
 
-    private void AddSimpleTypeTemplate<CSharpType>(string typeName, bool isRequired, string methodTemplate)
+    private void AddSimpleTypeTemplate(string typeName, bool isRequired, string methodTemplate, string cSharpTypeName)
     {
-        RegisterTypeMapping<CSharpType>(typeName, isRequired);
+        if (!_simpleTypeMap.TryGetValue(typeName, out var existingCSharpType))
+        {
+            _simpleTypeMap.TryAdd(typeName, cSharpTypeName);
+        }
+        else
+        {
+            if (cSharpTypeName != existingCSharpType)
+                throw new InvalidOperationException($"Adding XML type {typeName} should be mapped to {cSharpTypeName}, but is already mapped to {existingCSharpType}.");
+        }
 
         var typeTemplate = isRequired ? _requiredSimpleTypeTemplate : _optionalSimpleTypeTemplate;
         typeTemplate.Add(typeName, methodTemplate);
     }
 
-    private void RegisterTypeMapping<CSharpType>(string typeName, bool isRequired)
-    {
-        var registeredCSharpType = typeof(CSharpType);
-        if (!isRequired && registeredCSharpType.IsGenericType && registeredCSharpType.GetGenericTypeDefinition() == typeof(Nullable<>))
-            registeredCSharpType = registeredCSharpType.GetGenericArguments()[0];
-
-        if (!_typeMap.TryGetValue(typeName, out var existingCSharpType))
-        {
-            _typeMap.TryAdd(typeName, registeredCSharpType);
-        }
-        else
-        {
-            if (registeredCSharpType != existingCSharpType)
-                throw new InvalidOperationException($"Adding XML type {typeName} should be mapped to {typeof(CSharpType)}, but is already mapped to {existingCSharpType}.");
-        }
-    }
-
     internal string GetSimpleTypeName(string typeName)
     {
-        Type cSharpType = GetSimpleType(typeName);
-        return Type.GetTypeCode(cSharpType) switch
-        {
-            TypeCode.Boolean => "bool",
-            TypeCode.Int32 => "int",
-            TypeCode.UInt32 => "uint",
-            TypeCode.Double => "double",
-            TypeCode.String => "string",
-            _ => cSharpType.FullName ?? throw new InvalidOperationException("Missing full name")
-        };
-    }
-
-    internal Type GetSimpleType(string typeName)
-    {
-        return _typeMap[typeName];
+        return _simpleTypeMap[typeName];
     }
 
     internal string GetSimpleTypeMethod(AttributeElement attribute)
@@ -95,16 +72,16 @@ internal class SchemeTypeMap
 
     public SchemeTypeMap AddPrimitiveTypes()
     {
-        AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")");
-        AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")");
-        AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")");
-        AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")");
-        AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")");
-        AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")");
-        AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")");
-        AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")");
-        AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")");
-        AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")");
+        AddSimpleTypeRequired("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")", "uint");
+        AddSimpleTypeOptional("xsd:int", "_reader.GetOptionalInt(\"{0}\")", "int");
+        AddSimpleTypeRequired("xsd:boolean", "_reader.GetBool(\"{0}\")", "bool");
+        AddSimpleTypeOptional("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")", "bool");
+        AddSimpleTypeOptional("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")", "string");
+        AddSimpleTypeRequired("s:ST_Xstring", "_reader.GetXString(\"{0}\")", "string");
+        AddSimpleTypeOptional("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")", "uint");
+        AddSimpleTypeRequired("xsd:dateTime", "_reader.GetDateTime(\"{0}\")", "System.DateTime");
+        AddSimpleTypeOptional("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")", "uint");
+        AddSimpleTypeRequired("xsd:double", "_reader.GetDouble(\"{0}\")", "double");
         return this;
     }
 }

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -92,4 +92,19 @@ internal class SchemeTypeMap
 
         return string.Format(methodTemplate, attribute.Name);
     }
+
+    public SchemeTypeMap AddPrimitiveTypes()
+    {
+        AddSimpleTypeRequired<uint>("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")");
+        AddSimpleTypeOptional<int?>("xsd:int", "_reader.GetOptionalInt(\"{0}\")");
+        AddSimpleTypeRequired<bool>("xsd:boolean", "_reader.GetBool(\"{0}\")");
+        AddSimpleTypeOptional<bool?>("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")");
+        AddSimpleTypeOptional<string?>("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")");
+        AddSimpleTypeRequired<string>("s:ST_Xstring", "_reader.GetXString(\"{0}\")");
+        AddSimpleTypeOptional<uint?>("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")");
+        AddSimpleTypeRequired<DateTime>("xsd:dateTime", "_reader.GetDateTime(\"{0}\")");
+        AddSimpleTypeOptional<uint?>("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")");
+        AddSimpleTypeRequired<double>("xsd:double", "_reader.GetDouble(\"{0}\")");
+        return this;
+    }
 }

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.IO.CodeGen.Model;
+using ClosedXML.IO.CodeGen.Model;
 using System;
 using System.Collections.Generic;
 
@@ -26,7 +26,19 @@ internal class SchemeTypeMap
     /// </summary>
     private readonly Dictionary<string, string> _optionalSimpleTypeTemplate = new();
 
-    internal void AddSimpleTypeTemplate<CSharpType>(string typeName, bool isRequired, string methodTemplate)
+    internal SchemeTypeMap AddSimpleTypeRequired<CSharpType>(string typeName, string methodTemplate)
+    {
+        AddSimpleTypeTemplate<CSharpType>(typeName, true, methodTemplate);
+        return this;
+    }
+
+    internal SchemeTypeMap AddSimpleTypeOptional<CSharpType>(string typeName, string methodTemplate)
+    {
+        AddSimpleTypeTemplate<CSharpType>(typeName, false, methodTemplate);
+        return this;
+    }
+
+    private void AddSimpleTypeTemplate<CSharpType>(string typeName, bool isRequired, string methodTemplate)
     {
         RegisterTypeMapping<CSharpType>(typeName, isRequired);
 

--- a/ClosedXML/Excel/Style/XLFontName.cs
+++ b/ClosedXML/Excel/Style/XLFontName.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using ClosedXML.Excel.Formatting;
 
@@ -7,7 +7,7 @@ namespace ClosedXML.Excel;
 /// <summary>
 /// A font name, two font names are equal when they are case insensitive equal. It is a custom
 /// class because that way <see cref="XLFontFormat"/> and other structures don't have to implement
-/// custom ahs code and equality methods.
+/// custom hash code and equality methods.
 /// </summary>
 internal readonly record struct XLFontName
 {


### PR DESCRIPTION
CodeGen originally used generic arguments for simple types (e.g. `AddSimpleTypeRequired<int>`). That was a wrong way to do it, because CodeGen doesn't have reference to the ClosedXML project. Without reference to the ClosedXML project, it wasn't possible to define simple type enum mapping.

Pivot cache records part doesn't have any enums, so I didn't notice this problem there, but styles part does use enums.

This PR changes the **XML simple type** <-> **C# type** from strongly typed to stringly typed. Stringly typing allows use of types that are not referenced, including enums (`.AddSimpleTypeOptional("ST_PatternType", "_reader.GetOptionalEnum<XLFillPatternValues>(\"{0}\")", "XLFillPatternValues")`).