### PR TITLE
Fix MROUND when number parameter is zero (fixes #2763)

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/MathTrigTests.cs
@@ -1573,6 +1573,8 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase(1.4, 0.5, ExpectedResult = 1.5)]
         [TestCase(3, 7, ExpectedResult = 0)]
         [TestCase(3, 0, ExpectedResult = 0)]
+        [TestCase(0, 10, ExpectedResult = 0)]
+        [TestCase(0, -5, ExpectedResult = 0)]
         [DefaultFloatingPointTolerance(1e-12)]
         public double MRound(double number, double multiple)
         {

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -710,6 +710,9 @@ namespace ClosedXML.Excel.CalcEngine
             if (multiple == 0)
                 return 0;
 
+            if (number == 0)
+                return 0;
+
             if (Math.Sign(number) != Math.Sign(multiple))
                 return XLError.NumberInvalid;
 


### PR DESCRIPTION
Fixes [#2763](https://github.com/ClosedXML/ClosedXML/issues/2763)

MROUND should return 0 when the number parameter is 0, regardless of the sign of the multiple parameter. This matches Excel behavior where MROUND(0, 10) and MROUND(0, -10) both return 0.

The issue was that Math.Sign(0) returns 0, which didn't match Math.Sign(multiple) for non-zero multiples, causing an incorrect NumberInvalid error.

ClosedXML does not accept pull requests at this time.
