### PR TITLE
Add a method to shift references right on insert

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ReferenceShiftRefModTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ReferenceShiftRefModTests.cs
@@ -33,6 +33,36 @@ public class ReferenceShiftRefModTests
         Assert.AreEqual(expected, result);
     }
 
+    [TestCase("C2", "Sheet!B2", "D2")]
+    [TestCase("$C$2", "Sheet!B2", "$D$2")]
+    [TestCase("C2", "Sheet!C1", "C2")]
+    [TestCase("C2", "Sheet!D1", "C2")]
+    [TestCase("C2", "Sheet!E1", "C2")]
+    [TestCase("C2", "Sheet!E2", "C2")]
+    [TestCase("C2", "Sheet!E3", "C2")]
+    [TestCase("C2", "Sheet!D3", "C2")]
+    [TestCase("C2", "Sheet!B3", "C2")]
+    [TestCase("C2:E5", "Sheet!E2:G5", "C2:H5")] // Insert into middle of area
+    [TestCase("XFD1", "Sheet!XFD1", "#REF!")] // Pushed out of a sheet
+    [TestCase("XFB1:XFC1", "Sheet!XFC1:XFD1", "XFB1:XFD1")] // Grew out of a sheet
+    [TestCase("4:$5", "Sheet!B1:E10", "4:$5")]
+    [TestCase("$D:E", "Sheet!B1:E5", "$D:E")]
+
+    // Would cause split
+    [TestCase("C2:E5", "Sheet!B2:B3", "C2:E5")]
+    [TestCase("C2:E5", "Sheet!C2", "C2:E5")]
+    [TestCase("C2:E5", "Sheet!D2:D3", "C2:E5")]
+    public void Insert_area_and_shift_right_reference(string formula, string insertedArea, string expected)
+    {
+        // TODO: Once incorporated into area insertion, replace with a public API test case through SUM(reference) in a cell.
+        Assert.True(ReferenceParser.TryParseSheetA1(insertedArea, out var insertedSheet, out var insertedReference));
+        var inserted = new XLBookArea(insertedSheet, insertedReference.ToSheetRangeA1());
+
+        var result = FormulaConverter.ModifyA1(formula, "Sheet", 1, 1, new ReferenceShiftOnInsertRefModVisitor(inserted, false));
+
+        Assert.AreEqual(expected, result);
+    }
+
     /// <summary>
     /// This tests how are references changed inside a formula when an area is deleted and shifted up.
     /// They were derived by using SUM(reference) before and after deletion.

--- a/ClosedXML/Excel/CalcEngine/Visitors/ReferenceShiftOnInsertRefModVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/ReferenceShiftOnInsertRefModVisitor.cs
@@ -1,4 +1,3 @@
-using System;
 using ClosedXML.Extensions;
 using ClosedXML.Parser;
 
@@ -23,13 +22,12 @@ internal class ReferenceShiftOnInsertRefModVisitor : CopyVisitor
         if (!XLHelper.SheetComparer.Equals(_insertedBookArea.Name, ctx.Sheet))
             return TransformedSymbol.CopyOriginal(ctx.Formula, range);
 
-        return _shiftDown ? InsertAndShiftDown(ctx, range, referenceToShift) : throw new NotImplementedException();
-    }
+        var wouldSplitArea = _shiftDown
+            ? !referenceToShift.TryInsertAndShiftDown(_insertedBookArea.Area, out var shiftedReference)
+            : !referenceToShift.TryInsertAndShiftRight(_insertedBookArea.Area, out shiftedReference);
 
-    private TransformedSymbol InsertAndShiftDown(ModContext ctx, SymbolRange range, ReferenceArea referenceToShift)
-    {
         // Return original reference if the shift would cause a split
-        if (!referenceToShift.TryInsertAndShiftDown(_insertedBookArea.Area, out var shiftedReference))
+        if (wouldSplitArea)
             return TransformedSymbol.CopyOriginal(ctx.Formula, range);
 
         // If reference was shifted out of sheet, return #REF!

--- a/ClosedXML/Extensions/ReferenceAreaExtensions.cs
+++ b/ClosedXML/Extensions/ReferenceAreaExtensions.cs
@@ -87,7 +87,7 @@ namespace ClosedXML.Extensions
                 return false;
             }
 
-            // Reference was shifted out of sheet.
+            // Reference was pushed out of sheet.
             if (shifted is null)
             {
                 shiftedReference = null;
@@ -96,6 +96,42 @@ namespace ClosedXML.Extensions
 
             var first = Set(reference.First, shifted.Value.TopRow, referenceArea.LeftColumn);
             var second = Set(reference.Second, shifted.Value.BottomRow, referenceArea.RightColumn);
+            shiftedReference = new ReferenceArea(first, second);
+            return true;
+        }
+
+        /// <summary>
+        /// Shift a reference to the right on an area insertion. Do not shift if it would cause splits (returns <c>false</c>).
+        /// </summary>
+        /// <param name="reference">Reference to shift.</param>
+        /// <param name="insertedArea">An area inserted into a sheet.</param>
+        /// <param name="shiftedReference">The shifted reference. Can be <c>null</c>, if the reference is shifted out of sheet.</param>
+        /// <returns><c>false</c> if split, <c>true</c> when shift has a rectangular reference.</returns>
+        public static bool TryInsertAndShiftRight(this ReferenceArea reference, XLSheetRange insertedArea, out ReferenceArea? shiftedReference)
+        {
+            // Row span is never shifted
+            if (reference.IsRowSpan())
+            {
+                shiftedReference = reference;
+                return true;
+            }
+
+            var referenceArea = reference.ToSheetRangeA1();
+            if (!referenceArea.TryInsertAreaAndShiftRight(insertedArea, out var shifted))
+            {
+                shiftedReference = null;
+                return false;
+            }
+
+            // Reference was pushed out of sheet.
+            if (shifted is null)
+            {
+                shiftedReference = null;
+                return true;
+            }
+
+            var first = Set(reference.First, referenceArea.TopRow, shifted.Value.LeftColumn);
+            var second = Set(reference.Second, referenceArea.BottomRow, shifted.Value.RightColumn);
             shiftedReference = new ReferenceArea(first, second);
             return true;
         }


### PR DESCRIPTION
Add a method to shift reference when an area is inserted and cells are shifted to the right. Continuation of #2719  #2720 #2722.
Required for issue #2713.

* Insert, shift down <-- done
* Insert, shift right <-- this one
* Delete, shift up <-- done
* Delete, shift left <-- done

Now that I have all four, I can shift cell formula and defined named formula on structures changes.