### PR TITLE
Add styles part writer skeleton

### DIFF
--- a/ClosedXML.IO.CodeGen/XsdParser/XsdEnumMapper.cs
+++ b/ClosedXML.IO.CodeGen/XsdParser/XsdEnumMapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using ClosedXML.IO.CodeGen.Model;
 
@@ -21,6 +21,12 @@ public class XsdEnumMapper : IEnumMapper
     {
         var enumMap = (Dictionary<string, TEnum>)_textToEnumMaps[typeof(TEnum)];
         return enumMap.TryGetValue(text, out enumValue);
+    }
+
+    public bool TryGetText<TEnum>(TEnum enumValue, out string text)
+        where TEnum : struct, Enum
+    {
+        throw new NotSupportedException();
     }
 
     private void AddMaps()

--- a/ClosedXML.IO/IEnumMapper.cs
+++ b/ClosedXML.IO/IEnumMapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace ClosedXML.IO;
 
@@ -15,5 +15,15 @@ public interface IEnumMapper
     /// <param name="enumValue">Output enum value.</param>
     /// <returns><c>True</c> if enum was found for passed text value, false otherwise.</returns>
     bool TryGetEnum<TEnum>(string text, out TEnum enumValue)
+        where TEnum : struct, Enum;
+
+    /// <summary>
+    /// Try to get a text for an enum value.
+    /// </summary>
+    /// <typeparam name="TEnum">Type of an enum.</typeparam>
+    /// <param name="enumValue">Enum value.</param>
+    /// <param name="text">Output text for the enum value.</param>
+    /// <returns><c>True</c> if text was found for passed enum value, false otherwise.</returns>
+    bool TryGetText<TEnum>(TEnum enumValue, out string text)
         where TEnum : struct, Enum;
 }

--- a/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
+++ b/ClosedXML.Tests/IO/XmlTreeReaderAttributesTests.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Xml;
 using ClosedXML.Excel.IO;
 using ClosedXML.IO;
+using ClosedXML.Utils;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.IO;
@@ -117,7 +117,7 @@ internal class XmlTreeReaderAttributesTests
     [TestCase("NonExpectedValue", null)]
     public void GetOptionalEnum_returns_enum_parsed_by_enum_mapper(string xmlText, BindingFlags? enumValue)
     {
-        var mapper = new XmlToEnumMapper.Builder().Add(new Dictionary<string, BindingFlags>
+        var mapper = new XmlToEnumMapper.Builder().Add(new BiDictionary<string, BindingFlags>
         {
             { "def", BindingFlags.Default },
             { "ci", BindingFlags.IgnoreCase },

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -1,0 +1,414 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using ClosedXML.Excel.Formatting;
+using ClosedXML.Extensions;
+using ClosedXML.IO;
+using ClosedXML.Utils;
+using DocumentFormat.OpenXml.Packaging;
+using static ClosedXML.Excel.IO.OpenXmlConst;
+
+namespace ClosedXML.Excel.IO;
+
+internal class StylesWriter
+{
+    private const int FirstUserDefinedFormatIndex = 164;
+    private readonly string _ns = Main2006SsNs;
+
+    internal void WriteContent(WorkbookStylesPart stylesPart, IEnumMapper mapper, XLWorkbookStyles styles, XLWorkbook.SaveContext context)
+    {
+        // Determine which format components are used and thus should be saved.
+        // TODO: For now just assume everything in styles is used
+        var usedCellFormats = styles.CellFormats.Select(x => x.Value).ToHashSet();
+        var usedNumberFormats = new HashSet<string>();
+        var usedFonts = new HashSet<XLFontFormatValue>();
+        var usedFills = new HashSet<XLFillFormatValue>();
+        var usedBorders = new HashSet<XLBorderFormatValue>();
+        foreach (var cellFormat in usedCellFormats)
+        {
+            if (!string.IsNullOrEmpty(cellFormat.NumberFormat))
+                usedNumberFormats.Add(cellFormat.NumberFormat!);
+
+            if (cellFormat.Font is { } font)
+                usedFonts.Add(font);
+
+            if (cellFormat.Fill is { } fill)
+                usedFills.Add(fill);
+
+            if (cellFormat.Border is { } border)
+                usedBorders.Add(border);
+        }
+
+        var settings = new XmlWriterSettings
+        {
+            Encoding = XLHelper.NoBomUTF8
+        };
+
+        using var partStream = stylesPart.GetStream(FileMode.Create);
+        using var xml = new XmlTreeWriter(XmlWriter.Create(partStream, settings), mapper);
+
+        xml.WriteStartDocument("styleSheet", _ns);
+        xml.WriteAttribute("xmlns", _ns);
+
+        // Number formats
+        var numberFormatMap = new SequentialMap<int, string>(styles.NumberFormats, FirstUserDefinedFormatIndex);
+        foreach (var (actualId, format) in styles.NumberFormats)
+        {
+            if (!usedNumberFormats.Contains(format))
+                continue;
+
+            if (XLPredefinedFormat.NumberFormatIds.ContainsKey(format))
+                continue;
+
+            numberFormatMap.Add(actualId);
+        }
+
+        numberFormatMap.Sort();
+        if (numberFormatMap.Count > 0)
+            WriteNumberFormats(xml, numberFormatMap);
+
+        // Fonts
+        var fontFormatsMap = SequentialMap<int, XLFontFormatValue>.Create(usedFonts, styles.Fonts);
+        if (fontFormatsMap.Count > 0)
+            WriteFonts(xml, fontFormatsMap);
+
+        // TODO: Add the fixed fills (none+gray125) at the start
+        var fillsFormatsMap = SequentialMap<int, XLFillFormatValue>.Create(usedFills, styles.Fills);
+        if (fillsFormatsMap.Count > 0)
+            WriteFills(xml, fillsFormatsMap);
+
+        var borderFormatsMap = SequentialMap<int, XLBorderFormatValue>.Create(usedBorders, styles.Borders);
+        if (borderFormatsMap.Count > 0)
+            WriteBorders(xml, borderFormatsMap, styles);
+
+        // TODO: Ensure the normal style cellXfs has index 0
+        var cellXfsMap = SequentialMap<int, XLCellFormatValue>.Create(usedCellFormats, styles.CellFormats);
+        if (cellXfsMap.Count > 0)
+            WriteCellXfs(xml, cellXfsMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap);
+
+        // TODO: Rest of elements cellStyleXfs, cellStyles, dxfs, tableStyles, colors
+        xml.WriteEndElement();
+    }
+
+    private void WriteNumberFormats(XmlTreeWriter xml, SequentialMap<int, string> idMap)
+    {
+        xml.WriteStartElement("numFmts", _ns);
+        xml.WriteAttribute("count", idMap.Count);
+
+        var predefinedFormats = XLPredefinedFormat.FormatCodes;
+        foreach (var (savedId, format) in idMap.GetActual())
+        {
+            if (predefinedFormats.TryGetValue(savedId, out var predefinedFormat) && predefinedFormat == format)
+                continue;
+
+            xml.WriteStartElement("numFmt", _ns);
+            xml.WriteAttribute("numFmtId", savedId);
+            xml.WriteAttribute("formatCode", format);
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement(); // numFmts
+    }
+
+    private void WriteFonts(XmlTreeWriter xml, SequentialMap<int, XLFontFormatValue> idMap)
+    {
+        xml.WriteStartElement("fonts", _ns);
+        xml.WriteAttribute("count", idMap.Count);
+
+        foreach (var (_, font) in idMap.GetActual())
+        {
+            // MS-OI29500 dictates font elements order.
+            xml.WriteStartElement("font", _ns);
+
+            if (font.Bold is { } bold)
+                xml.WriteBooleanProperty("b", bold, _ns);
+
+            if (font.Italic is { } italic)
+                xml.WriteBooleanProperty("i", italic, _ns);
+
+            if (font.Strikethrough is { } strikethrough)
+                xml.WriteBooleanProperty("strike", strikethrough, _ns);
+
+            if (font.Condense is { } condense)
+                xml.WriteBooleanProperty("condense", condense, _ns);
+
+            if (font.Extend is { } extend)
+                xml.WriteBooleanProperty("extend", extend, _ns);
+
+            if (font.Outline is { } outline)
+                xml.WriteBooleanProperty("outline", outline, _ns);
+
+            if (font.Shadow is { } shadow)
+                xml.WriteBooleanProperty("shadow", shadow, _ns);
+
+            if (font.Underline is { } underline)
+            {
+                xml.WriteStartElement("u", _ns);
+                xml.WriteAttributeDefault("val", underline, XLFontUnderlineValues.Single);
+                xml.WriteEndElement();
+            }
+
+            if (font.VerticalAlignment is { } verticalAlignment)
+            {
+                xml.WriteStartElement("vertAlign", _ns);
+                xml.WriteAttribute("val", verticalAlignment);
+                xml.WriteEndElement();
+            }
+
+            if (font.Size is { } size)
+            {
+                xml.WriteStartElement("sz", _ns);
+                xml.WriteAttribute("val", size.Points);
+                xml.WriteEndElement();
+            }
+
+            if (font.Color is { } color)
+            {
+                xml.WriteColor("color", _ns, color);
+            }
+
+            if (font.Name is { } name)
+            {
+                xml.WriteStartElement("name", _ns);
+                xml.WriteAttribute("val", name.Text);
+                xml.WriteEndElement();
+            }
+
+            if (font.Family is { } family)
+            {
+                xml.WriteStartElement("family", _ns);
+                xml.WriteAttribute("val", (int)family);
+                xml.WriteEndElement();
+            }
+
+            if (font.Charset is { } charset)
+            {
+                // Charset is stored as an CT_IntProperty
+                xml.WriteStartElement("charset", _ns);
+                xml.WriteAttribute("val", (int)charset);
+                xml.WriteEndElement();
+            }
+
+            if (font.Scheme is { } scheme)
+            {
+                xml.WriteStartElement("scheme", _ns);
+                xml.WriteAttribute("val", scheme);
+                xml.WriteEndElement();
+            }
+
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement(); // fonts
+    }
+
+    private void WriteFills(XmlTreeWriter xml, SequentialMap<int, XLFillFormatValue> idMap)
+    {
+        xml.WriteStartElement("fills", _ns);
+        xml.WriteAttribute("count", idMap.Count);
+
+        foreach (var (_, fill) in idMap.GetActual())
+        {
+            xml.WriteStartElement("fill", _ns);
+            if (fill.Pattern is { } patternFill)
+            {
+                xml.WriteStartElement("patternFill", _ns);
+                xml.WriteAttribute("patternType", patternFill.PatternType);
+                xml.WriteColor("fgColor", _ns, patternFill.PatternColor);
+                xml.WriteColor("bgColor", _ns, patternFill.BackgroundColor);
+                xml.WriteEndElement();
+            }
+            else if (fill.LinearGradient is { } linearGradient)
+            {
+                throw new NotImplementedException();
+            }
+            else if (fill.PathGradient is { } pathGradient)
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                // Nothing, a fill with no fill/gradient is a valid state per XML
+            }
+
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement();
+    }
+
+    private void WriteBorders(XmlTreeWriter xml, SequentialMap<int, XLBorderFormatValue> idMap, XLWorkbookStyles styles)
+    {
+        xml.WriteStartElement("borders", _ns);
+        xml.WriteAttribute("count", idMap.Count);
+        foreach (var (_, border) in idMap.GetActual())
+        {
+            xml.WriteStartElement("border", _ns);
+            xml.WriteAttributeDefault("diagonalUp", border.DiagonalUp, false);
+            xml.WriteAttributeDefault("diagonalDown", border.DiagonalDown, false);
+            xml.WriteAttributeDefault("outline", border.Outline, true);
+
+            // ISO should be "start"+"end", but Excel uses "left"+"right"
+            WriteBorderPr("left", border.Left);
+            WriteBorderPr("right", border.Right);
+            WriteBorderPr("top", border.Top);
+            WriteBorderPr("bottom", border.Bottom);
+            WriteBorderPr("diagonal", border.Diagonal);
+            WriteBorderPr("vertical", border.Vertical);
+            WriteBorderPr("horizontal", border.Horizontal);
+
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement();
+        return;
+
+        void WriteBorderPr(string name, XLBorderLine? borderLine)
+        {
+            if (!borderLine.HasValue)
+                return;
+
+            xml.WriteStartElement(name, _ns);
+            xml.WriteAttributeDefault("style", borderLine.Value.Style, XLBorderStyleValues.None);
+            xml.WriteColor("color", _ns, borderLine.Value.Color);
+            xml.WriteEndElement();
+        }
+    }
+
+    private void WriteCellXfs(
+        XmlTreeWriter xml,
+        SequentialMap<int, XLCellFormatValue> idMap,
+        SequentialMap<int, string> numFmtIdMap,
+        SequentialMap<int, XLFontFormatValue> fontIdMap,
+        SequentialMap<int, XLFillFormatValue> fillIdMap,
+        SequentialMap<int, XLBorderFormatValue> borderIdMap)
+    {
+        xml.WriteStartElement("cellXfs", _ns);
+        xml.WriteAttribute("count", idMap.Count);
+        foreach (var (_, cellXf) in idMap.GetActual())
+        {
+            xml.WriteStartElement("xf", _ns);
+
+            if (cellXf.NumberFormat is not null)
+            {
+                if (!XLPredefinedFormat.NumberFormatIds.TryGetValue(cellXf.NumberFormat, out var numFmtId))
+                    numFmtId = numFmtIdMap.GetSavedId(cellXf.NumberFormat);
+
+                xml.WriteAttributeOptional("numFmtId", numFmtId);
+            }
+
+            if (cellXf.Font is not null)
+                xml.WriteAttributeOptional("fontId", fontIdMap.GetSavedId(cellXf.Font));
+
+            if (cellXf.Fill is not null)
+                xml.WriteAttributeOptional("fillId", fillIdMap.GetSavedId(cellXf.Fill));
+
+            if (cellXf.Border is not null)
+                xml.WriteAttributeOptional("borderId", borderIdMap.GetSavedId(cellXf.Border));
+
+            // TODO: Write cell style
+            // xml.WriteAttributeDefault("xfId", cellXf.CellStyleId, 0);
+            xml.WriteAttributeDefault("quotePrefix", cellXf.IncludeQuotePrefix, false);
+            xml.WriteAttributeDefault("pivotButton", cellXf.PivotButton, false);
+            xml.WriteAttributeDefault("applyNumberFormat", cellXf.CustomFormat.HasFlag(CellFormatComponents.NumberFormat), false);
+            xml.WriteAttributeDefault("applyFont", cellXf.CustomFormat.HasFlag(CellFormatComponents.Font), false);
+            xml.WriteAttributeDefault("applyFill", cellXf.CustomFormat.HasFlag(CellFormatComponents.Fill), false);
+            xml.WriteAttributeDefault("applyBorder", cellXf.CustomFormat.HasFlag(CellFormatComponents.Border), false);
+            xml.WriteAttributeDefault("applyAlignment", cellXf.CustomFormat.HasFlag(CellFormatComponents.Alignment), false);
+            xml.WriteAttributeDefault("applyProtection", cellXf.CustomFormat.HasFlag(CellFormatComponents.Protection), false);
+
+            if (cellXf.Alignment is { } alignment)
+            {
+                xml.WriteStartElement("alignment", _ns);
+                xml.WriteAttributeDefault("horizontal", alignment.Horizontal, XLAlignmentHorizontalValues.General);
+                xml.WriteAttributeDefault("vertical", alignment.Vertical, XLAlignmentVerticalValues.Bottom);
+                xml.WriteAttributeDefault("textRotation", alignment.TextRotation.GetIso(), 0);
+                xml.WriteAttributeDefault("wrapText", alignment.WrapText, false);
+                xml.WriteAttributeDefault("indent", alignment.Indent, 0);
+                xml.WriteAttributeDefault("relativeIndent", alignment.RelativeIndent, 0);
+                xml.WriteAttributeDefault("justifyLastLine", alignment.JustifyLastLine, false);
+                xml.WriteAttributeDefault("shrinkToFit", alignment.ShrinkToFit, false);
+                xml.WriteAttributeDefault("readingOrder", alignment.ReadingOrder, XLAlignmentReadingOrderValues.ContextDependent);
+                xml.WriteEndElement();
+            }
+
+            if (cellXf.Protection is { } protection)
+            {
+                xml.WriteStartElement("protection", _ns);
+                xml.WriteAttributeDefault("locked", protection.Locked, true);
+                xml.WriteAttributeDefault("hidden", protection.Hidden, false);
+                xml.WriteEndElement();
+            }
+
+            // TODO: extLst
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement();
+    }
+
+    private class SequentialMap<TKey, T>
+        where TKey : struct
+    {
+        /// <summary>
+        /// The index is the one that is used to save the <typeparamref name="T"/> while value is an index to the <c>_fullMap</c>.
+        /// </summary>
+        private readonly List<TKey> _savedIdToActualId = new();
+
+        private readonly int _offset;
+
+        private readonly IReadOnlyBiDictionary<TKey, T> _fullMap;
+
+        public SequentialMap(IReadOnlyBiDictionary<TKey, T> fullMap, int offset = 0)
+        {
+            _fullMap = fullMap;
+            _offset = offset;
+        }
+
+        /// <summary>
+        /// How many entries to save are in the map.
+        /// </summary>
+        public int Count => _savedIdToActualId.Count;
+
+        internal static SequentialMap<TKey, T> Create(HashSet<T> usedValues, IReadOnlyBiDictionary<TKey, T> allValuesMap, int offset = 0)
+        {
+            var map = new SequentialMap<TKey, T>(allValuesMap, offset);
+            foreach (var (actualId, value) in allValuesMap)
+            {
+                if (!usedValues.Contains(value))
+                    continue;
+
+                map.Add(actualId);
+            }
+
+            map.Sort();
+            return map;
+        }
+
+        public void Add(TKey actualId)
+        {
+            _savedIdToActualId.Add(actualId);
+        }
+
+        public void Sort()
+        {
+            _savedIdToActualId.Sort();
+        }
+
+        public IEnumerable<(int SaveId, T Actual)> GetActual()
+        {
+            return _savedIdToActualId.Select((value, index) => (index + _offset, _fullMap[value]));
+        }
+
+        public int GetSavedId(T item)
+        {
+            var actualId = _fullMap[item];
+
+            // TODO: make another identity map, plus this returns -1 on error
+            return _savedIdToActualId.IndexOf(actualId);
+        }
+    }
+}

--- a/ClosedXML/Excel/IO/XmlToEnumMapper.cs
+++ b/ClosedXML/Excel/IO/XmlToEnumMapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ClosedXML.IO;
+using ClosedXML.Utils;
 
 namespace ClosedXML.Excel.IO;
 
@@ -10,10 +11,10 @@ namespace ClosedXML.Excel.IO;
 internal sealed class XmlToEnumMapper : IEnumMapper
 {
     /// <summary>
-    /// A collection of all maps. The key is enum type, the value is Dictionary&lt;string,SomeEnum&gt;
+    /// A collection of all maps. The key is enum type, the value is BiDictionary&lt;string,SomeEnum&gt;
     /// Value can't be typed due to generic limitations (no common ancestor).
     /// </summary>
-    private readonly Dictionary<Type, object> _textToEnumMaps;
+    private readonly Dictionary<Type, object> _enumMaps;
 
     private static readonly Lazy<XmlToEnumMapper> LazyInstance = new(CreateSpreadsheetMapper);
 
@@ -21,14 +22,27 @@ internal sealed class XmlToEnumMapper : IEnumMapper
 
     private XmlToEnumMapper(Dictionary<Type, object> maps)
     {
-        _textToEnumMaps = maps;
+        _enumMaps = maps;
     }
 
     public bool TryGetEnum<TEnum>(string text, out TEnum enumValue)
         where TEnum : struct, Enum
     {
-        var enumMap = (Dictionary<string, TEnum>)_textToEnumMaps[typeof(TEnum)];
-        return enumMap.TryGetValue(text, out enumValue);
+        var enumMap = GetEnumMap<TEnum>();
+        return enumMap.KeyToValue.TryGetValue(text, out enumValue);
+    }
+
+    public bool TryGetText<TEnum>(TEnum enumValue, out string text)
+        where TEnum : struct, Enum
+    {
+        var enumMap = GetEnumMap<TEnum>();
+        return enumMap.ValueToKey.TryGetValue(enumValue, out text);
+    }
+
+    private BiDictionary<string, TEnum> GetEnumMap<TEnum>()
+        where TEnum : struct, Enum
+    {
+        return (BiDictionary<string, TEnum>)_enumMaps[typeof(TEnum)];
     }
 
     private static XmlToEnumMapper CreateSpreadsheetMapper()
@@ -36,7 +50,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         var builder = new Builder();
 
         // ST_FontScheme
-        builder.Add(new Dictionary<string, XLFontScheme>
+        builder.Add(new BiDictionary<string, XLFontScheme>
         {
             { "none", XLFontScheme.None },
             { "major", XLFontScheme.Major },
@@ -44,7 +58,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_UnderlineValues
-        builder.Add(new Dictionary<string, XLFontUnderlineValues>
+        builder.Add(new BiDictionary<string, XLFontUnderlineValues>
         {
             { "double", XLFontUnderlineValues.Double },
             { "doubleAccounting", XLFontUnderlineValues.DoubleAccounting },
@@ -54,7 +68,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_VerticalAlignRun
-        builder.Add(new Dictionary<string, XLFontVerticalTextAlignmentValues>
+        builder.Add(new BiDictionary<string, XLFontVerticalTextAlignmentValues>
         {
             { "baseline", XLFontVerticalTextAlignmentValues.Baseline },
             { "subscript", XLFontVerticalTextAlignmentValues.Subscript },
@@ -62,7 +76,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_PatternType
-        builder.Add(new Dictionary<string, XLFillPatternValues>
+        builder.Add(new BiDictionary<string, XLFillPatternValues>
         {
             { "none", XLFillPatternValues.None },
             { "solid", XLFillPatternValues.Solid },
@@ -86,7 +100,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_BorderStyle
-        builder.Add(new Dictionary<string, XLBorderStyleValues>
+        builder.Add(new BiDictionary<string, XLBorderStyleValues>
         {
             { "none", XLBorderStyleValues.None },
             { "thin", XLBorderStyleValues.Thin },
@@ -105,7 +119,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_HorizontalAlignment
-        builder.Add(new Dictionary<string, XLAlignmentHorizontalValues>
+        builder.Add(new BiDictionary<string, XLAlignmentHorizontalValues>
         {
             { "general", XLAlignmentHorizontalValues.General },
             { "left", XLAlignmentHorizontalValues.Left },
@@ -118,7 +132,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_VerticalAlignment
-        builder.Add(new Dictionary<string, XLAlignmentVerticalValues>
+        builder.Add(new BiDictionary<string, XLAlignmentVerticalValues>
         {
             { "top", XLAlignmentVerticalValues.Top },
             { "center", XLAlignmentVerticalValues.Center },
@@ -128,7 +142,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         });
 
         // ST_GradientType
-        builder.Add(new Dictionary<string, XLGradientType>
+        builder.Add(new BiDictionary<string, XLGradientType>
         {
             { "linear", XLGradientType.Linear },
             { "path", XLGradientType.Path }
@@ -141,7 +155,8 @@ internal sealed class XmlToEnumMapper : IEnumMapper
     {
         private readonly Dictionary<Type, object> _maps = new();
 
-        public Builder Add<T>(Dictionary<string, T> map)
+        public Builder Add<T>(BiDictionary<string, T> map)
+            where T : struct, Enum
         {
             _maps.Add(typeof(T), map);
             return this;

--- a/ClosedXML/Excel/IO/XmlTreeWriter.cs
+++ b/ClosedXML/Excel/IO/XmlTreeWriter.cs
@@ -1,0 +1,72 @@
+using ClosedXML.Extensions;
+using ClosedXML.IO;
+using System;
+using System.Xml;
+
+namespace ClosedXML.Excel.IO;
+
+[Janitor.SkipWeaving]
+internal class XmlTreeWriter : IDisposable
+{
+    private readonly XmlWriter _xml;
+    private readonly IEnumMapper _enumMapper;
+
+    internal XmlTreeWriter(XmlWriter xml, IEnumMapper enumMapper)
+    {
+        _xml = xml;
+        _enumMapper = enumMapper;
+    }
+
+    public void WriteStartDocument(string rootElementName, string ns)
+    {
+        _xml.WriteStartDocument();
+
+        // Make root element ns a default namespace to avoid prefix if possible
+        _xml.WriteStartElement(rootElementName, ns);
+        _xml.WriteAttributeString("xmlns", ns);
+    }
+
+    public void WriteStartElement(string localName, string ns)
+    {
+        _xml.WriteStartElement(localName, ns);
+    }
+
+    public void WriteAttribute(string attributeName, int value)
+    {
+        _xml.WriteAttribute(attributeName, value);
+    }
+
+    public void WriteAttribute(string attributeName, bool value)
+    {
+        _xml.WriteAttribute(attributeName, value);
+    }
+
+    public void WriteAttribute(string attributeName, string value)
+    {
+        _xml.WriteAttribute(attributeName, value);
+    }
+
+    public void WriteAttribute(string attributeName, double value)
+    {
+        _xml.WriteAttribute(attributeName, value);
+    }
+
+    public void WriteAttribute<TEnum>(string attributeName, TEnum value)
+        where TEnum : struct, Enum
+    {
+        if (!_enumMapper.TryGetText(value, out var text))
+            throw new InvalidOperationException($"Missing mapping for enum {value} ({typeof(TEnum).Name}).");
+
+        _xml.WriteAttribute(attributeName, text);
+    }
+
+    public void WriteEndElement()
+    {
+        _xml.WriteEndElement();
+    }
+
+    public void Dispose()
+    {
+        _xml.Dispose();
+    }
+}

--- a/ClosedXML/Excel/Style/Formatting/StyleId.cs
+++ b/ClosedXML/Excel/Style/Formatting/StyleId.cs
@@ -7,12 +7,17 @@ namespace ClosedXML.Excel.Formatting;
 /// a changeable <see cref="XLCellStyleValue"/>. API methods that needs access to a resolved format
 /// value should pass <see cref="XLWorkbookStyles.DefaultFormat"/> as a parameter.
 /// </summary>
-internal readonly record struct StyleId(int Value) : IEquatable<int>
+internal readonly record struct StyleId(int Value) : IEquatable<int>, IComparable<StyleId>
 {
     public static implicit operator StyleId(int v) => new(v);
 
     bool IEquatable<int>.Equals(int other)
     {
         return Value == other;
+    }
+
+    public int CompareTo(StyleId other)
+    {
+        return Value.CompareTo(other.Value);
     }
 }

--- a/ClosedXML/Excel/Style/Formatting/TextRotation.cs
+++ b/ClosedXML/Excel/Style/Formatting/TextRotation.cs
@@ -18,4 +18,17 @@ internal readonly record struct TextRotation
     }
 
     public int Value { get; }
+
+    /// <summary>
+    /// Get value that is stored in ISO-29500 (unsigned int)
+    /// </summary>
+    internal uint GetIso()
+    {
+        return Value switch
+        {
+            >= 0 and <= 90 => (uint)Value,
+            >= -90 and <= 0 => (uint)(90 - Value),
+            _ => (uint)Value
+        };
+    }
 }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -11,13 +11,13 @@ namespace ClosedXML.Excel;
 /// </summary>
 internal class XLWorkbookStyles
 {
-    private readonly Dictionary<int, string> _numberFormats;
+    private readonly BiDictionary<int, string> _numberFormats;
 
     private readonly BiDictionary<int, XLFontFormatValue> _fontFormats;
 
-    private readonly Dictionary<int, XLFillFormatValue> _fillFormats;
+    private readonly BiDictionary<int, XLFillFormatValue> _fillFormats;
 
-    private readonly Dictionary<int, XLBorderFormatValue> _borderFormats;
+    private readonly BiDictionary<int, XLBorderFormatValue> _borderFormats;
 
     /// <summary>
     /// The key is XfId, the value is cell format.
@@ -27,7 +27,7 @@ internal class XLWorkbookStyles
     /// <summary>
     /// The key is cellStyleXfId, the value is cell style.
     /// </summary>
-    private readonly Dictionary<StyleId, XLCellStyleValue> _cellStyles;
+    private readonly BiDictionary<StyleId, XLCellStyleValue> _cellStyles;
 
     private readonly BiDictionary<int, XLDxfValue> _differentialFormats;
 
@@ -47,28 +47,28 @@ internal class XLWorkbookStyles
 
     internal XLWorkbookStyles()
     {
-        _numberFormats = new Dictionary<int, string>();
+        _numberFormats = new BiDictionary<int, string>();
         _fontFormats = new BiDictionary<int, XLFontFormatValue>();
-        _fillFormats = new Dictionary<int, XLFillFormatValue>();
-        _borderFormats = new Dictionary<int, XLBorderFormatValue>();
+        _fillFormats = new BiDictionary<int, XLFillFormatValue>();
+        _borderFormats = new BiDictionary<int, XLBorderFormatValue>();
         _cellFormats = new BiDictionary<int, XLCellFormatValue>();
-        _cellStyles = new Dictionary<StyleId, XLCellStyleValue>();
+        _cellStyles = new BiDictionary<StyleId, XLCellStyleValue>();
         _differentialFormats = new BiDictionary<int, XLDxfValue>();
         _tableStyles = new Dictionary<string, XLTableTheme>(XLHelper.NameComparer);
         _pivotStyles = new Dictionary<string, XLPivotTableStyle>(XLHelper.NameComparer);
     }
 
-    internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
+    internal IReadOnlyBiDictionary<int, string> NumberFormats => _numberFormats;
 
     internal IReadOnlyBiDictionary<int, XLFontFormatValue> Fonts => _fontFormats;
 
-    internal IReadOnlyDictionary<int, XLFillFormatValue> Fills => _fillFormats;
+    internal IReadOnlyBiDictionary<int, XLFillFormatValue> Fills => _fillFormats;
 
-    internal IReadOnlyDictionary<int, XLBorderFormatValue> Borders => _borderFormats;
+    internal IReadOnlyBiDictionary<int, XLBorderFormatValue> Borders => _borderFormats;
 
     internal IReadOnlyBiDictionary<int, XLCellFormatValue> CellFormats => _cellFormats;
 
-    internal IReadOnlyDictionary<StyleId, XLCellStyleValue> CellStyles => _cellStyles;
+    internal IReadOnlyBiDictionary<StyleId, XLCellStyleValue> CellStyles => _cellStyles;
 
     internal IReadOnlyDictionary<int, XLDxfValue> DifferentialFormats => _differentialFormats.KeyToValue;
 

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -60,13 +60,13 @@ internal class XLWorkbookStyles
 
     internal IReadOnlyDictionary<int, string> NumberFormats => _numberFormats;
 
-    internal IReadOnlyDictionary<int, XLFontFormatValue> Fonts => _fontFormats.KeyToValue;
+    internal IReadOnlyBiDictionary<int, XLFontFormatValue> Fonts => _fontFormats;
 
     internal IReadOnlyDictionary<int, XLFillFormatValue> Fills => _fillFormats;
 
     internal IReadOnlyDictionary<int, XLBorderFormatValue> Borders => _borderFormats;
 
-    internal IReadOnlyDictionary<int, XLCellFormatValue> CellFormats => _cellFormats.KeyToValue;
+    internal IReadOnlyBiDictionary<int, XLCellFormatValue> CellFormats => _cellFormats;
 
     internal IReadOnlyDictionary<StyleId, XLCellStyleValue> CellStyles => _cellStyles;
 

--- a/ClosedXML/Extensions/XmlTreeWriterExtensions.cs
+++ b/ClosedXML/Extensions/XmlTreeWriterExtensions.cs
@@ -1,0 +1,79 @@
+using System;
+using ClosedXML.Excel;
+using ClosedXML.Excel.IO;
+
+namespace ClosedXML.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="XmlTreeWriter"/>. Keep the original class reasonably clean
+/// and place convenience method here.
+/// </summary>
+internal static class XmlTreeWriterExtensions
+{
+    /// <summary>
+    /// Write a <c>CT_BooleanProperty</c> element.
+    /// </summary>
+    public static void WriteBooleanProperty(this XmlTreeWriter xml, string elName, bool value, string ns)
+    {
+        xml.WriteStartElement(elName, ns);
+        xml.WriteAttributeDefault("val", value, true);
+        xml.WriteEndElement();
+    }
+
+    public static void WriteAttributeDefault(this XmlTreeWriter xml, string attrName, bool value, bool defaultValue)
+    {
+        if (value != defaultValue)
+            xml.WriteAttribute(attrName, value);
+    }
+
+    public static void WriteAttributeDefault(this XmlTreeWriter xml, string attrName, int value, int defaultValue)
+    {
+        if (value != defaultValue)
+            xml.WriteAttribute(attrName, value);
+    }
+
+    public static void WriteAttributeDefault(this XmlTreeWriter xml, string attrName, uint value, uint defaultValue)
+    {
+        if (value != defaultValue)
+            xml.WriteAttribute(attrName, value);
+    }
+
+    public static void WriteAttributeDefault<TEnum>(this XmlTreeWriter xml, string attrName, TEnum enumValue, TEnum defaultValue)
+        where TEnum : struct, Enum
+    {
+        if (!enumValue.Equals(defaultValue))
+            xml.WriteAttribute(attrName, enumValue);
+    }
+
+    public static void WriteAttributeOptional(this XmlTreeWriter xml, string attrName, int? value)
+    {
+        if (value is not null)
+            xml.WriteAttribute(attrName, value.Value);
+    }
+
+    public static void WriteColor(this XmlTreeWriter xml, string elName, string ns, XLColor color, bool isDifferential = false)
+    {
+        xml.WriteStartElement(elName, ns);
+        switch (color.ColorType)
+        {
+            case XLColorType.Color:
+                xml.WriteAttribute("rgb", color.Color.ToHex());
+                break;
+
+            case XLColorType.Indexed:
+                // 64 is 'transparent' and should be ignored for differential formats
+                if (!isDifferential || color.Indexed != 64)
+                    xml.WriteAttribute("indexed", color.Indexed);
+                break;
+
+            case XLColorType.Theme:
+                xml.WriteAttribute("theme", (int)color.ThemeColor);
+
+                if (color.ThemeTint != 0)
+                    xml.WriteAttribute("tint", color.ThemeTint);
+                break;
+        }
+
+        xml.WriteEndElement();
+    }
+}

--- a/ClosedXML/Utils/BiDictionary.cs
+++ b/ClosedXML/Utils/BiDictionary.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -12,20 +13,44 @@ namespace ClosedXML.Utils;
 /// the list can be duplicate (two same fonts with different id).
 /// </example>
 /// </summary>
-internal class BiDictionary<TKey, TValue>
+internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
     where TKey : notnull
     where TValue : IEquatable<TValue>
 {
-    private readonly Dictionary<TKey, TValue> _keyToValue = new();
+    private readonly Dictionary<TKey, TValue> _keyToValue;
 
     /// <summary>
     /// A reverse dictionary. The original <see cref="_keyToValue"/> can contain same entry multiple times.
     /// </summary>
-    private readonly Dictionary<TValue, TKey> _entryToKey = new();
+    private readonly Dictionary<TValue, TKey> _entryToKey;
+
+    internal BiDictionary()
+    {
+        _entryToKey = new Dictionary<TValue, TKey>();
+        _keyToValue = new Dictionary<TKey, TValue>();
+    }
+
+    internal BiDictionary(int capacity)
+    {
+        _entryToKey = new Dictionary<TValue, TKey>(capacity);
+        _keyToValue = new Dictionary<TKey, TValue>(capacity);
+    }
+
+    public TValue this[TKey key] => _keyToValue[key];
+
+    public int Count => _keyToValue.Count;
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    {
+        return _keyToValue.GetEnumerator();
+    }
 
     internal IReadOnlyDictionary<TKey, TValue> KeyToValue => _keyToValue;
-
-    internal int Count => _keyToValue.Count;
 
     public void Add(TKey id, TValue value)
     {

--- a/ClosedXML/Utils/BiDictionary.cs
+++ b/ClosedXML/Utils/BiDictionary.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -15,7 +14,7 @@ namespace ClosedXML.Utils;
 /// </summary>
 internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
     where TKey : notnull
-    where TValue : IEquatable<TValue>
+    where TValue : notnull
 {
     private readonly Dictionary<TKey, TValue> _keyToValue;
 
@@ -51,6 +50,8 @@ internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
     }
 
     internal IReadOnlyDictionary<TKey, TValue> KeyToValue => _keyToValue;
+
+    internal IReadOnlyDictionary<TValue, TKey> ValueToKey => _entryToKey;
 
     public void Add(TKey id, TValue value)
     {

--- a/ClosedXML/Utils/BiDictionary.cs
+++ b/ClosedXML/Utils/BiDictionary.cs
@@ -37,6 +37,12 @@ internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
 
     public TValue this[TKey key] => _keyToValue[key];
 
+    public IEnumerable<TKey> Keys => _keyToValue.Keys;
+
+    public IEnumerable<TValue> Values => _keyToValue.Values;
+
+    public TKey this[TValue value] => _entryToKey[value];
+
     public int Count => _keyToValue.Count;
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -47,6 +53,16 @@ internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
     {
         return _keyToValue.GetEnumerator();
+    }
+
+    public bool TryGetValue(TKey key, out TValue value)
+    {
+        return _keyToValue.TryGetValue(key, out value);
+    }
+
+    public bool ContainsKey(TKey key)
+    {
+        return _keyToValue.ContainsKey(key);
     }
 
     internal IReadOnlyDictionary<TKey, TValue> KeyToValue => _keyToValue;

--- a/ClosedXML/Utils/IReadOnlyBiDictionary.cs
+++ b/ClosedXML/Utils/IReadOnlyBiDictionary.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Collections.Generic;
 
 namespace ClosedXML.Utils;
 
 internal interface IReadOnlyBiDictionary<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>
     where TKey : notnull
-    where TValue : IEquatable<TValue>
 {
     TValue this[TKey key] { get; }
 }

--- a/ClosedXML/Utils/IReadOnlyBiDictionary.cs
+++ b/ClosedXML/Utils/IReadOnlyBiDictionary.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Utils;
+
+internal interface IReadOnlyBiDictionary<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+    where TValue : IEquatable<TValue>
+{
+    TValue this[TKey key] { get; }
+}

--- a/ClosedXML/Utils/IReadOnlyBiDictionary.cs
+++ b/ClosedXML/Utils/IReadOnlyBiDictionary.cs
@@ -2,8 +2,12 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Utils;
 
-internal interface IReadOnlyBiDictionary<TKey, TValue> : IReadOnlyCollection<KeyValuePair<TKey, TValue>>
+internal interface IReadOnlyBiDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
     where TKey : notnull
 {
-    TValue this[TKey key] { get; }
+    /// <summary>
+    /// Return the key associated with the value. The bi-dictionary does allow duplicate values.
+    /// In case of duplicates, the earliest added entry will be returned.
+    /// </summary>
+    TKey this[TValue value] { get; }
 }


### PR DESCRIPTION
Add a skeleton of styles writer. It is not yet used anywhere (it doesn't have a lot of things), but at least it can write a simplest styles part that is readable by Excel. This will be improved later.

The writer is using a new `XmlTreeWriter`. There are two main reasons to use a wrapper:
* Potential for async. ClosedXML is fully sync, but it would be nice to have option to be async for loading/writing. There is no perfect solution for the sync/async code sharing, but the [boolean argument hack](https://learn.microsoft.com/en-us/archive/msdn-magazine/2015/july/async-programming-brownfield-async-development#the-flag-argument-hack) is one of potential solutions. That requires control over the core writing code.
* Potential replacement. Although `XmlWriter` is a very good writer, it could conceivably be replaced by some other writer that is faster.
