### PR TITLE
Add a stub for cell formats

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/XLCellFormatTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/XLCellFormatTests.cs
@@ -1,0 +1,123 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using ClosedXML.Excel.Formatting;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Styles;
+
+/// <summary>
+/// Tests of <see cref="XLCellFormat"/> API.
+/// </summary>
+[TestOf(typeof(XLCellFormat))]
+[TestOf(typeof(IXLStyle))]
+internal class XLCellFormatTests
+{
+    [TestCaseSource(nameof(GetFontDefaultValueTestCases))]
+    public void Cell_format_resolves_font_property_as_its_own_format_value_or_default_value(ResolveFormatTestCase cellFontTestCase)
+    {
+        // This test checks resolution of a font property value when a cell has a format.
+        // * If cell has a format font property, that is resolved property.
+        // * If cell has a format, but font property is not specified, it uses default value.
+        //
+        // Default value for font and other styles is kind of vague. So far it seems that
+        // default value for missing font property is either a constant value that is essentially
+        // a false (0)/black (color 000000)/first enum entry or it is taken from a normal
+        // style if zero can't be a valid value (e.g. zero is not a valid font name or size).
+        // Note that row or sheet formatting is never used. Only a constant value or a normal style.
+        var styles = new XLWorkbookStyles();
+        var actual = cellFontTestCase.InitActual();
+        var rowOrColumn = cellFontTestCase.InitRowOrColumn();
+        var sheet = cellFontTestCase.InitSheet();
+        var normal = cellFontTestCase.InitNormal();
+        var hierarchy = new FormatHierarchy(new[] { actual }, rowOrColumn, rowOrColumn, sheet, normal);
+        var style = new XLCellFormat(hierarchy, styles);
+
+        // Resolve font property
+        var resolvedFontPropertyValue = cellFontTestCase.GetActual(style);
+
+        // Assert that it's same as expected value
+        Assert.AreEqual(cellFontTestCase.ExpectedValue, resolvedFontPropertyValue);
+    }
+
+    public static IEnumerable<object[]> GetFontDefaultValueTestCases()
+    {
+        return MakeFontFlagCases((b, f) => f with { Bold = (bool?)b }, x => x.Bold)
+            .Concat(MakeFontFlagCases((i, f) => f with { Italic = (bool?)i }, x => x.Italic))
+            .Concat(MakeFontNameCases())
+            .Select(x => new object[] { x })
+            .ToList();
+    }
+
+    private static IEnumerable<ResolveFormatTestCase> MakeFontFlagCases(Func<object?, XLFontFormatValue, XLFontFormatValue> setter, Func<XLFontCellFormat, object> getter)
+    {
+        // Font flags don't use normal style or any other fallback. If a cell font format doesn't have a value, it is just false.
+        yield return MakeTestCase(setter, getter, true, null, null, null, true);
+        yield return MakeTestCase(setter, getter, false, null, null, null, false);
+        yield return MakeTestCase(setter, getter, null, null, null, null, false);
+        yield return MakeTestCase(setter, getter, null, true, true, true, false);
+    }
+
+    private static IEnumerable<ResolveFormatTestCase> MakeFontNameCases()
+    {
+        // When cell has a font, use that font.
+        yield return MakeTestCase((v, f) => f with { Name = (XLFontName?)v }, f => f.Name.Text, "Cell Font", "Row or Col Font", "Sheet Font", "Normal Font", (XLFontName)"Cell Font");
+
+        // When cell doesn't have a font, use the font name form normal, even though there is a row and sheet in the hierarchy
+        yield return MakeTestCase((v, f) => f with { Name = (XLFontName?)v }, f => f.Name.Text, null, "Row or Col Font", "Sheet Font", "Normal Font", (XLFontName)"Normal Font");
+    }
+
+    private static ResolveFormatTestCase MakeTestCase<T>(Func<object?, XLFontFormatValue, XLFontFormatValue> setter, Func<XLFontCellFormat, object> getter, T? cellValue, T? rowOrColValue, T? sheetValue, T? normalValue, T expected)
+        where T : struct
+    {
+        return new ResolveFormatTestCase
+        {
+            ExpectedValue = expected,
+            GetActual = x => getter(x.Font),
+            Setter = setter,
+            CellValue = cellValue,
+            RowOrColValue = rowOrColValue,
+            SheetValue = sheetValue,
+            NormalValue = normalValue
+        };
+    }
+
+    internal class ResolveFormatTestCase
+    {
+        public required object ExpectedValue { get; init; }
+
+        public required Func<XLCellFormat, object> GetActual { get; init; }
+
+        public required Func<object?, XLFontFormatValue, XLFontFormatValue> Setter { get; init; }
+
+        public required object? CellValue { get; init; }
+
+        public required object? RowOrColValue { get; init; }
+
+        public required object? SheetValue { get; init; }
+
+        public required object? NormalValue { get; init; }
+
+        public IXLFormatContainer InitActual() => CreateFontContainer(CellValue);
+
+        public IXLFormatContainer InitRowOrColumn() => CreateFontContainer(RowOrColValue);
+
+        public IXLFormatContainer InitSheet() => CreateFontContainer(SheetValue);
+
+        public IXLFormatContainer InitNormal() => CreateFontContainer(NormalValue);
+
+        private FormatContainer CreateFontContainer(object? value)
+        {
+            var font = Setter(value, XLFontFormatValue.Empty);
+            var format = XLCellFormatValue.Empty with { Font = font };
+            return new FormatContainer { FormatValue = format };
+        }
+    }
+
+    private class FormatContainer : IXLFormatContainer
+    {
+        public XLCellFormatValue? FormatValue { get; set; } = XLCellFormatValue.Empty;
+    }
+}

--- a/ClosedXML/Excel/Style/Api/FormatHierarchy.cs
+++ b/ClosedXML/Excel/Style/Api/FormatHierarchy.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Format hierarchy is used to resolve a format properties. It has three main properties:
+/// <list type="bullet">
+///   <item>
+///     <term>Containers</term>
+///     <description>
+///     A workbook components with a format that should be updated when user uses API to change
+///     a format (e.g. a row). Container doesn't have to initially have a value, e.g. it's a cell
+///     or a row without a format (thus inherits normal).
+///     </description>
+///   </item>
+///   <item>
+///     <term>Areas</term>
+///     <description>
+///     Cell areas in a workbook that should be updated when format is changed, e.g. when we have
+///     a format API object for a row container, the area are all cells of the row. It must be
+///     an area, so we can satisfy the <see cref="IXLBorder.OutsideBorder"/> and
+///     <see cref="IXLBorder.InsideBorder"/> property setters.
+///     </description>
+///   </item>
+///   <item>
+///     <term>Format hierarchy</term>
+///     <description>
+///     It contains info about formats of format objects that are higher in a hierarchy. For
+///     a cell, higher objects are row, column, sheet and normal style. For a column, higher object
+///     is a sheet and then normal style. This info is used to determine format for containers
+///     without a format (don't create format unless necessary).
+///     </description>
+///   </item>
+/// </list>
+/// </summary>
+internal readonly struct FormatHierarchy
+{
+    /// <summary>
+    /// Containers that are modified by the API changes.
+    /// </summary>
+    private readonly IXLFormatContainer[] _containers;
+
+    /// <summary>
+    /// Cell areas that should have format updated upon a format change.
+    /// </summary>
+    private readonly IReadOnlyList<XLBookArea> _areas = Array.Empty<XLBookArea>();
+
+    /// <summary>
+    /// Row and column formats. They don't do anything for setting the value, but are useful when
+    /// asking for a value of a non-existent or non-styles cell.
+    /// </summary>
+    /// <remarks>
+    /// When a cell has no explicit style and column and row cross, the row style
+    /// wins (i.e. when both column and row specify color, the row one is displayed when cell
+    /// doesn't have a style or doesn't exist). Therefore row is asked before column.
+    /// </remarks>
+    private readonly IXLFormatContainer? _row;
+    private readonly IXLFormatContainer? _column;
+
+    /// <summary>
+    /// Sheet format is a ClosedXML fiction. OOXML doesn't have a style for a sheet. Think of it as
+    /// all columns without a specified format. The xml tag <![CDATA[<col/>]]> has attributes
+    /// <c>min</c> (column) and <c>max</c> (column), so we can easily specify formatting for
+    /// all columns from start to end (or just ones that don't have explicit format).
+    /// </summary>
+    private readonly IXLFormatContainer? _sheet;
+
+    /// <summary>
+    /// A normal style of a workbook. Should have all values.
+    /// </summary>
+    private readonly IXLFormatContainer _normal;
+
+    public FormatHierarchy(IXLFormatContainer[] containers, IXLFormatContainer? row, IXLFormatContainer? column, IXLFormatContainer? sheet, IXLFormatContainer normal)
+    {
+        _containers = containers ?? throw new ArgumentNullException(nameof(containers));
+        _row = row;
+        _column = column;
+        _sheet = sheet;
+        _normal = normal;
+    }
+
+    public T Resolve<T>(Func<XLCellFormatValue, T?> getFormatValue, T existingFormatMissingValueDefault)
+        where T : struct
+    {
+        var container = _containers[0];
+        var format = container.FormatValue;
+        if (format is not null)
+        {
+            return getFormatValue(format) ?? existingFormatMissingValueDefault;
+        }
+
+        // Container doesn't even have a format, e.g. it's a style-less cell or a row. 
+        throw new NotImplementedException();
+    }
+
+    public T ResolveWithNormalFallback<T>(Func<XLCellFormatValue, T?> getFormatValue)
+        where T : struct
+    {
+        var normalFormat = _normal.FormatValue ?? throw new InvalidOperationException("Normal style doesn't have format");
+        var normalValue = getFormatValue(normalFormat) ?? throw new InvalidOperationException("Normal style should have everything.");
+        return Resolve(getFormatValue, normalValue);
+    }
+}

--- a/ClosedXML/Excel/Style/Api/IXLFormatContainer.cs
+++ b/ClosedXML/Excel/Style/Api/IXLFormatContainer.cs
@@ -1,0 +1,17 @@
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// An interface for objects that have a cell format, for example cell or a row. This is used by
+/// the API to modify the cell formatting. Cell formats are immutable, so they can only be fully
+/// replaced, never modified. The set value must be registered in the <see cref="XLWorkbookStyles"/>.
+/// </summary>
+internal interface IXLFormatContainer
+{
+    /// <summary>
+    /// The format of a container can be <c>null</c>, e.g. a row that doesn't have format. In that
+    /// situation, we have a container (e.g. a row), but no format.
+    /// </summary>
+    XLCellFormatValue? FormatValue { get; set; }
+}

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// API object to modify font properties of a cell format of a <see cref="IXLFormatContainer"/>.
+/// Unlike the <see cref="XLStyle"/>, the <see cref="XLCellFormat"/> one modifies formatting
+/// in a <see cref="XLWorkbookStyles"/>.
+/// </summary>
+internal class XLCellFormat
+{
+    private readonly FormatHierarchy _hierarchy;
+    private readonly XLWorkbookStyles _styles;
+
+    internal XLCellFormat(FormatHierarchy hierarchy, XLWorkbookStyles styles)
+    {
+        _hierarchy = hierarchy;
+        _styles = styles ?? throw new ArgumentNullException(nameof(styles));
+    }
+
+    internal XLFontCellFormat Font => new(this, _hierarchy, _styles);
+}

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
@@ -1,0 +1,24 @@
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// API object to modify font properties of a cell format of a <see cref="IXLFormatContainer"/>.
+/// </summary>
+internal class XLFontCellFormat
+{
+    private readonly XLCellFormat _parent;
+    private readonly FormatHierarchy _hierarchy;
+    private readonly XLWorkbookStyles _styles;
+
+    internal XLFontCellFormat(XLCellFormat parent, FormatHierarchy hierarchy, XLWorkbookStyles styles)
+    {
+        _parent = parent;
+        _hierarchy = hierarchy;
+        _styles = styles;
+    }
+
+    public bool Bold => _hierarchy.Resolve(static x => x.Font?.Bold, false);
+
+    public bool Italic => _hierarchy.Resolve(static x => x.Font?.Italic, false);
+
+    public XLFontName Name => _hierarchy.ResolveWithNormalFallback(static x => x.Font?.Name);
+}

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormatValue.cs
@@ -17,6 +17,20 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal record XLCellFormatValue
 {
+    public static readonly XLCellFormatValue Empty = new()
+    {
+        NumberFormat = null,
+        Alignment = null,
+        Protection = null,
+        Font = null,
+        Fill = null,
+        Border = null,
+        CellStyle = null,
+        IncludeQuotePrefix = false,
+        PivotButton = false,
+        StyleComponents = CellFormatComponents.None
+    };
+
     public required string? NumberFormat { get; init; }
 
     public required XLAlignmentFormatValue? Alignment { get; init; }


### PR DESCRIPTION
This should eventually grow to fully replace current `XLStyle` and `XLStylized` classes. It will use the `XLWorkbookStyles` class. The internal structure is slightly more complex, but should provide support for all use cases:

1. Set a format of various container:
   * one cell (`IXLCell`)/row (`IXLRow`)/column (`IXLColumn`)
   * multiple cells(`IXLCells`)/rows(`IXLRows`)/column(`IXLColumns`)
   * sheet (`IXLWorksheet`) and
   * area (`IXLRangeBase`)

3. Should get a format of various containers (see above)

2. Should work even if container is not yet formatted (e.g. non-materilized cell or a column), without eager materialization

Formatting is not described anywhere and Excel is kind of insane, but I think this should work (once properly implemented) to match Excel and keep the current API.

The actual code is in a limbo and not yet used anywhere. The plan is to make it work and then try to switch and also change the saving format. We'll see how it goes.

This only introduces data structure and the most basic tests.

Sidenote: I am don't like the `IXLStyle` name, it should be `IXLFormat` or something like that, style is a _named_ format.