### PR TITLE
Load fill formatting through StylesReader

### DIFF
--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -116,8 +116,10 @@ public class Program
             .AddSimpleTypeEnum("ST_VerticalAlignment", "XLAlignmentVerticalValues", "bottom", "XLAlignmentVerticalValues.Bottom")
             .AddSimpleTypeEnum("ST_TableStyleType", "XLTableStyleType")
             .AddComplexTypeMapping("CT_Color", "XLColor")
-            //.AddComplexTypeMapping("CT_GradientStop", "(double Value, XLColor Color)")
+            .AddComplexTypeMapping("CT_GradientStop", "(FractionOfOne Value, XLColor Color)")
             .AddComplexTypeMapping("CT_BorderPr", "XLBorderLine")
+            .AddComplexTypeMapping("CT_PatternFill", "XLFillFormat")
+            .AddComplexTypeMapping("CT_GradientFill", "XLFillFormat")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ClosedXML.Excel;
+using ClosedXML.Excel.IO;
+using ClosedXML.IO;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.IO;
+
+[TestFixture]
+internal class StylesReaderTests
+{
+    [Test]
+    public void Can_read_empty_fill()
+    {
+        AssertFills("<fill/>", styles =>
+        {
+            var fill = styles.Fills.Single().Value;
+            Assert.Null(fill.Pattern);
+            Assert.Null(fill.LinearGradient);
+            Assert.Null(fill.PathGradient);
+        });
+    }
+
+    [Test]
+    public void Can_read_pattern_fill()
+    {
+        AssertFills(
+            """
+            <fill>
+              <patternFill patternType="lightGrid">
+                <bgColor rgb="FF804000"/>
+              </patternFill>
+            </fill>
+            """,
+            styles =>
+        {
+            var fill = styles.Fills.Single().Value;
+            Assert.NotNull(fill.Pattern);
+            Assert.AreEqual(XLFillPatternValues.LightGrid, fill.Pattern.PatternType);
+            Assert.AreEqual(XLColor.NoColor, fill.Pattern.PatternColor);
+            Assert.AreEqual(XLColor.FromRgb(0x804000), fill.Pattern.BackgroundColor);
+        });
+    }
+
+    [Test]
+    public void Can_read_linear_gradient_fill()
+    {
+        AssertFills(
+            """
+            <fill>
+              <gradientFill degree="90">
+                <stop position="0">
+                  <color rgb="FF92D050"/>
+                </stop>
+                <stop position="1">
+                  <color rgb="FF0070C0"/>
+                </stop>
+              </gradientFill>
+            </fill>
+            """,
+            styles =>
+            {
+                var linearGradient = styles.Fills.Single().Value.LinearGradient;
+                Assert.NotNull(linearGradient);
+                Assert.AreEqual(90, linearGradient.Degrees);
+                Assert.That(linearGradient.Stops, Is.EquivalentTo(new Dictionary<FractionOfOne, XLColor>
+                {
+                    { 0, XLColor.FromRgb(0x92D050) },
+                    { 1, XLColor.FromRgb(0x0070C0) }
+                }));
+            });
+    }
+
+    [Test]
+    public void Can_read_path_gradient_fill()
+    {
+        AssertFills(
+            """
+            <fill>
+              <gradientFill type="path" left="0.5" right="0.25" top="0.125" bottom="0.75">
+                <stop position="0">
+                  <color theme="0"/>
+                </stop>
+                <stop position="1">
+                  <color theme="4"/>
+                </stop>
+              </gradientFill>
+            </fill>
+            """,
+            styles =>
+            {
+                var pathGradient = styles.Fills.Single().Value.PathGradient;
+                Assert.NotNull(pathGradient);
+                Assert.AreEqual(0.5, pathGradient.InnerLeft);
+                Assert.AreEqual(0.25, pathGradient.InnerRight);
+                Assert.AreEqual(0.125, pathGradient.InnerTop);
+                Assert.AreEqual(0.75, pathGradient.InnerBottom);
+                Assert.That(pathGradient.Stops, Is.EquivalentTo(new Dictionary<FractionOfOne, XLColor>
+                {
+                    { 0, XLColor.FromTheme(XLThemeColor.Background1) },
+                    { 1, XLColor.FromTheme(XLThemeColor.Accent1) },
+                }));
+            });
+    }
+
+    private static void AssertFills(string fillsXml, Action<XLWorkbookStyles> assert)
+    {
+        var xml = $"""
+                   <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                     <fills>
+                       {fillsXml}
+                     </fills>
+                   </styleSheet>
+                   """;
+        using var stream = new MemoryStream(XLHelper.NoBomUTF8.GetBytes(xml));
+        using var xmlTreeReader = new XmlTreeReader(stream, XmlToEnumMapper.Instance, false);
+        var styles = new XLWorkbookStyles();
+        var reader = new StylesReader(xmlTreeReader, styles);
+        reader.Load();
+        assert(styles);
+    }
+}

--- a/ClosedXML/Excel/Coordinates/FractionOfOne.cs
+++ b/ClosedXML/Excel/Coordinates/FractionOfOne.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Represents a percentage position from 0 to 1 represented as a double (=inherently imprecise).
+/// In most cases, it represents a position relative to a different size. Some other percentage
+/// that are also limited to values 0%-100% often have a fixed precision (e.g.,
+/// <c>ST_PositiveFixedPercentage</c> has precision of 1/1000).
+/// </summary>
+internal readonly record struct FractionOfOne : IEquatable<double>
+{
+    private FractionOfOne(double value)
+    {
+        if (double.IsInfinity(value) || double.IsNaN(value) || value is < 0 or > 1)
+            throw new ArgumentOutOfRangeException(nameof(value), "Value must be between 0 and 1.");
+
+        Value = value;
+    }
+
+    public double Value { get; }
+
+    public static implicit operator FractionOfOne(double value) => new(value);
+
+    public bool Equals(double other)
+    {
+        return Value.Equals(other);
+    }
+}

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -1,5 +1,8 @@
 using ClosedXML.Excel.Formatting;
 using ClosedXML.IO;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace ClosedXML.Excel.IO;
 
@@ -107,6 +110,53 @@ internal partial class StylesReader
         _styles.AddFontFormat(format);
     }
 
+    partial void OnFillParsed(XLFillFormat? patternFill, XLFillFormat? gradientFill)
+    {
+        _styles.AddFillFormat(patternFill ?? gradientFill ?? XLFillFormat.Empty);
+    }
+
+    private XLFillFormat OnPatternFillParsed(XLColor? fgColor, XLColor? bgColor, XLFillPatternValues? patternType)
+    {
+        var patternFill = new XLPatternFill
+        {
+            PatternColor = fgColor ?? XLColor.NoColor,
+            BackgroundColor = bgColor ?? XLColor.NoColor,
+            PatternType = patternType ?? XLFillPatternValues.None,
+        };
+        return new XLFillFormat(patternFill);
+    }
+
+    private XLFillFormat OnGradientFillParsed(List<(FractionOfOne Value, XLColor Color)> stop, XLGradientType type, double degree, double left, double right, double top, double bottom)
+    {
+        var stops = stop.ToDictionary(x => x.Value, x => x.Color);
+        switch (type)
+        {
+            case XLGradientType.Linear:
+                return new XLFillFormat(new XLLinearGradientFill
+                {
+                    Stops = stops,
+                    Degrees = degree,
+                });
+            case XLGradientType.Path:
+                return new XLFillFormat(new XLPathGradientFill
+                {
+                    Stops = stops,
+                    InnerLeft = left,
+                    InnerRight = right,
+                    InnerTop = top,
+                    InnerBottom = bottom
+                });
+            default:
+                throw new UnreachableException();
+        }
+    }
+
+    private (FractionOfOne Position, XLColor Color) OnGradientStopParsed(XLColor color, double position)
+    {
+        // Spec requires stop positions to be 0..1, but doesn't have a type for that. Excel repairs workbook when it receives values outside 0..1.
+        return (position, color);
+    }
+
     partial void OnBorderParsed(XLBorderLine? left, XLBorderLine? right, XLBorderLine? top, XLBorderLine? bottom, XLBorderLine? diagonal, XLBorderLine? vertical, XLBorderLine? horizontal, bool? diagonalUp, bool? diagonalDown, bool outline)
     {
         var borderFormat = new XLBorderFormat
@@ -150,7 +200,7 @@ internal partial class StylesReader
         if (_insideCellXfs)
         {
             // We are in cellXfs
-            _styles.AddFormat(fontId, borderId);
+            _styles.AddFormat(fontId, fillId, borderId);
         }
     }
 

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -111,21 +111,23 @@ internal partial class StylesReader
 
     private void ParseFill(string elementName)
     {
+        XLFillFormat? patternFill = null;
+        XLFillFormat? gradientFill = null;
         if (_reader.TryOpen("patternFill", _ns))
         {
-            ParsePatternFill("patternFill");
+            patternFill = ParsePatternFill("patternFill");
         }
         else if (_reader.TryOpen("gradientFill", _ns))
         {
-            ParseGradientFill("gradientFill");
+            gradientFill = ParseGradientFill("gradientFill");
         }
         _reader.Close(elementName, _ns);
-        OnFillParsed();
+        OnFillParsed(patternFill, gradientFill);
     }
 
-    partial void OnFillParsed();
+    partial void OnFillParsed(XLFillFormat? patternFill, XLFillFormat? gradientFill);
 
-    private void ParsePatternFill(string elementName)
+    private XLFillFormat ParsePatternFill(string elementName)
     {
         var patternType = _reader.GetOptionalEnum<XLFillPatternValues>("patternType");
         XLColor? fgColor = default;
@@ -139,12 +141,10 @@ internal partial class StylesReader
             bgColor = ParseColor("bgColor");
         }
         _reader.Close(elementName, _ns);
-        OnPatternFillParsed(fgColor, bgColor, patternType);
+        return OnPatternFillParsed(fgColor, bgColor, patternType);
     }
 
-    partial void OnPatternFillParsed(XLColor? fgColor, XLColor? bgColor, XLFillPatternValues? patternType);
-
-    private void ParseGradientFill(string elementName)
+    private XLFillFormat ParseGradientFill(string elementName)
     {
         var type = _reader.GetOptionalEnum<XLGradientType>("type") ?? XLGradientType.Linear;
         var degree = _reader.GetOptionalDouble("degree") ?? 0;
@@ -152,26 +152,23 @@ internal partial class StylesReader
         var right = _reader.GetOptionalDouble("right") ?? 0;
         var top = _reader.GetOptionalDouble("top") ?? 0;
         var bottom = _reader.GetOptionalDouble("bottom") ?? 0;
+        var stop = new List<(FractionOfOne Value, XLColor Color)>();
         while (_reader.TryOpen("stop", _ns))
         {
-            ParseGradientStop("stop");
+            stop.Add(ParseGradientStop("stop"));
         }
         _reader.Close(elementName, _ns);
-        OnGradientFillParsed(type, degree, left, right, top, bottom);
+        return OnGradientFillParsed(stop, type, degree, left, right, top, bottom);
     }
 
-    partial void OnGradientFillParsed(XLGradientType type, double degree, double left, double right, double top, double bottom);
-
-    private void ParseGradientStop(string elementName)
+    private (FractionOfOne Value, XLColor Color) ParseGradientStop(string elementName)
     {
         var position = _reader.GetDouble("position");
         _reader.Open("color", _ns);
         var color = ParseColor("color");
         _reader.Close(elementName, _ns);
-        OnGradientStopParsed(color, position);
+        return OnGradientStopParsed(color, position);
     }
-
-    partial void OnGradientStopParsed(XLColor color, double position);
 
     private void ParseBorders(string elementName)
     {

--- a/ClosedXML/Excel/IO/XmlToEnumMapper.cs
+++ b/ClosedXML/Excel/IO/XmlToEnumMapper.cs
@@ -160,6 +160,13 @@ internal sealed class XmlToEnumMapper : IEnumMapper
             { "pageFieldValues", XLTableStyleType.PageFieldValues },
         });
 
+        // ST_GradientType
+        builder.Add(new Dictionary<string, XLGradientType>
+        {
+            { "linear", XLGradientType.Linear },
+            { "path", XLGradientType.Path }
+        });
+
         return builder.Build();
     }
 

--- a/ClosedXML/Excel/Style/Formatting/XLBorderFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderFormat.cs
@@ -35,7 +35,7 @@ internal record XLBorderFormat
 
     public required bool Outline { get; init; }
 
-    public XLBorderKey ApplyTo(XLBorderKey borderKey)
+    internal XLBorderKey ApplyTo(XLBorderKey borderKey)
     {
         if (Left is not null)
             borderKey = borderKey with { LeftBorder = Left.Value.Style, LeftBorderColor = Left.Value.Color.Key };

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -21,5 +21,7 @@ internal readonly record struct XLCellFormat
 
     public XLBorderFormat? Border { get; init; }
 
+    public XLFillFormat? Fill { get; init; }
+
     // TODO: Add remaining properties. For now only font
 }

--- a/ClosedXML/Excel/Style/Formatting/XLFillFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFillFormat.cs
@@ -1,0 +1,71 @@
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// A fill formatting. Fill can have at most one pattern that specifies how to fill a cell.
+/// </summary>
+internal record XLFillFormat
+{
+    public static readonly XLFillFormat Empty = new(null, null, null);
+
+    public XLFillFormat(XLPatternFill pattern)
+        : this(pattern, null, null)
+    {
+    }
+
+    public XLFillFormat(XLLinearGradientFill linearGradient)
+        : this(null, linearGradient, null)
+    {
+    }
+
+    public XLFillFormat(XLPathGradientFill pathGradient)
+        : this(null, null, pathGradient)
+    {
+    }
+
+    private XLFillFormat(XLPatternFill? pattern, XLLinearGradientFill? linearGradient, XLPathGradientFill? pathGradient)
+    {
+        Pattern = pattern;
+        LinearGradient = linearGradient;
+        PathGradient = pathGradient;
+    }
+
+    public XLPatternFill? Pattern { get; }
+
+    public XLLinearGradientFill? LinearGradient { get; }
+
+    public XLPathGradientFill? PathGradient { get; }
+
+    internal XLFillKey ApplyTo(XLFillKey fillKey)
+    {
+        // TODO: XLFillKey doesn't have structure to hold other gradient types. For now, keep original logic.
+        if (Pattern is null)
+            return fillKey;
+
+        switch (Pattern.PatternType)
+        {
+            case XLFillPatternValues.Solid:
+                // ISO-29500: For solid cell fills (no pattern), fgColor is used.
+                // That makes sense, because solid pattern means the pattern color fully covers
+                // everything, but the historical ClosedXML code expects color for solid to be
+                // in the background color, so keep it for now.
+                fillKey = new XLFillKey
+                {
+                    PatternType = Pattern.PatternType,
+                    PatternColor = XLColor.NoColor.Key,
+                    BackgroundColor = Pattern.PatternColor.Key
+                };
+                break;
+            default:
+                fillKey = new XLFillKey
+                {
+                    PatternType = Pattern.PatternType,
+                    PatternColor = Pattern.PatternColor.Key,
+                    BackgroundColor = Pattern.BackgroundColor.Key
+                };
+                break;
+        }
+
+        return fillKey;
+    }
+}
+

--- a/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
@@ -35,7 +35,7 @@ internal readonly record struct XLFontFormat
 
     public required XLFontScheme? Scheme { get; init; }
 
-    public XLFontKey ApplyTo(XLFontKey nf)
+    internal XLFontKey ApplyTo(XLFontKey nf)
     {
         // No Outline, Condense or Extend
         if (Name is not null)

--- a/ClosedXML/Excel/Style/Formatting/XLLinearGradientFill.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLLinearGradientFill.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// A linear gradient fill format of a cell.
+/// </summary>
+internal record XLLinearGradientFill
+{
+    /// <summary>
+    /// The key is a position of color gradient from position 0 to 1. If stops are not available
+    /// for values for 0 and 1, the gradient uses black color for them. The collection can be empty.
+    /// </summary>
+    public required IReadOnlyDictionary<FractionOfOne, XLColor> Stops { get; init; }
+
+    public required double Degrees { get; init; }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLPathGradientFill.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLPathGradientFill.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// A path gradient fill format for a cell. The gradient has a shape of two nested rectangles,
+/// where the outer rectangle is represented by cell borders and inner rectangle is defined by
+/// the gradient properties (<see cref="InnerLeft"/>, <see cref="InnerRight"/>, <see cref="InnerTop"/>
+/// and <see cref="InnerBottom"/>). The area inside the inner rectangle is filled by a color
+/// at stop position 0 and the area between inner rectangle and outer rectangle has a gradient
+/// color determined by the colors <see cref="Stops"/> collection (from color at position 0 at
+/// the inner rectangle to the color at position 1 at the outer rectangle).
+/// </summary>
+internal record XLPathGradientFill
+{
+    /// <summary>
+    /// The key is a position of color gradient from position 0 to 1. If stops are not available
+    /// for values for 0 and 1, the gradient uses black color for them. The collection can be empty.
+    /// </summary>
+    public required IReadOnlyDictionary<FractionOfOne, XLColor> Stops { get; init; }
+
+    /// <summary>
+    /// A fractional position of the left side of inner rectangle inside the outer rectangle.
+    /// </summary>
+    public required FractionOfOne InnerLeft { get; init; }
+
+    /// <summary>
+    /// A fractional position of the right side of inner rectangle inside the outer rectangle.
+    /// </summary>
+    public required FractionOfOne InnerRight { get; init; }
+
+    /// <summary>
+    /// A fractional position of the top side of inner rectangle inside the outer rectangle.
+    /// </summary>
+    public required FractionOfOne InnerTop { get; init; }
+
+    /// <summary>
+    /// A fractional position of the bottom side of inner rectangle inside the outer rectangle.
+    /// </summary>
+    public required FractionOfOne InnerBottom { get; init; }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLPatternFill.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLPatternFill.cs
@@ -1,0 +1,23 @@
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// A pattern fill format.
+/// </summary>
+internal record XLPatternFill
+{
+    /// <summary>
+    /// Foreground color of the pattern (i.e., if pattern is a grid, this is the color to draw
+    /// lines of the grid).
+    /// </summary>
+    public required XLColor PatternColor { get; init; }
+
+    /// <summary>
+    /// Background color of the pattern.
+    /// </summary>
+    public required XLColor BackgroundColor { get; init; }
+
+    /// <summary>
+    /// Shape of the pattern.
+    /// </summary>
+    public required XLFillPatternValues PatternType { get; init; }
+}

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -15,20 +15,32 @@ internal class XLWorkbookStyles
 
     private readonly Dictionary<int, XLFontFormat> _fontFormats;
 
+    private readonly Dictionary<int, XLFillFormat> _fillFormats;
+
     private readonly Dictionary<int, XLBorderFormat> _borderFormats;
 
     internal XLWorkbookStyles()
     {
         _masterFormats = new Dictionary<int, XLCellFormat>();
         _fontFormats = new Dictionary<int, XLFontFormat>();
+        _fillFormats = new Dictionary<int, XLFillFormat>();
         _borderFormats = new Dictionary<int, XLBorderFormat>();
     }
+
+    internal IReadOnlyDictionary<int, XLFillFormat> Fills => _fillFormats;
 
     internal XLStyleKey ApplyFontFormat(int fontId, ref XLStyleKey styleKey)
     {
         var fontFormat = _fontFormats[fontId];
         var fontKey = fontFormat.ApplyTo(styleKey.Font);
         return styleKey with { Font = fontKey };
+    }
+
+    internal XLStyleKey ApplyPatternFormat(int fillId, ref XLStyleKey styleKey)
+    {
+        var fillFormat = _fillFormats[fillId];
+        var fillKey = fillFormat.ApplyTo(styleKey.Fill);
+        return styleKey with { Fill = fillKey };
     }
 
     internal XLStyleKey ApplyBorderFormat(int borderId, ref XLStyleKey styleKey)
@@ -43,19 +55,26 @@ internal class XLWorkbookStyles
         _fontFormats.Add(_fontFormats.Count, fontFormat);
     }
 
+    internal void AddFillFormat(XLFillFormat fillFormat)
+    {
+        _fillFormats.Add(_fillFormats.Count, fillFormat);
+    }
+
     internal void AddBorderFormat(XLBorderFormat borderFormat)
     {
         _borderFormats.Add(_borderFormats.Count, borderFormat);
     }
 
-    internal void AddFormat(uint? fontId, uint? borderId)
+    internal void AddFormat(uint? fontId, uint? fillId, uint? borderId)
     {
         var xfId = _masterFormats.Count;
         XLFontFormat? font = fontId is not null ? _fontFormats[checked((int)fontId)] : null;
-        XLBorderFormat? border = borderId is not null ? _borderFormats[checked((int)borderId)] : null;
+        var fill = fillId is not null ? _fillFormats[checked((int)fillId)] : null;
+        var border = borderId is not null ? _borderFormats[checked((int)borderId)] : null;
         _masterFormats.Add(xfId, new XLCellFormat
         {
             Font = font,
+            Fill = fill,
             Border = border,
         });
     }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1193,17 +1193,6 @@ namespace ClosedXML.Excel
                 xlStyle = xlStyle with { Protection = xlProtection };
             }
 
-            if (UInt32HasValue(cellFormat.FillId))
-            {
-                var fill = (Fill)fills.ElementAt((Int32)cellFormat.FillId.Value);
-                if (fill.PatternFill != null)
-                {
-                    var xlFill = new XLFill();
-                    OpenXmlHelper.LoadFill(fill, xlFill, differentialFillFormat: false);
-                    xlStyle = xlStyle with { Fill = xlFill.Key };
-                }
-            }
-
             var alignment = cellFormat.Alignment;
             if (alignment != null)
             {
@@ -1214,6 +1203,11 @@ namespace ClosedXML.Excel
             if (cellFormat.FontId?.Value is { } fontId)
             {
                 xlStyle = styles.ApplyFontFormat(checked((int)fontId), ref xlStyle);
+            }
+
+            if (cellFormat.FillId?.Value is { } fillId)
+            {
+                xlStyle = styles.ApplyPatternFormat(checked((int)fillId), ref xlStyle);
             }
 
             if (cellFormat.BorderId?.Value is { } borderId)


### PR DESCRIPTION
This is another step towards full representation of data from styles part and OpenXML SDK removal.

The fill formatting records are now read through generated fast-forward reader and applied to current `XLFillKey`. The fill formatting records can be later used for differential formats.

I have split the gradient from `CT_GradientFill` into two classes. There already is `CT_PatternFill`, so there was always going to be multiple potential fills anyway. So there is pattern fill, linear gradient fill and path gradient fill.

There were no improvements to current `XLFillKey` (i.e. it still can't represent gradient). I will need to think far more about formatting/style representation and it is going to be refactored in not-too-distant future.
