### PR TITLE
Update reference on delete and shift left

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ReferenceShiftOnDeleteRefModTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ReferenceShiftOnDeleteRefModTests.cs
@@ -32,7 +32,7 @@ public class ReferenceShiftOnDeleteRefModTests
     [TestCase("A1:D3", "Sheet!B1:C3", "A1:D3")]
 
     // Deleted area covers full width of reference
-    [TestCase("A1:D3", "Sheet!A4:D4", "A1:D3")] // Deleted area is completely below the reference.
+    [TestCase("A1:D3", "Sheet!A5:D6", "A1:D3")] // Deleted area is completely below the reference.
     [TestCase("A5:A10", "Sheet!A10:D11", "A5:A9")]
     [TestCase("A5:A10", "Sheet!A10", "A5:A9")]
     [TestCase("A5:A10", "Sheet!A7:A10", "A5:A6")]
@@ -65,6 +65,65 @@ public class ReferenceShiftOnDeleteRefModTests
         var deleted = new XLBookArea(deletedSheet, deletedReference.ToSheetRangeA1());
 
         var result = FormulaConverter.ModifyA1(formula, "Sheet", 1, 1, new ReferenceShiftOnDeleteRefModVisitor(deleted, XLShiftDeletedCells.ShiftCellsUp));
+
+        Assert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// This tests how are references changed inside a formula when an area is deleted and shifted left.
+    /// They were derived by using SUM(reference) before and after deletion.
+    /// </summary>
+    [TestCase("D5", "Other!D5", "D5")] // Delete cell with same coordinate on different sheet.
+    [TestCase("D5", "Sheet!D5", "#REF!")] // Fully delete a cell.
+    [TestCase("$D$5", "Sheet!D5", "#REF!")] // Only posıtıon matter, reference style doesn't.
+
+    // Row span tests
+    [TestCase("2:$4", "Sheet!C:F", "2:$4")] // Row span is basically never changed.
+    [TestCase("$2:4", "Sheet!A1:D5", "$2:4")] // Row span is basically never changed.
+
+    // Deleted area is fully upward of the reference.
+    [TestCase("B3:D7", "Sheet!B1:D2", "B3:D7")]
+
+    // Deleted area is fully below of the reference.
+    [TestCase("B3:D7", "Sheet!B8:D9", "B3:D7")]
+
+    // Deleted area is inside and only partially covers rows of a reference.
+    [TestCase("B3:D9", "Sheet!B4:D6", "B3:D9")]
+
+    // Deleted area covers full height of the reference
+    [TestCase("A1:B3", "Sheet!D1:E3", "A1:B3")] // Deleted area is completely to the right of the reference.
+    [TestCase("E1:I2", "Sheet!I1:K5", "E1:H2")]
+    [TestCase("E1:I2", "Sheet!I1:I2", "E1:H2")]
+    [TestCase("E1:I2", "Sheet!H1:I2", "E1:G2")]
+    [TestCase("E1:I2", "Sheet!E1:I2", "#REF!")]
+    [TestCase("E1:I2", "Sheet!E1:F2", "E1:G2")]
+    [TestCase("E1:I2", "Sheet!D1:F2", "D1:F2")]
+    [TestCase("E1:I2", "Sheet!B1:D2", "B1:F2")]
+
+    // Deleted area covers a top slice of a reference
+    [TestCase("B3:D7", "Sheet!B3:D5", "B6:D7")]
+    [TestCase("B3:D7", "Sheet!B1:D5", "B6:D7")]
+    [TestCase("B3:D7", "Sheet!A1:G4", "B5:D7")]
+    [TestCase("B3:D7", "Sheet!C2:D5", "B3:D7")]
+    [TestCase("B3:D7", "Sheet!B1:C3", "B3:D7")]
+    [TestCase("B3:D7", "Sheet!A2:C5", "B3:D7")]
+    [TestCase("B3:D7", "Sheet!E3:F6", "B3:D7")]
+
+    // Deleted area covers bottom slice of a reference
+    [TestCase("C5:E12", "Sheet!C7:E12", "C5:E6")]
+    [TestCase("C5:E12", "Sheet!C10:E16", "C5:E9")]
+    [TestCase("C5:E12", "Sheet!A10:E13", "C5:E9")]
+    [TestCase("C5:E12", "Sheet!D8:E13", "C5:E12")]
+    [TestCase("C5:E12", "Sheet!C8:D13", "C5:E12")]
+    [TestCase("C5:E12", "Sheet!A8:B12", "C5:E12")]
+    [TestCase("C5:E12", "Sheet!F8:F12", "C5:E12")]
+    public void Delete_area_and_shift_left_reference(string formula, string deletedArea, string expected)
+    {
+        // TODO: Once incorporated into cell deletion, replace with a public API test case through SUM(reference) in a cell.
+        Assert.True(ReferenceParser.TryParseSheetA1(deletedArea, out var deletedSheet, out var deletedReference));
+        var deleted = new XLBookArea(deletedSheet, deletedReference.ToSheetRangeA1());
+
+        var result = FormulaConverter.ModifyA1(formula, "Sheet", 1, 1, new ReferenceShiftOnDeleteRefModVisitor(deleted, XLShiftDeletedCells.ShiftCellsLeft));
 
         Assert.AreEqual(expected, result);
     }

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ClosedXML.Excel;
 using NUnit.Framework;
 
@@ -133,7 +133,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var originalArea = XLSheetRange.Parse(original);
             var insertedArea = XLSheetRange.Parse(inserted);
 
-            Assert.False(originalArea.TryInsertAreaAndShiftRight(insertedArea, out var result));
+            Assert.False(originalArea.TryInsertAreaAndShiftRight(insertedArea, out _));
         }
 
         [TestCase("D6:G10", "A1:C15", "D6:G10")] // Inserted are is fully to the left
@@ -167,7 +167,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
             var originalArea = XLSheetRange.Parse(original);
             var insertedArea = XLSheetRange.Parse(inserted);
 
-            Assert.False(originalArea.TryInsertAreaAndShiftDown(insertedArea, out var result));
+            Assert.False(originalArea.TryInsertAreaAndShiftDown(insertedArea, out _));
         }
 
         [TestCase("E4:G4", "B3:C5", "C4:E4")] // Deleted area fully to the left with overlapping width
@@ -238,6 +238,67 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             Assert.False(success);
             Assert.Null(result);
+        }
+
+        // Subtrahend doesn't intersect the minuend
+        [TestCase("G10:O24", "C10:F24", "G10:O24")] // Left
+        [TestCase("G10:O24", "D5:F9", "G10:O24")] // Left Above
+        [TestCase("G10:O24", "G3:O9", "G10:O24")] // Above
+        [TestCase("G10:O24", "P6:Q9", "G10:O24")] // Above Right
+        [TestCase("G10:O24", "P10:R24", "G10:O24")] // Right
+        [TestCase("G10:O24", "P24:Q27", "G10:O24")] // Bottom Right
+        [TestCase("G10:O24", "G25:O27", "G10:O24")] // Bottom
+        [TestCase("G10:O24", "E25:F29", "G10:O24")] // Bottom Left
+
+        // Subtrahend fully covers the minuend
+        [TestCase("G10:O24", "F9:P25", null)]
+        [TestCase("G10:O24", "G10:O24", null)]
+
+        // Slice off a left side
+        [TestCase("G10:O24", "G10:G24", "H10:O24")]
+        [TestCase("G10:O24", "D5:L24", "M10:O24")]
+
+        // Slice off a top side
+        [TestCase("G10:O24", "G10:O10", "G11:O24")]
+        [TestCase("G10:O24", "D3:R14", "G15:O24")]
+
+        // Slice off a right side
+        [TestCase("G10:O24", "O10:O24", "G10:N24")]
+        [TestCase("G10:O24", "J4:Q30", "G10:I24")]
+
+        // Slice off a bottom side
+        [TestCase("G10:O24", "G24:O24", "G10:O23")]
+        [TestCase("G10:O24", "E12:P36", "G10:O11")]
+        public void TrySubtract_subtracts_one_area_from_another_and_returns_true_when_there_is_no_split(string minuend, string subtrahend, string expected)
+        {
+            var minuendArea = XLSheetRange.Parse(minuend);
+            var subtrahendArea = XLSheetRange.Parse(subtrahend);
+            var expectedResult = expected is not null ? XLSheetRange.Parse(expected) : (XLSheetRange?)null;
+
+            var noSplit = minuendArea.TrySubtract(subtrahendArea, out var resultArea);
+
+            Assert.True(noSplit);
+            Assert.AreEqual(expectedResult, resultArea);
+        }
+
+        [TestCase("G10:O24", "H11:N23")] // Subtrahend is inside the minuend, the result would in in a shape of O
+        [TestCase("G10:O24", "G13:I15")] // Result is a horseshoe opened to the left
+        [TestCase("G10:O24", "H7:K14")] // Result is a horseshoe opened to the top
+        [TestCase("G10:O24", "M13:Q16")] // Result is a horseshoe opened to the right
+        [TestCase("G10:O24", "J21:L27")] // Result is a horseshoe opened to the bottom
+        [TestCase("G10:O24", "E8:I12")] // Subtract top left corner
+        [TestCase("G10:O24", "N4:P12")] // Subtract top right corner
+        [TestCase("G10:O24", "K15:P26")] // Subtract bottom right corner
+        [TestCase("G10:O24", "E19:H28")] // Subtract bottom left corner
+        public void TrySubtract_returns_false_on_split(string minuend, string subtrahend)
+        {
+            var minuendArea = XLSheetRange.Parse(minuend);
+            var subtrahendArea = XLSheetRange.Parse(subtrahend);
+
+            var noSplit = minuendArea.TrySubtract(subtrahendArea, out var resultArea);
+
+            Assert.False(noSplit);
+            Assert.IsNull(resultArea);
         }
     }
 }

--- a/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
@@ -59,6 +59,11 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
         var result = shouldShiftUpwards
             ? subtracted.Value.ShiftRows(-deletedArea.Height)
             : subtracted.Value;
+
+        // If there was no change, just use original text. Don't allocate new symbol needlessly.
+        if (result == referenceToShiftArea)
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
         var first = Set(referenceToShift.First, result.TopRow, result.LeftColumn);
         var second = Set(referenceToShift.Second, result.BottomRow, result.RightColumn);
         var shiftedReference = new ReferenceArea(first, second);
@@ -89,6 +94,11 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
         var result = shouldShiftToLeft
             ? subtracted.Value.ShiftColumns(-deletedArea.Width)
             : subtracted.Value;
+
+        // If there was no change, just use original text. Don't allocate new symbol needlessly.
+        if (result == referenceToShiftArea)
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
         var first = Set(referenceToShift.First, result.TopRow, result.LeftColumn);
         var second = Set(referenceToShift.Second, result.BottomRow, result.RightColumn);
         var shiftedReference = new ReferenceArea(first, second);

--- a/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
@@ -1,7 +1,6 @@
+using System.Diagnostics;
 using ClosedXML.Extensions;
 using ClosedXML.Parser;
-using System;
-using System.Diagnostics;
 
 namespace ClosedXML.Excel.CalcEngine.Visitors;
 
@@ -27,8 +26,7 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
             return TransformedSymbol.CopyOriginal(ctx.Formula, range);
 
         // The two methods could be transposed into a single case, but it is hard to debug and I
-        // will rather take some duplication. Plus there are some problems like transposing row
-        // beyond last column and so on. Make sure to fix/refactor BOTH variants.
+        // will rather take some duplication.
         return _shift switch
         {
             XLShiftDeletedCells.ShiftCellsUp => DeleteAndShiftUp(ctx, range, referenceToShift),
@@ -46,86 +44,25 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
         var referenceToShiftArea = referenceToShift.ToSheetRangeA1();
         var deletedArea = _deletedBookArea.Area;
 
-        // Deleted area is fully to the left of the reference - reference will never be shifted up
-        if (deletedArea.RightColumn < referenceToShiftArea.LeftColumn)
+        // Subtraction would cause split -> return original
+        if (!referenceToShiftArea.TrySubtract(deletedArea, out var subtracted))
             return TransformedSymbol.CopyOriginal(ctx.Formula, range);
 
-        // Deleted area is fully to the right of the reference - reference will never be shifted up
-        if (deletedArea.LeftColumn > referenceToShiftArea.RightColumn)
-            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+        // Whole area was subtracted -> #REF!
+        if (subtracted is null)
+            return TransformedSymbol.ToText(ctx.Formula, range, RefError);
 
-        // Deleted area doesn't fully cover reference columns. It will either cause splits or not move -> keep original.
-        if (deletedArea.LeftColumn > referenceToShiftArea.LeftColumn &&
-            deletedArea.RightColumn < referenceToShiftArea.RightColumn)
-            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
-
-        // Deleted area fully cover reference columns.
-        if (deletedArea.LeftColumn <= referenceToShiftArea.LeftColumn &&
-            deletedArea.RightColumn >= referenceToShiftArea.RightColumn)
-        {
-            // Deleted area is below the reference
-            if (deletedArea.TopRow > referenceToShiftArea.BottomRow)
-                return TransformedSymbol.CopyOriginal(ctx.Formula, range);
-
-            // The deleted area either partially covers the reference or is above the reference -> shift up.
-
-            // How many rows to shift up the reference.
-            var shiftUp = Math.Min(deletedArea.BottomRow + 1, referenceToShiftArea.TopRow) - Math.Min(deletedArea.TopRow, referenceToShiftArea.TopRow);
-
-            // By how many rows to shrink the reference
-            var shrinkBy = deletedArea.BottomRow >= referenceToShiftArea.TopRow
-                ? Math.Min(referenceToShiftArea.BottomRow, deletedArea.BottomRow) - Math.Max(referenceToShiftArea.TopRow, deletedArea.TopRow) + 1
-                : 0;
-
-            // The reference was completely removed by deleted area
-            if (shrinkBy >= referenceToShiftArea.Height)
-                return TransformedSymbol.ToText(ctx.Formula, range, RefError);
-
-            var first = Shift(referenceToShift.First, shiftUp, 0);
-            var second = Shift(referenceToShift.Second, shiftUp + shrinkBy, 0);
-            var shiftedReference = new ReferenceArea(first, second);
-            return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
-        }
-
-        // Deleted area slices off a left part of the reference
-        if (deletedArea.LeftColumn <= referenceToShiftArea.LeftColumn &&
-            deletedArea.RightColumn < referenceToShiftArea.RightColumn &&
-            deletedArea.RightColumn >= referenceToShiftArea.LeftColumn)
-        {
-            if (deletedArea.TopRow <= referenceToShiftArea.TopRow &&
-                deletedArea.BottomRow >= referenceToShiftArea.BottomRow)
-            {
-                // Slice off the right side of the reference
-                var sliceOffLeftColumns = referenceToShiftArea.LeftColumn - deletedArea.RightColumn - 1;
-                var first = Shift(referenceToShift.First, 0, sliceOffLeftColumns);
-                var shiftedReference = new ReferenceArea(first, referenceToShift.Second);
-                return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
-            }
-
-            // Slicing would not change anything or would cause split -> keep original.
-            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
-        }
-
-        // Deleted area slices off a right part of the reference
-        if (deletedArea.RightColumn >= referenceToShiftArea.RightColumn &&
-            deletedArea.LeftColumn > referenceToShiftArea.LeftColumn &&
-            deletedArea.LeftColumn <= referenceToShiftArea.RightColumn)
-        {
-            if (deletedArea.TopRow <= referenceToShiftArea.TopRow &&
-                deletedArea.BottomRow >= referenceToShiftArea.BottomRow)
-            {
-                // Slice off the right side of the reference
-                var sliceOffRightColumns = referenceToShiftArea.RightColumn - deletedArea.LeftColumn + 1;
-                var second = Shift(referenceToShift.Second, 0, sliceOffRightColumns);
-                var shiftedReference = new ReferenceArea(referenceToShift.First, second);
-                return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
-            }
-
-            // Slicing would not change anything or would cause split -> keep original.
-            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
-        }
-
-        throw new UnreachableException($"Unhandled case between a delete area {deletedArea} and a reference area {referenceToShiftArea}.");
+        // If delete area is upwards and covers full width of the subtracted area, then shift
+        var shouldShiftUpwards = deletedArea.BottomRow < subtracted.Value.TopRow &&
+                                 deletedArea.LeftColumn <= subtracted.Value.LeftColumn &&
+                                 deletedArea.RightColumn >= subtracted.Value.RightColumn;
+        var result = shouldShiftUpwards
+            ? subtracted.Value.ShiftRows(-deletedArea.Height)
+            : subtracted.Value;
+        var first = Set(referenceToShift.First, result.TopRow, result.LeftColumn);
+        var second = Set(referenceToShift.Second, result.BottomRow, result.RightColumn);
+        var shiftedReference = new ReferenceArea(first, second);
+        return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
     }
 
     private TransformedSymbol DeleteAndShiftLeft(ModContext ctx, SymbolRange range, ReferenceArea referenceToShift)
@@ -158,12 +95,6 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
         return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
     }
 
-    private static RowCol Shift(RowCol rowCol, int rowUpShift, int columnLeftShift)
-    {
-        var r = rowCol.RowType != ReferenceAxisType.None ? rowCol.RowValue - rowUpShift : rowCol.RowValue;
-        var c = rowCol.ColumnType != ReferenceAxisType.None ? rowCol.ColumnValue - columnLeftShift : rowCol.ColumnValue;
-        return new RowCol(rowCol.RowType, r, rowCol.ColumnType, c, rowCol.Style);
-    }
     private static RowCol Set(RowCol rowCol, int row, int column)
     {
         var r = rowCol.RowType != ReferenceAxisType.None ? row : rowCol.RowValue;

--- a/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/DeleteRefModVisitor.cs
@@ -26,10 +26,13 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
         if (!XLHelper.SheetComparer.Equals(_deletedBookArea.Name, ctx.Sheet))
             return TransformedSymbol.CopyOriginal(ctx.Formula, range);
 
+        // The two methods could be transposed into a single case, but it is hard to debug and I
+        // will rather take some duplication. Plus there are some problems like transposing row
+        // beyond last column and so on. Make sure to fix/refactor BOTH variants.
         return _shift switch
         {
             XLShiftDeletedCells.ShiftCellsUp => DeleteAndShiftUp(ctx, range, referenceToShift),
-            XLShiftDeletedCells.ShiftCellsLeft => throw new NotImplementedException(),
+            XLShiftDeletedCells.ShiftCellsLeft => DeleteAndShiftLeft(ctx, range, referenceToShift),
             _ => throw new UnreachableException()
         };
     }
@@ -125,10 +128,46 @@ internal class ReferenceShiftOnDeleteRefModVisitor : CopyVisitor
         throw new UnreachableException($"Unhandled case between a delete area {deletedArea} and a reference area {referenceToShiftArea}.");
     }
 
+    private TransformedSymbol DeleteAndShiftLeft(ModContext ctx, SymbolRange range, ReferenceArea referenceToShift)
+    {
+        // Rows are never changed by shift left deletion.
+        if (referenceToShift.IsRowSpan())
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        var referenceToShiftArea = referenceToShift.ToSheetRangeA1();
+        var deletedArea = _deletedBookArea.Area;
+
+        // Subtraction would cause split -> return original
+        if (!referenceToShiftArea.TrySubtract(deletedArea, out var subtracted))
+            return TransformedSymbol.CopyOriginal(ctx.Formula, range);
+
+        // Whole area was subtracted -> #REF!
+        if (subtracted is null)
+            return TransformedSymbol.ToText(ctx.Formula, range, RefError);
+
+        // If delete area is to the left and covers full height of the subtracted area, then shift
+        var shouldShiftToLeft = deletedArea.RightColumn < subtracted.Value.LeftColumn &&
+                                deletedArea.TopRow <= subtracted.Value.TopRow &&
+                                deletedArea.BottomRow >= subtracted.Value.BottomRow;
+        var result = shouldShiftToLeft
+            ? subtracted.Value.ShiftColumns(-deletedArea.Width)
+            : subtracted.Value;
+        var first = Set(referenceToShift.First, result.TopRow, result.LeftColumn);
+        var second = Set(referenceToShift.Second, result.BottomRow, result.RightColumn);
+        var shiftedReference = new ReferenceArea(first, second);
+        return TransformedSymbol.ToText(ctx.Formula, range, shiftedReference.GetDisplayStringA1());
+    }
+
     private static RowCol Shift(RowCol rowCol, int rowUpShift, int columnLeftShift)
     {
         var r = rowCol.RowType != ReferenceAxisType.None ? rowCol.RowValue - rowUpShift : rowCol.RowValue;
         var c = rowCol.ColumnType != ReferenceAxisType.None ? rowCol.ColumnValue - columnLeftShift : rowCol.ColumnValue;
+        return new RowCol(rowCol.RowType, r, rowCol.ColumnType, c, rowCol.Style);
+    }
+    private static RowCol Set(RowCol rowCol, int row, int column)
+    {
+        var r = rowCol.RowType != ReferenceAxisType.None ? row : rowCol.RowValue;
+        var c = rowCol.ColumnType != ReferenceAxisType.None ? column : rowCol.ColumnValue;
         return new RowCol(rowCol.RowType, r, rowCol.ColumnType, c, rowCol.Style);
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -645,5 +645,85 @@ namespace ClosedXML.Excel
             result = repositioned;
             return true;
         }
+
+        /// <summary>
+        /// Try to subtract the <paramref name="subtrahend"/> from this minuend. If the result of
+        /// subtraction would cause a split (non-rectangular shape), return false.
+        /// </summary>
+        /// <param name="subtrahend">Area that will be subtracted from this area.</param>
+        /// <param name="result">Result of the subtraction. Only used when return value is <c>true</c>. <c>null</c> indicates whole minuend was removed.</param>
+        /// <returns><c>false</c> if the subtraction would cause a split, <c>true</c> otherwise (even full removal returns <c>true</c>).</returns>
+        public bool TrySubtract(XLSheetRange subtrahend, out XLSheetRange? result)
+        {
+            // Subtracted area doesn't even overlap with the area
+            if (subtrahend.RightColumn < LeftColumn ||
+                subtrahend.LeftColumn > RightColumn ||
+                subtrahend.TopRow > BottomRow ||
+                subtrahend.BottomRow < TopRow)
+            {
+                result = this;
+                return true;
+            }
+
+            // Subtrahend overlaps the minuend, clamp it to the minuend.
+            var left = Math.Max(subtrahend.LeftColumn, LeftColumn);
+            var top = Math.Max(subtrahend.TopRow, TopRow);
+            var right = Math.Min(subtrahend.RightColumn, RightColumn);
+            var bottom = Math.Min(subtrahend.BottomRow, BottomRow);
+
+            var isLeftCoincident = left == LeftColumn;
+            var isTopCoincident = top == TopRow;
+            var isRightCoincident = right == RightColumn;
+            var isBottomCoincident = bottom == BottomRow;
+
+            var coincidentCount =
+                (isLeftCoincident ? 1 : 0) +
+                (isTopCoincident ? 1 : 0) +
+                (isRightCoincident ? 1 : 0) +
+                (isBottomCoincident ? 1 : 0);
+            if (coincidentCount <= 2)
+            {
+                // Result would be split
+                // 0 - a area square inside the area, the rest is O
+                // 1 - only touches one side, the result is U
+                // 2 - touches one corner, the rest is L
+                result = null;
+                return false;
+            }
+
+            // Both 4 sides are coincident, the subtracted area completely covered the area.
+            if (coincidentCount == 4)
+            {
+                result = null;
+                return true;
+            }
+
+            // 3 sides coincident.
+            if (!isLeftCoincident)
+            {
+                result = new XLSheetRange(FirstPoint, new XLSheetPoint(LastPoint.Row, left - 1));
+                return true;
+            }
+
+            if (!isTopCoincident)
+            {
+                result = new XLSheetRange(FirstPoint, new XLSheetPoint(top - 1, LastPoint.Column));
+                return true;
+            }
+
+            if (!isRightCoincident)
+            {
+                result = new XLSheetRange(new XLSheetPoint(FirstPoint.Row, right + 1), LastPoint);
+                return true;
+            }
+
+            if (!isBottomCoincident)
+            {
+                result = new XLSheetRange(new XLSheetPoint(bottom + 1, FirstPoint.Column), LastPoint);
+                return true;
+            }
+
+            throw new UnreachableException($"Unhandled case of subtraction {this} - {subtrahend}.");
+        }
     }
 }

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -10,7 +10,16 @@ namespace ClosedXML.Extensions
     internal static class ReferenceAreaExtensions
     {
         /// <summary>
-        /// Is reference a row span (e.g. $B:G).
+        /// Is reference a row span (e.g. $3:7).
+        /// </summary>
+        public static bool IsRowSpan(this ReferenceArea reference)
+        {
+            return reference.First.ColumnType == ReferenceAxisType.None &&
+                   reference.Second.ColumnType == ReferenceAxisType.None;
+        }
+
+        /// <summary>
+        /// Is reference a column span (e.g. $B:G).
         /// </summary>
         public static bool IsColumnSpan(this ReferenceArea reference)
         {


### PR DESCRIPTION
Continuation of #2719, add a method to update references in a formula when an area is deleted and shifted left.
Required for issue #2713.