### PR TITLE
Read pivot style to XLWorkbookStyles

### DIFF
--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -627,6 +627,25 @@ internal class StylesReaderTests
             });
     }
 
+    [TestCase(true, true)]
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(false, false)]
+    public void Only_reads_table_or_pivot_style_when_flag_is_set(bool table, bool pivot)
+    {
+        var xml =
+            $"""
+            <tableStyles>
+              <tableStyle name="Test Style" table="{(table ? 1 : 0)}" pivot="{(pivot ? 1 : 0)}"/>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            Assert.AreEqual(table, styles.TableStyles.ContainsKey("Test Style"));
+            Assert.AreEqual(pivot, styles.PivotStyles.ContainsKey("Test Style"));
+        });
+    }
+
     [Test]
     public void Can_read_table_style()
     {
@@ -742,6 +761,127 @@ internal class StylesReaderTests
         AssertTableStyles(xml, styles =>
         {
             var tableStyle = styles.TableStyles["Test Style"];
+            Assert.That(tableStyle.RegionFormats, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Can_read_pivot_style()
+    {
+        var xml =
+            """
+            <dxfs>
+              <dxf><font><sz val="5"/></font></dxf>
+              <dxf><font><sz val="10"/></font></dxf>
+              <dxf><font><color rgb="FF00FF00"/></font></dxf>
+              <dxf><font><color rgb="FF0000FF"/></font></dxf>
+            </dxfs>
+            <tableStyles count="1"
+                         defaultTableStyle="TableStyleMedium2">
+              <tableStyle name="Test Style"
+                          pivot="1"
+                          count="7">
+                <tableStyleElement type="wholeTable" dxfId="0"/>
+                <tableStyleElement type="totalRow" dxfId="1"/>
+                <tableStyleElement type="firstRowStripe" size="2" dxfId="0"/>
+                <tableStyleElement type="secondRowStripe" size="3" dxfId="1"/>
+                <tableStyleElement type="firstColumnStripe" size="4" dxfId="2"/>
+                <tableStyleElement type="secondColumnStripe" size="5" dxfId="3"/>
+                <tableStyleElement type="firstSubtotalColumn" dxfId="2"/>
+              </tableStyle>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            // TODO: Read default table style
+            // Style names are case insensitive
+            var pivotStyle = styles.PivotStyles["test style"];
+            Assert.AreEqual("Test Style", pivotStyle.Name);
+
+            Assert.That(pivotStyle.RegionFormats, Is.EquivalentTo(new Dictionary<XLPivotStyleRegionValues, XLDifferentialFormat>
+            {
+                { XLPivotStyleRegionValues.WholeTable, styles.DifferentialFormats[0] },
+                { XLPivotStyleRegionValues.GrandTotalRow, styles.DifferentialFormats[1] },
+                { XLPivotStyleRegionValues.FirstRowStripe, styles.DifferentialFormats[0] },
+                { XLPivotStyleRegionValues.SecondRowStripe, styles.DifferentialFormats[1] },
+                { XLPivotStyleRegionValues.FirstColumnStripe, styles.DifferentialFormats[2] },
+                { XLPivotStyleRegionValues.SecondColumnStripe, styles.DifferentialFormats[3] },
+                { XLPivotStyleRegionValues.SubtotalColumn1, styles.DifferentialFormats[2] },
+            }));
+
+            Assert.AreEqual(2, pivotStyle.RowStripe1BandSize);
+            Assert.AreEqual(3, pivotStyle.RowStripe2BandSize);
+            Assert.AreEqual(4, pivotStyle.ColumnStripe1BandSize);
+            Assert.AreEqual(5, pivotStyle.ColumnStripe2BandSize);
+        });
+    }
+
+    [Test]
+    public void Can_read_pivot_style_with_repeated_elements()
+    {
+        var xml =
+            """
+            <dxfs>
+              <dxf><font><sz val="5"/></font></dxf>
+              <dxf><font><color rgb="FF00FF00"/></font></dxf>
+            </dxfs>
+            <tableStyles>
+              <tableStyle name="Test Style" pivot="1">
+                <tableStyleElement type="pageFieldLabels" dxfId="0"/>
+                <tableStyleElement type="pageFieldLabels" dxfId="1"/>
+              </tableStyle>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            // When a region is specified multiple times, take the last one
+            var pivotStyle = styles.PivotStyles["Test Style"];
+            Assert.That(pivotStyle.RegionFormats, Is.EquivalentTo(new Dictionary<XLPivotStyleRegionValues, XLDifferentialFormat>
+            {
+                { XLPivotStyleRegionValues.PageFieldLabels, styles.DifferentialFormats[1] }
+            }));
+        });
+    }
+
+    [Test]
+    public void Ignores_pivot_style_elements_that_are_only_for_table_style()
+    {
+        var xml =
+            """
+            <dxfs>
+              <dxf><font><sz val="5"/></font></dxf>
+            </dxfs>
+            <tableStyles>
+              <tableStyle name="Test Style">
+                <tableStyleElement type="lastHeaderCell" dxfId="0"/>
+                <tableStyleElement type="lastColumn" dxfId="0"/>
+              </tableStyle>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            var tableStyle = styles.PivotStyles["Test Style"];
+            Assert.That(tableStyle.RegionFormats, Is.EquivalentTo(new Dictionary<XLPivotStyleRegionValues, XLDifferentialFormat>
+            {
+                { XLPivotStyleRegionValues.GrandTotalColumn, styles.DifferentialFormats[0] }
+            }));
+        });
+    }
+
+    [Test]
+    public void Ignores_pivot_style_elements_without_differential_format()
+    {
+        var xml =
+            """
+            <tableStyles>
+              <tableStyle name="Test Style">
+                <tableStyleElement type="firstColumn" />
+              </tableStyle>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            var tableStyle = styles.PivotStyles["Test Style"];
             Assert.That(tableStyle.RegionFormats, Is.Empty);
         });
     }

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -703,6 +703,49 @@ internal class StylesReaderTests
         });
     }
 
+    [Test]
+    public void Ignores_table_style_elements_that_are_only_for_pivot_table()
+    {
+        var xml =
+            """
+            <dxfs>
+              <dxf><font><sz val="5"/></font></dxf>
+            </dxfs>
+            <tableStyles>
+              <tableStyle name="Test Style">
+                <tableStyleElement type="firstSubtotalColumn" dxfId="0"/>
+                <tableStyleElement type="headerRow" dxfId="0"/>
+              </tableStyle>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            var tableStyle = styles.TableStyles["Test Style"];
+            Assert.That(tableStyle.RegionFormats, Is.EquivalentTo(new Dictionary<XLTableStyleRegionValues, XLDifferentialFormat>
+            {
+                { XLTableStyleRegionValues.HeaderRow, styles.DifferentialFormats[0] }
+            }));
+        });
+    }
+
+    [Test]
+    public void Ignores_table_style_elements_without_differential_format()
+    {
+        var xml =
+            """
+            <tableStyles>
+              <tableStyle name="Test Style">
+                <tableStyleElement type="totalRow" />
+              </tableStyle>
+            </tableStyles>
+            """;
+        AssertTableStyles(xml, styles =>
+        {
+            var tableStyle = styles.TableStyles["Test Style"];
+            Assert.That(tableStyle.RegionFormats, Is.Empty);
+        });
+    }
+
     private static void AssertNumberFormats(string numberFormatsXml, Action<XLWorkbookStyles> assert)
     {
         var xml = $"""

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -19,6 +19,7 @@ internal partial class StylesReader
 
     // Currently read CT_TableStyle element
     private Dictionary<TS, (XLDifferentialFormat Dxf, int BandSize)> _currentTableStyle = new();
+    private Dictionary<PTS, (XLDifferentialFormat Dxf, int BandSize)> _currentPivotStyle = new();
 
     /// <summary>
     /// Style formats from <c>cellStyleXfs</c>.
@@ -582,10 +583,15 @@ internal partial class StylesReader
 
         if (type.Item1 is { } tableStyleRegion)
             _currentTableStyle[tableStyleRegion] = (dxf, (int)size);
+
+        if (type.Item2 is { } pivotStyleRegion)
+            _currentPivotStyle[pivotStyleRegion] = (dxf, (int)size);
     }
 
     partial void OnTableStyleParsed(string name, bool pivot, bool table, uint? count)
     {
+        // Because of tableStyle element duality, we are filling both styles and
+        // only insert types that have set flag.
         if (table)
         {
             var tableStyle = new XLTableTheme(name);
@@ -596,6 +602,17 @@ internal partial class StylesReader
         }
 
         _currentTableStyle = new Dictionary<TS, (XLDifferentialFormat Dxf, int BandSize)>();
+
+        if (pivot)
+        {
+            var pivotStyle = new XLPivotTableStyle(name);
+            foreach (var (region, (dxf, bandSize)) in _currentPivotStyle)
+                pivotStyle.SetRegionFormat(region, dxf, bandSize);
+
+            _styles.AddPivotStyle(pivotStyle);
+        }
+
+        _currentPivotStyle = new Dictionary<PTS, (XLDifferentialFormat Dxf, int BandSize)>();
     }
 
     private XLColor ParseColor(string elementName)

--- a/ClosedXML/Excel/Style/XLPivotTableStyle.cs
+++ b/ClosedXML/Excel/Style/XLPivotTableStyle.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// A named style for a pivot table.
+/// </summary>
+internal class XLPivotTableStyle
+{
+    private readonly Dictionary<XLPivotStyleRegionValues, XLDifferentialFormat> _regionFormats = new();
+
+    public XLPivotTableStyle(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException("Name can't be empty.");
+
+        Name = name;
+    }
+
+    internal string Name { get; }
+
+    internal IReadOnlyDictionary<XLPivotStyleRegionValues, XLDifferentialFormat> RegionFormats => _regionFormats;
+
+    /// <summary>
+    /// A band size (i.e. how many rows does a stripe have) for a <see cref="XLPivotStyleRegionValues.FirstRowStripe"/>.
+    /// </summary>
+    internal int RowStripe1BandSize { get; private set; } = 1;
+
+    /// <summary>
+    /// A band size (i.e. how many rows does a stripe have) for a <see cref="XLPivotStyleRegionValues.SecondRowStripe"/>.
+    /// </summary>
+    internal int RowStripe2BandSize { get; private set; } = 1;
+
+    /// <summary>
+    /// A band size (i.e. how many column does a stripe have) for a <see cref="XLPivotStyleRegionValues.FirstColumnStripe"/>.
+    /// </summary>
+    internal int ColumnStripe1BandSize { get; private set; } = 1;
+
+    /// <summary>
+    /// A band size (i.e. how many column does a stripe have) for a <see cref="XLPivotStyleRegionValues.SecondColumnStripe"/>.
+    /// </summary>
+    internal int ColumnStripe2BandSize { get; private set; } = 1;
+
+    internal void SetRegionFormat(XLPivotStyleRegionValues region, XLDifferentialFormat dxf, int bandSize = 1)
+    {
+        // Keep values excel compatible.
+        if (bandSize is < 0 or > 9)
+            throw new ArgumentOutOfRangeException(nameof(bandSize));
+
+        // Band size has only meaning for stripe regions
+        switch (region)
+        {
+            case XLPivotStyleRegionValues.FirstRowStripe:
+                RowStripe1BandSize = bandSize;
+                break;
+            case XLPivotStyleRegionValues.SecondRowStripe:
+                RowStripe2BandSize = bandSize;
+                break;
+            case XLPivotStyleRegionValues.FirstColumnStripe:
+                ColumnStripe1BandSize = bandSize;
+                break;
+            case XLPivotStyleRegionValues.SecondColumnStripe:
+                ColumnStripe2BandSize = bandSize;
+                break;
+        }
+
+        _regionFormats[region] = dxf;
+    }
+}

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -33,6 +33,11 @@ internal class XLWorkbookStyles
     /// </summary>
     private readonly Dictionary<string, XLTableTheme> _tableStyles;
 
+    /// <summary>
+    /// Key is a pivot table style name, value is a pivot table style.
+    /// </summary>
+    private readonly Dictionary<string, XLPivotTableStyle> _pivotStyles;
+
     internal XLWorkbookStyles()
     {
         _numberFormats = new Dictionary<int, string>();
@@ -43,6 +48,7 @@ internal class XLWorkbookStyles
         _cellStyles = new Dictionary<int, XLCellStyle>();
         _differentialFormats = new Dictionary<int, XLDifferentialFormat>();
         _tableStyles = new Dictionary<string, XLTableTheme>(XLHelper.NameComparer);
+        _pivotStyles = new Dictionary<string, XLPivotTableStyle>(XLHelper.NameComparer);
     }
 
     internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
@@ -60,6 +66,8 @@ internal class XLWorkbookStyles
     internal IReadOnlyDictionary<int, XLDifferentialFormat> DifferentialFormats => _differentialFormats;
 
     internal IReadOnlyDictionary<string, XLTableTheme> TableStyles => _tableStyles;
+
+    internal IReadOnlyDictionary<string, XLPivotTableStyle> PivotStyles => _pivotStyles;
 
     internal XLNumberFormatValue GetNumberFormat(int numberFormatId)
     {
@@ -110,5 +118,10 @@ internal class XLWorkbookStyles
     public void AddTableStyle(XLTableTheme tableStyle)
     {
         _tableStyles.Add(tableStyle.Name, tableStyle);
+    }
+
+    public void AddPivotStyle(XLPivotTableStyle pivotStyle)
+    {
+        _pivotStyles.Add(pivotStyle.Name, pivotStyle);
     }
 }


### PR DESCRIPTION
This is part of an effort for full representation of a workbook in the ClosedXML. Pivot style should be preserved during round-trip of load+save. The pivot style might be used in a pivot table or user might want to use it later. This only reads the style, writing will be done later.

The implementation is very similar to table style, though some `ST_TableStyleType` values are mapped to different enums, e.g. value XML value _"lastColumn"_ is mapped to `GrandTotalColumn` in pivot style whereas it's mapped to `LastColumn` in table style.