### PR TITLE
Remove restriction for loading a long named picture.

### DIFF
--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -344,9 +344,6 @@ namespace ClosedXML.Excel.Drawings
             if (value.IndexOfAny(InvalidNameChars.ToCharArray()) != -1)
                 throw new ArgumentException($"Picture names cannot contain any of the following characters: {InvalidNameChars}");
 
-            if (value.Length > 31)
-                throw new ArgumentException("Picture names cannot be more than 31 characters");
-
             _name = value;
         }
 


### PR DESCRIPTION
Remove restriction for loading a sheet with any picture has a name longer than 31 characters.

This seems has been a problem for some years. #1564 #1671 
If this exception is be thrown for compatibility consideration, would it be better to validate when saving the file, not when loading one?