### PR TITLE
Update reference on delete and shift up

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ReferenceShiftOnDeleteRefModTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ReferenceShiftOnDeleteRefModTests.cs
@@ -1,0 +1,71 @@
+using ClosedXML.Excel;
+using ClosedXML.Excel.CalcEngine.Visitors;
+using ClosedXML.Extensions;
+using ClosedXML.Parser;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.CalcEngine;
+
+[TestFixture]
+[TestOf(typeof(ReferenceShiftOnDeleteRefModVisitor))]
+public class ReferenceShiftOnDeleteRefModTests
+{
+    /// <summary>
+    /// This tests how are references changed inside a formula when an area is deleted and shifted up.
+    /// They were derived by using SUM(reference) before and after deletion.
+    /// </summary>
+    [TestCase("C2", "Other!C2", "C2")] // Delete cell with same coordinate on different sheet.
+    [TestCase("C2", "Sheet!C2", "#REF!")] // Fully delete a cell.
+    [TestCase("$C$2", "Sheet!C2", "#REF!")] // Only posıtıon matter, reference style doesn't.
+
+    // Column span tests
+    [TestCase("A:B", "Sheet!10:20", "A:B")] // Column span is basically never changed.
+    [TestCase("A:B", "Sheet!A1:B5", "A:B")] // Column span is basically never changed.
+
+    // Deleted area is fully to the left of a reference.
+    [TestCase("C1:D3", "Sheet!A1:B3", "C1:D3")]
+
+    // Deleted area is fully to the right of a reference.
+    [TestCase("A1:B3", "Sheet!C1:D3", "A1:B3")]
+
+    // Deleted area is inside and only partially covers a reference.
+    [TestCase("A1:D3", "Sheet!B1:C3", "A1:D3")]
+
+    // Deleted area covers full width of reference
+    [TestCase("A1:D3", "Sheet!A4:D4", "A1:D3")] // Deleted area is completely below the reference.
+    [TestCase("A5:A10", "Sheet!A10:D11", "A5:A9")]
+    [TestCase("A5:A10", "Sheet!A10", "A5:A9")]
+    [TestCase("A5:A10", "Sheet!A7:A10", "A5:A6")]
+    [TestCase("A5:A10", "Sheet!A5:A10", "#REF!")]
+    [TestCase("A5:A10", "Sheet!A5:A6", "A5:A8")]
+    [TestCase("A5:A10", "Sheet!A4:A6", "A4:A7")]
+    [TestCase("A5:A10", "Sheet!A2:A4", "A2:A7")]
+
+    // Deleted area covers a left slice of a reference
+    [TestCase("C5:E10", "Sheet!C5:D10", "E5:E10")]
+    [TestCase("C5:E10", "Sheet!A5:D10", "E5:E10")]
+    [TestCase("C5:E10", "Sheet!A2:D15", "E5:E10")]
+    [TestCase("C5:E10", "Sheet!A6:D10", "C5:E10")]
+    [TestCase("C5:E10", "Sheet!A5:D9", "C5:E10")]
+    [TestCase("C5:E10", "Sheet!C1:D4", "C5:E10")]
+    [TestCase("C5:E10", "Sheet!C11:D14", "C5:E10")]
+
+    // Deleted area covers a right slice of a reference
+    [TestCase("C5:E10", "Sheet!D5:E10", "C5:C10")]
+    [TestCase("C5:E10", "Sheet!D5:F10", "C5:C10")]
+    [TestCase("C5:E10", "Sheet!D2:E15", "C5:C10")]
+    [TestCase("C5:E10", "Sheet!D6:F10", "C5:E10")]
+    [TestCase("C5:E10", "Sheet!D5:F9", "C5:E10")]
+    [TestCase("C5:E10", "Sheet!D1:E4", "C5:E10")]
+    [TestCase("C5:E10", "Sheet!D11:E14", "C5:E10")]
+    public void Delete_area_and_shift_up_reference(string formula, string deletedArea, string expected)
+    {
+        // TODO: Once incorporated into cell deletion, replace with a public API test case through SUM(reference) in a cell.
+        Assert.True(ReferenceParser.TryParseSheetA1(deletedArea, out var deletedSheet, out var deletedReference));
+        var deleted = new XLBookArea(deletedSheet, deletedReference.ToSheetRangeA1());
+
+        var result = FormulaConverter.ModifyA1(formula, "Sheet", 1, 1, new ReferenceShiftOnDeleteRefModVisitor(deleted, XLShiftDeletedCells.ShiftCellsUp));
+
+        Assert.AreEqual(expected, result);
+    }
+}

--- a/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
+++ b/ClosedXML.Tests/Extensions/ReferenceAreaExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using ClosedXML.Excel;
 using ClosedXML.Extensions;
 using ClosedXML.Parser;

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -133,6 +133,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDBETWEEN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=REPT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ROUNDDOWN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=rowspan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RRGGBBAA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SECH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SERIESSUM/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
@@ -1,0 +1,134 @@
+using ClosedXML.Extensions;
+using ClosedXML.Parser;
+using System;
+using System.Diagnostics;
+
+namespace ClosedXML.Excel.CalcEngine.Visitors;
+
+/// <summary>
+/// A RefModVisitor that adjusts a reference in a formula when an area is deleted and shifted up/left.
+/// </summary>
+internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
+{
+    private const string RefError = "#REF!";
+    private readonly XLBookArea _deletedBookArea;
+    private readonly XLShiftDeletedCells _shift;
+
+    public ReferenceShiftOnDeleteRefModVisitor(XLBookArea deletedBookArea, XLShiftDeletedCells shift)
+    {
+        _deletedBookArea = deletedBookArea;
+        _shift = shift;
+    }
+
+    public override TransformedSymbol Reference(ModContext ctx, SymbolRange range, ReferenceArea referenceToShift)
+    {
+        // If reference is for a different sheet than deleted one, return the original reference.
+        if (!XLHelper.SheetComparer.Equals(_deletedBookArea.Name, ctx.Sheet))
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        return _shift switch
+        {
+            XLShiftDeletedCells.ShiftCellsUp => DeleteAndShiftUp(ctx, range, referenceToShift),
+            XLShiftDeletedCells.ShiftCellsLeft => throw new NotImplementedException(),
+            _ => throw new UnreachableException()
+        };
+    }
+
+    private TransformedSymbol DeleteAndShiftUp(ModContext ctx, SymbolRange range, ReferenceArea referenceToShift)
+    {
+        // Columns are never changed by shift up deletion.
+        if (referenceToShift.IsColumnSpan())
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        var referenceToShiftArea = referenceToShift.ToSheetRangeA1();
+        var deletedArea = _deletedBookArea.Area;
+
+        // Deleted area is fully to the left of the reference - reference will never be shifted up
+        if (deletedArea.RightColumn < referenceToShiftArea.LeftColumn)
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        // Deleted area is fully to the right of the reference - reference will never be shifted up
+        if (deletedArea.LeftColumn > referenceToShiftArea.RightColumn)
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        // Deleted area doesn't fully cover reference columns. It will either cause splits or not move -> keep original.
+        if (deletedArea.LeftColumn > referenceToShiftArea.LeftColumn &&
+            deletedArea.RightColumn < referenceToShiftArea.RightColumn)
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        // Deleted area fully cover reference columns.
+        if (deletedArea.LeftColumn <= referenceToShiftArea.LeftColumn &&
+            deletedArea.RightColumn >= referenceToShiftArea.RightColumn)
+        {
+            // Deleted area is below the reference
+            if (deletedArea.TopRow > referenceToShiftArea.BottomRow)
+                return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+            // The deleted area either partially covers the reference or is above the reference -> shift up.
+
+            // How many rows to shift up the reference.
+            var shiftUp = Math.Min(deletedArea.BottomRow + 1, referenceToShiftArea.TopRow) - Math.Min(deletedArea.TopRow, referenceToShiftArea.TopRow);
+
+            // By how many rows to shrink the reference
+            var shrinkBy = deletedArea.BottomRow >= referenceToShiftArea.TopRow
+                ? Math.Min(referenceToShiftArea.BottomRow, deletedArea.BottomRow) - Math.Max(referenceToShiftArea.TopRow, deletedArea.TopRow) + 1
+                : 0;
+
+            // The reference was completely removed by deleted area
+            if (shrinkBy >= referenceToShiftArea.Height)
+                return TransformedSymbol.ToText(ctx.Formula, range, RefError);
+
+            var first = Shift(referenceToShift.First, shiftUp, 0);
+            var second = Shift(referenceToShift.Second, shiftUp + shrinkBy, 0);
+            var shiftedReference = new ReferenceArea(first, second);
+            return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
+        }
+
+        // Deleted area slices off a left part of the reference
+        if (deletedArea.LeftColumn <= referenceToShiftArea.LeftColumn &&
+            deletedArea.RightColumn < referenceToShiftArea.RightColumn &&
+            deletedArea.RightColumn >= referenceToShiftArea.LeftColumn)
+        {
+            if (deletedArea.TopRow <= referenceToShiftArea.TopRow &&
+                deletedArea.BottomRow >= referenceToShiftArea.BottomRow)
+            {
+                // Slice off the right side of the reference
+                var sliceOffLeftColumns = referenceToShiftArea.LeftColumn - deletedArea.RightColumn - 1;
+                var first = Shift(referenceToShift.First, 0, sliceOffLeftColumns);
+                var shiftedReference = new ReferenceArea(first, referenceToShift.Second);
+                return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
+            }
+
+            // Slicing would not change anything or would cause split -> keep original.
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+        }
+
+        // Deleted area slices off a right part of the reference
+        if (deletedArea.RightColumn >= referenceToShiftArea.RightColumn &&
+            deletedArea.LeftColumn > referenceToShiftArea.LeftColumn &&
+            deletedArea.LeftColumn <= referenceToShiftArea.RightColumn)
+        {
+            if (deletedArea.TopRow <= referenceToShiftArea.TopRow &&
+                deletedArea.BottomRow >= referenceToShiftArea.BottomRow)
+            {
+                // Slice off the right side of the reference
+                var sliceOffRightColumns = referenceToShiftArea.RightColumn - deletedArea.LeftColumn + 1;
+                var second = Shift(referenceToShift.Second, 0, sliceOffRightColumns);
+                var shiftedReference = new ReferenceArea(referenceToShift.First, second);
+                return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
+            }
+
+            // Slicing would not change anything or would cause split -> keep original.
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+        }
+
+        throw new UnreachableException($"Unhandled case between a delete area {deletedArea} and a reference area {referenceToShiftArea}.");
+    }
+
+    private static RowCol Shift(RowCol rowCol, int rowUpShift, int columnLeftShift)
+    {
+        var r = rowCol.RowType != ReferenceAxisType.None ? rowCol.RowValue - rowUpShift : rowCol.RowValue;
+        var c = rowCol.ColumnType != ReferenceAxisType.None ? rowCol.ColumnValue - columnLeftShift : rowCol.ColumnValue;
+        return new RowCol(rowCol.RowType, r, rowCol.ColumnType, c, rowCol.Style);
+    }
+}

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ClosedXML.Excel;
 using ClosedXML.Parser;
 
@@ -9,6 +9,15 @@ namespace ClosedXML.Extensions
     /// </summary>
     internal static class ReferenceAreaExtensions
     {
+        /// <summary>
+        /// Is reference a row span (e.g. $B:G).
+        /// </summary>
+        public static bool IsColumnSpan(this ReferenceArea reference)
+        {
+            return reference.First.RowType == ReferenceAxisType.None &&
+                   reference.Second.RowType == ReferenceAxisType.None;
+        }
+
         /// <summary>
         /// Convert area to an absolute sheet range (regardless if the area is A1 or R1C1).
         /// </summary>

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -17,22 +17,37 @@ namespace ClosedXML.Extensions
         /// <returns>Converted absolute range.</returns>
         public static XLSheetRange ToSheetRange(this ReferenceArea area, XLSheetPoint anchor)
         {
-            int col1, row1, col2, row2;
-            if (area.First.IsA1)
-            {
-                row1 = A1ToPosition(area.First.RowType, area.First.RowValue, XLHelper.MinRowNumber);
-                col1 = A1ToPosition(area.First.ColumnType, area.First.ColumnValue, XLHelper.MinColumnNumber);
-                row2 = A1ToPosition(area.Second.RowType, area.Second.RowValue, XLHelper.MaxRowNumber);
-                col2 = A1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, XLHelper.MaxColumnNumber);
-            }
-            else
-            {
-                row1 = R1C1ToPosition(area.First.RowType, area.First.RowValue, anchor.Row, XLHelper.MinRowNumber, XLHelper.MaxRowNumber);
-                col1 = R1C1ToPosition(area.First.ColumnType, area.First.ColumnValue, anchor.Column, XLHelper.MinColumnNumber, XLHelper.MaxColumnNumber);
-                row2 = R1C1ToPosition(area.Second.RowType, area.Second.RowValue, anchor.Row, XLHelper.MaxRowNumber, XLHelper.MaxRowNumber);
-                col2 = R1C1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, anchor.Column, XLHelper.MaxColumnNumber, XLHelper.MaxColumnNumber);
-            }
+            return area.First.IsA1
+                ? ToSheetRangeA1(area)
+                : ToSheetRangeR1C1(area, anchor);
+        }
 
+        public static XLSheetRange ToSheetRangeA1(this ReferenceArea area)
+        {
+            if (area.Style != ReferenceStyle.A1)
+                throw new ArgumentException(nameof(area));
+
+            var row1 = A1ToPosition(area.First.RowType, area.First.RowValue, XLHelper.MinRowNumber);
+            var col1 = A1ToPosition(area.First.ColumnType, area.First.ColumnValue, XLHelper.MinColumnNumber);
+            var row2 = A1ToPosition(area.Second.RowType, area.Second.RowValue, XLHelper.MaxRowNumber);
+            var col2 = A1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, XLHelper.MaxColumnNumber);
+            return ToSheetRange(row1, row2, col1, col2);
+        }
+
+        public static XLSheetRange ToSheetRangeR1C1(this ReferenceArea area, XLSheetPoint anchor)
+        {
+            if (area.Style != ReferenceStyle.R1C1)
+                throw new ArgumentException(nameof(area));
+
+            var row1 = R1C1ToPosition(area.First.RowType, area.First.RowValue, anchor.Row, XLHelper.MinRowNumber, XLHelper.MaxRowNumber);
+            var col1 = R1C1ToPosition(area.First.ColumnType, area.First.ColumnValue, anchor.Column, XLHelper.MinColumnNumber, XLHelper.MaxColumnNumber);
+            var row2 = R1C1ToPosition(area.Second.RowType, area.Second.RowValue, anchor.Row, XLHelper.MaxRowNumber, XLHelper.MaxRowNumber);
+            var col2 = R1C1ToPosition(area.Second.ColumnType, area.Second.ColumnValue, anchor.Column, XLHelper.MaxColumnNumber, XLHelper.MaxColumnNumber);
+            return ToSheetRange(row1, row2, col1, col2);
+        }
+
+        private static XLSheetRange ToSheetRange(int row1, int row2, int col1, int col2)
+        {
             // Points in the token `area` don't have to be in top left and bottom right corners,
             // e.g. D4:A1 or D1:A4. Normalize coordinates, so the sheet range has expected corners.
             var colStart = Math.Min(col1, col2);


### PR DESCRIPTION
Add a method to update references in a formula when an area is deleted and cells are shifted up. Required for issue #2713

Currently, references in formulas are shifted in a `XLCell.ShiftFormulaRows` method. It has two problems:
* It uses regular expression to find references in a formula. It should use the parser.
* It only handles a full row deletion, not an area deletion.

This is first of four methods (stored in RefMods) that will update a reference upon a structural change:
* Insert, shift down
* Insert, shift right
* Delete, shift up <-- this one
* Delete, shift left

Code is not used anywhere, it will be once all structural change handlers are implemented.