### PR TITLE
Read indexed/MRU colors to XLWorkbookStyles

### DIFF
--- a/ClosedXML.IO.CodeGen/Program.cs
+++ b/ClosedXML.IO.CodeGen/Program.cs
@@ -135,6 +135,7 @@ public class Program
             .AddComplexTypeMapping("CT_CellXfs", "List<(XLCellFormat Format, int? CellStyleXfId)>")
             .AddComplexTypeMapping("CT_CellStyle", "(int CellStyleXfId, XLCellStyle Style)")
             .AddComplexTypeMapping("CT_CellStyles", "Dictionary<int, XLCellStyle>")
+            .AddComplexTypeMapping("CT_RgbColor", "uint")
             ;
 
         var stylesReaderGenerator = new ParserGenerator(schema, typeMap, "StylesReader", "_ns")

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -673,7 +673,8 @@ internal class StylesReaderTests
             """;
         AssertTableStyles(xml, styles =>
         {
-            // TODO: Read default table style
+            Assert.AreEqual("TableStyleMedium2", styles.DefaultTableStyle);
+
             // Style names are case insensitive
             var tableStyle = styles.TableStyles["test style"];
             Assert.AreEqual("Test Style", tableStyle.Name);
@@ -777,7 +778,7 @@ internal class StylesReaderTests
               <dxf><font><color rgb="FF0000FF"/></font></dxf>
             </dxfs>
             <tableStyles count="1"
-                         defaultTableStyle="TableStyleMedium2">
+                         defaultPivotStyle="PivotStyleLight1">
               <tableStyle name="Test Style"
                           pivot="1"
                           count="7">
@@ -793,7 +794,8 @@ internal class StylesReaderTests
             """;
         AssertTableStyles(xml, styles =>
         {
-            // TODO: Read default table style
+            Assert.AreEqual("PivotStyleLight1", styles.DefaultPivotStyle);
+
             // Style names are case insensitive
             var pivotStyle = styles.PivotStyles["test style"];
             Assert.AreEqual("Test Style", pivotStyle.Name);

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -927,6 +927,32 @@ internal class StylesReaderTests
         }, xml);
     }
 
+    [Test]
+    public void Can_read_most_recently_used_colors()
+    {
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <colors>
+                <mruColors>
+                  <color rgb="FF90FF66"/>
+                  <color rgb="FF663399"/>
+                  <color theme="4"/>
+                </mruColors>
+              </colors>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            Assert.That(styles.MruColors, Is.EqualTo(new[]
+            {
+                XLColor.FromRgb(0x90FF66),
+                XLColor.FromRgb(0x663399),
+                XLColor.FromTheme(XLThemeColor.Accent1)
+            }));
+        }, xml);
+    }
+
     private static void AssertNumberFormats(string numberFormatsXml, Action<XLWorkbookStyles> assert)
     {
         var xml = $"""

--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -888,6 +888,45 @@ internal class StylesReaderTests
         });
     }
 
+    [Test]
+    public void Can_read_indexed_colors()
+    {
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <colors>
+                <indexedColors>
+                  <rgbColor rgb="FF20FF00"/>
+                  <rgbColor/>
+                </indexedColors>
+              </colors>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            // Color with missing rgb attribute use black color
+            Assert.That(styles.IndexedColorsArgb, Is.EqualTo(new[] { 0xFF20FF00, 0xFF000000 }));
+        }, xml);
+    }
+
+    [Test]
+    public void Indexed_colors_will_use_default_indexed_colors_from_spec()
+    {
+        var xml =
+            """
+            <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <colors/>
+            </styleSheet>
+            """;
+        AssertFormat(styles =>
+        {
+            // When styles part doesn't contain custom indexed colors, we default to the ones from
+            // ISO-29500. Keep custom indexed colors null to detect that situation (plus that way
+            // we know not to write custom indexed colors).
+            Assert.That(styles.IndexedColorsArgb, Is.Null);
+        }, xml);
+    }
+
     private static void AssertNumberFormats(string numberFormatsXml, Action<XLWorkbookStyles> assert)
     {
         var xml = $"""

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -53,6 +53,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DEVSQ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DOCTYPE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Doesnt/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dxfs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=EDATE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enumerables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=EOMONTH/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/ClosedXML.csproj.DotSettings
+++ b/ClosedXML/ClosedXML.csproj.DotSettings
@@ -9,4 +9,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cpivottables_005Careas/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cranges/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Csparkline/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cstyle/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cstyle/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=excel_005Cstyle_005Ccolors/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -615,6 +615,15 @@ internal partial class StylesReader
         _currentPivotStyle = new Dictionary<PTS, (XLDifferentialFormat Dxf, int BandSize)>();
     }
 
+    partial void OnTableStylesParsed(uint? count, string? defaultTableStyle, string? defaultPivotStyle)
+    {
+        if (!string.IsNullOrEmpty(defaultTableStyle))
+            _styles.DefaultTableStyle = defaultTableStyle;
+
+        if (!string.IsNullOrEmpty(defaultPivotStyle))
+            _styles.DefaultPivotStyle = defaultPivotStyle;
+    }
+
     private XLColor ParseColor(string elementName)
     {
         return _reader.ParseColor(elementName, _ns);

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -624,6 +624,18 @@ internal partial class StylesReader
             _styles.DefaultPivotStyle = defaultPivotStyle;
     }
 
+    private uint OnRgbColorParsed(uint? rgb)
+    {
+        // Despite the name, it's ARGB. If not specified, use black (Excel supplies 0x00000000, but
+        // Excel plays very fast and loose with transparency).
+        return rgb ?? 0xFF000000;
+    }
+
+    partial void OnIndexedColorsParsed(List<uint> rgbColor)
+    {
+        _styles.SetIndexedColors(rgbColor);
+    }
+
     private XLColor ParseColor(string elementName)
     {
         return _reader.ParseColor(elementName, _ns);

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -636,6 +636,11 @@ internal partial class StylesReader
         _styles.SetIndexedColors(rgbColor);
     }
 
+    partial void OnMRUColorsParsed(List<XLColor> color)
+    {
+        _styles.SetMruColors(color);
+    }
+
     private XLColor ParseColor(string elementName)
     {
         return _reader.ParseColor(elementName, _ns);

--- a/ClosedXML/Excel/IO/StylesReader.g.cs
+++ b/ClosedXML/Excel/IO/StylesReader.g.cs
@@ -418,17 +418,18 @@ internal partial class StylesReader
 
     private void ParseIndexedColors(string elementName)
     {
+        var rgbColor = new List<uint>();
         _reader.Open("rgbColor", _ns);
         do
         {
-            ParseRgbColor("rgbColor");
+            rgbColor.Add(ParseRgbColor("rgbColor"));
         }
         while (_reader.TryOpen("rgbColor", _ns));
         _reader.Close(elementName, _ns);
-        OnIndexedColorsParsed();
+        OnIndexedColorsParsed(rgbColor);
     }
 
-    partial void OnIndexedColorsParsed();
+    partial void OnIndexedColorsParsed(List<uint> rgbColor);
 
     private void ParseMRUColors(string elementName)
     {
@@ -445,12 +446,10 @@ internal partial class StylesReader
 
     partial void OnMRUColorsParsed(List<XLColor> color);
 
-    private void ParseRgbColor(string elementName)
+    private uint ParseRgbColor(string elementName)
     {
         var rgb = _reader.GetOptionalUIntHex("rgb");
         _reader.Close(elementName, _ns);
-        OnRgbColorParsed(rgb);
+        return OnRgbColorParsed(rgb);
     }
-
-    partial void OnRgbColorParsed(uint? rgb);
 }

--- a/ClosedXML/Excel/Style/Colors/XLColor_Internal.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Internal.cs
@@ -1,20 +1,17 @@
-#nullable disable
+namespace ClosedXML.Excel;
 
-namespace ClosedXML.Excel
+public partial class XLColor
 {
-    public partial class XLColor
+    internal XLColorKey Key { get; }
+
+    private XLColor() : this(new XLColorKey())
     {
-        internal XLColorKey Key { get; private set; }
+        HasValue = false;
+    }
 
-        private XLColor() : this(new XLColorKey())
-        {
-            HasValue = false;
-        }
-
-        internal XLColor(XLColorKey key)
-        {
-            Key = key;
-            HasValue = true;
-        }
+    internal XLColor(XLColorKey key)
+    {
+        Key = key;
+        HasValue = true;
     }
 }

--- a/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Static.cs
@@ -70,6 +70,80 @@ namespace ClosedXML.Excel
             { "Aqua", Aqua },
         });
 
+        private static readonly Lazy<Dictionary<Int32, XLColor>> IndexedColorsLazy = new(() => new Dictionary<int, XLColor>
+        {
+            {  0, FromArgb(0xFF000000) },
+            {  1, FromArgb(0xFFFFFFFF) },
+            {  2, FromArgb(0xFFFF0000) },
+            {  3, FromArgb(0xFF00FF00) },
+            {  4, FromArgb(0xFF0000FF) },
+            {  5, FromArgb(0xFFFFFF00) },
+            {  6, FromArgb(0xFFFF00FF) },
+            {  7, FromArgb(0xFF00FFFF) },
+            {  8, FromArgb(0xFF000000) },
+            {  9, FromArgb(0xFFFFFFFF) },
+            { 10, FromArgb(0xFFFF0000) },
+            { 11, FromArgb(0xFF00FF00) },
+            { 12, FromArgb(0xFF0000FF) },
+            { 13, FromArgb(0xFFFFFF00) },
+            { 14, FromArgb(0xFFFF00FF) },
+            { 15, FromArgb(0xFF00FFFF) },
+            { 16, FromArgb(0xFF800000) },
+            { 17, FromArgb(0xFF008000) },
+            { 18, FromArgb(0xFF000080) },
+            { 19, FromArgb(0xFF808000) },
+            { 20, FromArgb(0xFF800080) },
+            { 21, FromArgb(0xFF008080) },
+            { 22, FromArgb(0xFFC0C0C0) },
+            { 23, FromArgb(0xFF808080) },
+            { 24, FromArgb(0xFF9999FF) },
+            { 25, FromArgb(0xFF993366) },
+            { 26, FromArgb(0xFFFFFFCC) },
+            { 27, FromArgb(0xFFCCFFFF) },
+            { 28, FromArgb(0xFF660066) },
+            { 29, FromArgb(0xFFFF8080) },
+            { 30, FromArgb(0xFF0066CC) },
+            { 31, FromArgb(0xFFCCCCFF) },
+            { 32, FromArgb(0xFF000080) },
+            { 33, FromArgb(0xFFFF00FF) },
+            { 34, FromArgb(0xFFFFFF00) },
+            { 35, FromArgb(0xFF00FFFF) },
+            { 36, FromArgb(0xFF800080) },
+            { 37, FromArgb(0xFF800000) },
+            { 38, FromArgb(0xFF008080) },
+            { 39, FromArgb(0xFF0000FF) },
+            { 40, FromArgb(0xFF00CCFF) },
+            { 41, FromArgb(0xFFCCFFFF) },
+            { 42, FromArgb(0xFFCCFFCC) },
+            { 43, FromArgb(0xFFFFFF99) },
+            { 44, FromArgb(0xFF99CCFF) },
+            { 45, FromArgb(0xFFFF99CC) },
+            { 46, FromArgb(0xFFCC99FF) },
+            { 47, FromArgb(0xFFFFCC99) },
+            { 48, FromArgb(0xFF3366FF) },
+            { 49, FromArgb(0xFF33CCCC) },
+            { 50, FromArgb(0xFF99CC00) },
+            { 51, FromArgb(0xFFFFCC00) },
+            { 52, FromArgb(0xFFFF9900) },
+            { 53, FromArgb(0xFFFF6600) },
+            { 54, FromArgb(0xFF666699) },
+            { 55, FromArgb(0xFF969696) },
+            { 56, FromArgb(0xFF003366) },
+            { 57, FromArgb(0xFF339966) },
+            { 58, FromArgb(0xFF003300) },
+            { 59, FromArgb(0xFF333300) },
+            { 60, FromArgb(0xFF993300) },
+            { 61, FromArgb(0xFF993366) },
+            { 62, FromArgb(0xFF333399) },
+            { 63, FromArgb(0xFF333333) },
+            { 64, FromColor(Color.Transparent) }, // System Foreground
+        });
+
+        /// <summary>
+        /// Default indexed colors per ISO-298500 indexedColors. All values are either RGB or named.
+        /// </summary>
+        public static Dictionary<Int32, XLColor> IndexedColors => IndexedColorsLazy.Value;
+
         internal static XLColor FromKey(ref XLColorKey key)
         {
             return Repository.GetOrCreate(ref key);
@@ -200,88 +274,6 @@ namespace ClosedXML.Excel
             // Don't crash on unparsable colors, e.g. None or malformed #RED should still be represented, even
             // though we don't actually know how to map them.
             return FromName(vmlColor);
-        }
-
-        private static Dictionary<Int32, XLColor>? _indexedColors;
-
-        public static Dictionary<Int32, XLColor> IndexedColors
-        {
-            get
-            {
-                if (_indexedColors == null)
-                {
-                    var retVal = new Dictionary<Int32, XLColor>
-                        {
-                            {0, FromHtml("#FF000000")},
-                            {1, FromHtml("#FFFFFFFF")},
-                            {2, FromHtml("#FFFF0000")},
-                            {3, FromHtml("#FF00FF00")},
-                            {4, FromHtml("#FF0000FF")},
-                            {5, FromHtml("#FFFFFF00")},
-                            {6, FromHtml("#FFFF00FF")},
-                            {7, FromHtml("#FF00FFFF")},
-                            {8, FromHtml("#FF000000")},
-                            {9, FromHtml("#FFFFFFFF")},
-                            {10, FromHtml("#FFFF0000")},
-                            {11, FromHtml("#FF00FF00")},
-                            {12, FromHtml("#FF0000FF")},
-                            {13, FromHtml("#FFFFFF00")},
-                            {14, FromHtml("#FFFF00FF")},
-                            {15, FromHtml("#FF00FFFF")},
-                            {16, FromHtml("#FF800000")},
-                            {17, FromHtml("#FF008000")},
-                            {18, FromHtml("#FF000080")},
-                            {19, FromHtml("#FF808000")},
-                            {20, FromHtml("#FF800080")},
-                            {21, FromHtml("#FF008080")},
-                            {22, FromHtml("#FFC0C0C0")},
-                            {23, FromHtml("#FF808080")},
-                            {24, FromHtml("#FF9999FF")},
-                            {25, FromHtml("#FF993366")},
-                            {26, FromHtml("#FFFFFFCC")},
-                            {27, FromHtml("#FFCCFFFF")},
-                            {28, FromHtml("#FF660066")},
-                            {29, FromHtml("#FFFF8080")},
-                            {30, FromHtml("#FF0066CC")},
-                            {31, FromHtml("#FFCCCCFF")},
-                            {32, FromHtml("#FF000080")},
-                            {33, FromHtml("#FFFF00FF")},
-                            {34, FromHtml("#FFFFFF00")},
-                            {35, FromHtml("#FF00FFFF")},
-                            {36, FromHtml("#FF800080")},
-                            {37, FromHtml("#FF800000")},
-                            {38, FromHtml("#FF008080")},
-                            {39, FromHtml("#FF0000FF")},
-                            {40, FromHtml("#FF00CCFF")},
-                            {41, FromHtml("#FFCCFFFF")},
-                            {42, FromHtml("#FFCCFFCC")},
-                            {43, FromHtml("#FFFFFF99")},
-                            {44, FromHtml("#FF99CCFF")},
-                            {45, FromHtml("#FFFF99CC")},
-                            {46, FromHtml("#FFCC99FF")},
-                            {47, FromHtml("#FFFFCC99")},
-                            {48, FromHtml("#FF3366FF")},
-                            {49, FromHtml("#FF33CCCC")},
-                            {50, FromHtml("#FF99CC00")},
-                            {51, FromHtml("#FFFFCC00")},
-                            {52, FromHtml("#FFFF9900")},
-                            {53, FromHtml("#FFFF6600")},
-                            {54, FromHtml("#FF666699")},
-                            {55, FromHtml("#FF969696")},
-                            {56, FromHtml("#FF003366")},
-                            {57, FromHtml("#FF339966")},
-                            {58, FromHtml("#FF003300")},
-                            {59, FromHtml("#FF333300")},
-                            {60, FromHtml("#FF993300")},
-                            {61, FromHtml("#FF993366")},
-                            {62, FromHtml("#FF333399")},
-                            {63, FromHtml("#FF333333")},
-                            {64, FromColor(Color.Transparent)}
-                        };
-                    _indexedColors = retVal;
-                }
-                return _indexedColors;
-            }
         }
 
         internal static bool IsNullOrTransparent(XLColor color)

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -69,6 +69,18 @@ internal class XLWorkbookStyles
 
     internal IReadOnlyDictionary<string, XLPivotTableStyle> PivotStyles => _pivotStyles;
 
+    /// <summary>
+    /// Name of a table style that should be used for newly added tables. It's not used for tables
+    /// without a specified style.
+    /// </summary>
+    internal string? DefaultTableStyle { get; set; }
+
+    /// <summary>
+    /// Name of a pivot style that should be used for newly added pivot tables. It's not used for
+    /// pivot tables without a specified style.
+    /// </summary>
+    internal string? DefaultPivotStyle { get; set; }
+
     internal XLNumberFormatValue GetNumberFormat(int numberFormatId)
     {
         var xlNumberFormat = new XLNumberFormatKey

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -38,6 +38,8 @@ internal class XLWorkbookStyles
     /// </summary>
     private readonly Dictionary<string, XLPivotTableStyle> _pivotStyles;
 
+    private List<uint>? _indexedColorsArgb;
+
     internal XLWorkbookStyles()
     {
         _numberFormats = new Dictionary<int, string>();
@@ -80,6 +82,13 @@ internal class XLWorkbookStyles
     /// pivot tables without a specified style.
     /// </summary>
     internal string? DefaultPivotStyle { get; set; }
+
+    /// <summary>
+    /// Some workbooks use indexed colors that are not in the standard <see cref="XLColor.IndexedColors"/>,
+    /// but have their own list of indexed colors. Legacy feature, do not expose. If the value is null, use
+    /// predefined indexed colors.
+    /// </summary>
+    internal IReadOnlyList<uint>? IndexedColorsArgb => _indexedColorsArgb;
 
     internal XLNumberFormatValue GetNumberFormat(int numberFormatId)
     {
@@ -135,5 +144,10 @@ internal class XLWorkbookStyles
     public void AddPivotStyle(XLPivotTableStyle pivotStyle)
     {
         _pivotStyles.Add(pivotStyle.Name, pivotStyle);
+    }
+
+    public void SetIndexedColors(List<uint> indexedColors)
+    {
+        _indexedColorsArgb = indexedColors;
     }
 }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -40,6 +40,8 @@ internal class XLWorkbookStyles
 
     private List<uint>? _indexedColorsArgb;
 
+    private List<XLColor> _mruColors = new();
+
     internal XLWorkbookStyles()
     {
         _numberFormats = new Dictionary<int, string>();
@@ -89,6 +91,13 @@ internal class XLWorkbookStyles
     /// predefined indexed colors.
     /// </summary>
     internal IReadOnlyList<uint>? IndexedColorsArgb => _indexedColorsArgb;
+
+    /// <summary>
+    /// Most recently used colors are colors <em>hand-picked</em> by a user that are displayed in
+    /// the color picker dialogue. The standard and theme colors are always offered in the color
+    /// picker, so they are (in general) not added to the MRU color list.
+    /// </summary>
+    internal IReadOnlyList<XLColor> MruColors => _mruColors;
 
     internal XLNumberFormatValue GetNumberFormat(int numberFormatId)
     {
@@ -149,5 +158,10 @@ internal class XLWorkbookStyles
     public void SetIndexedColors(List<uint> indexedColors)
     {
         _indexedColorsArgb = indexedColors;
+    }
+
+    public void SetMruColors(List<XLColor> mruColors)
+    {
+        _mruColors = mruColors;
     }
 }


### PR DESCRIPTION
The indexed colors and most-recently-used colors are the last (non-extension) elements from styles part that are now read through codegen reader. Yay.

That means I can move onto fixing the formatting internals and then actually saving the styles part.

Should probably fix some bugs.

And also get started on the XML reader+full representation+writer for the worksheet part. Full representation/pass-through is an essential property of any editing library.

Also, I need to deal with extensions/MC&E at some point, but that can wait.

¯\\_(ツ)\_/¯

On the bright side, I am actually very happy with my codegen XML reader design so far.