### PR TITLE
Map enum default value for codegen

### DIFF
--- a/ClosedXML.IO.CodeGen/CodeBuilder.cs
+++ b/ClosedXML.IO.CodeGen/CodeBuilder.cs
@@ -92,7 +92,14 @@ internal class CodeBuilder
 
     internal string GetSimpleType(string simpleType)
     {
-        return _typeMap.GetSimpleTypeName(simpleType);
+        return _typeMap.GetSimpleType(simpleType).CsTypeName;
+    }
+
+    internal CodeBuilder AppendValue(string simpleType, string value)
+    {
+        var mappedValue = _typeMap.GetSimpleType(simpleType).MapValue(value);
+        _sb.Append(mappedValue);
+        return this;
     }
 
     internal bool TryGetComplexType(string complexType, [NotNullWhen(true)] out string? csType)

--- a/ClosedXML.IO.CodeGen/IXsdVisitor.cs
+++ b/ClosedXML.IO.CodeGen/IXsdVisitor.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.IO.CodeGen.Model;
+using ClosedXML.IO.CodeGen.Model;
 using ClosedXML.IO.CodeGen.Model.Elements;
 using ClosedXML.IO.CodeGen.Model.SimpleTypes;
 using ClosedXML.IO.CodeGen.Model.TopLevel;

--- a/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
@@ -30,7 +30,7 @@ public class AttributeElement : INode
 
     internal bool IsOptional => Use is AttributeUseType.Default or AttributeUseType.Optional;
 
-    internal bool CanBeNull => IsOptional && DefaultValue is null;
+    private bool CanBeNull => IsOptional && DefaultValue is null;
 
     public T Accept<T>(IXsdVisitor<T> visitor)
     {
@@ -44,6 +44,7 @@ public class AttributeElement : INode
         code.WriteIndent().Append("var ").AppendVariable(Name).Append(" = ").AppendSimpleTypeMethod(this);
         if (DefaultValue is not null)
             code.Append(" ?? ").Append(DefaultValue);
+
         code.Append(";").EndLine();
 
         var csType = CanBeNull ? code.GetSimpleType(Type) + '?' : code.GetSimpleType(Type);

--- a/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
+++ b/ClosedXML.IO.CodeGen/Model/AttributeElement.cs
@@ -43,7 +43,7 @@ public class AttributeElement : INode
         Debug.Assert(Type is not null);
         code.WriteIndent().Append("var ").AppendVariable(Name).Append(" = ").AppendSimpleTypeMethod(this);
         if (DefaultValue is not null)
-            code.Append(" ?? ").Append(DefaultValue);
+            code.Append(" ?? ").AppendValue(Type, DefaultValue);
 
         code.Append(";").EndLine();
 

--- a/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeList.cs
+++ b/ClosedXML.IO.CodeGen/Model/SimpleTypes/SimpleTypeList.cs
@@ -1,4 +1,4 @@
-﻿namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
+namespace ClosedXML.IO.CodeGen.Model.SimpleTypes;
 
 /// <summary>
 /// <c><![CDATA[<xsd:simpleType>]]></c> inside <c><![CDATA[<xsd:schema>]]></c>. List items are

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -60,8 +60,18 @@ public class Program
     {
         var typeMap = new SchemeTypeMap()
             .AddPrimitiveTypes()
-            .AddSimpleTypeRequired("ST_NumFmtId", "_reader.GetUInt(\"{0}\")", "uint")
-            .AddSimpleTypeOptional("ST_PatternType", "_reader.GetOptionalEnum<XLFillPatternValues>(\"{0}\")", "XLFillPatternValues")
+            .AddSimpleType(new SimpleTypeMapping
+            {
+                Name = "ST_NumFmtId",
+                CsTypeName = "uint",
+                RequiredTemplate = "_reader.GetUInt(\"{0}\")"
+            })
+            .AddSimpleType(new SimpleTypeMapping
+            {
+                Name = "ST_PatternType",
+                CsTypeName = "XLFillPatternValues",
+                OptionalTemplate = "_reader.GetOptionalEnum<XLFillPatternValues>(\"{0}\")"
+            })
             .AddComplexTypeMapping("CT_Color", "XLColor")
             ;
 

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -66,17 +66,14 @@ public class Program
                 CsTypeName = "uint",
                 RequiredTemplate = "_reader.GetUInt(\"{0}\")"
             })
-            .AddSimpleType(new SimpleTypeMapping
-            {
-                Name = "ST_PatternType",
-                CsTypeName = "XLFillPatternValues",
-                OptionalTemplate = "_reader.GetOptionalEnum<XLFillPatternValues>(\"{0}\")"
-            })
+            .AddSimpleTypeEnum("ST_PatternType", "XLFillPatternValues")
+            .AddSimpleTypeEnum("ST_GradientType", "XLGradientType", new() { { "linear", "XLGradientType.Linear" } })
             .AddComplexTypeMapping("CT_Color", "XLColor")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")
             .AddParseMethod("CT_PatternFill")
+            .AddParseMethod("CT_GradientFill")
             ;
 
         var stylesReaderSource = stylesReaderGenerator.Generate();

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -8,10 +8,9 @@ namespace ClosedXML.IO.CodeGen;
 internal class SchemeTypeMap
 {
     /// <summary>
-    /// Simple type map. The key is an XML simple name, the value is C# type name (including
-    /// namespace). The type is never nullable, nullability is determined by other XML attributes.
+    /// Simple type map. The key is an XML simple name, the value is info about how to work with it in the C# code.
     /// </summary>
-    private readonly Dictionary<string, string> _simpleTypeMap = new();
+    private readonly Dictionary<string, SimpleTypeMapping> _simpleTypeMap = new();
 
     /// <summary>
     /// Map of XML complex type name to C# type (as a text). If there isn't a record in the map,
@@ -19,69 +18,29 @@ internal class SchemeTypeMap
     /// </summary>
     private readonly Dictionary<string, string> _complexTypeMap = new();
 
-    /// <summary>
-    /// Templates for required attributes in XML. The key is XML simple type name, the value is a
-    /// code expression template used to get the value. The template has one argument (<c>{0}</c>)
-    /// that is substituted with a name of an attribute.
-    /// </summary>
-    private readonly Dictionary<string, string> _requiredSimpleTypeTemplate = new();
-
-    /// <summary>
-    /// Templates for optional attributes in XML. The key is XML simple type name, the value is a
-    /// code expression template used to get the value. The template has one argument (<c>{0}</c>)
-    /// that is substituted with a name of an attribute.
-    /// </summary>
-    private readonly Dictionary<string, string> _optionalSimpleTypeTemplate = new();
-
     internal SchemeTypeMap AddComplexTypeMapping(string typeName, string cSharpType)
     {
         _complexTypeMap.Add(typeName, cSharpType);
         return this;
     }
 
-    internal SchemeTypeMap AddSimpleTypeRequired(string typeName, string methodTemplate, string cSharpTypeName)
+    internal SchemeTypeMap AddSimpleType(SimpleTypeMapping simpleType)
     {
-        AddSimpleTypeTemplate(typeName, true, methodTemplate, cSharpTypeName);
+        _simpleTypeMap.Add(simpleType.Name, simpleType);
         return this;
-    }
-
-    internal SchemeTypeMap AddSimpleTypeOptional(string typeName, string methodTemplate, string cSharpTypeName)
-    {
-        AddSimpleTypeTemplate(typeName, false, methodTemplate, cSharpTypeName);
-        return this;
-    }
-
-    private void AddSimpleTypeTemplate(string typeName, bool isRequired, string methodTemplate, string cSharpTypeName)
-    {
-        // Simple type can be added multiple types for optional and required templates
-        if (!_simpleTypeMap.TryGetValue(typeName, out var existingCSharpType))
-        {
-            _simpleTypeMap.Add(typeName, cSharpTypeName);
-        }
-        else
-        {
-            if (cSharpTypeName != existingCSharpType)
-                throw new InvalidOperationException($"The XML type {typeName} should be mapped to {cSharpTypeName}, but is already mapped to {existingCSharpType}.");
-        }
-
-        var typeTemplate = isRequired ? _requiredSimpleTypeTemplate : _optionalSimpleTypeTemplate;
-        typeTemplate.Add(typeName, methodTemplate);
     }
 
     internal string GetSimpleTypeName(string typeName)
     {
-        return _simpleTypeMap[typeName];
+        return _simpleTypeMap[typeName].CsTypeName;
     }
 
     internal string GetSimpleTypeMethod(AttributeElement attribute)
     {
-        var isOptional = attribute.Use is AttributeUseType.Default or AttributeUseType.Optional;
-        var templates = isOptional ? _optionalSimpleTypeTemplate : _requiredSimpleTypeTemplate;
-        var typeName = attribute.Type ?? throw new InvalidOperationException();
-        if (!templates.TryGetValue(typeName, out var methodTemplate))
-            throw new InvalidOperationException($"Simple type {typeName} ({(isOptional ? "optional" : "required")}) doesn't have defined template.");
-
-        return string.Format(methodTemplate, attribute.Name);
+        var simpleTypeName = attribute.Type ?? throw new InvalidOperationException();
+        var simpleType = _simpleTypeMap[simpleTypeName];
+        var expressionTemplate = attribute.IsOptional ? simpleType.OptionalTemplate : simpleType.RequiredTemplate;
+        return string.Format(expressionTemplate, attribute.Name);
     }
 
     internal bool TryGetComplexTypeCsType(string complexType, [NotNullWhen(true)] out string? csType)
@@ -91,16 +50,54 @@ internal class SchemeTypeMap
 
     public SchemeTypeMap AddPrimitiveTypes()
     {
-        AddSimpleTypeRequired("xsd:unsignedInt", "_reader.GetUInt(\"{0}\")", "uint");
-        AddSimpleTypeOptional("xsd:int", "_reader.GetOptionalInt(\"{0}\")", "int");
-        AddSimpleTypeRequired("xsd:boolean", "_reader.GetBool(\"{0}\")", "bool");
-        AddSimpleTypeOptional("xsd:boolean", "_reader.GetOptionalBool(\"{0}\")", "bool");
-        AddSimpleTypeOptional("s:ST_Xstring", "_reader.GetOptionalXString(\"{0}\")", "string");
-        AddSimpleTypeRequired("s:ST_Xstring", "_reader.GetXString(\"{0}\")", "string");
-        AddSimpleTypeOptional("xsd:unsignedInt", "_reader.GetOptionalUInt(\"{0}\")", "uint");
-        AddSimpleTypeRequired("xsd:dateTime", "_reader.GetDateTime(\"{0}\")", "System.DateTime");
-        AddSimpleTypeOptional("ST_UnsignedIntHex", "_reader.GetOptionalUIntHex(\"{0}\")", "uint");
-        AddSimpleTypeRequired("xsd:double", "_reader.GetDouble(\"{0}\")", "double");
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "xsd:boolean",
+            CsTypeName = "bool",
+            RequiredTemplate = "_reader.GetBool(\"{0}\")",
+            OptionalTemplate = "_reader.GetOptionalBool(\"{0}\")"
+        });
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "xsd:int",
+            CsTypeName = "int",
+            RequiredTemplate = "_reader.GetInt(\"{0}\")",
+            OptionalTemplate = "_reader.GetOptionalInt(\"{0}\")"
+        });
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "xsd:unsignedInt",
+            CsTypeName = "uint",
+            RequiredTemplate = "_reader.GetUInt(\"{0}\")",
+            OptionalTemplate = "_reader.GetOptionalUInt(\"{0}\")"
+        });
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "xsd:double",
+            CsTypeName = "double",
+            RequiredTemplate = "_reader.GetDouble(\"{0}\")",
+            OptionalTemplate = "_reader.GetOptionalDouble(\"{0}\")"
+        });
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "s:ST_Xstring",
+            CsTypeName = "string",
+            RequiredTemplate = "_reader.GetXString(\"{0}\")",
+            OptionalTemplate = "_reader.GetOptionalXString(\"{0}\")"
+        });
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "xsd:dateTime",
+            CsTypeName = "System.DateTime",
+            RequiredTemplate = "_reader.GetDateTime(\"{0}\")",
+            OptionalTemplate = "_reader.GetOptionalDateTime(\"{0}\")"
+        });
+        AddSimpleType(new SimpleTypeMapping
+        {
+            Name = "ST_UnsignedIntHex",
+            CsTypeName = "uint",
+            OptionalTemplate = "_reader.GetOptionalUIntHex(\"{0}\")"
+        });
         return this;
     }
 }

--- a/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
+++ b/ClosedXML.IO.CodeGen/SchemeTypeMap.cs
@@ -30,9 +30,21 @@ internal class SchemeTypeMap
         return this;
     }
 
-    internal string GetSimpleTypeName(string typeName)
+    internal SchemeTypeMap AddSimpleTypeEnum(string simpleType, string csTypeName, Dictionary<string, string>? valuesMap = null)
     {
-        return _simpleTypeMap[typeName].CsTypeName;
+        return AddSimpleType(new SimpleTypeMapping
+        {
+            Name = simpleType,
+            CsTypeName = csTypeName,
+            RequiredTemplate = $"_reader.GetEnum<{csTypeName}>(\"{{0}}\")",
+            OptionalTemplate = $"_reader.GetOptionalEnum<{csTypeName}>(\"{{0}}\")",
+            MapValue = xmlName => valuesMap?[xmlName] ?? throw new InvalidOperationException($"The XML value {xmlName} is not mapped to {csTypeName}.")
+        });
+    }
+
+    internal SimpleTypeMapping GetSimpleType(string typeName)
+    {
+        return _simpleTypeMap[typeName];
     }
 
     internal string GetSimpleTypeMethod(AttributeElement attribute)

--- a/ClosedXML.IO.CodeGen/SimpleTypeMapping.cs
+++ b/ClosedXML.IO.CodeGen/SimpleTypeMapping.cs
@@ -34,4 +34,9 @@ internal record SimpleTypeMapping
         get => _optionalTemplate ?? throw new InvalidOperationException();
         init => _optionalTemplate = value;
     }
+
+    /// <summary>
+    /// Map values from XML default value to C# value.
+    /// </summary>
+    public Func<string, string> MapValue { get; init; } = x => x;
 }

--- a/ClosedXML.IO.CodeGen/SimpleTypeMapping.cs
+++ b/ClosedXML.IO.CodeGen/SimpleTypeMapping.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace ClosedXML.IO.CodeGen;
+
+internal record SimpleTypeMapping
+{
+    private readonly string? _requiredTemplate;
+    private readonly string? _optionalTemplate;
+
+    /// <summary>
+    /// Name of the simple type in the XML.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Name of the mapped C# type.
+    /// </summary>
+    public required string CsTypeName { get; init; }
+
+    /// <summary>
+    /// C# code template for getting a value from a required attribute. The name of attribute is in the string as <c>{0}</c>.
+    /// </summary>
+    public string RequiredTemplate
+    {
+        get => _requiredTemplate ?? throw new InvalidOperationException();
+        init => _requiredTemplate = value;
+    }
+
+    /// <summary>
+    /// C# code template for getting a value from an optional attribute. The name of attribute is in the string as <c>{0}</c>.
+    /// </summary>
+    public string OptionalTemplate
+    {
+        get => _optionalTemplate ?? throw new InvalidOperationException();
+        init => _optionalTemplate = value;
+    }
+}

--- a/ClosedXML.IO.CodeGen/XsdCopyVisitor.cs
+++ b/ClosedXML.IO.CodeGen/XsdCopyVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Text;
 using ClosedXML.IO.CodeGen.Model;


### PR DESCRIPTION
When XML attribute has a default value (e.g., `<xsd:attribute name="type" type="ST_GradientType" use="optional" default="linear"/>`), the value must be transformed to enum value in C#.

Originally, default value was basically copied. That worked, because it was used mostly or numbers (XML number format `1.7` is same as C# `1.7`). That is fine for numbers, but for enums, it is insufficient.

Registration of simple the can now contain a mapping function that maps the XML values to the C# values. For enums, it uses dictionary, strings could just add quotes and so on.