### PR TITLE
Search for worksheets in without unescaping

### DIFF
--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -2,6 +2,7 @@ using ClosedXML.Excel;
 using ClosedXML.Excel.Drawings;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1365,6 +1366,27 @@ namespace ClosedXML.Tests
             Assert.Throws<ArgumentException>(() => _ = ws.Range("DEAD1"));
             Assert.Throws<ArgumentException>(() => _ = ws.Range("DEAD4:BEEF10"));
             Assert.Throws<ArgumentException>(() => _ = ws.Range("nonexistent_range"));
+        }
+
+        [TestCase("Sheet1", "Sheet1")]
+        [TestCase("Sheet1", "SHEET1")]
+        [TestCase("Baker's Paradise", "BAKER'S PARADISE")]
+        [TestCase("XXX''XXX", "XXX''XXX")]
+        public void Worksheet_by_name_returns_worksheet_with_the_same_case_insensitive_name(string sheetName, string searchedSheetName)
+        {
+            using var wb = new XLWorkbook();
+            var sheet = wb.AddWorksheet(sheetName);
+
+            Assert.That(wb.Worksheets.Worksheet(searchedSheetName), Is.SameAs(sheet));
+        }
+
+        [Test]
+        public void Worksheet_by_name_throws_exception_when_no_sheet_with_name_found()
+        {
+            using var wb = new XLWorkbook();
+            wb.AddWorksheet("Sheet");
+
+            Assert.That(() => wb.Worksheets.Worksheet("Nonexistent"), Throws.TypeOf<KeyNotFoundException>());
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -1388,5 +1388,22 @@ namespace ClosedXML.Tests
 
             Assert.That(() => wb.Worksheets.Worksheet("Nonexistent"), Throws.TypeOf<KeyNotFoundException>());
         }
+
+        [TestCase("Sheet1", "Sheet1", true)]
+        [TestCase("Sheet1", "SHEET1", true)]
+        [TestCase("Sheet1", "Sheet", false)]
+        [TestCase("Sheet1", " Sheet1", false)]
+        [TestCase("Baker's Paradise", "BAKER'S PARADISE", true)]
+        [TestCase("XXX''XXX", "XXX''XXX", true)]
+        public void TryGetWorksheet_finds_worksheet_with_the_same_case_insensitive_name(string sheetName, string searchedSheetName, bool expectedFound)
+        {
+            using var wb = new XLWorkbook();
+            var sheet = wb.AddWorksheet(sheetName);
+
+            var found = wb.Worksheets.TryGetWorksheet(searchedSheetName, out var foundSheet);
+
+            Assert.AreEqual(expectedFound, found);
+            Assert.That(foundSheet, found ? Is.SameAs(sheet): Is.Null);
+        }
     }
 }

--- a/ClosedXML/Excel/IXLWorksheets.cs
+++ b/ClosedXML/Excel/IXLWorksheets.cs
@@ -33,7 +33,13 @@ namespace ClosedXML.Excel
 
         bool TryGetWorksheet(string sheetName, [NotNullWhen(true)] out IXLWorksheet? worksheet);
 
-        IXLWorksheet Worksheet(String sheetName);
+        /// <summary>
+        /// Get a sheet of a workbook with specified name. Sheet names are case-insensitive.
+        /// </summary>
+        /// <param name="sheetName">Name of sought sheet.</param>
+        /// <returns>Sheet with the specified name.</returns>
+        /// <exception cref="KeyNotFoundException">When sheet with <paramref name="sheetName"/> isn't among the sheets.</exception>
+        IXLWorksheet Worksheet(string sheetName);
 
         IXLWorksheet Worksheet(Int32 position);
     }

--- a/ClosedXML/Excel/IXLWorksheets.cs
+++ b/ClosedXML/Excel/IXLWorksheets.cs
@@ -31,6 +31,12 @@ namespace ClosedXML.Excel
 
         void Delete(Int32 position);
 
+        /// <summary>
+        /// Try to get a sheet of a workbook with the specified name. Sheet names are case-insensitive.
+        /// </summary>
+        /// <param name="sheetName">Name of sought sheet.</param>
+        /// <param name="worksheet">Found sheet or null if sheet is not found.</param>
+        /// <returns><c>true</c> when sheet was found or <c>false</c> when it wasn't.</returns>
         bool TryGetWorksheet(string sheetName, [NotNullWhen(true)] out IXLWorksheet? worksheet);
 
         /// <summary>

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -65,13 +65,7 @@ namespace ClosedXML.Excel
 
         internal bool TryGetWorksheet(string sheetName, [NotNullWhen(true)] out XLWorksheet? worksheet)
         {
-            if (_worksheets.TryGetValue(sheetName.UnescapeSheetName(), out worksheet))
-            {
-                return true;
-            }
-
-            worksheet = null;
-            return false;
+            return _worksheets.TryGetValue(sheetName, out worksheet);
         }
 
         public IXLWorksheet Worksheet(string sheetName)

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
     internal class XLWorksheets : IXLWorksheets, IEnumerable<XLWorksheet>
     {
         private readonly XLWorkbook _workbook;
-        private readonly Dictionary<String, XLWorksheet> _worksheets = new Dictionary<String, XLWorksheet>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, XLWorksheet> _worksheets = new(XLHelper.SheetComparer);
         internal ICollection<String> Deleted { get; private set; }
 
         /// <summary>
@@ -74,14 +74,12 @@ namespace ClosedXML.Excel
             return false;
         }
 
-        public IXLWorksheet Worksheet(String sheetName)
+        public IXLWorksheet Worksheet(string sheetName)
         {
-            sheetName = sheetName.UnescapeSheetName();
+            if (!_worksheets.TryGetValue(sheetName, out var foundSheet))
+                throw new KeyNotFoundException($"There isn't a worksheet named '{sheetName}'.");
 
-            if (_worksheets.TryGetValue(sheetName, out XLWorksheet w))
-                return w;
-
-            throw new ArgumentException("There isn't a worksheet named '" + sheetName + "'.");
+            return foundSheet;
         }
 
         public IXLWorksheet Worksheet(Int32 position)

--- a/ClosedXML/Extensions/StringExtensions.cs
+++ b/ClosedXML/Extensions/StringExtensions.cs
@@ -86,11 +86,6 @@ namespace ClosedXML.Excel
                 .Replace("''", "'");
         }
 
-        internal static string WithoutLast(this String value, int length)
-        {
-            return length < value.Length ? value.Substring(0, value.Length - length) : String.Empty;
-        }
-
         /// <summary>
         /// Convert a string (containing code units) into code points.
         /// Surrogate pairs of code units are joined to code points.

--- a/docs/migrations/migrate-to-0.106.rst
+++ b/docs/migrations/migrate-to-0.106.rst
@@ -20,3 +20,14 @@ The number format setters (```IXLNumberFormatBase.NumberFormatId```,
 ```IXLNumberFormat.SetNumberFormatId(int)``` and ```IXLPivotValueFormat.SetNumberFormatId(int)```)
 now throw an ```ArgumentOutOfRangeException``` when supplied number format id is
 not a predefined format id from ```XLPredefinedFormat```.
+
+*************
+IXLWorksheets
+*************
+
+The method ``IXLWorksheets.Worksheet(string sheetName)`` now throws ``KeyNotFoundException`` when
+sheet is not found, instead of original ``ArgumentException``.
+
+Generally speaking, get-by-name methods of all unique-name collections (e.g., worksheets, styles,
+table fields ect) should throw ``KeyNotFoundException`` when item is not found. This change aligns
+the behavior of the ``IXLWorksheets`` with the rest of API.


### PR DESCRIPTION
When searching for a sheet in a `IXLWorksheets`, accept the argument as-is, without any unescaping. The original logic not only cause problematic behavior when using the API, it also crashed during workbook load.

Resolves #2704