### PR TITLE
Load cell formats through StylesReader

### DIFF
--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -129,7 +129,7 @@ public class Program
             .AddUsing("System.Collections.Generic")
             .AddUsing("ClosedXML.IO")
             .AddUsing("ClosedXML.Excel.Formatting")
-            .AddParseMethod("CT_Stylesheet")
+            //.AddParseMethod("CT_Stylesheet")
             .AddParseMethod("CT_NumFmts")
             .AddParseMethod("CT_NumFmt")
             .AddParseMethod("CT_Fonts")

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -27,6 +27,114 @@ internal class StylesReaderTests
     }
 
     [Test]
+    public void Can_read_empty_font()
+    {
+        // Empty font is valid, it will just inherit everything
+        AssertFonts("<font/>", styles =>
+        {
+            var font = styles.Fonts.Single().Value;
+            Assert.Null(font.Name);
+            Assert.Null(font.Charset);
+            Assert.Null(font.Family);
+            Assert.Null(font.Bold);
+            Assert.Null(font.Italic);
+            Assert.Null(font.Strikethrough);
+            Assert.Null(font.Outline);
+            Assert.Null(font.Shadow);
+            Assert.Null(font.Condense);
+            Assert.Null(font.Extend);
+            Assert.Null(font.Color);
+            Assert.Null(font.Size);
+            Assert.Null(font.Underline);
+            Assert.Null(font.VerticalAlignment);
+            Assert.Null(font.Scheme);
+        });
+    }
+
+    [Test]
+    public void Can_read_font()
+    {
+        AssertFonts(
+            """
+            <font>
+              <b/>
+              <i/>
+              <strike/>
+              <condense/>
+              <extend/>
+              <outline/>
+              <shadow/>
+              <u val="double"/>
+              <vertAlign val="superscript"/>
+              <sz val="8.5"/>
+              <color rgb="FF802010"/>
+              <name val="Calibri"/>
+              <family val="2"/>
+              <charset val="128"/>
+              <scheme val="none"/>
+            </font>
+            """, styles =>
+        {
+            var font = styles.Fonts.Single().Value;
+            Assert.AreEqual("Calibri", font.Name);
+            Assert.AreEqual(XLFontCharSet.ShiftJIS, font.Charset);
+            Assert.AreEqual(XLFontFamilyNumberingValues.Swiss, font.Family);
+            Assert.IsTrue(font.Bold);
+            Assert.IsTrue(font.Italic);
+            Assert.IsTrue(font.Strikethrough);
+            Assert.IsTrue(font.Outline);
+            Assert.IsTrue(font.Shadow);
+            Assert.IsTrue(font.Condense);
+            Assert.IsTrue(font.Extend);
+            Assert.AreEqual(XLColor.FromRgb(0x802010), font.Color);
+            Assert.AreEqual(8.5, font.Size);
+            Assert.AreEqual(XLFontUnderlineValues.Double, font.Underline);
+            Assert.AreEqual(XLFontVerticalTextAlignmentValues.Superscript, font.VerticalAlignment);
+            Assert.AreEqual(XLFontScheme.None, font.Scheme);
+        });
+    }
+
+    [TestCase(6)]
+    [TestCase(14)]
+    public void Interprets_undefined_font_family_values_as_unknown_font_family(int fontFamily)
+    {
+        // Deal with serious difference between standard and Excel. Standard only defines range of
+        // numerical values, but there is no meaning assigned. Thus it makes sense to take font
+        // family values allowed by standard (that have no defined meaning) and convert them
+        // to unknown font family.
+        AssertFonts(
+            $"""
+            <font>
+              <family val="{fontFamily}"/>
+            </font>
+            """, styles =>
+            {
+                var font = styles.Fonts.Single().Value;
+                Assert.AreEqual(XLFontFamilyNumberingValues.NotApplicable, font.Family);
+            });
+    }
+
+    [Test]
+    public void Can_repeat_and_reorder_font_properties()
+    {
+        // Excel requires basically a sequence, but spec allows to repeat properties and mix the order.
+        AssertFonts(
+            """
+            <font>
+              <name val="First Font"/>
+              <name val="Second Font"/>
+              <b/>
+              <b val="0"/>
+            </font>
+            """, styles =>
+            {
+                var font = styles.Fonts.Single().Value;
+                Assert.AreEqual("Second Font", font.Name);
+                Assert.IsFalse(font.Bold);
+            });
+    }
+
+    [Test]
     public void Can_read_empty_fill()
     {
         AssertFills("<fill/>", styles =>
@@ -180,6 +288,17 @@ internal class StylesReaderTests
         AssertFormat(assert, xml);
     }
 
+    private static void AssertFonts(string fontsXml, Action<XLWorkbookStyles> assert)
+    {
+        var xml = $"""
+                   <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                     <fonts>
+                       {fontsXml}
+                     </fonts>
+                   </styleSheet>
+                   """;
+        AssertFormat(assert, xml);
+    }
 
     private static void AssertFills(string fillsXml, Action<XLWorkbookStyles> assert)
     {

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -229,7 +229,7 @@ internal class StylesReaderTests
     }
 
     [Test]
-    public void Can_read_alignment()
+    public void Can_read_cell_format_alignment()
     {
         AssertCellXfs(
             """
@@ -261,7 +261,7 @@ internal class StylesReaderTests
     }
 
     [Test]
-    public void Can_read_protection()
+    public void Can_read_cell_format_protection()
     {
         AssertCellXfs(
             """
@@ -274,6 +274,65 @@ internal class StylesReaderTests
                 Assert.IsFalse(protection.Locked);
                 Assert.IsTrue(protection.Hidden);
             });
+    }
+
+    [Test]
+    public void Can_read_cell_format_properties()
+    {
+        var xml =
+            $"""
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <numFmts>
+                <numFmt numFmtId="164" formatCode="&quot;$&quot;#,##0.00"/>
+              </numFmts>
+              <fonts>
+                <font>
+                  <color theme="1"/>
+                </font>
+                <font>
+                  <sz val="11"/>
+                </font>
+              </fonts>
+              <fills count="5">
+                <fill>
+                  <patternFill patternType="none"/>
+                </fill>
+                <fill>
+                  <patternFill patternType="gray125"/>
+                </fill>
+              </fills>
+              <borders>
+                <border>
+                  <bottom style="double">
+                    <color indexed="64"/>
+                  </bottom>
+                </border>
+              </borders>
+              <cellXfs>
+                <xf numFmtId="164" fontId="1" fillId="1" borderId="0" xfId="0" quotePrefix="1" pivotButton="1" applyNumberFormat="0" applyFont="0" applyFill="0" applyBorder="0" applyAlignment="0" applyProtection="0">
+                  <alignment horizontal="left"/>
+                  <protection/>
+                </xf>
+              </cellXfs>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            var format = styles.CellFormats[0];
+            Assert.NotNull(format.Alignment);
+            Assert.AreEqual(XLAlignmentHorizontalValues.Left, format.Alignment.Horizontal);
+
+            Assert.NotNull(format.Protection);
+            Assert.IsTrue(format.Protection.Locked);
+            Assert.IsFalse(format.Protection.Hidden);
+
+            Assert.AreEqual(styles.NumberFormats[164], format.NumberFormat);
+            Assert.AreEqual(styles.Fonts[1], format.Font);
+            Assert.AreEqual(styles.Fills[1], format.Fill);
+            Assert.AreEqual(styles.Borders[0], format.Border);
+
+            // TODO: Add style and style components, once they will be loaded
+        }, xml);
     }
 
     private static void AssertNumberFormats(string numberFormatsXml, Action<XLWorkbookStyles> assert)

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -119,6 +119,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=kanji/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Katakana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=numFmts/@EntryIndexedValue">True</s:Boolean>	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MDETERM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MDeterm/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -23,7 +23,66 @@ internal partial class StylesReader
     {
         _reader.Open("styleSheet", _ns);
         ParseStylesheet("styleSheet");
+    }
 
+    private void ParseStylesheet(string elementName)
+    {
+        if (_reader.TryOpen("numFmts", _ns))
+        {
+            ParseNumFmts("numFmts");
+        }
+
+        // The spec says that the predefined formats have "formatCode value [..] implied rather
+        // than explicitly saved in the file."... so if there was something saved, it should have
+        // be used. If something was saved, it's explicit and explicit (generally) has preference
+        // over implicit. It needs to be added after numFmts, but before cellStyleXfs/cellXfs.
+        AddImpliedNumberFormats();
+
+        if (_reader.TryOpen("fonts", _ns))
+        {
+            ParseFonts("fonts");
+        }
+        if (_reader.TryOpen("fills", _ns))
+        {
+            ParseFills("fills");
+        }
+        if (_reader.TryOpen("borders", _ns))
+        {
+            ParseBorders("borders");
+        }
+        if (_reader.TryOpen("cellStyleXfs", _ns))
+        {
+            ParseCellStyleXfs("cellStyleXfs");
+        }
+        if (_reader.TryOpen("cellXfs", _ns))
+        {
+            ParseCellXfs("cellXfs");
+        }
+        if (_reader.TryOpen("cellStyles", _ns))
+        {
+            ParseCellStyles("cellStyles");
+        }
+        if (_reader.TryOpen("dxfs", _ns))
+        {
+            ParseDxfs("dxfs");
+        }
+        if (_reader.TryOpen("tableStyles", _ns))
+        {
+            ParseTableStyles("tableStyles");
+        }
+        if (_reader.TryOpen("colors", _ns))
+        {
+            ParseColors("colors");
+        }
+        if (_reader.TryOpen("extLst", _ns))
+        {
+            ParseExtensionList("extLst");
+        }
+        _reader.Close(elementName, _ns);
+    }
+
+    private void AddImpliedNumberFormats()
+    {
         // Add predefined formats, so we can treat predefined number formats and
         // user defined number formats the same way.
         foreach (var (numFmtId, formatCode) in XLPredefinedFormat.FormatCodes)
@@ -44,10 +103,6 @@ internal partial class StylesReader
     {
         foreach (var (numFmtId, formatCode) in numFmt)
         {
-            // Excel skips empty format codes.
-            if (string.IsNullOrEmpty(formatCode))
-                continue;
-
             // Even if numFmtId is predefined, store the supplied value. Excel accepts predefined
             // numFmtId and uses supplied format instead of predefined format. It fixes situation
             // during save, where such items are saved to user supplied numFmtId range.
@@ -247,11 +302,25 @@ internal partial class StylesReader
         if (_reader.Context[^1] == "cellXfs")
         {
             // We are in cellXfs
+            var numberFormat = numFmtId is not null ? _styles.NumberFormats[checked((int)numFmtId)] : null;
             var font = fontId is not null ? _styles.Fonts[checked((int)fontId)] : null;
             var fill = fillId is not null ? _styles.Fills[checked((int)fillId)] : null;
             var border = borderId is not null ? _styles.Borders[checked((int)borderId)] : null;
 
-            _styles.AddFormat(alignment, protection, font, fill, border);
+            var cellFormat = new XLCellFormat
+            {
+                NumberFormat = numberFormat,
+                Alignment = alignment,
+                Protection = protection,
+                Font = font,
+                Fill = fill,
+                Border = border,
+                CellStyle = null, // TODO: Set once cell styles are read
+                QuotePrefix = quotePrefix,
+                PivotButton = pivotButton,
+                StyleComponents = CellFormatComponents.None // TODO: No cell style = no components
+            };
+            _styles.AddFormat(cellFormat);
         }
     }
 

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -59,72 +59,89 @@ internal partial class StylesReader
     {
         // Font is mostly buggy specification. Excel basically chokes on anything but a sequence,
         // but standard requires an unbound choice where elements can repeat.
-        XLFontFormat format = default;
+        XLFontName? fontName = null;
+        XLFontCharSet? fontCharset = null;
+        XLFontFamilyNumberingValues? fontFamily = null;
+        bool? fontBold = null, fontItalic = null, fontStrikethrough = null, fontOutline = null, fontShadow = null, fontCondense = null, fontExtend = null;
+        XLColor? fontColor = null;
+        XLFontSize? fontSize = null;
+        XLFontUnderlineValues? fontUnderline = null;
+        XLFontVerticalTextAlignmentValues? fontVerticalAlignment = null;
+        XLFontScheme? fontScheme = null;
         while (!_reader.TryClose(elementName, _ns))
         {
-            if (_reader.TryReadXStringValElement("name", _ns, out var fontName))
+            if (_reader.TryReadXStringValElement("name", _ns, out var name))
             {
-                format = format with { Name = fontName };
+                fontName = name;
             }
             else if (_reader.TryReadIntValElement("charset", _ns, out var charset))
             {
-                format = format with { Charset = (XLFontCharSet?)charset };
+                fontCharset = (XLFontCharSet)charset;
             }
             else if (_reader.TryReadIntValElement("family", _ns, out var family))
             {
-                format = format with { Family = (XLFontFamilyNumberingValues)family };
+                // Bug in the spec. Spec says that it has values 0-14 and doesn't specify meaning
+                // for the numerical values. It's supposed to refer to the same enum ST_FontFamily
+                // as in WordML. The OI-29500 fixes this problem:
+                // "Excel restricts the value of this attribute to be at least 0 and at most 5."
+                fontFamily = family switch
+                {
+                    >= 0 and <= 5 => (XLFontFamilyNumberingValues)family,
+                    > 5 and <= 14 => XLFontFamilyNumberingValues.NotApplicable,
+                    _ => throw PartStructureException.InvalidAttributeFormat(),
+                };
             }
             else if (_reader.TryReadBoolElement("b", _ns, out var b))
             {
-                format = format with { Bold = b };
+                fontBold = b;
             }
             else if (_reader.TryReadBoolElement("i", _ns, out var i))
             {
-                format = format with { Italic = i };
+                fontItalic = i;
             }
             else if (_reader.TryReadBoolElement("strike", _ns, out var strike))
             {
-                format = format with { Strikethrough = strike };
+                fontStrikethrough = strike;
             }
             else if (_reader.TryReadBoolElement("outline", _ns, out var outline))
             {
-                format = format with { Outline = outline };
+                fontOutline = outline;
             }
             else if (_reader.TryReadBoolElement("shadow", _ns, out var shadow))
             {
-                format = format with { Shadow = shadow };
+                fontShadow = shadow;
             }
             else if (_reader.TryReadBoolElement("condense", _ns, out var condense))
             {
-                format = format with { Condense = condense };
+                fontCondense = condense;
             }
             else if (_reader.TryReadBoolElement("extend", _ns, out var extend))
             {
-                format = format with { Extend = extend };
+                fontExtend = extend;
             }
             else if (_reader.TryReadColor("color", _ns, out var color))
             {
-                format = format with { Color = color };
+                fontColor = color;
             }
             else if (_reader.TryOpen("sz", _ns))
             {
                 var fontSizePt = _reader.GetDouble("val");
                 _reader.Close("sz", _ns);
-                format = format with { Size = XLFontSize.FromPoints(fontSizePt) };
+                fontSize = XLFontSize.FromPoints(fontSizePt);
             }
             else if (_reader.TryOpen("u", _ns))
             {
                 var underline = _reader.GetOptionalEnum<XLFontUnderlineValues>("val") ?? XLFontUnderlineValues.Single;
                 _reader.Close("u", _ns);
-                format = format with { Underline = underline };
+                fontUnderline = underline;
             }
             else if (_reader.TryReadEnumValElement<XLFontVerticalTextAlignmentValues>("vertAlign", _ns, out var vertAlign))
             {
-                format = format with { VerticalAlignment = vertAlign };
+                fontVerticalAlignment = vertAlign;
             }
             else if (_reader.TryReadEnumValElement<XLFontScheme>("scheme", _ns, out var scheme))
             {
-                format = format with { Scheme = scheme };
+                fontScheme = scheme;
             }
             else
             {
@@ -132,6 +149,24 @@ internal partial class StylesReader
             }
         }
 
+        var format = new XLFontFormat
+        {
+            Name = fontName,
+            Charset = fontCharset,
+            Family = fontFamily,
+            Bold = fontBold,
+            Italic = fontItalic,
+            Strikethrough = fontStrikethrough,
+            Outline = fontOutline,
+            Shadow = fontShadow,
+            Condense = fontCondense,
+            Extend = fontExtend,
+            Color = fontColor,
+            Size = fontSize,
+            Underline = fontUnderline,
+            VerticalAlignment = fontVerticalAlignment,
+            Scheme = fontScheme,
+        };
         _styles.AddFontFormat(format);
     }
 
@@ -212,10 +247,11 @@ internal partial class StylesReader
         if (_reader.Context[^1] == "cellXfs")
         {
             // We are in cellXfs
+            var font = fontId is not null ? _styles.Fonts[checked((int)fontId)] : null;
             var fill = fillId is not null ? _styles.Fills[checked((int)fillId)] : null;
             var border = borderId is not null ? _styles.Borders[checked((int)borderId)] : null;
 
-            _styles.AddFormat(alignment, protection, fontId, fill, border);
+            _styles.AddFormat(alignment, protection, font, fill, border);
         }
     }
 

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -316,7 +316,7 @@ internal partial class StylesReader
                 Fill = fill,
                 Border = border,
                 CellStyle = null, // TODO: Set once cell styles are read
-                QuotePrefix = quotePrefix,
+                IncludeQuotePrefix = quotePrefix,
                 PivotButton = pivotButton,
                 StyleComponents = CellFormatComponents.None // TODO: No cell style = no components
             };

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -8,58 +8,6 @@ namespace ClosedXML.Excel.IO;
 
 internal partial class StylesReader
 {
-    private void ParseStylesheet(string elementName)
-    {
-        if (_reader.TryOpen("numFmts", _ns))
-        {
-            ParseNumFmts("numFmts");
-        }
-        if (_reader.TryOpen("fonts", _ns))
-        {
-            ParseFonts("fonts");
-        }
-        if (_reader.TryOpen("fills", _ns))
-        {
-            ParseFills("fills");
-        }
-        if (_reader.TryOpen("borders", _ns))
-        {
-            ParseBorders("borders");
-        }
-        if (_reader.TryOpen("cellStyleXfs", _ns))
-        {
-            ParseCellStyleXfs("cellStyleXfs");
-        }
-        if (_reader.TryOpen("cellXfs", _ns))
-        {
-            ParseCellXfs("cellXfs");
-        }
-        if (_reader.TryOpen("cellStyles", _ns))
-        {
-            ParseCellStyles("cellStyles");
-        }
-        if (_reader.TryOpen("dxfs", _ns))
-        {
-            ParseDxfs("dxfs");
-        }
-        if (_reader.TryOpen("tableStyles", _ns))
-        {
-            ParseTableStyles("tableStyles");
-        }
-        if (_reader.TryOpen("colors", _ns))
-        {
-            ParseColors("colors");
-        }
-        if (_reader.TryOpen("extLst", _ns))
-        {
-            ParseExtensionList("extLst");
-        }
-        _reader.Close(elementName, _ns);
-        OnStylesheetParsed();
-    }
-
-    partial void OnStylesheetParsed();
-
     private void ParseNumFmts(string elementName)
     {
         var count = _reader.GetOptionalUInt("count");

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -31,8 +31,6 @@ internal class WorksheetPartReader
 
     internal void LoadWorksheet(XLWorksheet ws, Stylesheet s, WorksheetPart worksheetPart, SharedStringItem[] sharedStrings, Dictionary<int, DifferentialFormat> differentialFormats, LoadContext context)
     {
-        ApplyStyle(ws, 0, s, ws.Workbook.Styles);
-
         var styleList = new Dictionary<int, IXLStyle>();// {{0, ws.Style}};
         PageSetupProperties pageSetupProperties = null;
 
@@ -79,9 +77,9 @@ internal class WorksheetPartReader
                     }
                 }
                 else if (reader.ElementType == typeof(Columns))
-                    LoadColumns(s, ws, (Columns)reader.LoadCurrentElement());
+                    LoadColumns(ws, (Columns)reader.LoadCurrentElement());
                 else if (reader.ElementType == typeof(Row))
-                    LoadRow(s, ws, sharedStrings, styleList, reader);
+                    LoadRow(ws, sharedStrings, styleList, reader);
                 else if (reader.ElementType == typeof(AutoFilter))
                     AutoFilterReader.LoadAutoFilter((AutoFilter)reader.LoadCurrentElement(), ws);
                 else if (reader.ElementType == typeof(SheetProtection))
@@ -144,7 +142,7 @@ internal class WorksheetPartReader
             pageSetupProperties = sheetProperty.PageSetupProperties;
     }
 
-    private static void LoadColumns(Stylesheet s, XLWorksheet ws, Columns columns)
+    private static void LoadColumns(XLWorksheet ws, Columns columns)
     {
         if (columns == null) return;
 
@@ -158,7 +156,7 @@ internal class WorksheetPartReader
                                       ? Int32.Parse(wsDefaultColumn.Style.InnerText)
                                       : -1;
         if (styleIndexDefault >= 0)
-            ApplyStyle(ws, styleIndexDefault, s, ws.Workbook.Styles);
+            ApplyStyle(ws, styleIndexDefault, ws.Workbook.Styles);
 
         foreach (Column col in columns.Elements<Column>())
         {
@@ -190,7 +188,7 @@ internal class WorksheetPartReader
             Int32 styleIndex = col.Style != null ? Int32.Parse(col.Style.InnerText) : -1;
             if (styleIndex >= 0)
             {
-                ApplyStyle(xlColumns, styleIndex, s, ws.Workbook.Styles);
+                ApplyStyle(xlColumns, styleIndex, ws.Workbook.Styles);
             }
             else
             {
@@ -199,7 +197,7 @@ internal class WorksheetPartReader
         }
     }
 
-    private void LoadRow(Stylesheet s, XLWorksheet ws, SharedStringItem[] sharedStrings,
+    private void LoadRow(XLWorksheet ws, SharedStringItem[] sharedStrings,
                           Dictionary<Int32, IXLStyle> styleList,
                           OpenXmlPartReader reader)
     {
@@ -249,7 +247,7 @@ internal class WorksheetPartReader
             var styleIndex = attributes.GetIntAttribute("s");
             if (styleIndex is not null)
             {
-                ApplyStyle(xlRow, styleIndex.Value, s, ws.Workbook.Styles);
+                ApplyStyle(xlRow, styleIndex.Value, ws.Workbook.Styles);
             }
             else
             {
@@ -264,7 +262,7 @@ internal class WorksheetPartReader
 
         while (reader.IsStartElement("c"))
         {
-            LoadCell(sharedStrings, s, ws, styleList, reader, rowIndex);
+            LoadCell(sharedStrings, ws, styleList, reader, rowIndex);
 
             // Move from end element of 'cell' either to next cell, extList start or end of row.
             reader.MoveAhead();
@@ -275,7 +273,7 @@ internal class WorksheetPartReader
             reader.Skip();
     }
 
-    private void LoadCell(SharedStringItem[] sharedStrings, Stylesheet s,
+    private void LoadCell(SharedStringItem[] sharedStrings,
                           XLWorksheet ws, Dictionary<Int32, IXLStyle> styleList, OpenXmlPartReader reader, Int32 rowIndex)
     {
         Debug.Assert(reader.LocalName == "c" && reader.IsStartElement);
@@ -308,7 +306,7 @@ internal class WorksheetPartReader
         }
         else
         {
-            ApplyStyle(xlCell, styleIndex, s, ws.Workbook.Styles);
+            ApplyStyle(xlCell, styleIndex, ws.Workbook.Styles);
         }
 
         var showPhonetic = attributes.GetBoolAttribute("ph", false);
@@ -1230,10 +1228,10 @@ internal class WorksheetPartReader
         }
     }
 
-    private static void ApplyStyle(IXLStylized xlStylized, Int32 styleIndex, Stylesheet s, XLWorkbookStyles styles)
+    private static void ApplyStyle(IXLStylized xlStylized, Int32 styleIndex, XLWorkbookStyles styles)
     {
         var xlStyleKey = XLStyle.Default.Key;
-        XLWorkbook.LoadStyle(ref xlStyleKey, styleIndex, s, styles);
+        XLWorkbook.LoadStyle(ref xlStyleKey, styleIndex, styles);
 
         // When loading columns we must propagate style to each column but not deeper. In other cases we do not propagate at all.
         if (xlStylized is IXLColumns columns)

--- a/ClosedXML/Excel/IO/XmlTreeReaderExtensions.cs
+++ b/ClosedXML/Excel/IO/XmlTreeReaderExtensions.cs
@@ -112,7 +112,7 @@ internal static class XmlTreeReaderExtensions
     /// <summary>
     /// Try to read an optional element of type <c>CT_IntProperty</c>
     /// </summary>
-    public static bool TryReadIntValElement(this XmlTreeReader reader, string elementName, string ns, [NotNullWhen(true)] out int? value)
+    public static bool TryReadIntValElement(this XmlTreeReader reader, string elementName, string ns, out int value)
     {
         if (reader.TryOpen(elementName, ns))
         {
@@ -121,7 +121,7 @@ internal static class XmlTreeReaderExtensions
             return true;
         }
 
-        value = null;
+        value = default;
         return false;
     }
 

--- a/ClosedXML/Excel/Style/Formatting/CellFormatComponents.cs
+++ b/ClosedXML/Excel/Style/Formatting/CellFormatComponents.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ClosedXML.Excel.Formatting;
+
+[Flags]
+internal enum CellFormatComponents
+{
+    None = 0,
+    NumberFormat = 1,
+    Font = 2,
+    Fill = 4,
+    Border = 8,
+    Alignment = 16,
+    Protection = 32,
+    All = NumberFormat | Font | Fill | Border | Alignment | Protection
+}

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -15,8 +15,10 @@ namespace ClosedXML.Excel.Formatting;
 /// cell.
 /// </para>
 /// </summary>
-internal readonly record struct XLCellFormat
+internal record XLCellFormat
 {
+    public required string? NumberFormat { get; init; }
+
     public required XLAlignmentFormat? Alignment { get; init; }
 
     public required XLProtectionFormat? Protection { get; init; }
@@ -27,5 +29,33 @@ internal readonly record struct XLCellFormat
 
     public required XLBorderFormat? Border { get; init; }
 
-    // TODO: Add remaining properties. For now only font
+    /// <summary>
+    /// A cell style that was originally used to create this format.
+    /// </summary>
+    public required XLCellStyle? CellStyle {get; init; }
+
+    public required bool QuotePrefix { get; init; }
+
+    public required bool PivotButton { get; init; }
+
+    /// <summary>
+    /// <para>
+    /// Format components that should be updated when the original <see cref="CellStyle"/> is
+    /// changed. The format is immutable, so the change is actually creation of derived format and
+    /// usage replacement.
+    /// </para>
+    /// <para>
+    /// Only used if format was created from a style.
+    /// </para>
+    /// <para>
+    /// <example>
+    /// User stylizes a cell with an <em>Input</em> style that specifies a font, fill and border.
+    /// User then changes size of a text in a cell, thus the cell format now contains a different
+    /// font format. If the style <em>Input</em> changes background, the cell format should now use
+    /// a new background. But if style <em>Input</em> changes font, it shouldn't be reflected in
+    /// the format, because it was explicitly set to a different value from a style.
+    /// </example>
+    /// </para>
+    /// </summary>
+    public required CellFormatComponents StyleComponents { get; init; }
 }

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormat.cs
@@ -34,7 +34,7 @@ internal record XLCellFormat
     /// </summary>
     public required XLCellStyle? CellStyle {get; init; }
 
-    public required bool QuotePrefix { get; init; }
+    public required bool IncludeQuotePrefix { get; init; }
 
     public required bool PivotButton { get; init; }
 

--- a/ClosedXML/Excel/Style/Formatting/XLCellStyle.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellStyle.cs
@@ -1,0 +1,15 @@
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// <para>
+/// A cell style available in the workbook.
+/// </para>
+/// <para>
+/// Cell style isn't actually used for formatting. A <see cref="XLCellFormat"/> is created from
+/// a style and the cell format is then used to format.
+/// </para>
+/// </summary>
+internal class XLCellStyle
+{
+    // TODO: Fill with data
+}

--- a/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFontFormat.cs
@@ -3,7 +3,7 @@ namespace ClosedXML.Excel.Formatting;
 /// <summary>
 /// A formatting record for <see cref="XLCellFormat"/>. Unlike <see cref="XLFontKey"/>, attributes are optional.
 /// </summary>
-internal readonly record struct XLFontFormat
+internal record XLFontFormat
 {
     public required XLFontName? Name { get; init; }
 

--- a/ClosedXML/Excel/Style/IXLFont.cs
+++ b/ClosedXML/Excel/Style/IXLFont.cs
@@ -22,11 +22,35 @@ namespace ClosedXML.Excel
 
     public enum XLFontFamilyNumberingValues
     {
+        /// <summary>
+        /// No information about font family is available.
+        /// </summary>
         NotApplicable = 0,
+
+        /// <summary>
+        /// Proportional font with serifs.
+        /// </summary>
         Roman = 1,
+
+        /// <summary>
+        /// Proportional font without serifs.
+        /// </summary>
         Swiss = 2,
+
+        /// <summary>
+        /// Monospace font with or without serifs.
+        /// </summary>
         Modern = 3,
+
+        /// <summary>
+        /// Font that mimics the appearance of handwriting.
+        /// </summary>
         Script = 4,
+
+        /// <summary>
+        /// A Novelty font family. A decorative or thematic fonts, suitable for headlines or
+        /// posters, not suitable for text.
+        /// </summary>
         Decorative = 5
     }
 

--- a/ClosedXML/Excel/Style/XLFontName.cs
+++ b/ClosedXML/Excel/Style/XLFontName.cs
@@ -9,19 +9,25 @@ namespace ClosedXML.Excel;
 /// class because that way <see cref="XLFontFormat"/> and other structures don't have to implement
 /// custom hash code and equality methods.
 /// </summary>
-internal readonly record struct XLFontName
+internal readonly record struct XLFontName : IEquatable<string>
 {
     private const StringComparison Comparison = StringComparison.OrdinalIgnoreCase;
 
     private XLFontName(string text)
     {
-        if (string.IsNullOrWhiteSpace(text))
+        // Spec says at most 31 chars, Excel also tries to repair workbook when value is longer.
+        if (string.IsNullOrWhiteSpace(text) || text.Length > 31)
             throw new ArgumentException(nameof(text));
 
         Text = text;
     }
 
     public string Text { get; }
+
+    public bool Equals(string other)
+    {
+        return string.Equals(Text, other, Comparison);
+    }
 
     public override int GetHashCode()
     {
@@ -30,7 +36,7 @@ internal readonly record struct XLFontName
 
     public bool Equal(XLFontName other)
     {
-        return string.Equals(Text, other.Text, Comparison);
+        return Equals(other.Text);
     }
 
     [return: NotNullIfNotNull(nameof(text))]

--- a/ClosedXML/Excel/Style/XLFontSize.cs
+++ b/ClosedXML/Excel/Style/XLFontSize.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace ClosedXML.Excel;
 
@@ -8,20 +7,31 @@ namespace ClosedXML.Excel;
 /// equality of font size. Per MS-OI29500: Office converts the points provided to twips, and
 /// rounding may occur when writing sz@val back to SpreadsheetML files.
 /// </summary>
-internal readonly record struct XLFontSize(short Twips)
+internal readonly record struct XLFontSize : IEquatable<double>
 {
-    [return: NotNullIfNotNull(nameof(sizeInPoints))]
-    public static XLFontSize? FromPoints(double? sizeInPoints)
+    public XLFontSize(short twips)
     {
-        if (sizeInPoints is null)
-            return null;
+        if (twips is < 20 or > 8191)
+            throw new ArgumentOutOfRangeException(nameof(twips), "Font size must be between 1 and 409.55 points.");
 
-        var twips = Math.Round(sizeInPoints.Value * 20, MidpointRounding.AwayFromZero);
+        Twips = twips;
+    }
+
+    public static XLFontSize FromPoints(double sizeInPoints)
+    {
+        var twips = Math.Round(sizeInPoints * 20, MidpointRounding.AwayFromZero);
         return new XLFontSize(checked((short)twips));
     }
+
+    public short Twips { get; }
 
     /// <summary>
     /// Font size converted to points. Can have rounding issues, so use only when necessary.
     /// </summary>
     public double Points => Twips / 20.0;
+
+    public bool Equals(double other)
+    {
+        return other.Equals(Points);
+    }
 }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -105,10 +105,9 @@ internal class XLWorkbookStyles
         _borderFormats.Add(_borderFormats.Count, borderFormat);
     }
 
-    internal void AddFormat(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? fontId, XLFillFormat? fill, XLBorderFormat? border)
+    internal void AddFormat(XLAlignmentFormat? alignment, XLProtectionFormat? protection, XLFontFormat? font, XLFillFormat? fill, XLBorderFormat? border)
     {
         var xfId = _cellFormats.Count;
-        XLFontFormat? font = fontId is not null ? _fontFormats[checked((int)fontId)] : null;
         _cellFormats.Add(xfId, new XLCellFormat
         {
             Alignment = alignment,

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -40,20 +40,6 @@ internal class XLWorkbookStyles
 
     internal IReadOnlyDictionary<int, XLCellFormat> CellFormats => _cellFormats;
 
-    internal XLStyleKey ApplyNumberFormat(int numberFormatId, ref XLStyleKey styleKey)
-    {
-        // Unlike other aspects of formatting, number format is skipped when numFmtId is not found
-        if (!_numberFormats.TryGetValue(numberFormatId, out var formatCode))
-            return styleKey;
-
-        var numberFormat = new XLNumberFormatKey
-        {
-            NumberFormatId = numberFormatId,
-            Format = formatCode
-        };
-        return styleKey with { NumberFormat = numberFormat };
-    }
-
     internal XLNumberFormatValue GetNumberFormat(int numberFormatId)
     {
         var xlNumberFormat = new XLNumberFormatKey
@@ -62,27 +48,6 @@ internal class XLWorkbookStyles
             Format = _numberFormats[numberFormatId]
         };
         return XLNumberFormatValue.FromKey(ref xlNumberFormat);
-    }
-
-    internal XLStyleKey ApplyFontFormat(int fontId, ref XLStyleKey styleKey)
-    {
-        var fontFormat = _fontFormats[fontId];
-        var fontKey = fontFormat.ApplyTo(styleKey.Font);
-        return styleKey with { Font = fontKey };
-    }
-
-    internal XLStyleKey ApplyPatternFormat(int fillId, ref XLStyleKey styleKey)
-    {
-        var fillFormat = _fillFormats[fillId];
-        var fillKey = fillFormat.ApplyTo(styleKey.Fill);
-        return styleKey with { Fill = fillKey };
-    }
-
-    internal XLStyleKey ApplyBorderFormat(int borderId, ref XLStyleKey styleKey)
-    {
-        var borderFormat = _borderFormats[borderId];
-        var borderKey = borderFormat.ApplyTo(styleKey.Border);
-        return styleKey with { Border = borderKey };
     }
 
     internal void AddNumberFormat(int numFmtId, string formatCode)

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -105,16 +105,9 @@ internal class XLWorkbookStyles
         _borderFormats.Add(_borderFormats.Count, borderFormat);
     }
 
-    internal void AddFormat(XLAlignmentFormat? alignment, XLProtectionFormat? protection, XLFontFormat? font, XLFillFormat? fill, XLBorderFormat? border)
+    internal void AddFormat(XLCellFormat cellFormat)
     {
         var xfId = _cellFormats.Count;
-        _cellFormats.Add(xfId, new XLCellFormat
-        {
-            Alignment = alignment,
-            Protection = protection,
-            Font = font,
-            Fill = fill,
-            Border = border,
-        });
+        _cellFormats.Add(xfId, cellFormat);
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -198,7 +198,7 @@ namespace ClosedXML.Excel
             if (normalStyle != null)
             {
                 var normalStyleKey = ((XLStyle)Style).Key;
-                LoadStyle(ref normalStyleKey, (Int32)normalStyle.FormatId.Value, s, Styles);
+                LoadStyle(ref normalStyleKey, (Int32)normalStyle.FormatId.Value, Styles);
                 Style = new XLStyle(null, normalStyleKey);
                 ColumnWidth = XLHelper.CalculateColumnWidth(8, Style.Font, this);
             }
@@ -1169,16 +1169,11 @@ namespace ClosedXML.Excel
             Properties.Title = p.Title;
         }
 
-        internal static void LoadStyle(ref XLStyleKey xlStyle, Int32 styleIndex, Stylesheet s, XLWorkbookStyles styles)
+        internal static void LoadStyle(ref XLStyleKey xlStyle, Int32 styleIndex, XLWorkbookStyles styles)
         {
-            if (s == null || s.CellFormats is null) return; //No Stylesheet, no Styles
-
-            var cellFormat = (CellFormat)s.CellFormats.ElementAt(styleIndex);
-
-            var xlIncludeQuotePrefix = OpenXmlHelper.GetBooleanValueAsBool(cellFormat.QuotePrefix, false);
-            xlStyle = xlStyle with { IncludeQuotePrefix = xlIncludeQuotePrefix };
-
             var xlCellFormat = styles.CellFormats[styleIndex];
+            xlStyle = xlStyle with { IncludeQuotePrefix = xlCellFormat.IncludeQuotePrefix };
+
             if (xlCellFormat.Alignment is not null)
             {
                 var alignmentKey = xlCellFormat.Alignment.ApplyTo(xlStyle.Alignment);
@@ -1191,24 +1186,24 @@ namespace ClosedXML.Excel
                 xlStyle = xlStyle with { Protection = protectionKey };
             }
 
-            if (cellFormat.NumberFormatId?.Value is { } numberFormatId)
+            if (xlCellFormat.NumberFormat is not null)
             {
-                xlStyle = styles.ApplyNumberFormat(checked((int)numberFormatId), ref xlStyle);
+                xlStyle = xlStyle with { NumberFormat = XLNumberFormatKey.ForFormat(xlCellFormat.NumberFormat) };
             }
 
-            if (cellFormat.FontId?.Value is { } fontId)
+            if (xlCellFormat.Font is not null)
             {
-                xlStyle = styles.ApplyFontFormat(checked((int)fontId), ref xlStyle);
+                xlStyle = xlStyle with { Font = xlCellFormat.Font.ApplyTo(xlStyle.Font) };
             }
 
-            if (cellFormat.FillId?.Value is { } fillId)
+            if (xlCellFormat.Fill is not null)
             {
-                xlStyle = styles.ApplyPatternFormat(checked((int)fillId), ref xlStyle);
+                xlStyle = xlStyle with { Fill = xlCellFormat.Fill.ApplyTo(xlStyle.Fill) };
             }
 
-            if (cellFormat.BorderId?.Value is { } borderId)
+            if (xlCellFormat.Border is not null)
             {
-                xlStyle = styles.ApplyBorderFormat(checked((int)borderId), ref xlStyle);
+                xlStyle = xlStyle with { Border = xlCellFormat.Border.ApplyTo(xlStyle.Border) };
             }
         }
 


### PR DESCRIPTION
Load `XLCellFormat` (equivalent of `<cellXfs>/<xf>` in XML) is now loaded through StylesReader and it is used to apply the styles during workbook load.

With this change, the key loading method in `XLWorkbook.LoadStyle` now completely relies on `XLWorkbookStyles` and `StylesReader`.