### PR TITLE
Load cell styles through StylesReader

### DIFF
--- a/ClosedXML.IO.CodeGen/ClosedXML.IO.CodeGen.csproj
+++ b/ClosedXML.IO.CodeGen/ClosedXML.IO.CodeGen.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="*">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="PolySharp" Version="*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/ClosedXML.IO.CodeGen/Model/Elements/ElementType.cs
+++ b/ClosedXML.IO.CodeGen/Model/Elements/ElementType.cs
@@ -96,12 +96,27 @@ public class ElementType : IElementGroup
         }
         else if (min == 1 && max == int.MaxValue)
         {
-            code.AddLine($"_reader.Open({openArgs});");
-            code.AddLine("do");
-            code.OpenBrace();
-            code.WriteIndent().Append(elementParseCall).Append(";").EndLine();
-            code.CloseBrace();
-            code.AddLine($"while (_reader.TryOpen({openArgs}));");
+            if (code.TryGetComplexType(TypeName, out var csType))
+            {
+                csType = $"List<{csType}>";
+                variable = new Variable(csType, Name);
+                code.WriteIndent().Append("var ").AppendVariable(variable.Name).Append($" = new {csType}();").EndLine();
+                code.AddLine($"_reader.Open({openArgs});");
+                code.AddLine("do");
+                code.OpenBrace();
+                code.WriteIndent().AppendVariable(variable.Name).Append($".Add({elementParseCall})").Append(";").EndLine();
+                code.CloseBrace();
+                code.AddLine($"while (_reader.TryOpen({openArgs}));");
+            }
+            else
+            {
+                code.AddLine($"_reader.Open({openArgs});");
+                code.AddLine("do");
+                code.OpenBrace();
+                code.WriteIndent().Append(elementParseCall).Append(";").EndLine();
+                code.CloseBrace();
+                code.AddLine($"while (_reader.TryOpen({openArgs}));");
+            }
         }
         else
         {

--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -123,6 +123,10 @@ public class Program
             .AddComplexTypeMapping("CT_NumFmt", "(int NumFmtId, string FormatCode)")
             .AddComplexTypeMapping("CT_CellAlignment", "XLAlignmentFormat")
             .AddComplexTypeMapping("CT_CellProtection", "XLProtectionFormat")
+            .AddComplexTypeMapping("CT_Xf", "(XLCellFormat Format, int? CellStyleXfId)")
+            .AddComplexTypeMapping("CT_CellXfs", "List<(XLCellFormat Format, int? CellStyleXfId)>")
+            .AddComplexTypeMapping("CT_CellStyle", "(int CellStyleXfId, XLCellStyle Style)")
+            .AddComplexTypeMapping("CT_CellStyles", "Dictionary<int, XLCellStyle>")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ClosedXML.Excel;
+using ClosedXML.Excel.Formatting;
 using ClosedXML.Excel.IO;
 using ClosedXML.IO;
 using NUnit.Framework;
@@ -280,40 +281,35 @@ internal class StylesReaderTests
     public void Can_read_cell_format_properties()
     {
         var xml =
-            $"""
+            """
             <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
               <numFmts>
                 <numFmt numFmtId="164" formatCode="&quot;$&quot;#,##0.00"/>
               </numFmts>
               <fonts>
-                <font>
-                  <color theme="1"/>
-                </font>
-                <font>
-                  <sz val="11"/>
-                </font>
+                <font><color theme="1"/></font>
+                <font><sz val="11"/></font>
               </fonts>
-              <fills count="5">
-                <fill>
-                  <patternFill patternType="none"/>
-                </fill>
-                <fill>
-                  <patternFill patternType="gray125"/>
-                </fill>
+              <fills>
+                <fill><patternFill patternType="none"/></fill>
+                <fill><patternFill patternType="gray125"/></fill>
               </fills>
               <borders>
-                <border>
-                  <bottom style="double">
-                    <color indexed="64"/>
-                  </bottom>
-                </border>
+                <border><bottom style="double"><color indexed="64"/></bottom></border>
               </borders>
+              <cellStyleXfs>
+                <xf />
+              </cellStyleXfs>
               <cellXfs>
-                <xf numFmtId="164" fontId="1" fillId="1" borderId="0" xfId="0" quotePrefix="1" pivotButton="1" applyNumberFormat="0" applyFont="0" applyFill="0" applyBorder="0" applyAlignment="0" applyProtection="0">
+                <xf numFmtId="164" fontId="1" fillId="1" borderId="0" xfId="0" quotePrefix="1" pivotButton="1"
+                    applyNumberFormat="0" applyBorder="0" applyAlignment="0" applyProtection="0">
                   <alignment horizontal="left"/>
                   <protection/>
                 </xf>
               </cellXfs>
+              <cellStyles>
+                <cellStyle name="Test" xfId="0" />
+              </cellStyles>
             </styleSheet>
             """;
         AssertFormat(styles =>
@@ -326,15 +322,214 @@ internal class StylesReaderTests
             Assert.IsTrue(format.Protection.Locked);
             Assert.IsFalse(format.Protection.Hidden);
 
-            Assert.AreEqual(styles.NumberFormats[164], format.NumberFormat);
-            Assert.AreEqual(styles.Fonts[1], format.Font);
-            Assert.AreEqual(styles.Fills[1], format.Fill);
-            Assert.AreEqual(styles.Borders[0], format.Border);
+            Assert.AreSame(styles.NumberFormats[164], format.NumberFormat);
+            Assert.AreSame(styles.Fonts[1], format.Font);
+            Assert.AreSame(styles.Fills[1], format.Fill);
+            Assert.AreSame(styles.Borders[0], format.Border);
 
-            // TODO: Add style and style components, once they will be loaded
+            // All apply* are 0 or default -> nothing should be overwritten
+            Assert.AreEqual(CellFormatComponents.None, format.StyleComponents);
+            Assert.NotNull(format.CellStyle);
+            Assert.AreEqual("Test", format.CellStyle.Name);
         }, xml);
     }
 
+    [Test]
+    public void Can_read_cell_styles()
+    {
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <numFmts>
+                <numFmt numFmtId="190" formatCode="0.00"/>
+              </numFmts>
+              <fonts>
+                <font/>
+                <font><sz val="15"/></font>
+              </fonts>
+              <fills>
+                <fill><patternFill patternType="gray125"/></fill>
+                <fill><patternFill patternType="lightGrid"/></fill>
+              </fills>
+              <borders>
+                <border><bottom style="double"><color rgb="FF801040"/></bottom></border>
+              </borders>
+              <cellStyleXfs>
+                <xf numFmtId="190" fontId="1" fillId="1" borderId="0" xfId="0" 
+                    applyNumberFormat="1" applyBorder="1" applyAlignment="1" applyProtection="1">
+                  <alignment horizontal="right"/>
+                  <protection/>
+                </xf>
+              </cellStyleXfs>
+              <cellStyles>
+                <cellStyle name="Test" xfId="0" builtinId="26"/>
+              </cellStyles>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            var style = styles.CellStyles[0];
+            Assert.AreEqual("Test", style.Name);
+            Assert.AreEqual(BuiltInStyleValues.Good, style.BuiltInStyle);
+            Assert.IsFalse(style.Hidden);
+
+            Assert.NotNull(style.Alignment);
+            Assert.AreEqual(XLAlignmentHorizontalValues.Right, style.Alignment.Horizontal);
+
+            Assert.NotNull(style.Protection);
+            Assert.IsTrue(style.Protection.Locked);
+            Assert.IsFalse(style.Protection.Hidden);
+
+            Assert.AreSame(styles.NumberFormats[190], style.NumberFormat);
+            Assert.AreEqual("0.00", style.NumberFormat);
+
+            Assert.AreSame(styles.Fonts[1], style.Font);
+            Assert.AreEqual(15.0, style.Font?.Size);
+
+            Assert.AreSame(styles.Fills[1], style.Fill);
+            Assert.AreEqual(XLFillPatternValues.LightGrid, style.Fill?.Pattern?.PatternType);
+
+            Assert.AreSame(styles.Borders[0], style.Border);
+            Assert.AreEqual(XLBorderStyleValues.Double, style.Border?.Bottom?.Style);
+
+            // All apply* are true or default (true) -> everything should be overwritten
+            Assert.AreEqual(CellFormatComponents.All, style.ApplyComponents);
+        }, xml);
+    }
+
+    [Test]
+    public void Outline_cell_styles_are_normalized()
+    {
+        // builtinId 1 (RowLevel_*) and 2 (ColLevel_*) combined with iLevel are converted
+        // to an item within all builtin styles instead of requiring two combined attributes.
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <fonts><font/></fonts>
+              <fills><fill/></fills>
+              <borders><border/></borders>
+              <cellStyleXfs>
+                <xf/>
+              </cellStyleXfs>
+              <cellStyles>
+                <cellStyle name="RowLevel_3" xfId="0" builtinId="1" iLevel="2"/>
+              </cellStyles>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            var style = styles.CellStyles[0];
+            Assert.AreEqual("RowLevel_3", style.Name);
+            Assert.AreEqual(BuiltInStyleValues.RowLevel3, style.BuiltInStyle);
+        }, xml);
+    }
+
+    [Test]
+    public void Cell_styles_without_name_have_a_generated_one()
+    {
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <fonts><font/></fonts>
+              <fills><fill/></fills>
+              <borders><border/></borders>
+              <cellStyleXfs>
+                <xf/>
+                <xf/>
+                <xf/>
+              </cellStyleXfs>
+              <cellStyles>
+                <cellStyle name="Style 1" xfId="0"/>
+                <cellStyle xfId="1"/>
+                <cellStyle xfId="2"/>
+              </cellStyles>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            Assert.AreEqual(3, styles.CellStyles.Count);
+            Assert.AreEqual("Style 1", styles.CellStyles[0].Name);
+            Assert.AreEqual("Style 2", styles.CellStyles[1].Name);
+            Assert.AreEqual("Style 3", styles.CellStyles[2].Name);
+        }, xml);
+    }
+
+    [Test]
+    public void Can_read_cell_styles_referencing_same_cell_style_format()
+    {
+        // This is basically pointless, but valid situation. Cell formats reference
+        // the cellStyleXfs, but there are multiple cellStyles for the cellStyleXfs.
+        // Having two names for essentially one style is pretty invalid and OI-29500
+        // even forbids it, but Excel reads it and there are many producers in the world.
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <fonts><font><sz val="15"/></font></fonts>
+              <fills><fill/></fills>
+              <borders><border/></borders>
+              <cellStyleXfs>
+                <xf fontId="0"/>
+              </cellStyleXfs>
+              <cellXfs>
+                <xf xfId="0"/>
+              </cellXfs>
+              <cellStyles>
+                <cellStyle name="Style 1" xfId="0"/>
+                <cellStyle name="Style 2" xfId="0"/>
+              </cellStyles>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            Assert.AreEqual(2, styles.CellStyles.Count);
+            Assert.AreEqual("Style 1", styles.CellStyles[0].Name);
+            Assert.AreEqual(15.0, styles.CellStyles[0].Font?.Size);
+
+            Assert.AreEqual("Style 2", styles.CellStyles[1].Name);
+            Assert.AreEqual(15.0, styles.CellStyles[1].Font?.Size);
+
+            Assert.AreEqual(1, styles.CellFormats.Count);
+            Assert.AreSame(styles.CellStyles[0], styles.CellFormats[0].CellStyle);
+        }, xml);
+    }
+
+    [Test]
+    public void Cell_style_formatting_records_without_cell_style_have_generated_one()
+    {
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <fonts>
+                <font><sz val="15"/></font>
+                <font><sz val="10"/></font>
+              </fonts>
+              <fills><fill/></fills>
+              <borders><border/></borders>
+              <cellStyleXfs>
+                <xf fontId="0"/>
+                <xf fontId="1"/>
+                <xf/>
+              </cellStyleXfs>
+              <cellStyles>
+                <cellStyle xfId="0"/>
+                <cellStyle name="Style 2" xfId="1"/>
+              </cellStyles>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            Assert.AreEqual(3, styles.CellStyles.Count);
+            Assert.AreEqual("Style 1", styles.CellStyles[0].Name);
+            Assert.AreEqual(15.0, styles.CellStyles[0].Font?.Size);
+
+            Assert.AreEqual("Style 2", styles.CellStyles[1].Name);
+            Assert.AreEqual(10.0, styles.CellStyles[1].Font?.Size);
+
+            // Created style from last formatting record without a cellStyle element
+            Assert.AreEqual("Style 3", styles.CellStyles[2].Name);
+            Assert.IsNull(styles.CellStyles[2].Font);
+        }, xml);
+    }
     private static void AssertNumberFormats(string numberFormatsXml, Action<XLWorkbookStyles> assert)
     {
         var xml = $"""

--- a/ClosedXML/Excel/IO/SequentialNameGenerator.cs
+++ b/ClosedXML/Excel/IO/SequentialNameGenerator.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Globalization;
+
+namespace ClosedXML.Excel.IO;
+
+internal class SequentialNameGenerator
+{
+    private readonly string _prefix;
+    private int _nextNumber;
+
+    internal SequentialNameGenerator(string prefix, int nextNumber)
+    {
+        _prefix = prefix;
+        _nextNumber = nextNumber;
+    }
+
+    internal void AddName(string name)
+    {
+        if (!name.StartsWith(_prefix))
+            return;
+
+        if (!int.TryParse(name[_prefix.Length..], NumberStyles.None, XLHelper.ParseCulture, out var styleNumber))
+            return;
+
+        _nextNumber = Math.Max(styleNumber + 1, _nextNumber);
+    }
+
+    internal string NextUnusedStyleName()
+    {
+        return $"{_prefix}{_nextNumber++}";
+    }
+}

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -13,6 +13,12 @@ internal partial class StylesReader
     private readonly XmlTreeReader _reader;
     private readonly XLWorkbookStyles _styles;
     private readonly string _ns = OpenXmlConst.Main2006SsNs;
+    private readonly SequentialNameGenerator _styleNameGenerator = new("Style ", 1);
+
+    /// <summary>
+    /// Style formats from <c>cellStyleXfs</c>.
+    /// </summary>
+    private List<XLCellFormat> _styleFormats = new();
 
     public StylesReader(XmlTreeReader reader, XLWorkbookStyles styles)
     {
@@ -55,14 +61,23 @@ internal partial class StylesReader
         {
             ParseCellStyleXfs("cellStyleXfs");
         }
+
+        var cellFormats = new List<(XLCellFormat Format, int? CellStyleXfId)>();
         if (_reader.TryOpen("cellXfs", _ns))
         {
-            ParseCellXfs("cellXfs");
+            cellFormats = ParseCellXfs("cellXfs");
         }
+
+        var cellStyles = new Dictionary<int, XLCellStyle>();
         if (_reader.TryOpen("cellStyles", _ns))
         {
-            ParseCellStyles("cellStyles");
+            cellStyles = ParseCellStyles("cellStyles");
         }
+
+        RepairMissingStyles(cellStyles);
+        AddCellStyles(cellStyles);
+        AddFormats(cellFormats, cellStyles);
+
         if (_reader.TryOpen("dxfs", _ns))
         {
             ParseDxfs("dxfs");
@@ -93,6 +108,56 @@ internal partial class StylesReader
                 _styles.AddNumberFormat(numFmtId, formatCode);
             }
         }
+    }
+
+    private void RepairMissingStyles(Dictionary<int, XLCellStyle> cellStyles)
+    {
+        // Because cellStyleXfs might be referenced from cell formats, each one must be converted
+        // to a cell style. If the cellStyles didn't contain a record for any cellStyleXf, add it.
+        for (var cellStyleXfId = 0; cellStyleXfId < _styleFormats.Count; ++cellStyleXfId)
+        {
+            if (!cellStyles.ContainsKey(cellStyleXfId))
+            {
+                var format = _styleFormats[cellStyleXfId];
+                var generatedName = _styleNameGenerator.NextUnusedStyleName();
+                cellStyles.Add(cellStyleXfId, new XLCellStyle
+                {
+                    Name = generatedName,
+                    BuiltInStyle = null,
+                    Hidden = false,
+                    NumberFormat = format.NumberFormat,
+                    Alignment = format.Alignment,
+                    Protection = format.Protection,
+                    Font = format.Font,
+                    Fill = format.Fill,
+                    Border = format.Border,
+                    ApplyComponents = CellFormatComponents.All
+                });
+            }
+        }
+    }
+
+    private void AddCellStyles(Dictionary<int, XLCellStyle> cellStyles)
+    {
+        foreach (var (cellStyleXfId, cellStyle) in cellStyles)
+            _styles.AddCellStyle(cellStyleXfId, cellStyle);
+    }
+
+    private void AddFormats(List<(XLCellFormat Format, int? CellStyleXfId)> cellFormats, Dictionary<int, XLCellStyle> cellStyles)
+    {
+        // At the time when cellXf were parsed, cell styles weren't resolved. Resolve them now.
+        for (var xfId = 0; xfId < cellFormats.Count; ++xfId)
+        {
+            if (cellFormats[xfId].CellStyleXfId is { } cellStyleXfId)
+            {
+                var cellStyle = cellStyles[cellStyleXfId];
+                var cellFormat = cellFormats[xfId].Format with { CellStyle = cellStyle };
+                cellFormats[xfId] = (cellFormat, cellStyleXfId);
+            }
+        }
+
+        foreach (var (cellFormat, _) in cellFormats)
+            _styles.AddFormat(cellFormat);
     }
 
     private (int NumFmtId, string FormatCode) OnNumFmtParsed(uint numFmtId, string formatCode)
@@ -296,33 +361,130 @@ internal partial class StylesReader
         return new XLBorderLine(color ?? XLColor.NoColor, style);
     }
 
-    partial void OnXfParsed(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
+    partial void OnCellStyleXfsParsed(List<(XLCellFormat Format, int? CellStyleXfId)> xf, uint? count)
+    {
+        _styleFormats = xf.Select(x => x.Format).ToList();
+    }
+
+    private (XLCellFormat Format, int? CellStyleXfId) OnXfParsed(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection)
     {
         // When xf is parsed, all number formats, fonts, fills and borders should already be read.
-        // Skip cell style xfs for now.
-        if (_reader.Context[^1] == "cellXfs")
-        {
-            // We are in cellXfs
-            var numberFormat = numFmtId is not null ? _styles.NumberFormats[checked((int)numFmtId)] : null;
-            var font = fontId is not null ? _styles.Fonts[checked((int)fontId)] : null;
-            var fill = fillId is not null ? _styles.Fills[checked((int)fillId)] : null;
-            var border = borderId is not null ? _styles.Borders[checked((int)borderId)] : null;
+        // The apply* attributes have default value true for cellStyleXfs and false for cellXfs.
+        var defaultApply = _reader.Context[^1] == "cellStyleXfs";
+        string? numberFormat = null;
+        if (numFmtId is not null)
+            numberFormat = _styles.NumberFormats.GetValueOrDefault(checked((int)numFmtId));
 
-            var cellFormat = new XLCellFormat
-            {
-                NumberFormat = numberFormat,
-                Alignment = alignment,
-                Protection = protection,
-                Font = font,
-                Fill = fill,
-                Border = border,
-                CellStyle = null, // TODO: Set once cell styles are read
-                IncludeQuotePrefix = quotePrefix,
-                PivotButton = pivotButton,
-                StyleComponents = CellFormatComponents.None // TODO: No cell style = no components
-            };
-            _styles.AddFormat(cellFormat);
+        var font = fontId is not null ? _styles.Fonts[checked((int)fontId)] : null;
+        var fill = fillId is not null ? _styles.Fills[checked((int)fillId)] : null;
+        var border = borderId is not null ? _styles.Borders[checked((int)borderId)] : null;
+
+        var components = CellFormatComponents.None;
+        components |= (applyNumberFormat ?? defaultApply) ? CellFormatComponents.NumberFormat : CellFormatComponents.None;
+        components |= (applyFont ?? defaultApply) ? CellFormatComponents.Font : CellFormatComponents.None;
+        components |= (applyFill ?? defaultApply) ? CellFormatComponents.Fill : CellFormatComponents.None;
+        components |= (applyBorder ?? defaultApply) ? CellFormatComponents.Border : CellFormatComponents.None;
+        components |= (applyAlignment ?? defaultApply) ? CellFormatComponents.Alignment : CellFormatComponents.None;
+        components |= (applyProtection ?? defaultApply) ? CellFormatComponents.Protection : CellFormatComponents.None;
+
+        var format = new XLCellFormat
+        {
+            NumberFormat = numberFormat,
+            Alignment = alignment,
+            Protection = protection,
+            Font = font,
+            Fill = fill,
+            Border = border,
+            CellStyle = null, // The style is set once cell styles are resolved
+            IncludeQuotePrefix = quotePrefix,
+            PivotButton = pivotButton,
+            StyleComponents = components
+        };
+        return (format, checked((int?)xfId));
+    }
+
+    private List<(XLCellFormat Format, int? CellStyleXfId)> OnCellXfsParsed(List<(XLCellFormat Format, int? CellStyleXfId)> xf, uint? count)
+    {
+        return xf;
+    }
+
+    private (int XfId, XLCellStyle Style) OnCellStyleParsed(string? name, uint xfId, uint? builtinId, uint? iLevel, bool? hidden, bool? customBuiltin)
+    {
+        // The quotePrefix and pivotButton attributes of the cellStyleXf are not applied, plus
+        // the xfId of the cellStyle is ignored. The OI-29500 also requires uniqueness of xfId
+        // in the cellStyle elements, although Excel can load such workbook and has several
+        // "linked" styles. It's likely the separation into two elements is based on the internal
+        // structure inside the Excel.
+
+        // Fill dummy name for the style
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = _styleNameGenerator.NextUnusedStyleName();
         }
+        else
+        {
+            _styleNameGenerator.AddName(name);
+        }
+
+        var cellStyleFormat = _styleFormats[checked((int)xfId)];
+
+        // If the built in style is an outline style, expand it to avoid ugly representation.
+        // The spec has only one only builtIn id for all RowLevel* styles (1) and one builtIn
+        // id for all ColLevel* styles (2). Since the iLevel/outlineLevel is used only for
+        // the RowLevel/ColLevel (OI-29500), expand the builtIn+iLevel for Row/Col level into
+        // a separate builtIn styles (101-107 for RowLevel1-7, 201-207 for ColumnLevel1-7).
+        if (builtinId is 1 or 2)
+            builtinId = builtinId.Value * 100 + 1 + iLevel ?? 0;
+
+        // BuiltIn must be among defined built-in styles ("implementers should restrict the content
+        // of this attribute to enumerations present in the list")
+        if (builtinId is not null && !Enum.IsDefined(typeof(BuiltInStyleValues), checked((int)builtinId.Value)))
+        {
+            throw PartStructureException.InvalidAttributeFormat();
+        }
+
+        // The apply* attributes have default `true` for cellStyleXfs and `false` for cellXfs.
+        // We already took care of correct default value during the parsing of <xf>, so we don't
+        // have to deal with it here.
+        var applyComponents = cellStyleFormat.StyleComponents;
+        var cellStyle = new XLCellStyle
+        {
+            Name = name,
+            BuiltInStyle = builtinId is not null ? (BuiltInStyleValues)builtinId.Value : null,
+            Hidden = hidden ?? false,
+            NumberFormat = cellStyleFormat.NumberFormat,
+            Alignment = cellStyleFormat.Alignment,
+            Protection = cellStyleFormat.Protection,
+            Font = cellStyleFormat.Font,
+            Fill = cellStyleFormat.Fill,
+            Border = cellStyleFormat.Border,
+            ApplyComponents = applyComponents
+        };
+
+        return (checked((int)xfId), cellStyle);
+    }
+
+    private Dictionary<int, XLCellStyle> OnCellStylesParsed(List<(int CellStyleXfId, XLCellStyle Style)> cellStyle, uint? count)
+    {
+        var cellStyles = new Dictionary<int, XLCellStyle>();
+        foreach (var (cellStyleXfId, style) in cellStyle)
+        {
+            // Multiple cell styles use same style formatting - split them, so each one uses
+            // separate formatting. I considered removing duplicates, but it could mean that I
+            // also might remove normal style, which is not desirable.
+            if (!cellStyles.ContainsKey(cellStyleXfId))
+            {
+                cellStyles.Add(cellStyleXfId, style);
+            }
+            else
+            {
+                _styleFormats.Add(_styleFormats[cellStyleXfId]);
+                var newCellStyleXfId = _styleFormats.Count - 1;
+                cellStyles.Add(newCellStyleXfId, style);
+            }
+        }
+
+        return cellStyles;
     }
 
     private XLAlignmentFormat OnCellAlignmentParsed(XLAlignmentHorizontalValues? horizontal, XLAlignmentVerticalValues vertical, uint? textRotation, bool? wrapText, uint? indent, int? relativeIndent, bool? justifyLastLine, bool? shrinkToFit, uint? readingOrder)

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -1,3 +1,4 @@
+using System;
 using ClosedXML.Excel.Formatting;
 using ClosedXML.IO;
 using System.Collections.Generic;

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -191,19 +191,20 @@ internal partial class StylesReader
     private void ParseCellStyleXfs(string elementName)
     {
         var count = _reader.GetOptionalUInt("count");
+        var xf = new List<(XLCellFormat Format, int? CellStyleXfId)>();
         _reader.Open("xf", _ns);
         do
         {
-            ParseXf("xf");
+            xf.Add(ParseXf("xf"));
         }
         while (_reader.TryOpen("xf", _ns));
         _reader.Close(elementName, _ns);
-        OnCellStyleXfsParsed(count);
+        OnCellStyleXfsParsed(xf, count);
     }
 
-    partial void OnCellStyleXfsParsed(uint? count);
+    partial void OnCellStyleXfsParsed(List<(XLCellFormat Format, int? CellStyleXfId)> xf, uint? count);
 
-    private void ParseXf(string elementName)
+    private (XLCellFormat Format, int? CellStyleXfId) ParseXf(string elementName)
     {
         var numFmtId = _reader.GetOptionalUInt("numFmtId");
         var fontId = _reader.GetOptionalUInt("fontId");
@@ -233,10 +234,8 @@ internal partial class StylesReader
             ParseExtensionList("extLst");
         }
         _reader.Close(elementName, _ns);
-        OnXfParsed(alignment, protection, numFmtId, fontId, fillId, borderId, xfId, quotePrefix, pivotButton, applyNumberFormat, applyFont, applyFill, applyBorder, applyAlignment, applyProtection);
+        return OnXfParsed(alignment, protection, numFmtId, fontId, fillId, borderId, xfId, quotePrefix, pivotButton, applyNumberFormat, applyFont, applyFill, applyBorder, applyAlignment, applyProtection);
     }
-
-    partial void OnXfParsed(XLAlignmentFormat? alignment, XLProtectionFormat? protection, uint? numFmtId, uint? fontId, uint? fillId, uint? borderId, uint? xfId, bool quotePrefix, bool pivotButton, bool? applyNumberFormat, bool? applyFont, bool? applyFill, bool? applyBorder, bool? applyAlignment, bool? applyProtection);
 
     private XLAlignmentFormat ParseCellAlignment(string elementName)
     {
@@ -261,37 +260,35 @@ internal partial class StylesReader
         return OnCellProtectionParsed(locked, hidden);
     }
 
-    private void ParseCellXfs(string elementName)
+    private List<(XLCellFormat Format, int? CellStyleXfId)> ParseCellXfs(string elementName)
     {
         var count = _reader.GetOptionalUInt("count");
+        var xf = new List<(XLCellFormat Format, int? CellStyleXfId)>();
         _reader.Open("xf", _ns);
         do
         {
-            ParseXf("xf");
+            xf.Add(ParseXf("xf"));
         }
         while (_reader.TryOpen("xf", _ns));
         _reader.Close(elementName, _ns);
-        OnCellXfsParsed(count);
+        return OnCellXfsParsed(xf, count);
     }
 
-    partial void OnCellXfsParsed(uint? count);
-
-    private void ParseCellStyles(string elementName)
+    private Dictionary<int, XLCellStyle> ParseCellStyles(string elementName)
     {
         var count = _reader.GetOptionalUInt("count");
+        var cellStyle = new List<(int CellStyleXfId, XLCellStyle Style)>();
         _reader.Open("cellStyle", _ns);
         do
         {
-            ParseCellStyle("cellStyle");
+            cellStyle.Add(ParseCellStyle("cellStyle"));
         }
         while (_reader.TryOpen("cellStyle", _ns));
         _reader.Close(elementName, _ns);
-        OnCellStylesParsed(count);
+        return OnCellStylesParsed(cellStyle, count);
     }
 
-    partial void OnCellStylesParsed(uint? count);
-
-    private void ParseCellStyle(string elementName)
+    private (int CellStyleXfId, XLCellStyle Style) ParseCellStyle(string elementName)
     {
         var name = _reader.GetOptionalXString("name");
         var xfId = _reader.GetUInt("xfId");
@@ -304,10 +301,8 @@ internal partial class StylesReader
             ParseExtensionList("extLst");
         }
         _reader.Close(elementName, _ns);
-        OnCellStyleParsed(name, xfId, builtinId, iLevel, hidden, customBuiltin);
+        return OnCellStyleParsed(name, xfId, builtinId, iLevel, hidden, customBuiltin);
     }
-
-    partial void OnCellStyleParsed(string? name, uint xfId, uint? builtinId, uint? iLevel, bool? hidden, bool? customBuiltin);
 
     private void ParseDxfs(string elementName)
     {
@@ -435,17 +430,18 @@ internal partial class StylesReader
 
     private void ParseMRUColors(string elementName)
     {
+        var color = new List<XLColor>();
         _reader.Open("color", _ns);
         do
         {
-            ParseColor("color");
+            color.Add(ParseColor("color"));
         }
         while (_reader.TryOpen("color", _ns));
         _reader.Close(elementName, _ns);
-        OnMRUColorsParsed();
+        OnMRUColorsParsed(color);
     }
 
-    partial void OnMRUColorsParsed();
+    partial void OnMRUColorsParsed(List<XLColor> color);
 
     private void ParseRgbColor(string elementName)
     {

--- a/ClosedXML/Excel/Style/Formatting/BuiltInStyleValues.cs
+++ b/ClosedXML/Excel/Style/Formatting/BuiltInStyleValues.cs
@@ -1,0 +1,342 @@
+namespace ClosedXML.Excel.Formatting;
+
+/// <summary>
+/// List of built-in cell styles. The built-in style RowLevel_* is expanded from builtIn 1
+/// to 101-107, depending on the outline level. Same is true for ColLevel_* that is expanded
+/// from 2 to 201-207.
+/// </summary>
+internal enum BuiltInStyleValues
+{
+    /// <summary>
+    /// Normal
+    /// </summary>
+    Normal = 0,
+
+    /// <summary>
+    /// RowLevel_1
+    /// </summary>
+    RowLevel1 = 101,
+
+    /// <summary>
+    /// RowLevel_2
+    /// </summary>
+    RowLevel2 = 102,
+
+    /// <summary>
+    /// RowLevel_3
+    /// </summary>
+    RowLevel3 = 103,
+
+    /// <summary>
+    /// RowLevel_4
+    /// </summary>
+    RowLevel4 = 104,
+
+    /// <summary>
+    /// RowLevel_5
+    /// </summary>
+    RowLevel5 = 105,
+
+    /// <summary>
+    /// RowLevel_6
+    /// </summary>
+    RowLevel6 = 106,
+
+    /// <summary>
+    /// RowLevel_7
+    /// </summary>
+    RowLevel7 = 107,
+
+    /// <summary>
+    /// ColLevel_1
+    /// </summary>
+    ColumnLevel1 = 201,
+
+    /// <summary>
+    /// ColLevel_2
+    /// </summary>
+    ColumnLevel2 = 202,
+
+    /// <summary>
+    /// ColLevel_3
+    /// </summary>
+    ColumnLevel3 = 203,
+
+    /// <summary>
+    /// ColLevel_4
+    /// </summary>
+    ColumnLevel4 = 204,
+
+    /// <summary>
+    /// ColLevel_5
+    /// </summary>
+    ColumnLevel5 = 205,
+
+    /// <summary>
+    /// ColLevel_6
+    /// </summary>
+    ColumnLevel6 = 206,
+
+    /// <summary>
+    /// ColLevel_7
+    /// </summary>
+    ColumnLevel7 = 207,
+
+    /// <summary>
+    /// Comma
+    /// </summary>
+    Comma = 3,
+
+    /// <summary>
+    /// Currency
+    /// </summary>
+    Currency = 4,
+
+    /// <summary>
+    /// Percent
+    /// </summary>
+    Percent = 5,
+
+    /// <summary>
+    /// Comma [0]
+    /// </summary>
+    Comma0 = 6,
+
+    /// <summary>
+    /// Currency [0]
+    /// </summary>
+    Currency0 = 7,
+
+    /// <summary>
+    /// Hyperlink
+    /// </summary>
+    Hyperlink = 8,
+
+    /// <summary>
+    /// Followed Hyperlink
+    /// </summary>
+    FollowedHyperlink = 9,
+
+    /// <summary>
+    /// Note
+    /// </summary>
+    Note = 10,
+
+    /// <summary>
+    /// Warning Text
+    /// </summary>
+    WarningText = 11,
+
+    /// <summary>
+    /// Emphasis 1
+    /// </summary>
+    /// <remarks>Deprecated style.</remarks>
+    Emphasis1 = 12,
+
+    /// <summary>
+    /// Emphasis 2
+    /// </summary>
+    /// <remarks>Deprecated style.</remarks>
+    Emphasis2 = 13,
+
+    /// <summary>
+    /// Emphasis 3
+    /// </summary>
+    /// <remarks>Deprecated style.</remarks>
+    Emphasis3 = 14,
+
+    /// <summary>
+    /// Title
+    /// </summary>
+    Title = 15,
+
+    /// <summary>
+    /// Heading 1
+    /// </summary>
+    Heading1 = 16,
+
+    /// <summary>
+    /// Heading 2
+    /// </summary>
+    Heading2 = 17,
+
+    /// <summary>
+    /// Heading 3
+    /// </summary>
+    Heading3 = 18,
+
+    /// <summary>
+    /// Heading 4
+    /// </summary>
+    Heading4 = 19,
+
+    /// <summary>
+    /// Input
+    /// </summary>
+    Input = 20,
+
+    /// <summary>
+    /// Output
+    /// </summary>
+    Output = 21,
+
+    /// <summary>
+    /// Calculation
+    /// </summary>
+    Calculation = 22,
+
+    /// <summary>
+    /// Check Cell
+    /// </summary>
+    CheckCell = 23,
+
+    /// <summary>
+    /// Linked Cell
+    /// </summary>
+    LinkedCell = 24,
+
+    /// <summary>
+    /// Total
+    /// </summary>
+    Total = 25,
+
+    /// <summary>
+    /// Good
+    /// </summary>
+    Good = 26,
+
+    /// <summary>
+    /// Bad
+    /// </summary>
+    Bad = 27,
+
+    /// <summary>
+    /// Neutral
+    /// </summary>
+    Neutral = 28,
+
+    /// <summary>
+    /// Accent1
+    /// </summary>
+    Accent1 = 29,
+
+    /// <summary>
+    /// 20% - Accent1
+    /// </summary>
+    Accent1At20Percent = 30,
+
+    /// <summary>
+    /// 40% - Accent1
+    /// </summary>
+    Accent1At40Percent = 31,
+
+    /// <summary>
+    /// 60% - Accent1
+    /// </summary>
+    Accent1At60Percent = 32,
+
+    /// <summary>
+    /// Accent2
+    /// </summary>
+    Accent2 = 33,
+
+    /// <summary>
+    /// 20% - Accent2
+    /// </summary>
+    Accent2At20Percent = 34,
+
+    /// <summary>
+    /// 40% - Accent2
+    /// </summary>
+    Accent2At40Percent = 35,
+
+    /// <summary>
+    /// 60% - Accent2
+    /// </summary>
+    Accent2At60Percent = 36,
+
+    /// <summary>
+    /// Accent3
+    /// </summary>
+    Accent3 = 37,
+
+    /// <summary>
+    /// 20% - Accent3
+    /// </summary>
+    Accent3At20Percent = 38,
+
+    /// <summary>
+    /// 40% - Accent3
+    /// </summary>
+    Accent3At40Percent = 39,
+
+    /// <summary>
+    /// 60% - Accent3
+    /// </summary>
+    Accent3At60Percent = 40,
+
+    /// <summary>
+    /// Accent4
+    /// </summary>
+    Accent4 = 41,
+
+    /// <summary>
+    /// 20% - Accent4
+    /// </summary>
+    Accent4At20Percent = 42,
+
+    /// <summary>
+    /// 40% - Accent4
+    /// </summary>
+    Accent4At40Percent = 43,
+
+    /// <summary>
+    /// 60% - Accent4
+    /// </summary>
+    Accent4At60Percent = 44,
+
+    /// <summary>
+    /// Accent5
+    /// </summary>
+    Accent5 = 45,
+
+    /// <summary>
+    /// 20% - Accent5
+    /// </summary>
+    Accent5At20Percent = 46,
+
+    /// <summary>
+    /// 40% - Accent5
+    /// </summary>
+    Accent5At40Percent = 47,
+
+    /// <summary>
+    /// 60% - Accent5
+    /// </summary>
+    Accent5At60Percent = 48,
+
+    /// <summary>
+    /// Accent6
+    /// </summary>
+    Accent6 = 49,
+
+    /// <summary>
+    /// 20% - Accent6
+    /// </summary>
+    Accent6At20Percent = 50,
+
+    /// <summary>
+    /// 40% - Accent6
+    /// </summary>
+    Accent6At40Percent = 51,
+
+    /// <summary>
+    /// 60% - Accent6
+    /// </summary>
+    Accent6At60Percent = 52,
+
+    /// <summary>
+    /// Explanatory Text
+    /// </summary>
+    ExplanatoryText = 53,
+}

--- a/ClosedXML/Excel/Style/Formatting/XLCellStyle.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellStyle.cs
@@ -11,5 +11,29 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal class XLCellStyle
 {
-    // TODO: Fill with data
+    /// <summary>
+    /// Name of the style.
+    /// </summary>
+    public required string Name { get; init; }
+
+    public required BuiltInStyleValues? BuiltInStyle { get; init; }
+
+    /// <summary>
+    /// Is style hidden in the UI?
+    /// </summary>
+    public required bool Hidden { get; init; }
+
+    public required string? NumberFormat { get; init; }
+
+    public required XLAlignmentFormat? Alignment { get; init; }
+
+    public required XLProtectionFormat? Protection { get; init; }
+
+    public required XLFontFormat? Font { get; init; }
+
+    public required XLFillFormat? Fill { get; init; }
+
+    public required XLBorderFormat? Border { get; init; }
+
+    public required CellFormatComponents ApplyComponents { get; init; }
 }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -1,5 +1,7 @@
+using System;
 using ClosedXML.Excel.Formatting;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace ClosedXML.Excel;
 
@@ -8,11 +10,6 @@ namespace ClosedXML.Excel;
 /// </summary>
 internal class XLWorkbookStyles
 {
-    /// <summary>
-    /// The index is XfId, the value is formatting record.
-    /// </summary>
-    private readonly Dictionary<int, XLCellFormat> _cellFormats;
-
     private readonly Dictionary<int, string> _numberFormats;
 
     private readonly Dictionary<int, XLFontFormat> _fontFormats;
@@ -21,13 +18,24 @@ internal class XLWorkbookStyles
 
     private readonly Dictionary<int, XLBorderFormat> _borderFormats;
 
+    /// <summary>
+    /// The key is XfId, the value is cell format.
+    /// </summary>
+    private readonly Dictionary<int, XLCellFormat> _cellFormats;
+
+    /// <summary>
+    /// The key is cellStyleXfId, the value is cell style.
+    /// </summary>
+    private readonly Dictionary<int, XLCellStyle> _cellStyles;
+
     internal XLWorkbookStyles()
     {
-        _cellFormats = new Dictionary<int, XLCellFormat>();
         _numberFormats = new Dictionary<int, string>();
         _fontFormats = new Dictionary<int, XLFontFormat>();
         _fillFormats = new Dictionary<int, XLFillFormat>();
         _borderFormats = new Dictionary<int, XLBorderFormat>();
+        _cellFormats = new Dictionary<int, XLCellFormat>();
+        _cellStyles = new Dictionary<int, XLCellStyle>();
     }
 
     internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
@@ -39,6 +47,8 @@ internal class XLWorkbookStyles
     internal IReadOnlyDictionary<int, XLBorderFormat> Borders => _borderFormats;
 
     internal IReadOnlyDictionary<int, XLCellFormat> CellFormats => _cellFormats;
+
+    internal IReadOnlyDictionary<int, XLCellStyle> CellStyles => _cellStyles;
 
     internal XLNumberFormatValue GetNumberFormat(int numberFormatId)
     {
@@ -74,5 +84,10 @@ internal class XLWorkbookStyles
     {
         var xfId = _cellFormats.Count;
         _cellFormats.Add(xfId, cellFormat);
+    }
+
+    public void AddCellStyle(int cellStyleXfId, XLCellStyle cellStyle)
+    {
+        _cellStyles.Add(cellStyleXfId, cellStyle);
     }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.105.0-rc</Version>
+    <Version>0.106.0-preview1</Version>
   </PropertyGroup>
 
   <!-- Set common properties regarding assembly information and nuget packages -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.104.0.{build}
+version: 0.106.0.{build}
 
 image: Visual Studio 2022
 


### PR DESCRIPTION
Load cell styles through `StylesReader`. This is there mostly for full representation, so I can read and write cell styles without modifying them (long term plan to remove OpenXML SDK).