### PR TITLE
Population of auto filters in the WorksheetPartWriter class support tables with only some colums filtered

### DIFF
--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -1487,7 +1487,8 @@ namespace ClosedXML.Excel.IO
             var filterRange = xlAutoFilter.Range;
             autoFilter.Reference = filterRange.RangeAddress.ToString();
 
-            foreach (var (columnNumber, xlFilterColumn) in xlAutoFilter.Columns)
+            // Filter out the XLFilterType.None case to sopport the case when only some columns have automatic filters
+            foreach (var (columnNumber, xlFilterColumn) in xlAutoFilter.Columns.Where(xlAFC => xlAFC.Value.FilterType != XLFilterType.None))
             {
                 var filterColumn = new FilterColumn { ColumnId = (UInt32)columnNumber - 1 };
 


### PR DESCRIPTION
Fix: Correct The population of auto filters in the WorksheetPartWriter class
Previously, tha case when a Table Object don't have auto filters in all columns was not taking into account, which could lead to a NotSupportedException being thrown to the user. This change ensures that only the columns with filters are processed in the switch preventing potential runtime errors when saving.