### PR TITLE
Load alignment and protection through StylesReader

### DIFF
--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -122,6 +122,7 @@ public class Program
             .AddComplexTypeMapping("CT_GradientFill", "XLFillFormat")
             .AddComplexTypeMapping("CT_NumFmt", "(int NumFmtId, string FormatCode)")
             .AddComplexTypeMapping("CT_CellAlignment", "XLAlignmentFormat")
+            .AddComplexTypeMapping("CT_CellProtection", "XLProtectionFormat")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -144,7 +144,7 @@ public class Program
             .AddParseMethod("CT_Xf")
             .AddParseMethod("CT_CellAlignment")
             .AddParseMethod("CT_CellProtection")
-            //.AddParseMethod("CT_CellXfs")
+            .AddParseMethod("CT_CellXfs")
             .AddParseMethod("CT_CellStyles")
             .AddParseMethod("CT_CellStyle")
             .AddParseMethod("CT_Dxfs")

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -121,6 +121,7 @@ public class Program
             .AddComplexTypeMapping("CT_PatternFill", "XLFillFormat")
             .AddComplexTypeMapping("CT_GradientFill", "XLFillFormat")
             .AddComplexTypeMapping("CT_NumFmt", "(int NumFmtId, string FormatCode)")
+            .AddComplexTypeMapping("CT_CellAlignment", "XLAlignmentFormat")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")

--- a/ClosedXML.IO/XmlTreeReader.cs
+++ b/ClosedXML.IO/XmlTreeReader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
@@ -117,6 +118,8 @@ public sealed class XmlTreeReader : IDisposable
     /// </summary>
     private bool _inLookup = true;
 
+    private readonly List<string> _context = new();
+
     public XmlTreeReader(Stream stream, IEnumMapper enumMapper, bool suppressFormatErrors)
     {
         _reader = XmlReader.Create(stream, Settings);
@@ -130,6 +133,13 @@ public sealed class XmlTreeReader : IDisposable
         _enumMapper = enumMapper;
         SuppressFormatErrors = suppressFormatErrors;
     }
+
+    /// <summary>
+    /// Returns names of elements from currently processed element to root. The <c>On*Parsed</c>
+    /// hook is called after processed element is closed. Therefore when the context is inspected
+    /// in the <c>On*Parsed</c> hook, it doesn't contain the name of element that was just processed.
+    /// </summary>
+    public IReadOnlyList<string> Context => _context;
 
     /// <summary>
     /// Get name of current element (lookup/processing). It includes an alias for ns.
@@ -156,6 +166,7 @@ public sealed class XmlTreeReader : IDisposable
         {
             // Element has been opened, so it should be processed.
             SwitchToProcessing();
+            _context.Add(localName);
             return true;
         }
 
@@ -176,6 +187,7 @@ public sealed class XmlTreeReader : IDisposable
         // as "done." Be lazy, e.g. last element of a document doesn't have next element. If
         // parsing logic needs further elements, it will read them when they are needed.
         SwitchToProcessing();
+        _context.RemoveAt(_context.Count - 1);
         return true;
     }
 

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -125,7 +125,7 @@ internal class StylesReaderTests
     {
         AssertCellXfs(
             """
-            <alignment horizontal="center" 
+            <alignment horizontal="center"
                        vertical="top"
                        textRotation="45"
                        wrapText="1"
@@ -149,6 +149,22 @@ internal class StylesReaderTests
                 Assert.IsTrue(alignment.JustifyLastLine);
                 Assert.IsTrue(alignment.ShrinkToFit);
                 Assert.AreEqual(XLAlignmentReadingOrderValues.RightToLeft, alignment.ReadingOrder);
+            });
+    }
+
+    [Test]
+    public void Can_read_protection()
+    {
+        AssertCellXfs(
+            """
+            <protection locked="false" hidden="1"/>
+            """,
+            styles =>
+            {
+                var protection = styles.CellFormats[0].Protection;
+                Assert.NotNull(protection);
+                Assert.IsFalse(protection.Locked);
+                Assert.IsTrue(protection.Hidden);
             });
     }
 

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -120,6 +120,38 @@ internal class StylesReaderTests
             });
     }
 
+    [Test]
+    public void Can_read_alignment()
+    {
+        AssertCellXfs(
+            """
+            <alignment horizontal="center" 
+                       vertical="top"
+                       textRotation="45"
+                       wrapText="1"
+                       indent="7"
+                       relativeIndent="4"
+                       justifyLastLine="1"
+                       shrinkToFit="1"
+                       readingOrder="2"
+                       />
+            """,
+            styles =>
+            {
+                var alignment = styles.CellFormats[0].Alignment;
+                Assert.NotNull(alignment);
+                Assert.AreEqual(XLAlignmentHorizontalValues.Center, alignment.Horizontal);
+                Assert.AreEqual(XLAlignmentVerticalValues.Top, alignment.Vertical);
+                Assert.AreEqual(45, alignment.TextRotation.Value);
+                Assert.IsTrue(alignment.WrapText);
+                Assert.AreEqual(7, alignment.Indent);
+                Assert.AreEqual(4, alignment.RelativeIndent);
+                Assert.IsTrue(alignment.JustifyLastLine);
+                Assert.IsTrue(alignment.ShrinkToFit);
+                Assert.AreEqual(XLAlignmentReadingOrderValues.RightToLeft, alignment.ReadingOrder);
+            });
+    }
+
     private static void AssertNumberFormats(string numberFormatsXml, Action<XLWorkbookStyles> assert)
     {
         var xml = $"""
@@ -140,6 +172,20 @@ internal class StylesReaderTests
                      <fills>
                        {fillsXml}
                      </fills>
+                   </styleSheet>
+                   """;
+        AssertFormat(assert, xml);
+    }
+
+    private static void AssertCellXfs(string cellXfsXml, Action<XLWorkbookStyles> assert)
+    {
+        var xml = $"""
+                   <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                     <cellXfs>
+                       <xf>
+                         {cellXfsXml}
+                       </xf>
+                     </cellXfs>
                    </styleSheet>
                    """;
         AssertFormat(assert, xml);

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -205,14 +205,17 @@ internal partial class StylesReader
         return new XLBorderLine(color ?? XLColor.NoColor, style);
     }
 
-    partial void OnXfParsed(XLAlignmentFormat? alignment, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
+    partial void OnXfParsed(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
     {
         // When xf is parsed, all number formats, fonts, fills and borders should already be read.
         // Skip cell style xfs for now.
         if (_reader.Context[^1] == "cellXfs")
         {
             // We are in cellXfs
-            _styles.AddFormat(fontId, fillId, borderId, alignment);
+            var fill = fillId is not null ? _styles.Fills[checked((int)fillId)] : null;
+            var border = borderId is not null ? _styles.Borders[checked((int)borderId)] : null;
+
+            _styles.AddFormat(alignment, protection, fontId, fill, border);
         }
     }
 
@@ -244,5 +247,15 @@ internal partial class StylesReader
     private void ParseExtensionList(string elementName)
     {
         _reader.Skip(elementName);
+    }
+
+    private XLProtectionFormat OnCellProtectionParsed(bool? locked, bool? hidden)
+    {
+        // Defaults are from OI-29500
+        return new XLProtectionFormat
+        {
+            Locked = locked ?? true,
+            Hidden = hidden ?? false
+        };
     }
 }

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -12,12 +12,6 @@ internal partial class StylesReader
     private readonly XLWorkbookStyles _styles;
     private readonly string _ns = OpenXmlConst.Main2006SsNs;
 
-    /// <summary>
-    /// A marker for <c>xf</c>> parsing. The <c>cellStyleXfs</c> and <c>cellXfs</c> both use same
-    /// element and even same name. This flag is used on the hook to differentiate them.
-    /// </summary>
-    private bool _insideCellXfs = false;
-
     public StylesReader(XmlTreeReader reader, XLWorkbookStyles styles)
     {
         _reader = reader;
@@ -210,24 +204,11 @@ internal partial class StylesReader
         return new XLBorderLine(color ?? XLColor.NoColor, style);
     }
 
-    private void ParseCellXfs(string elementName)
-    {
-        _insideCellXfs = true;
-        _reader.Open("xf", _ns);
-        do
-        {
-            ParseXf("xf");
-        }
-        while (_reader.TryOpen("xf", _ns));
-        _reader.Close(elementName, _ns);
-        _insideCellXfs = false;
-    }
-
     partial void OnXfParsed(uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
     {
         // When xf is parsed, all number formats, fonts, fills and borders should already be read.
         // Skip cell style xfs for now.
-        if (_insideCellXfs)
+        if (_reader.Context[^1] == "cellXfs")
         {
             // We are in cellXfs
             _styles.AddFormat(fontId, fillId, borderId);

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -3,6 +3,7 @@ using ClosedXML.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using ClosedXML.Utils;
 
 namespace ClosedXML.Excel.IO;
 
@@ -204,15 +205,35 @@ internal partial class StylesReader
         return new XLBorderLine(color ?? XLColor.NoColor, style);
     }
 
-    partial void OnXfParsed(uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
+    partial void OnXfParsed(XLAlignmentFormat? alignment, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
     {
         // When xf is parsed, all number formats, fonts, fills and borders should already be read.
         // Skip cell style xfs for now.
         if (_reader.Context[^1] == "cellXfs")
         {
             // We are in cellXfs
-            _styles.AddFormat(fontId, fillId, borderId);
+            _styles.AddFormat(fontId, fillId, borderId, alignment);
         }
+    }
+
+    private XLAlignmentFormat OnCellAlignmentParsed(XLAlignmentHorizontalValues? horizontal, XLAlignmentVerticalValues vertical, uint? textRotation, bool? wrapText, uint? indent, int? relativeIndent, bool? justifyLastLine, bool? shrinkToFit, uint? readingOrder)
+    {
+        if (readingOrder is not null && readingOrder is not (0 or 1 or 2))
+            throw PartStructureException.InvalidAttributeFormat();
+
+        var normalizedTextRotation = OpenXmlHelper.NormalizeRotation(textRotation ?? 0);
+        return new XLAlignmentFormat
+        {
+            Horizontal = horizontal ?? XLAlignmentHorizontalValues.General,
+            Vertical = vertical,
+            TextRotation = new TextRotation(normalizedTextRotation),
+            WrapText = wrapText ?? false,
+            Indent = indent is not null ? checked((int)indent.Value) : 0,
+            RelativeIndent = relativeIndent ?? 0,
+            JustifyLastLine = justifyLastLine ?? false,
+            ShrinkToFit = shrinkToFit ?? false,
+            ReadingOrder = readingOrder is not null ? (XLAlignmentReadingOrderValues)readingOrder.Value : XLAlignmentReadingOrderValues.ContextDependent
+        };
     }
 
     private XLColor ParseColor(string elementName)

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -270,9 +270,10 @@ internal partial class StylesReader
         var applyBorder = _reader.GetOptionalBool("applyBorder");
         var applyAlignment = _reader.GetOptionalBool("applyAlignment");
         var applyProtection = _reader.GetOptionalBool("applyProtection");
+        XLAlignmentFormat? alignment = default;
         if (_reader.TryOpen("alignment", _ns))
         {
-            ParseCellAlignment("alignment");
+            alignment = ParseCellAlignment("alignment");
         }
         if (_reader.TryOpen("protection", _ns))
         {
@@ -283,12 +284,12 @@ internal partial class StylesReader
             ParseExtensionList("extLst");
         }
         _reader.Close(elementName, _ns);
-        OnXfParsed(numFmtId, fontId, fillId, borderId, xfId, quotePrefix, pivotButton, applyNumberFormat, applyFont, applyFill, applyBorder, applyAlignment, applyProtection);
+        OnXfParsed(alignment, numFmtId, fontId, fillId, borderId, xfId, quotePrefix, pivotButton, applyNumberFormat, applyFont, applyFill, applyBorder, applyAlignment, applyProtection);
     }
 
-    partial void OnXfParsed(uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection);
+    partial void OnXfParsed(XLAlignmentFormat? alignment, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection);
 
-    private void ParseCellAlignment(string elementName)
+    private XLAlignmentFormat ParseCellAlignment(string elementName)
     {
         var horizontal = _reader.GetOptionalEnum<XLAlignmentHorizontalValues>("horizontal");
         var vertical = _reader.GetOptionalEnum<XLAlignmentVerticalValues>("vertical") ?? XLAlignmentVerticalValues.Bottom;
@@ -300,10 +301,8 @@ internal partial class StylesReader
         var shrinkToFit = _reader.GetOptionalBool("shrinkToFit");
         var readingOrder = _reader.GetOptionalUInt("readingOrder");
         _reader.Close(elementName, _ns);
-        OnCellAlignmentParsed(horizontal, vertical, textRotation, wrapText, indent, relativeIndent, justifyLastLine, shrinkToFit, readingOrder);
+        return OnCellAlignmentParsed(horizontal, vertical, textRotation, wrapText, indent, relativeIndent, justifyLastLine, shrinkToFit, readingOrder);
     }
-
-    partial void OnCellAlignmentParsed(XLAlignmentHorizontalValues? horizontal, XLAlignmentVerticalValues vertical, uint? textRotation, bool? wrapText, uint? indent, int? relativeIndent, bool? justifyLastLine, bool? shrinkToFit, uint? readingOrder);
 
     private void ParseCellProtection(string elementName)
     {
@@ -391,9 +390,10 @@ internal partial class StylesReader
         {
             ParseFill("fill");
         }
+        XLAlignmentFormat? alignment = default;
         if (_reader.TryOpen("alignment", _ns))
         {
-            ParseCellAlignment("alignment");
+            alignment = ParseCellAlignment("alignment");
         }
         if (_reader.TryOpen("border", _ns))
         {
@@ -408,10 +408,10 @@ internal partial class StylesReader
             ParseExtensionList("extLst");
         }
         _reader.Close(elementName, _ns);
-        OnDxfParsed(numFmt);
+        OnDxfParsed(numFmt, alignment);
     }
 
-    partial void OnDxfParsed((int NumFmtId, string FormatCode)? numFmt);
+    partial void OnDxfParsed((int NumFmtId, string FormatCode)? numFmt, XLAlignmentFormat? alignment);
 
     private void ParseTableStyles(string elementName)
     {

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -315,6 +315,21 @@ internal partial class StylesReader
 
     partial void OnCellProtectionParsed(bool? locked, bool? hidden);
 
+    private void ParseCellXfs(string elementName)
+    {
+        var count = _reader.GetOptionalUInt("count");
+        _reader.Open("xf", _ns);
+        do
+        {
+            ParseXf("xf");
+        }
+        while (_reader.TryOpen("xf", _ns));
+        _reader.Close(elementName, _ns);
+        OnCellXfsParsed(count);
+    }
+
+    partial void OnCellXfsParsed(uint? count);
+
     private void ParseCellStyles(string elementName)
     {
         var count = _reader.GetOptionalUInt("count");

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -275,19 +275,20 @@ internal partial class StylesReader
         {
             alignment = ParseCellAlignment("alignment");
         }
+        XLProtectionFormat? protection = default;
         if (_reader.TryOpen("protection", _ns))
         {
-            ParseCellProtection("protection");
+            protection = ParseCellProtection("protection");
         }
         if (_reader.TryOpen("extLst", _ns))
         {
             ParseExtensionList("extLst");
         }
         _reader.Close(elementName, _ns);
-        OnXfParsed(alignment, numFmtId, fontId, fillId, borderId, xfId, quotePrefix, pivotButton, applyNumberFormat, applyFont, applyFill, applyBorder, applyAlignment, applyProtection);
+        OnXfParsed(alignment, protection, numFmtId, fontId, fillId, borderId, xfId, quotePrefix, pivotButton, applyNumberFormat, applyFont, applyFill, applyBorder, applyAlignment, applyProtection);
     }
 
-    partial void OnXfParsed(XLAlignmentFormat? alignment, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection);
+    partial void OnXfParsed(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection);
 
     private XLAlignmentFormat ParseCellAlignment(string elementName)
     {
@@ -304,15 +305,13 @@ internal partial class StylesReader
         return OnCellAlignmentParsed(horizontal, vertical, textRotation, wrapText, indent, relativeIndent, justifyLastLine, shrinkToFit, readingOrder);
     }
 
-    private void ParseCellProtection(string elementName)
+    private XLProtectionFormat ParseCellProtection(string elementName)
     {
         var locked = _reader.GetOptionalBool("locked");
         var hidden = _reader.GetOptionalBool("hidden");
         _reader.Close(elementName, _ns);
-        OnCellProtectionParsed(locked, hidden);
+        return OnCellProtectionParsed(locked, hidden);
     }
-
-    partial void OnCellProtectionParsed(bool? locked, bool? hidden);
 
     private void ParseCellXfs(string elementName)
     {
@@ -399,19 +398,20 @@ internal partial class StylesReader
         {
             ParseBorder("border");
         }
+        XLProtectionFormat? protection = default;
         if (_reader.TryOpen("protection", _ns))
         {
-            ParseCellProtection("protection");
+            protection = ParseCellProtection("protection");
         }
         if (_reader.TryOpen("extLst", _ns))
         {
             ParseExtensionList("extLst");
         }
         _reader.Close(elementName, _ns);
-        OnDxfParsed(numFmt, alignment);
+        OnDxfParsed(numFmt, alignment, protection);
     }
 
-    partial void OnDxfParsed((int NumFmtId, string FormatCode)? numFmt, XLAlignmentFormat? alignment);
+    partial void OnDxfParsed((int NumFmtId, string FormatCode)? numFmt, XLAlignmentFormat? alignment, XLProtectionFormat? protection);
 
     private void ParseTableStyles(string elementName)
     {

--- a/ClosedXML/Excel/Style/Formatting/TextRotation.cs
+++ b/ClosedXML/Excel/Style/Formatting/TextRotation.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// An angle of text rotation of a text in a cell.
+/// </summary>
+internal readonly record struct TextRotation
+{
+    public static readonly TextRotation VerticalText = new(255);
+
+    public TextRotation(int value)
+    {
+        if (value is not (>= -90 and <= 90 or 255))
+            throw new ArgumentOutOfRangeException();
+
+        Value = value;
+    }
+
+    public int Value { get; }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLAlignmentFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLAlignmentFormat.cs
@@ -1,0 +1,47 @@
+namespace ClosedXML.Excel.Formatting;
+
+internal record XLAlignmentFormat
+{
+    public required XLAlignmentHorizontalValues Horizontal { get; init; }
+
+    public required XLAlignmentVerticalValues Vertical { get; init; }
+
+    public required TextRotation TextRotation { get; init; }
+
+    /// <summary>
+    /// Should the text be line-wrapped within the cell?
+    /// </summary>
+    public required bool WrapText { get; init; }
+
+    /// <summary>
+    /// Indicates number of 3*spaces (of the normal style font) of indentation for text in a cell.
+    /// </summary>
+    public required int Indent { get; init; }
+
+    /// <summary>
+    /// Relative indentation for dxf. Indicates number of spaces to indent text in a cell.
+    /// </summary>
+    public required int RelativeIndent { get; init; }
+
+    public required bool JustifyLastLine { get; init; }
+
+    public required bool ShrinkToFit { get; init; }
+
+    public required XLAlignmentReadingOrderValues ReadingOrder { get; init; }
+
+    internal XLAlignmentKey ApplyTo(XLAlignmentKey alignmentKey)
+    {
+        return new XLAlignmentKey
+        {
+            Horizontal = Horizontal,
+            Vertical = Vertical,
+            TextRotation = TextRotation.Value,
+            WrapText = WrapText,
+            Indent = Indent,
+            RelativeIndent = RelativeIndent,
+            JustifyLastLine = JustifyLastLine,
+            ShrinkToFit = ShrinkToFit,
+            ReadingOrder = ReadingOrder
+        };
+    }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -17,11 +17,13 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal readonly record struct XLCellFormat
 {
-    public XLFontFormat? Font { get; init; }
+    public required XLFontFormat? Font { get; init; }
 
-    public XLBorderFormat? Border { get; init; }
+    public required XLBorderFormat? Border { get; init; }
 
-    public XLFillFormat? Fill { get; init; }
+    public required XLFillFormat? Fill { get; init; }
+
+    public required XLAlignmentFormat? Alignment { get; init; }
 
     // TODO: Add remaining properties. For now only font
 }

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -17,13 +17,15 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal readonly record struct XLCellFormat
 {
-    public required XLFontFormat? Font { get; init; }
+    public required XLAlignmentFormat? Alignment { get; init; }
 
-    public required XLBorderFormat? Border { get; init; }
+    public required XLProtectionFormat? Protection { get; init; }
+
+    public required XLFontFormat? Font { get; init; }
 
     public required XLFillFormat? Fill { get; init; }
 
-    public required XLAlignmentFormat? Alignment { get; init; }
+    public required XLBorderFormat? Border { get; init; }
 
     // TODO: Add remaining properties. For now only font
 }

--- a/ClosedXML/Excel/Style/Formatting/XLProtectionFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLProtectionFormat.cs
@@ -1,0 +1,17 @@
+namespace ClosedXML.Excel.Formatting;
+
+internal class XLProtectionFormat
+{
+    public required bool Locked { get; init; }
+
+    public required bool Hidden { get; init; }
+
+    internal XLProtectionKey ApplyTo(XLProtectionKey protectionKey)
+    {
+        return new XLProtectionKey
+        {
+            Locked = Locked,
+            Hidden = Hidden
+        };
+    }
+}

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -11,7 +11,7 @@ internal class XLWorkbookStyles
     /// <summary>
     /// The index is XfId, the value is formatting record.
     /// </summary>
-    private readonly Dictionary<int, XLCellFormat> _masterFormats;
+    private readonly Dictionary<int, XLCellFormat> _cellFormats;
 
     private readonly Dictionary<int, string> _numberFormats;
 
@@ -23,7 +23,7 @@ internal class XLWorkbookStyles
 
     internal XLWorkbookStyles()
     {
-        _masterFormats = new Dictionary<int, XLCellFormat>();
+        _cellFormats = new Dictionary<int, XLCellFormat>();
         _numberFormats = new Dictionary<int, string>();
         _fontFormats = new Dictionary<int, XLFontFormat>();
         _fillFormats = new Dictionary<int, XLFillFormat>();
@@ -33,6 +33,8 @@ internal class XLWorkbookStyles
     internal IReadOnlyDictionary<int, XLFillFormat> Fills => _fillFormats;
 
     internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
+
+    internal IReadOnlyDictionary<int, XLCellFormat> CellFormats => _cellFormats;
 
     internal XLStyleKey ApplyNumberFormat(int numberFormatId, ref XLStyleKey styleKey)
     {
@@ -99,17 +101,18 @@ internal class XLWorkbookStyles
         _borderFormats.Add(_borderFormats.Count, borderFormat);
     }
 
-    internal void AddFormat(uint? fontId, uint? fillId, uint? borderId)
+    internal void AddFormat(uint? fontId, uint? fillId, uint? borderId, XLAlignmentFormat? alignment)
     {
-        var xfId = _masterFormats.Count;
+        var xfId = _cellFormats.Count;
         XLFontFormat? font = fontId is not null ? _fontFormats[checked((int)fontId)] : null;
         var fill = fillId is not null ? _fillFormats[checked((int)fillId)] : null;
         var border = borderId is not null ? _borderFormats[checked((int)borderId)] : null;
-        _masterFormats.Add(xfId, new XLCellFormat
+        _cellFormats.Add(xfId, new XLCellFormat
         {
             Font = font,
             Fill = fill,
             Border = border,
+            Alignment = alignment
         });
     }
 }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -30,9 +30,13 @@ internal class XLWorkbookStyles
         _borderFormats = new Dictionary<int, XLBorderFormat>();
     }
 
+    internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
+
+    internal IReadOnlyDictionary<int, XLFontFormat> Fonts=> _fontFormats;
+
     internal IReadOnlyDictionary<int, XLFillFormat> Fills => _fillFormats;
 
-    internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
+    internal IReadOnlyDictionary<int, XLBorderFormat> Borders => _borderFormats;
 
     internal IReadOnlyDictionary<int, XLCellFormat> CellFormats => _cellFormats;
 
@@ -101,18 +105,17 @@ internal class XLWorkbookStyles
         _borderFormats.Add(_borderFormats.Count, borderFormat);
     }
 
-    internal void AddFormat(uint? fontId, uint? fillId, uint? borderId, XLAlignmentFormat? alignment)
+    internal void AddFormat(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? fontId, XLFillFormat? fill, XLBorderFormat? border)
     {
         var xfId = _cellFormats.Count;
         XLFontFormat? font = fontId is not null ? _fontFormats[checked((int)fontId)] : null;
-        var fill = fillId is not null ? _fillFormats[checked((int)fillId)] : null;
-        var border = borderId is not null ? _borderFormats[checked((int)borderId)] : null;
         _cellFormats.Add(xfId, new XLCellFormat
         {
+            Alignment = alignment,
+            Protection = protection,
             Font = font,
             Fill = fill,
             Border = border,
-            Alignment = alignment
         });
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1188,11 +1188,11 @@ namespace ClosedXML.Excel
                 xlStyle = xlStyle with { Protection = xlProtection };
             }
 
-            var alignment = cellFormat.Alignment;
-            if (alignment != null)
+            var xlCellFormat = styles.CellFormats[styleIndex];
+            if (xlCellFormat.Alignment is not null)
             {
-                var xlAlignment = OpenXmlHelper.AlignmentToClosedXml(alignment, xlStyle.Alignment);
-                xlStyle = xlStyle with { Alignment = xlAlignment };
+                var alignmentKey = xlCellFormat.Alignment.ApplyTo(xlStyle.Alignment);
+                xlStyle = xlStyle with { Alignment = alignmentKey };
             }
 
             if (cellFormat.NumberFormatId?.Value is { } numberFormatId)

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -1178,21 +1178,17 @@ namespace ClosedXML.Excel
             var xlIncludeQuotePrefix = OpenXmlHelper.GetBooleanValueAsBool(cellFormat.QuotePrefix, false);
             xlStyle = xlStyle with { IncludeQuotePrefix = xlIncludeQuotePrefix };
 
-            if (cellFormat.ApplyProtection != null)
-            {
-                var protection = cellFormat.Protection;
-                var xlProtection = XLProtectionValue.Default.Key;
-                if (protection is not null)
-                    xlProtection = OpenXmlHelper.ProtectionToClosedXml(protection, xlProtection);
-
-                xlStyle = xlStyle with { Protection = xlProtection };
-            }
-
             var xlCellFormat = styles.CellFormats[styleIndex];
             if (xlCellFormat.Alignment is not null)
             {
                 var alignmentKey = xlCellFormat.Alignment.ApplyTo(xlStyle.Alignment);
                 xlStyle = xlStyle with { Alignment = alignmentKey };
+            }
+
+            if (xlCellFormat.Protection is not null)
+            {
+                var protectionKey = xlCellFormat.Protection.ApplyTo(xlStyle.Protection);
+                xlStyle = xlStyle with { Protection = protectionKey };
             }
 
             if (cellFormat.NumberFormatId?.Value is { } numberFormatId)

--- a/ClosedXML/Utils/OpenXmlHelper.cs
+++ b/ClosedXML/Utils/OpenXmlHelper.cs
@@ -237,7 +237,7 @@ namespace ClosedXML.Utils
                 ReadingOrder = alignment.ReadingOrder?.Value.ToClosedXml() ?? defaultAlignment.ReadingOrder,
                 WrapText = alignment.WrapText?.Value ?? defaultAlignment.WrapText,
                 TextRotation = alignment.TextRotation is not null
-                    ? OpenXmlHelper.GetClosedXmlTextRotation(alignment)
+                    ? NormalizeRotation(alignment.TextRotation?.Value ?? 0)
                     : defaultAlignment.TextRotation,
                 ShrinkToFit = alignment.ShrinkToFit?.Value ?? defaultAlignment.ShrinkToFit,
                 RelativeIndent = alignment.RelativeIndent?.Value ?? defaultAlignment.RelativeIndent,
@@ -432,17 +432,14 @@ namespace ClosedXML.Utils
             }
         }
 
-        internal static int GetClosedXmlTextRotation(Alignment alignment)
+        internal static int NormalizeRotation(uint textRotation)
         {
-            if (alignment.TextRotation is null)
-                return 0;
-
-            var textRotation = (int)alignment.TextRotation.Value;
             return textRotation switch
             {
+                <= 90 => (int)textRotation,
+                <= 180 => 90 - (int)textRotation,
                 255 => 255,
-                > 90 => 90 - textRotation,
-                _ => textRotation
+                _ => throw new ArgumentOutOfRangeException()
             };
         }
 


### PR DESCRIPTION
Another step toward full representation of styles part in ClosedXML, combined with incremental replacement of OpenXML SDK.

Load the alignment and protection of cell styles through StylesReader and apply it to the XLStyleKey during style loading.