### PR TITLE
Shift references in defined name formulas

### DIFF
--- a/ClosedXML.Tests/Excel/NamedRanges/DefinedNameShiftTests.cs
+++ b/ClosedXML.Tests/Excel/NamedRanges/DefinedNameShiftTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.NamedRanges;
+
+internal class DefinedNameShiftTests
+{
+    [TestCaseSource(nameof(GetShiftTestCases))]
+    public void Defined_name_shifts_references_in_formula_on_structural_changes(Action<IXLWorksheet> shiftAction, string expectedNameFormula)
+    {
+        using var wb = new XLWorkbook();
+        var shiftSheet = wb.AddWorksheet("Shift");
+        var otherSheet = wb.AddWorksheet("Other");
+
+        var workbookName = wb.DefinedNames.Add("WorkbookName", "Shift!$C$3:$D$5");
+        var shiftName = shiftSheet.DefinedNames.Add("ShiftName", "Shift!$C$3:$D$5");
+        var otherName = otherSheet.DefinedNames.Add("OtherName", "Other!$C$3:$D$5");
+
+        shiftAction(shiftSheet);
+
+        Assert.AreEqual(expectedNameFormula, workbookName.RefersTo);
+        Assert.AreEqual(expectedNameFormula, shiftName.RefersTo);
+        Assert.AreEqual("Other!$C$3:$D$5", otherName.RefersTo);
+    }
+
+    [Test]
+    public void Shift_references_inside_formulas()
+    {
+        // When a shift happens, defined name will keep the original formula, references inside
+        // the formula will be shifted though. Issue #2713.
+        using var wb = new XLWorkbook();
+        var lookupSheet = wb.AddWorksheet("Lookup");
+        var name = wb.DefinedNames.Add("Name", "OFFSET(Lookup!$G$2,0,0,COUNTA(Lookup!$G:$G)-1,1)");
+
+        lookupSheet.Row(1).Delete();
+
+        Assert.AreEqual("OFFSET(Lookup!$G$1,0,0,COUNTA(Lookup!$G:$G)-1,1)", name.RefersTo);
+    }
+
+    public static IEnumerable<object[]> GetShiftTestCases
+    {
+        get
+        {
+            // Insert and shift reference down
+            yield return Test(ws => ws.Range("C2:D2").InsertRowsBelow(4), "Shift!$C$7:$D$9");
+
+            // Insert and shift reference right
+            yield return Test(ws => ws.Range("B2:C7").InsertColumnsBefore(4), "Shift!$G$3:$H$5");
+
+            // Delete area and shift cells up. Also partially shrinks reference to 1-row from 3-rows original.
+            yield return Test(ws => ws.Range("C2:D4").Delete(XLShiftDeletedCells.ShiftCellsUp), "Shift!$C$2:$D$2");
+
+            // Delete area and shift cells left. Also partially shrinks reference to 1-column from 2-column original.
+            yield return Test(ws => ws.Range("B2:C7").Delete(XLShiftDeletedCells.ShiftCellsLeft), "Shift!$B$3:$B$5");
+
+            // When the whole area is deleted, the defined name is a #REF! error.
+            yield return Test(ws => ws.Range("A1:E8").Delete(XLShiftDeletedCells.ShiftCellsLeft), "#REF!");
+
+            // When insert area doesn't push reference (in this case columns are different), no change will happen.
+            yield return Test(ws => ws.Range("A1:B2").InsertRowsBelow(4), "Shift!$C$3:$D$5");
+
+            // When insert area would cause a split, keep original reference.
+            yield return Test(ws => ws.Range("C2").Delete(XLShiftDeletedCells.ShiftCellsUp), "Shift!$C$3:$D$5");
+
+            yield break;
+
+            static object[] Test(Action<IXLWorksheet> shift, string result)
+            {
+                return new object[] { shift, result };
+            }
+        }
+    }
+}

--- a/ClosedXML/Excel/DefinedNames/XLDefinedNames.cs
+++ b/ClosedXML/Excel/DefinedNames/XLDefinedNames.cs
@@ -2,13 +2,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using ClosedXML.Excel.CalcEngine.Visitors;
+using ClosedXML.Parser;
 
 namespace ClosedXML.Excel
 {
     /// <summary>
     /// A collection of a named ranges, either for workbook or for worksheet.
     /// </summary>
-    internal class XLDefinedNames : IXLDefinedNames, IEnumerable<XLDefinedName>
+    internal class XLDefinedNames : IXLDefinedNames, IEnumerable<XLDefinedName>, ISheetListener
     {
         private readonly Dictionary<String, XLDefinedName> _namedRanges = new(XLHelper.NameComparer);
 
@@ -227,5 +229,50 @@ namespace ClosedXML.Excel
             _namedRanges.Values
                 .ForEach(nr => nr.OnWorksheetDeleted(worksheetName));
         }
+
+        #region ISheetListner
+
+        void ISheetListener.OnInsertAreaAndShiftDown(XLWorksheet sheet, XLSheetRange insertedArea)
+        {
+            var insertedBookArea = new XLBookArea(sheet.Name, insertedArea);
+            var refMod = new ReferenceShiftOnInsertRefModVisitor(insertedBookArea, true);
+            ShiftReferences(refMod);
+        }
+
+        void ISheetListener.OnInsertAreaAndShiftRight(XLWorksheet sheet, XLSheetRange insertedArea)
+        {
+            var insertedBookArea = new XLBookArea(sheet.Name, insertedArea);
+            var refMod = new ReferenceShiftOnInsertRefModVisitor(insertedBookArea, false);
+            ShiftReferences(refMod);
+        }
+
+        void ISheetListener.OnDeleteAreaAndShiftLeft(XLWorksheet sheet, XLSheetRange deletedArea)
+        {
+            var deletedBookArea = new XLBookArea(sheet.Name, deletedArea);
+            var refMod = new ReferenceShiftOnDeleteRefModVisitor(deletedBookArea, XLShiftDeletedCells.ShiftCellsLeft);
+            ShiftReferences(refMod);
+        }
+
+        void ISheetListener.OnDeleteAreaAndShiftUp(XLWorksheet sheet, XLSheetRange deletedArea)
+        {
+            var deletedBookArea = new XLBookArea(sheet.Name, deletedArea);
+            var refMod = new ReferenceShiftOnDeleteRefModVisitor(deletedBookArea, XLShiftDeletedCells.ShiftCellsUp);
+            ShiftReferences(refMod);
+        }
+
+        private void ShiftReferences(CopyVisitor refMod)
+        {
+            foreach (var definedName in _namedRanges.Values)
+            {
+                var nameFormula = definedName.RefersTo;
+
+                // Defined name formula should never rely on a context info. Formula should contain
+                // only absolute references with a sheet -> use empty sheet that should never match
+                // and the cell point is thus never used and can be left at A1.
+                var shiftedFormula = FormulaConverter.ModifyA1(nameFormula, string.Empty, 1, 1, refMod);
+                definedName.SetRefersTo(shiftedFormula);
+            }
+        }
+        #endregion
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1193,8 +1193,6 @@ namespace ClosedXML.Excel
                 }
             }
 
-            Workbook.WorksheetsInternal.ForEach<XLWorksheet>(ws => MoveDefinedNamesColumns(range, columnsShifted, ws.DefinedNames));
-            MoveDefinedNamesColumns(range, columnsShifted, Workbook.DefinedNamesInternal);
             ShiftConditionalFormattingColumns(range, columnsShifted);
             ShiftDataValidationColumns(range, columnsShifted);
             ShiftPageBreaksColumns(range, columnsShifted);
@@ -1203,15 +1201,21 @@ namespace ClosedXML.Excel
             var sheetListeners = new List<ISheetListener>
             {
                 Workbook.CalcEngine,
-                Hyperlinks
+                Hyperlinks,
+                Workbook.DefinedNamesInternal,
             };
+
+            foreach (var worksheet in Workbook.WorksheetsInternal)
+                sheetListeners.Add(worksheet.DefinedNames);
+
             if (columnsShifted > 0)
             {
-                var area = XLSheetRange
+                var insertedArea = XLSheetRange
                     .FromRangeAddress(range.RangeAddress)
+                    .SliceFromLeft(1)
                     .ExtendRight(columnsShifted - 1);
                 foreach (var listener in sheetListeners)
-                    listener.OnInsertAreaAndShiftRight(range.Worksheet, area);
+                    listener.OnInsertAreaAndShiftRight(range.Worksheet, insertedArea);
             }
             else if (columnsShifted < 0)
             {
@@ -1343,8 +1347,6 @@ namespace ClosedXML.Excel
                 }
             }
 
-            Workbook.WorksheetsInternal.ForEach<XLWorksheet>(ws => MoveDefinedNamesRows(range, rowsShifted, ws.DefinedNames));
-            MoveDefinedNamesRows(range, rowsShifted, Workbook.DefinedNamesInternal);
             ShiftConditionalFormattingRows(range, rowsShifted);
             ShiftDataValidationRows(range, rowsShifted);
             RemoveInvalidSparklines();
@@ -1354,14 +1356,19 @@ namespace ClosedXML.Excel
             {
                 Workbook.CalcEngine,
                 Hyperlinks,
+                Workbook.DefinedNamesInternal,
             };
+            foreach (var worksheet in Workbook.WorksheetsInternal)
+                sheetListeners.Add(worksheet.DefinedNames);
+
             if (rowsShifted > 0)
             {
-                var area = XLSheetRange
+                var insertedArea = XLSheetRange
                     .FromRangeAddress(range.RangeAddress)
+                    .SliceFromTop(1)
                     .ExtendBelow(rowsShifted - 1);
                 foreach (var listener in sheetListeners)
-                    listener.OnInsertAreaAndShiftDown(range.Worksheet, area);
+                    listener.OnInsertAreaAndShiftDown(range.Worksheet, insertedArea);
             }
             else if (rowsShifted < 0)
             {
@@ -1482,33 +1489,6 @@ namespace ClosedXML.Excel
             foreach (var sparkline in invalidSparklines)
             {
                 Worksheet.SparklineGroups.Remove(sparkline.Location);
-            }
-        }
-
-        private void MoveDefinedNamesRows(XLRange range, int rowsShifted, XLDefinedNames definedNames)
-        {
-            foreach (var definedName in definedNames)
-            {
-                if (definedName.SheetReferencesList.Count() > 0)
-                {
-                    var newRangeList =
-                        definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaRows(r, this, range, rowsShifted)).Where(
-                            newReference => newReference.Length > 0).ToList();
-                    var unionFormula = string.Join(",", newRangeList);
-                    definedName.SetRefersTo(unionFormula);
-                }
-            }
-        }
-
-        private void MoveDefinedNamesColumns(XLRange range, int columnsShifted, XLDefinedNames definedNames)
-        {
-            foreach (var definedName in definedNames)
-            {
-                var newRangeList =
-                    definedName.SheetReferencesList.Select(r => XLCell.ShiftFormulaColumns(r, this, range, columnsShifted)).Where(
-                        newReference => newReference.Length > 0).ToList();
-                var unionFormula = string.Join(",", newRangeList);
-                definedName.SetRefersTo(unionFormula);
             }
         }
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1200,20 +1200,24 @@ namespace ClosedXML.Excel
             ShiftPageBreaksColumns(range, columnsShifted);
             RemoveInvalidSparklines();
 
-            ISheetListener hyperlinks = Hyperlinks;
+            var sheetListeners = new List<ISheetListener>
+            {
+                Workbook.CalcEngine,
+                Hyperlinks
+            };
             if (columnsShifted > 0)
             {
                 var area = XLSheetRange
                     .FromRangeAddress(range.RangeAddress)
                     .ExtendRight(columnsShifted - 1);
-                Workbook.CalcEngine.OnInsertAreaAndShiftRight(range.Worksheet, area);
-                hyperlinks.OnInsertAreaAndShiftRight(range.Worksheet, area);
+                foreach (var listener in sheetListeners)
+                    listener.OnInsertAreaAndShiftRight(range.Worksheet, area);
             }
             else if (columnsShifted < 0)
             {
                 var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
-                Workbook.CalcEngine.OnDeleteAreaAndShiftLeft(range.Worksheet, area);
-                hyperlinks.OnDeleteAreaAndShiftLeft(range.Worksheet, area);
+                foreach (var listener in sheetListeners)
+                    listener.OnDeleteAreaAndShiftLeft(range.Worksheet, area);
             }
         }
 
@@ -1346,20 +1350,24 @@ namespace ClosedXML.Excel
             RemoveInvalidSparklines();
             ShiftPageBreaksRows(range, rowsShifted);
 
-            ISheetListener hyperlinks = Hyperlinks;
+            var sheetListeners = new List<ISheetListener>
+            {
+                Workbook.CalcEngine,
+                Hyperlinks,
+            };
             if (rowsShifted > 0)
             {
                 var area = XLSheetRange
                     .FromRangeAddress(range.RangeAddress)
                     .ExtendBelow(rowsShifted - 1);
-                Workbook.CalcEngine.OnInsertAreaAndShiftDown(range.Worksheet, area);
-                hyperlinks.OnInsertAreaAndShiftDown(range.Worksheet, area);
+                foreach (var listener in sheetListeners)
+                    listener.OnInsertAreaAndShiftDown(range.Worksheet, area);
             }
             else if (rowsShifted < 0)
             {
                 var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
-                Workbook.CalcEngine.OnDeleteAreaAndShiftUp(range.Worksheet, area);
-                hyperlinks.OnDeleteAreaAndShiftUp(range.Worksheet, area);
+                foreach (var listener in sheetListeners)
+                    listener.OnDeleteAreaAndShiftUp(range.Worksheet, area);
             }
         }
 


### PR DESCRIPTION
Fix shifting of defined name formulas. The defined names removed functions and left only references. In case of #2717, a defined name with a `OFFSET(Lookup!$G$2,0,0,COUNTA(Lookup!$G:$G)-1,1)` formula was turned into `Lookup!$G$1,Lookup!$G:$G`. Having multiple areas (it's `ST_Sqref`) is fine for a parameter, but Excel doesn't like overlapping ones.

This PR properly shifts references in a formula in defined names using the `ISheetListener` pattern.

Fixes #2713 