### PR TITLE
Styles writer - colors

### DIFF
--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -255,11 +254,26 @@ internal class StylesWriter
             }
             else if (fill.LinearGradient is { } linearGradient)
             {
-                throw new NotImplementedException();
+                // Linear is the default type, so no need to write it
+                xml.WriteStartElement("gradientFill", _ns);
+                xml.WriteAttributeDefault("degree", linearGradient.Degrees, 0);
+
+                WriteStops(linearGradient.Stops);
+
+                xml.WriteEndElement();
             }
             else if (fill.PathGradient is { } pathGradient)
             {
-                throw new NotImplementedException();
+                xml.WriteStartElement("gradientFill", _ns);
+                xml.WriteAttribute("type", "path");
+                xml.WriteAttributeDefault("left", pathGradient.InnerLeft.Value, 0);
+                xml.WriteAttributeDefault("right", pathGradient.InnerRight.Value, 0);
+                xml.WriteAttributeDefault("top", pathGradient.InnerTop.Value, 0);
+                xml.WriteAttributeDefault("bottom", pathGradient.InnerBottom.Value, 0);
+
+                WriteStops(pathGradient.Stops);
+
+                xml.WriteEndElement();
             }
             else
             {
@@ -270,6 +284,19 @@ internal class StylesWriter
         }
 
         xml.WriteEndElement();
+        return;
+
+        void WriteStops(IReadOnlyDictionary<FractionOfOne, XLColor> stops)
+        {
+            // Excel doesn't care about stop order by positions, but sort anyway
+            foreach (var (position, color) in stops.OrderBy(x => x.Key.Value))
+            {
+                xml.WriteStartElement("stop", _ns);
+                xml.WriteAttribute("position", position.Value);
+                xml.WriteColor("color", _ns, color);
+                xml.WriteEndElement();
+            }
+        }
     }
 
     private void WriteBorders(XmlTreeWriter xml, SequentialMap<int, XLBorderFormatValue> idMap)

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -120,7 +120,9 @@ internal class StylesWriter
 
         WriteCellStyles(xml, cellStylesMap);
 
-        // TODO: Rest of elements dxfs, tableStyles, colors
+        // TODO: Rest of elements dxfs, tableStyles and indexed colors
+        WriteColors(xml, styles);
+
         xml.WriteEndElement();
     }
 
@@ -501,6 +503,23 @@ internal class StylesWriter
         }
 
         xml.WriteEndElement();
+    }
+
+    private void WriteColors(XmlTreeWriter xml, XLWorkbookStyles styles)
+    {
+        var hasMruColors = styles.MruColors.Count > 0;
+        if (!hasMruColors)
+            return;
+
+        xml.WriteStartElement("colors", _ns);
+
+        xml.WriteStartElement("mruColors", _ns);
+        foreach (var mruColor in styles.MruColors)
+            xml.WriteColor("color", _ns, mruColor);
+
+        xml.WriteEndElement(); // mruColors
+
+        xml.WriteEndElement(); // colors
     }
 
     private class SequentialMap<TKey, T>

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -244,6 +244,8 @@ internal class StylesWriter
         foreach (var (_, fill) in idMap.GetActual())
         {
             xml.WriteStartElement("fill", _ns);
+
+            // A fill element with no pattern/gradient is a valid state per XML
             if (fill.Pattern is { } patternFill)
             {
                 xml.WriteStartElement("patternFill", _ns);
@@ -274,10 +276,6 @@ internal class StylesWriter
                 WriteStops(pathGradient.Stops);
 
                 xml.WriteEndElement();
-            }
-            else
-            {
-                // Nothing, a fill with no fill/gradient is a valid state per XML
             }
 
             xml.WriteEndElement();

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -117,7 +117,7 @@ internal class StylesWriter
 
         // TODO: Ensure the normal style cellXfs has index 0
         var cellXfsMap = SequentialMap<int, XLCellFormatValue>.Create(usedCellFormats, styles.CellFormats);
-        WriteCellXfs(xml, cellXfsMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap);
+        WriteCellXfs(xml, cellXfsMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap, cellStylesMap);
 
         WriteCellStyles(xml, cellStylesMap);
 
@@ -364,7 +364,8 @@ internal class StylesWriter
         SequentialMap<int, string> numFmtIdMap,
         SequentialMap<int, XLFontFormatValue> fontIdMap,
         SequentialMap<int, XLFillFormatValue> fillIdMap,
-        SequentialMap<int, XLBorderFormatValue> borderIdMap)
+        SequentialMap<int, XLBorderFormatValue> borderIdMap,
+        SequentialMap<StyleId, XLCellStyleValue> cellStyleIdMap)
     {
         xml.WriteStartElement("cellXfs", _ns);
         xml.WriteAttribute("count", idMap.Count);
@@ -389,8 +390,9 @@ internal class StylesWriter
             if (cellXf.Border is not null)
                 xml.WriteAttributeOptional("borderId", borderIdMap.GetSavedId(cellXf.Border));
 
-            // TODO: Write cell style
-            // xml.WriteAttributeDefault("xfId", cellXf.CellStyleId, 0);
+            if (cellXf.CellStyleId is not null)
+                xml.WriteAttributeDefault("xfId", cellStyleIdMap.GetSavedId(cellXf.CellStyleId.Value), 0);
+
             xml.WriteAttributeDefault("quotePrefix", cellXf.IncludeQuotePrefix, false);
             xml.WriteAttributeDefault("pivotButton", cellXf.PivotButton, false);
             xml.WriteAttributeDefault("applyNumberFormat", cellXf.CustomFormat.HasFlag(CellFormatComponents.NumberFormat), false);
@@ -532,7 +534,11 @@ internal class StylesWriter
         public int GetSavedId(T item)
         {
             var actualId = _fullMap[item];
+            return GetSavedId(actualId);
+        }
 
+        public int GetSavedId(TKey actualId)
+        {
             // TODO: make another identity map, plus this returns -1 on error
             return _savedIdToActualId.IndexOf(actualId);
         }

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -120,7 +120,7 @@ internal class StylesWriter
 
         WriteCellStyles(xml, cellStylesMap);
 
-        // TODO: Rest of elements dxfs, tableStyles and indexed colors
+        // TODO: Rest of elements dxfs and tableStyles
         WriteColors(xml, styles);
 
         xml.WriteEndElement();
@@ -508,16 +508,34 @@ internal class StylesWriter
     private void WriteColors(XmlTreeWriter xml, XLWorkbookStyles styles)
     {
         var hasMruColors = styles.MruColors.Count > 0;
-        if (!hasMruColors)
+        var indexedColors = styles.IndexedColorsArgb;
+        var hasIndexColors = indexedColors is { Count: > 0 };
+        if (!hasMruColors && !hasIndexColors)
             return;
 
         xml.WriteStartElement("colors", _ns);
 
-        xml.WriteStartElement("mruColors", _ns);
-        foreach (var mruColor in styles.MruColors)
-            xml.WriteColor("color", _ns, mruColor);
+        if (hasIndexColors)
+        {
+            xml.WriteStartElement("indexedColors", _ns);
+            foreach (var indexedColor in indexedColors!)
+            {
+                xml.WriteStartElement("rgbColor", _ns);
+                xml.WriteAttributeHex("rgb", indexedColor);
+                xml.WriteEndElement();
+            }
 
-        xml.WriteEndElement(); // mruColors
+            xml.WriteEndElement();
+        }
+
+        if (hasMruColors)
+        {
+            xml.WriteStartElement("mruColors", _ns);
+            foreach (var mruColor in styles.MruColors)
+                xml.WriteColor("color", _ns, mruColor);
+
+            xml.WriteEndElement();
+        }
 
         xml.WriteEndElement(); // colors
     }

--- a/ClosedXML/Extensions/XmlTreeWriterExtensions.cs
+++ b/ClosedXML/Extensions/XmlTreeWriterExtensions.cs
@@ -38,6 +38,12 @@ internal static class XmlTreeWriterExtensions
             xml.WriteAttribute(attrName, value);
     }
 
+    public static void WriteAttributeDefault(this XmlTreeWriter xml, string attrName, double value, double defaultValue)
+    {
+        if (!value.Equals(defaultValue))
+            xml.WriteAttribute(attrName, value);
+    }
+
     public static void WriteAttributeDefault<TEnum>(this XmlTreeWriter xml, string attrName, TEnum enumValue, TEnum defaultValue)
         where TEnum : struct, Enum
     {

--- a/ClosedXML/Extensions/XmlTreeWriterExtensions.cs
+++ b/ClosedXML/Extensions/XmlTreeWriterExtensions.cs
@@ -20,6 +20,14 @@ internal static class XmlTreeWriterExtensions
         xml.WriteEndElement();
     }
 
+    /// <summary>
+    /// Write <c>ST_UnsignedIntHex</c> attribute value (8 hex digits).
+    /// </summary>
+    public static void WriteAttributeHex(this XmlTreeWriter xml, string attrName, uint value)
+    {
+        xml.WriteAttribute(attrName, value.ToString("X8"));
+    }
+
     public static void WriteAttributeDefault(this XmlTreeWriter xml, string attrName, bool value, bool defaultValue)
     {
         if (value != defaultValue)


### PR DESCRIPTION
Add a code to the not-yet-used WIP writer of a styles part that writes colors (indexed colors and most-recently-used colors). Also write fill gradients in the styles part.

Indexed colors are a legacy feature and it would be best to convert them to standard colors on load and not even expose them in the API. But that is a super-low-priority problem for far future. The goal is to get pass-through and so we load and save them as-is.