### PR TITLE
Move reading of a border format to StyleReader

### DIFF
--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -117,7 +117,7 @@ public class Program
             .AddSimpleTypeEnum("ST_TableStyleType", "XLTableStyleType")
             .AddComplexTypeMapping("CT_Color", "XLColor")
             //.AddComplexTypeMapping("CT_GradientStop", "(double Value, XLColor Color)")
-            //.AddComplexTypeMapping("CT_BorderPr", "XLBorderProperty")
+            .AddComplexTypeMapping("CT_BorderPr", "XLBorderLine")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -107,6 +107,29 @@ internal partial class StylesReader
         _styles.AddFontFormat(format);
     }
 
+    partial void OnBorderParsed(XLBorderLine? left, XLBorderLine? right, XLBorderLine? top, XLBorderLine? bottom, XLBorderLine? diagonal, XLBorderLine? vertical, XLBorderLine? horizontal, bool? diagonalUp, bool? diagonalDown, bool outline)
+    {
+        var borderFormat = new XLBorderFormat
+        {
+            Left = left,
+            Right = right,
+            Top = top,
+            Bottom = bottom,
+            Diagonal = diagonal,
+            Vertical = vertical,
+            Horizontal = horizontal,
+            DiagonalUp = diagonalUp ?? false, // OI-29500: Excel uses false as default value
+            DiagonalDown = diagonalDown ?? false, // OI-29500: Excel uses false as default value
+            Outline = outline
+        };
+        _styles.AddBorderFormat(borderFormat);
+    }
+
+    private XLBorderLine OnBorderPrParsed(XLColor? color, XLBorderStyleValues style)
+    {
+        return new XLBorderLine(color ?? XLColor.NoColor, style);
+    }
+
     private void ParseCellXfs(string elementName)
     {
         _insideCellXfs = true;
@@ -127,7 +150,7 @@ internal partial class StylesReader
         if (_insideCellXfs)
         {
             // We are in cellXfs
-            _styles.AddFormat(fontId);
+            _styles.AddFormat(fontId, borderId);
         }
     }
 

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -191,41 +191,48 @@ internal partial class StylesReader
         var diagonalUp = _reader.GetOptionalBool("diagonalUp");
         var diagonalDown = _reader.GetOptionalBool("diagonalDown");
         var outline = _reader.GetOptionalBool("outline") ?? true;
+        XLBorderLine? left = default;
         if (_reader.TryOpen("left", _ns))
         {
-            ParseBorderPr("left");
+            left = ParseBorderPr("left");
         }
+        XLBorderLine? right = default;
         if (_reader.TryOpen("right", _ns))
         {
-            ParseBorderPr("right");
+            right = ParseBorderPr("right");
         }
+        XLBorderLine? top = default;
         if (_reader.TryOpen("top", _ns))
         {
-            ParseBorderPr("top");
+            top = ParseBorderPr("top");
         }
+        XLBorderLine? bottom = default;
         if (_reader.TryOpen("bottom", _ns))
         {
-            ParseBorderPr("bottom");
+            bottom = ParseBorderPr("bottom");
         }
+        XLBorderLine? diagonal = default;
         if (_reader.TryOpen("diagonal", _ns))
         {
-            ParseBorderPr("diagonal");
+            diagonal = ParseBorderPr("diagonal");
         }
+        XLBorderLine? vertical = default;
         if (_reader.TryOpen("vertical", _ns))
         {
-            ParseBorderPr("vertical");
+            vertical = ParseBorderPr("vertical");
         }
+        XLBorderLine? horizontal = default;
         if (_reader.TryOpen("horizontal", _ns))
         {
-            ParseBorderPr("horizontal");
+            horizontal = ParseBorderPr("horizontal");
         }
         _reader.Close(elementName, _ns);
-        OnBorderParsed(diagonalUp, diagonalDown, outline);
+        OnBorderParsed(left, right, top, bottom, diagonal, vertical, horizontal, diagonalUp, diagonalDown, outline);
     }
 
-    partial void OnBorderParsed(bool? diagonalUp, bool? diagonalDown, bool outline);
+    partial void OnBorderParsed(XLBorderLine? left, XLBorderLine? right, XLBorderLine? top, XLBorderLine? bottom, XLBorderLine? diagonal, XLBorderLine? vertical, XLBorderLine? horizontal, bool? diagonalUp, bool? diagonalDown, bool outline);
 
-    private void ParseBorderPr(string elementName)
+    private XLBorderLine ParseBorderPr(string elementName)
     {
         var style = _reader.GetOptionalEnum<XLBorderStyleValues>("style") ?? XLBorderStyleValues.None;
         XLColor? color = default;
@@ -234,10 +241,8 @@ internal partial class StylesReader
             color = ParseColor("color");
         }
         _reader.Close(elementName, _ns);
-        OnBorderPrParsed(color, style);
+        return OnBorderPrParsed(color, style);
     }
-
-    partial void OnBorderPrParsed(XLColor? color, XLBorderStyleValues style);
 
     private void ParseCellStyleXfs(string elementName)
     {

--- a/ClosedXML/Excel/Style/Formatting/XLBorderFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderFormat.cs
@@ -1,0 +1,65 @@
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// A border format master record.
+/// </summary>
+internal record XLBorderFormat
+{
+    public required XLBorderLine? Left { get; init; }
+
+    public required XLBorderLine? Right { get; init; }
+
+    public required XLBorderLine? Top { get; init; }
+
+    public required XLBorderLine? Bottom { get; init; }
+
+    /// <summary>
+    /// Used when <see cref="DiagonalUp"/> or <see cref="DiagonalDown"/> are set. It's not possible
+    /// to have different style for up/down diagonal.
+    /// </summary>
+    public required XLBorderLine? Diagonal { get; init; }
+
+    /// <summary>
+    /// For pivot tables only.
+    /// </summary>
+    public required XLBorderLine? Vertical { get; init; }
+
+    /// <summary>
+    /// For pivot tables only.
+    /// </summary>
+    public required XLBorderLine? Horizontal { get; init; }
+
+    public required bool DiagonalUp { get; init; }
+
+    public required bool DiagonalDown { get; init; }
+
+    public required bool Outline { get; init; }
+
+    public XLBorderKey ApplyTo(XLBorderKey borderKey)
+    {
+        if (Left is not null)
+            borderKey = borderKey with { LeftBorder = Left.Value.Style, LeftBorderColor = Left.Value.Color.Key };
+
+        if (Right is not null)
+            borderKey = borderKey with { RightBorder = Right.Value.Style, RightBorderColor = Right.Value.Color.Key };
+
+        if (Top is not null)
+            borderKey = borderKey with { TopBorder = Top.Value.Style, TopBorderColor = Top.Value.Color.Key };
+
+        if (Bottom is not null)
+            borderKey = borderKey with { BottomBorder = Bottom.Value.Style, BottomBorderColor = Bottom.Value.Color.Key };
+
+        if (Diagonal is not null)
+        {
+            borderKey = borderKey with
+            {
+                DiagonalBorder = Diagonal.Value.Style,
+                DiagonalBorderColor = Diagonal.Value.Color.Key,
+                DiagonalUp = DiagonalUp,
+                DiagonalDown = DiagonalDown
+            };
+        }
+
+        return borderKey;
+    }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLBorderLine.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderLine.cs
@@ -1,0 +1,6 @@
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// Border line properties.
+/// </summary>
+internal readonly record struct XLBorderLine(XLColor Color, XLBorderStyleValues Style);

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -1,4 +1,4 @@
-﻿namespace ClosedXML.Excel.Formatting;
+namespace ClosedXML.Excel.Formatting;
 
 /// <summary>
 /// <para>
@@ -18,6 +18,8 @@
 internal readonly record struct XLCellFormat
 {
     public XLFontFormat? Font { get; init; }
+
+    public XLBorderFormat? Border { get; init; }
 
     // TODO: Add remaining properties. For now only font
 }

--- a/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
@@ -1,4 +1,4 @@
-﻿namespace ClosedXML.Excel.Formatting;
+namespace ClosedXML.Excel.Formatting;
 
 /// <summary>
 /// A formatting record for <see cref="XLCellFormat"/>. Unlike <see cref="XLFontKey"/>, attributes are optional.

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -15,17 +15,27 @@ internal class XLWorkbookStyles
 
     private readonly Dictionary<int, XLFontFormat> _fontFormats;
 
+    private readonly Dictionary<int, XLBorderFormat> _borderFormats;
+
     internal XLWorkbookStyles()
     {
         _masterFormats = new Dictionary<int, XLCellFormat>();
         _fontFormats = new Dictionary<int, XLFontFormat>();
+        _borderFormats = new Dictionary<int, XLBorderFormat>();
     }
 
-    internal XLStyleKey ApplyFontFormat(int fontId, ref XLStyleKey xlStyle)
+    internal XLStyleKey ApplyFontFormat(int fontId, ref XLStyleKey styleKey)
     {
         var fontFormat = _fontFormats[fontId];
-        var xlFont = fontFormat.ApplyTo(xlStyle.Font);
-        return xlStyle with { Font = xlFont };
+        var fontKey = fontFormat.ApplyTo(styleKey.Font);
+        return styleKey with { Font = fontKey };
+    }
+
+    internal XLStyleKey ApplyBorderFormat(int borderId, ref XLStyleKey styleKey)
+    {
+        var borderFormat = _borderFormats[borderId];
+        var borderKey = borderFormat.ApplyTo(styleKey.Border);
+        return styleKey with { Border = borderKey };
     }
 
     internal void AddFontFormat(XLFontFormat fontFormat)
@@ -33,13 +43,20 @@ internal class XLWorkbookStyles
         _fontFormats.Add(_fontFormats.Count, fontFormat);
     }
 
-    internal void AddFormat(uint? fontId)
+    internal void AddBorderFormat(XLBorderFormat borderFormat)
+    {
+        _borderFormats.Add(_borderFormats.Count, borderFormat);
+    }
+
+    internal void AddFormat(uint? fontId, uint? borderId)
     {
         var xfId = _masterFormats.Count;
         XLFontFormat? font = fontId is not null ? _fontFormats[checked((int)fontId)] : null;
+        XLBorderFormat? border = borderId is not null ? _borderFormats[checked((int)borderId)] : null;
         _masterFormats.Add(xfId, new XLCellFormat
         {
-            Font = font
+            Font = font,
+            Border = border,
         });
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1211,20 +1211,14 @@ namespace ClosedXML.Excel
                 xlStyle = xlStyle with { Alignment = xlAlignment };
             }
 
-            if (UInt32HasValue(cellFormat.BorderId))
-            {
-                uint borderId = cellFormat.BorderId.Value;
-                var border = (Border)borders.ElementAt((Int32)borderId);
-                if (border is not null)
-                {
-                    var xlBorder = OpenXmlHelper.BorderToClosedXml(border, xlStyle.Border);
-                    xlStyle = xlStyle with { Border = xlBorder };
-                }
-            }
-
             if (cellFormat.FontId?.Value is { } fontId)
             {
-                xlStyle = styles.ApplyFontFormat((int)fontId, ref xlStyle);
+                xlStyle = styles.ApplyFontFormat(checked((int)fontId), ref xlStyle);
+            }
+
+            if (cellFormat.BorderId?.Value is { } borderId)
+            {
+                xlStyle = styles.ApplyBorderFormat(checked((int)borderId), ref xlStyle);
             }
 
             if (UInt32HasValue(cellFormat.NumberFormatId))


### PR DESCRIPTION
Move the load of border and initialization of XLStyleKey from OpenXML SDK read method to fast-forward only StylesReader.

This also adds a formatting class for border: `XLBorderFormat`. The key difference between this one and `XLBorderValue`/`XLBorderKey` is that this is a formatting record, while `XLBorderValue`/`XLBorderKey` is a final border of applied style that could be composed from several formatting records.

`XLBorderFormat` could also be used for differential formatting.