### PR TITLE
CodeGen: element Parse* method can return a value

### DIFF
--- a/ClosedXML.IO.CodeGen/CodeBuilder.cs
+++ b/ClosedXML.IO.CodeGen/CodeBuilder.cs
@@ -1,6 +1,7 @@
 using ClosedXML.IO.CodeGen.Model;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace ClosedXML.IO.CodeGen;
@@ -89,6 +90,16 @@ internal class CodeBuilder
         return typeName[CtPrefix.Length..];
     }
 
+    internal string GetSimpleType(string simpleType)
+    {
+        return _typeMap.GetSimpleTypeName(simpleType);
+    }
+
+    internal bool TryGetComplexType(string complexType, [NotNullWhen(true)] out string? csType)
+    {
+        return _typeMap.TryGetComplexTypeCsType(complexType, out csType);
+    }
+
     internal CodeBuilder AppendComplexType(string typeName)
     {
         _sb.Append(NormalizeCt(typeName));
@@ -99,24 +110,6 @@ internal class CodeBuilder
     {
         var codeFragment = _typeMap.GetSimpleTypeMethod(attribute);
         return Append(codeFragment);
-    }
-
-    internal CodeBuilder AppendSimpleType(AttributeElement attribute)
-    {
-        AppendSimpleType(attribute.Type!);
-
-        var isOptional = attribute.Use is AttributeUseType.Default or AttributeUseType.Optional;
-        var nullable = isOptional && attribute.DefaultValue is null;
-        if (nullable)
-            _sb.Append('?');
-
-        return this;
-    }
-
-    private void AppendSimpleType(string typeName)
-    {
-        var cSharpTypeName = _typeMap.GetSimpleTypeName(typeName);
-        _sb.Append(cSharpTypeName);
     }
 
     private void AddIndentedLine(string text)

--- a/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace ClosedXML.IO.CodeGen.Model;
 
@@ -28,12 +28,16 @@ public class AttributeElement : INode
 
     public string? DefaultValue { get; set; }
 
+    internal bool IsOptional => Use is AttributeUseType.Default or AttributeUseType.Optional;
+
+    internal bool CanBeNull => IsOptional && DefaultValue is null;
+
     public T Accept<T>(IXsdVisitor<T> visitor)
     {
         return visitor.Visit(this);
     }
 
-    internal void Generate(CodeBuilder code)
+    internal Variable Generate(CodeBuilder code)
     {
         Debug.Assert(Name is not null);
         Debug.Assert(Type is not null);
@@ -41,5 +45,8 @@ public class AttributeElement : INode
         if (DefaultValue is not null)
             code.Append(" ?? ").Append(DefaultValue);
         code.Append(";").EndLine();
+
+        var csType = CanBeNull ? code.GetSimpleType(Type) + '?' : code.GetSimpleType(Type);
+        return new Variable(csType, Name);
     }
 }

--- a/ClosedXML.IO.CodeGen/Model/Elements/ElementType.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/ElementType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ClosedXML.IO.CodeGen.Model.TopLevel;
 using System.Collections.Generic;
 
@@ -34,31 +34,44 @@ public class ElementType : IElementGroup
         return visitor.Visit(this);
     }
 
-    internal void Generate(CodeBuilder code, string namespaceField)
+    internal Variable? Generate(CodeBuilder code, string namespaceField)
     {
         var typeName = code.NormalizeCt(TypeName);
-        var elementParseCall = $"Parse{typeName}(\"{Name}\");";
+        var elementParseCall = $"Parse{typeName}(\"{Name}\")";
         var openArgs = $"\"{Name}\", {namespaceField}";
         var min = Occurrences.Min ?? 1;
         var max = Occurrences.Max ?? 1;
 
         if (min == 1 && max == 1)
         {
-            code.AddLine($"_reader.Open({openArgs}))")
-                .AddLine(elementParseCall);
+            code.AddLine($"_reader.Open({openArgs}))");
+            code.WriteIndent().Append(elementParseCall).Append(";").EndLine();
         }
         else if (min == 0 && max == 1)
         {
-            code.AddLine($"if (_reader.TryOpen({openArgs}))")
-                .OpenBrace()
-                .AddLine(elementParseCall)
-                .CloseBrace();
+            if (code.TryGetComplexType(TypeName, out var csType))
+            {
+                csType += "?";
+                code.WriteIndent().Append(csType).Append(" ").AppendVariable(Name).Append(" = default;").EndLine();
+                code.AddLine($"if (_reader.TryOpen({openArgs}))");
+                code.OpenBrace();
+                code.WriteIndent().AppendVariable(Name).Append(" = ").Append(elementParseCall).Append(";").EndLine();
+                code.CloseBrace();
+                return new Variable(csType, Name);
+            }
+            else
+            {
+                code.AddLine($"if (_reader.TryOpen({openArgs}))");
+                code.OpenBrace();
+                code.WriteIndent().Append(elementParseCall).Append(";").EndLine();
+                code.CloseBrace();
+            }
         }
         else if (min == 0 && max == int.MaxValue)
         {
             code.AddLine($"while (_reader.TryOpen({openArgs}))")
                 .OpenBrace()
-                .AddLine(elementParseCall)
+                .WriteIndent().Append(elementParseCall).Append(";").EndLine()
                 .CloseBrace();
         }
         else if (min == 1 && max == int.MaxValue)
@@ -66,7 +79,7 @@ public class ElementType : IElementGroup
             code.AddLine($"_reader.Open({openArgs});")
                 .AddLine("do")
                 .OpenBrace()
-                .AddLine(elementParseCall)
+                .WriteIndent().Append(elementParseCall).Append(";").EndLine()
                 .CloseBrace()
                 .AddLine($"while (_reader.TryOpen({openArgs}));");
         }
@@ -74,5 +87,7 @@ public class ElementType : IElementGroup
         {
             throw new NotSupportedException($"Unexpected occurence range {min}-{max}.");
         }
+
+        return null;
     }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexType.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using ClosedXML.IO.CodeGen.Model.Elements;
 
@@ -24,13 +24,15 @@ public abstract class ComplexType : IReferencable
 
     internal void Generate(CodeBuilder code, string namespaceField)
     {
+        var attributeVariables = new List<Variable>();
         code.StartMethod("void Parse{0}(string elementName)", Name);
         code.OpenBrace();
         foreach (var oneOfAttribute in Attributes)
         {
             if (oneOfAttribute.TryPickT1(out var attribute, out var attributeGroup))
             {
-                attribute.Generate(code);
+                var attributeVariable = attribute.Generate(code);
+                attributeVariables.Add(attributeVariable);
             }
             else
             {
@@ -38,57 +40,45 @@ public abstract class ComplexType : IReferencable
             }
         }
 
-        GenerateParseMethod(code, namespaceField);
-        CallListener(code);
+        var elementVariables = GenerateParseMethod(code, namespaceField);
+        List<Variable> dataVariables = [.. elementVariables, .. attributeVariables];
+        CallListener(code, dataVariables);
         code.CloseBrace();
 
-        AddPartialMethodSignature(code, Name);
+        AddPartialMethodSignature(code, Name, dataVariables);
     }
 
-    internal abstract void GenerateParseMethod(CodeBuilder code, string namespaceField);
+    internal abstract List<Variable> GenerateParseMethod(CodeBuilder code, string namespaceField);
 
-    private void CallListener(CodeBuilder code)
+    private void CallListener(CodeBuilder code, IReadOnlyList<Variable> arguments)
     {
         code.WriteIndent().Append("On").AppendComplexType(Name).Append("Parsed(");
         var isFirst = true;
-        foreach (var oneOfAttribute in Attributes)
+        foreach (var variable in arguments)
         {
-            if (oneOfAttribute.TryPickT1(out var attribute, out var attributeGroup))
-            {
-                if (!isFirst)
-                    code.Append(", ");
-                code.AppendVariable(attribute.Name!);
-                isFirst = false;
-            }
-            else
-            {
-                throw new NotImplementedException($"Attribute group ({attributeGroup.RefName}) not yet implemented.");
-            }
+            if (!isFirst)
+                code.Append(", ");
+
+            code.AppendVariable(variable.Name);
+            isFirst = false;
         }
 
         code.Append(");").EndLine();
     }
 
-    private void AddPartialMethodSignature(CodeBuilder code, string typeName)
+    private void AddPartialMethodSignature(CodeBuilder code, string typeName, IReadOnlyList<Variable> parameters)
     {
         code.EndLine();
-        code.WriteIndent().Append($"partial void On").AppendComplexType(typeName).Append("Parsed(");
+        code.WriteIndent().Append("partial void On").AppendComplexType(typeName).Append("Parsed(");
 
         var isFirst = true;
-        foreach (var oneOfAttribute in Attributes)
+        foreach (var parameter in parameters)
         {
-            if (oneOfAttribute.TryPickT1(out var attribute, out var attributeGroup))
-            {
-                if (!isFirst)
-                    code.Append(", ");
+            if (!isFirst)
+                code.Append(", ");
 
-                code.AppendSimpleType(attribute).Append(" ").AppendVariable(attribute.Name!);
-                isFirst = false;
-            }
-            else
-            {
-                throw new NotImplementedException($"Attribute group ({attributeGroup.RefName}) not yet implemented.");
-            }
+            code.Append(parameter.Type).Append(" ").AppendVariable(parameter.Name);
+            isFirst = false;
         }
 
         code.Append(");").EndLine();

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeChoice.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeChoice.cs
@@ -1,5 +1,6 @@
-﻿using ClosedXML.IO.CodeGen.Model.Elements;
+using ClosedXML.IO.CodeGen.Model.Elements;
 using System;
+using System.Collections.Generic;
 
 namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
@@ -27,7 +28,7 @@ public class ComplexTypeChoice : ComplexType, INode
         return visitor.Visit(this);
     }
 
-    internal override void GenerateParseMethod(CodeBuilder code, string namespaceField)
+    internal override List<Variable> GenerateParseMethod(CodeBuilder code, string namespaceField)
     {
         var min = Choice.Occurrences.Min ?? 1;
         var max = Choice.Occurrences.Max ?? 1;
@@ -60,5 +61,7 @@ public class ComplexTypeChoice : ComplexType, INode
         {
             throw new NotImplementedException($"{min}-{max} choice is not implemented.");
         }
+
+        return [];
     }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeElement.cs
@@ -1,4 +1,6 @@
-﻿namespace ClosedXML.IO.CodeGen.Model.TopLevel;
+using System.Collections.Generic;
+
+namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
 /// <summary>
 /// <c><![CDATA[<xsd:complexType/>]]></c> inside <c><![CDATA[<xsd:schema/>]]></c>. It doesn't have
@@ -11,8 +13,9 @@ public class ComplexTypeElement : ComplexType, INode
         return visitor.Visit(this);
     }
 
-    internal override void GenerateParseMethod(CodeBuilder code, string namespaceField)
+    internal override List<Variable> GenerateParseMethod(CodeBuilder code, string namespaceField)
     {
         code.AddLine($"_reader.Close(elementName, {namespaceField});");
+        return [];
     }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSequence.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSequence.cs
@@ -1,5 +1,6 @@
-﻿using ClosedXML.IO.CodeGen.Model.Elements;
+using ClosedXML.IO.CodeGen.Model.Elements;
 using System;
+using System.Collections.Generic;
 
 namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
@@ -27,8 +28,9 @@ public class ComplexTypeSequence : ComplexType, INode
         return visitor.Visit(this);
     }
 
-    internal override void GenerateParseMethod(CodeBuilder code, string namespaceField)
+    internal override List<Variable> GenerateParseMethod(CodeBuilder code, string namespaceField)
     {
+        var dataVariables = new List<Variable>();
         var min = Sequence.Occurrences.Min ?? 1;
         var max = Sequence.Occurrences.Max ?? 1;
         if (min == 1 && max == 1)
@@ -37,7 +39,9 @@ public class ComplexTypeSequence : ComplexType, INode
             {
                 if (element is ElementType elementType)
                 {
-                    elementType.Generate(code, namespaceField);
+                    var variable = elementType.Generate(code, namespaceField);
+                    if (variable is not null)
+                        dataVariables.Add(variable);
                 }
                 else
                 {
@@ -51,5 +55,6 @@ public class ComplexTypeSequence : ComplexType, INode
         }
 
         code.AddLine($"_reader.Close(elementName, {namespaceField});");
+        return dataVariables;
     }
 }

--- a/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSimpleContent.cs
+++ b/ClosedXML.IO.CodeGen/Model/TopLevel/ComplexTypeSimpleContent.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ClosedXML.IO.CodeGen.Model.TopLevel;
 
 /// <summary>
@@ -22,7 +24,7 @@ public class ComplexTypeSimpleContent : ComplexType, INode
         return visitor.Visit(this);
     }
 
-    internal override void GenerateParseMethod(CodeBuilder code, string namespaceField)
+    internal override List<Variable> GenerateParseMethod(CodeBuilder code, string namespaceField)
     {
         throw new System.NotImplementedException();
     }

--- a/ClosedXML.IO.CodeGen/Model/Variable.cs
+++ b/ClosedXML.IO.CodeGen/Model/Variable.cs
@@ -1,0 +1,8 @@
+namespace ClosedXML.IO.CodeGen.Model;
+
+/// <summary>
+/// A variable in the generated code.
+/// </summary>
+/// <param name="Type">C# type of variable, includes nullability.</param>
+/// <param name="Name">Name of variable (unescaped).</param>
+internal record Variable(string Type, string Name);

--- a/ClosedXML.IO.CodeGen/ParserGenerator.cs
+++ b/ClosedXML.IO.CodeGen/ParserGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using ClosedXML.IO.CodeGen.Model;

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -62,9 +62,10 @@ public class Program
             .AddPrimitiveTypes()
             .AddSimpleTypeRequired("ST_NumFmtId", "_reader.GetUInt(\"{0}\")", "uint")
             .AddSimpleTypeOptional("ST_PatternType", "_reader.GetOptionalEnum<XLFillPatternValues>(\"{0}\")", "XLFillPatternValues")
+            .AddComplexTypeMapping("CT_Color", "XLColor")
             ;
 
-        var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesPartReader", "_ns")
+        var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")
             .AddParseMethod("CT_PatternFill")
             ;
 

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -1,6 +1,7 @@
 using ClosedXML.IO.CodeGen.Model;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ClosedXML.IO.CodeGen;
 
@@ -11,6 +12,12 @@ internal class SchemeTypeMap
     /// namespace). The type is never nullable, nullability is determined by other XML attributes.
     /// </summary>
     private readonly Dictionary<string, string> _simpleTypeMap = new();
+
+    /// <summary>
+    /// Map of XML complex type name to C# type (as a text). If there isn't a record in the map,
+    /// complex type isn't mapped to C# type and returns <c>void</c>.
+    /// </summary>
+    private readonly Dictionary<string, string> _complexTypeMap = new();
 
     /// <summary>
     /// Templates for required attributes in XML. The key is XML simple type name, the value is a
@@ -25,6 +32,12 @@ internal class SchemeTypeMap
     /// that is substituted with a name of an attribute.
     /// </summary>
     private readonly Dictionary<string, string> _optionalSimpleTypeTemplate = new();
+
+    internal SchemeTypeMap AddComplexTypeMapping(string typeName, string cSharpType)
+    {
+        _complexTypeMap.Add(typeName, cSharpType);
+        return this;
+    }
 
     internal SchemeTypeMap AddSimpleTypeRequired(string typeName, string methodTemplate, string cSharpTypeName)
     {
@@ -69,6 +82,11 @@ internal class SchemeTypeMap
             throw new InvalidOperationException($"Simple type {typeName} ({(isOptional ? "optional" : "required")}) doesn't have defined template.");
 
         return string.Format(methodTemplate, attribute.Name);
+    }
+
+    internal bool TryGetComplexTypeCsType(string complexType, [NotNullWhen(true)] out string? csType)
+    {
+        return _complexTypeMap.TryGetValue(complexType, out csType);
     }
 
     public SchemeTypeMap AddPrimitiveTypes()


### PR DESCRIPTION
The generated `Parse*` methods expected that other `Parse*` methods will always return void. That was rather limiting and made it hard to hand-code logic that transferred parsed data into internal structures.

This change adds a `AddComplexTypeMapping` method to the `SchemaTypeMap` that indicates the `Parse*` method for mapped complex type will return a value of specified C# type. The returned value will be then passed to the `On*Parsed()` listener.

This doesn't allow for generated `Parse*` methods to return value. Only hand-coded Parse* methods can do that for now. That will be done in later PRs.

As a practical example, originally `Parse` method would look like this:
```csharp
private void ParsePatternFill(string elementName)
{
    var patternType = _reader.GetOptionalEnum<XLFillPatternValues>("patternType");
    if (_reader.TryOpen("fgColor", _ns))
        ParseColor("fgColor");

    if (_reader.TryOpen("bgColor", _ns))
        ParseColor("bgColor");

    _reader.Close(elementName, _ns);
    OnPatternFillParsed(patternType);
}
```
and now it can look like this (provided the `CT_Color` XML complex type is mapped to `XLColor` C# type)
```csharp
private void ParsePatternFill(string elementName)
{
    var patternType = _reader.GetOptionalEnum<XLFillPatternValues>("patternType");
    XLColor? fgColor = default;
    if (_reader.TryOpen("fgColor", _ns))
        fgColor = ParseColor("fgColor");

    XLColor? bgColor = default;
    if (_reader.TryOpen("bgColor", _ns))
        bgColor = ParseColor("bgColor");

    _reader.Close(elementName, _ns);
    OnPatternFillParsed(fgColor, bgColor, patternType);
}
```