### PR TITLE
Styles writer - dxfs

### DIFF
--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -252,41 +252,44 @@ internal class StylesWriter
         xml.WriteAttribute("count", idMap.Count);
 
         foreach (var (_, fill) in idMap.GetActual())
+            WriteFill(xml, "fill", fill);
+
+        xml.WriteEndElement();
+    }
+
+    private void WriteFill(XmlTreeWriter xml, string elementName, XLFillFormatValue fill)
+    {
+        xml.WriteStartElement(elementName, _ns);
+
+        // A fill element with no pattern/gradient is a valid state per XML
+        if (fill.Pattern is { } patternFill)
         {
-            xml.WriteStartElement("fill", _ns);
+            xml.WriteStartElement("patternFill", _ns);
+            xml.WriteAttribute("patternType", patternFill.PatternType);
+            xml.WriteColor("fgColor", _ns, patternFill.PatternColor);
+            xml.WriteColor("bgColor", _ns, patternFill.BackgroundColor);
+            xml.WriteEndElement();
+        }
+        else if (fill.LinearGradient is { } linearGradient)
+        {
+            // Linear is the default type, so no need to write it
+            xml.WriteStartElement("gradientFill", _ns);
+            xml.WriteAttributeDefault("degree", linearGradient.Degrees, 0);
 
-            // A fill element with no pattern/gradient is a valid state per XML
-            if (fill.Pattern is { } patternFill)
-            {
-                xml.WriteStartElement("patternFill", _ns);
-                xml.WriteAttribute("patternType", patternFill.PatternType);
-                xml.WriteColor("fgColor", _ns, patternFill.PatternColor);
-                xml.WriteColor("bgColor", _ns, patternFill.BackgroundColor);
-                xml.WriteEndElement();
-            }
-            else if (fill.LinearGradient is { } linearGradient)
-            {
-                // Linear is the default type, so no need to write it
-                xml.WriteStartElement("gradientFill", _ns);
-                xml.WriteAttributeDefault("degree", linearGradient.Degrees, 0);
+            WriteStops(linearGradient.Stops);
 
-                WriteStops(linearGradient.Stops);
+            xml.WriteEndElement();
+        }
+        else if (fill.PathGradient is { } pathGradient)
+        {
+            xml.WriteStartElement("gradientFill", _ns);
+            xml.WriteAttribute("type", "path");
+            xml.WriteAttributeDefault("left", pathGradient.InnerLeft.Value, 0);
+            xml.WriteAttributeDefault("right", pathGradient.InnerRight.Value, 0);
+            xml.WriteAttributeDefault("top", pathGradient.InnerTop.Value, 0);
+            xml.WriteAttributeDefault("bottom", pathGradient.InnerBottom.Value, 0);
 
-                xml.WriteEndElement();
-            }
-            else if (fill.PathGradient is { } pathGradient)
-            {
-                xml.WriteStartElement("gradientFill", _ns);
-                xml.WriteAttribute("type", "path");
-                xml.WriteAttributeDefault("left", pathGradient.InnerLeft.Value, 0);
-                xml.WriteAttributeDefault("right", pathGradient.InnerRight.Value, 0);
-                xml.WriteAttributeDefault("top", pathGradient.InnerTop.Value, 0);
-                xml.WriteAttributeDefault("bottom", pathGradient.InnerBottom.Value, 0);
-
-                WriteStops(pathGradient.Stops);
-
-                xml.WriteEndElement();
-            }
+            WriteStops(pathGradient.Stops);
 
             xml.WriteEndElement();
         }

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -157,90 +157,93 @@ internal class StylesWriter
         xml.WriteAttribute("count", idMap.Count);
 
         foreach (var (_, font) in idMap.GetActual())
+            WriteFont(xml, "font", font);
+
+        xml.WriteEndElement();
+    }
+
+    private void WriteFont(XmlTreeWriter xml, string elementName, XLFontFormatValue font)
+    {
+        // MS-OI29500 dictates font elements order.
+        xml.WriteStartElement(elementName, _ns);
+
+        if (font.Bold is { } bold)
+            xml.WriteBooleanProperty("b", bold, _ns);
+
+        if (font.Italic is { } italic)
+            xml.WriteBooleanProperty("i", italic, _ns);
+
+        if (font.Strikethrough is { } strikethrough)
+            xml.WriteBooleanProperty("strike", strikethrough, _ns);
+
+        if (font.Condense is { } condense)
+            xml.WriteBooleanProperty("condense", condense, _ns);
+
+        if (font.Extend is { } extend)
+            xml.WriteBooleanProperty("extend", extend, _ns);
+
+        if (font.Outline is { } outline)
+            xml.WriteBooleanProperty("outline", outline, _ns);
+
+        if (font.Shadow is { } shadow)
+            xml.WriteBooleanProperty("shadow", shadow, _ns);
+
+        if (font.Underline is { } underline)
         {
-            // MS-OI29500 dictates font elements order.
-            xml.WriteStartElement("font", _ns);
-
-            if (font.Bold is { } bold)
-                xml.WriteBooleanProperty("b", bold, _ns);
-
-            if (font.Italic is { } italic)
-                xml.WriteBooleanProperty("i", italic, _ns);
-
-            if (font.Strikethrough is { } strikethrough)
-                xml.WriteBooleanProperty("strike", strikethrough, _ns);
-
-            if (font.Condense is { } condense)
-                xml.WriteBooleanProperty("condense", condense, _ns);
-
-            if (font.Extend is { } extend)
-                xml.WriteBooleanProperty("extend", extend, _ns);
-
-            if (font.Outline is { } outline)
-                xml.WriteBooleanProperty("outline", outline, _ns);
-
-            if (font.Shadow is { } shadow)
-                xml.WriteBooleanProperty("shadow", shadow, _ns);
-
-            if (font.Underline is { } underline)
-            {
-                xml.WriteStartElement("u", _ns);
-                xml.WriteAttributeDefault("val", underline, XLFontUnderlineValues.Single);
-                xml.WriteEndElement();
-            }
-
-            if (font.VerticalAlignment is { } verticalAlignment)
-            {
-                xml.WriteStartElement("vertAlign", _ns);
-                xml.WriteAttribute("val", verticalAlignment);
-                xml.WriteEndElement();
-            }
-
-            if (font.Size is { } size)
-            {
-                xml.WriteStartElement("sz", _ns);
-                xml.WriteAttribute("val", size.Points);
-                xml.WriteEndElement();
-            }
-
-            if (font.Color is { } color)
-            {
-                xml.WriteColor("color", _ns, color);
-            }
-
-            if (font.Name is { } name)
-            {
-                xml.WriteStartElement("name", _ns);
-                xml.WriteAttribute("val", name.Text);
-                xml.WriteEndElement();
-            }
-
-            if (font.Family is { } family)
-            {
-                xml.WriteStartElement("family", _ns);
-                xml.WriteAttribute("val", (int)family);
-                xml.WriteEndElement();
-            }
-
-            if (font.Charset is { } charset)
-            {
-                // Charset is stored as an CT_IntProperty
-                xml.WriteStartElement("charset", _ns);
-                xml.WriteAttribute("val", (int)charset);
-                xml.WriteEndElement();
-            }
-
-            if (font.Scheme is { } scheme)
-            {
-                xml.WriteStartElement("scheme", _ns);
-                xml.WriteAttribute("val", scheme);
-                xml.WriteEndElement();
-            }
-
+            xml.WriteStartElement("u", _ns);
+            xml.WriteAttributeDefault("val", underline, XLFontUnderlineValues.Single);
             xml.WriteEndElement();
         }
 
-        xml.WriteEndElement(); // fonts
+        if (font.VerticalAlignment is { } verticalAlignment)
+        {
+            xml.WriteStartElement("vertAlign", _ns);
+            xml.WriteAttribute("val", verticalAlignment);
+            xml.WriteEndElement();
+        }
+
+        if (font.Size is { } size)
+        {
+            xml.WriteStartElement("sz", _ns);
+            xml.WriteAttribute("val", size.Points);
+            xml.WriteEndElement();
+        }
+
+        if (font.Color is { } color)
+        {
+            xml.WriteColor("color", _ns, color);
+        }
+
+        if (font.Name is { } name)
+        {
+            xml.WriteStartElement("name", _ns);
+            xml.WriteAttribute("val", name.Text);
+            xml.WriteEndElement();
+        }
+
+        if (font.Family is { } family)
+        {
+            xml.WriteStartElement("family", _ns);
+            xml.WriteAttribute("val", (int)family);
+            xml.WriteEndElement();
+        }
+
+        if (font.Charset is { } charset)
+        {
+            // Charset is stored as an CT_IntProperty
+            xml.WriteStartElement("charset", _ns);
+            xml.WriteAttribute("val", (int)charset);
+            xml.WriteEndElement();
+        }
+
+        if (font.Scheme is { } scheme)
+        {
+            xml.WriteStartElement("scheme", _ns);
+            xml.WriteAttribute("val", scheme);
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement();
     }
 
     private void WriteFills(XmlTreeWriter xml, SequentialMap<int, XLFillFormatValue> idMap)

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -120,7 +120,17 @@ internal class StylesWriter
 
         WriteCellStyles(xml, cellStylesMap);
 
-        // TODO: Rest of elements dxfs and tableStyles
+        // TODO: Create dxfMap from used dxfs in tables, pivot tables and so on
+        var dxfMap = new SequentialMap<int, XLDxfValue>(styles.DifferentialFormats);
+        foreach (var dxfId in styles.DifferentialFormats.Keys)
+            dxfMap.Add(dxfId);
+
+        dxfMap.Sort();
+
+        if (dxfMap.Count > 0)
+            WriteDxfs(xml, dxfMap, numberFormatMap.Count);
+
+        // TODO: tableStyles
         WriteColors(xml, styles);
 
         xml.WriteEndElement();
@@ -387,10 +397,10 @@ internal class StylesWriter
             xml.WriteAttributeDefault("applyProtection", cellStyle.IncludedComponents.HasFlag(CellFormatComponents.Protection), true);
 
             if (cellStyle.Alignment is { } alignment)
-                WriteAlignment(xml, alignment);
+                WriteAlignment(xml, "alignment", alignment);
 
             if (cellStyle.Protection is { } protection)
-                WriteProtection(xml, protection);
+                WriteProtection(xml, "protection", protection);
 
             // TODO: extLst
             xml.WriteEndElement();
@@ -444,10 +454,10 @@ internal class StylesWriter
             xml.WriteAttributeDefault("applyProtection", cellXf.CustomFormat.HasFlag(CellFormatComponents.Protection), false);
 
             if (cellXf.Alignment is { } alignment)
-                WriteAlignment(xml, alignment);
+                WriteAlignment(xml, "alignment", alignment);
 
             if (cellXf.Protection is { } protection)
-                WriteProtection(xml, protection);
+                WriteProtection(xml, "protection", protection);
 
             // TODO: extLst
             xml.WriteEndElement();
@@ -456,9 +466,9 @@ internal class StylesWriter
         xml.WriteEndElement();
     }
 
-    private void WriteAlignment(XmlTreeWriter xml, XLAlignmentFormatValue alignment)
+    private void WriteAlignment(XmlTreeWriter xml, string elementName, XLAlignmentFormatValue alignment)
     {
-        xml.WriteStartElement("alignment", _ns);
+        xml.WriteStartElement(elementName, _ns);
         xml.WriteAttributeDefault("horizontal", alignment.Horizontal, XLAlignmentHorizontalValues.General);
         xml.WriteAttributeDefault("vertical", alignment.Vertical, XLAlignmentVerticalValues.Bottom);
         xml.WriteAttributeDefault("textRotation", alignment.TextRotation.GetIso(), 0);
@@ -471,9 +481,9 @@ internal class StylesWriter
         xml.WriteEndElement();
     }
 
-    private void WriteProtection(XmlTreeWriter xml, XLProtectionFormatValue protection)
+    private void WriteProtection(XmlTreeWriter xml, string elementName, XLProtectionFormatValue protection)
     {
-        xml.WriteStartElement("protection", _ns);
+        xml.WriteStartElement(elementName, _ns);
         xml.WriteAttributeDefault("locked", protection.Locked, true);
         xml.WriteAttributeDefault("hidden", protection.Hidden, false);
         xml.WriteEndElement();
@@ -513,6 +523,42 @@ internal class StylesWriter
             // Hidden + flag are optional per schema, but basically it's a bool with default
             xml.WriteAttributeDefault("hidden", cellStyle.Hidden, false);
             xml.WriteAttributeDefault("customBuiltin", cellStyle.BuiltInStyle is not null, true);
+            xml.WriteEndElement();
+        }
+
+        xml.WriteEndElement();
+    }
+
+    private void WriteDxfs(XmlTreeWriter xml, SequentialMap<int, XLDxfValue> differentialFormats, int lastNumFmtId)
+    {
+        xml.WriteStartElement("dxfs", _ns);
+        xml.WriteAttribute("count", differentialFormats.Count);
+        foreach (var (_, dxf) in differentialFormats.GetActual())
+        {
+            xml.WriteStartElement("dxf", _ns);
+
+            if (dxf.Font is { } font)
+                WriteFont(xml, "font", font);
+
+            if (dxf.NumberFormat is { } numberFormat)
+            {
+                // numFmtId doesn't matter in dxf, but keep them unique (Excel-like behavior)
+                WriteNumFmt(xml, "numFmt", ++lastNumFmtId, numberFormat);
+            }
+
+            if (dxf.Fill is { } fill)
+                WriteFill(xml, "fill", fill);
+
+            if (dxf.Alignment is { } alignment)
+                WriteAlignment(xml, "alignment", alignment);
+
+            if (dxf.Border is { } border)
+                WriteBorder(xml, "border", border);
+
+            if (dxf.Protection is { } protection)
+                WriteProtection(xml, "protection", protection);
+
+            // TODO: extLst
             xml.WriteEndElement();
         }
 

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -315,23 +315,26 @@ internal class StylesWriter
         xml.WriteStartElement("borders", _ns);
         xml.WriteAttribute("count", idMap.Count);
         foreach (var (_, border) in idMap.GetActual())
-        {
-            xml.WriteStartElement("border", _ns);
-            xml.WriteAttributeDefault("diagonalUp", border.DiagonalUp, false);
-            xml.WriteAttributeDefault("diagonalDown", border.DiagonalDown, false);
-            xml.WriteAttributeDefault("outline", border.Outline, true);
+            WriteBorder(xml, "border", border);
 
-            // ISO should be "start"+"end", but Excel uses "left"+"right"
-            WriteBorderPr("left", border.Left);
-            WriteBorderPr("right", border.Right);
-            WriteBorderPr("top", border.Top);
-            WriteBorderPr("bottom", border.Bottom);
-            WriteBorderPr("diagonal", border.Diagonal);
-            WriteBorderPr("vertical", border.Vertical);
-            WriteBorderPr("horizontal", border.Horizontal);
+        xml.WriteEndElement();
+    }
 
-            xml.WriteEndElement();
-        }
+    private void WriteBorder(XmlTreeWriter xml, string elementName, XLBorderFormatValue border)
+    {
+        xml.WriteStartElement(elementName, _ns);
+        xml.WriteAttributeDefault("diagonalUp", border.DiagonalUp, false);
+        xml.WriteAttributeDefault("diagonalDown", border.DiagonalDown, false);
+        xml.WriteAttributeDefault("outline", border.Outline, true);
+
+        // ISO should be "start"+"end", but Excel uses "left"+"right"
+        WriteBorderPr("left", border.Left);
+        WriteBorderPr("right", border.Right);
+        WriteBorderPr("top", border.Top);
+        WriteBorderPr("bottom", border.Bottom);
+        WriteBorderPr("diagonal", border.Diagonal);
+        WriteBorderPr("vertical", border.Vertical);
+        WriteBorderPr("horizontal", border.Horizontal);
 
         xml.WriteEndElement();
         return;

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -137,13 +137,18 @@ internal class StylesWriter
             if (savedId < FirstUserDefinedFormatIndex)
                 continue;
 
-            xml.WriteStartElement("numFmt", _ns);
-            xml.WriteAttribute("numFmtId", savedId);
-            xml.WriteAttribute("formatCode", format);
-            xml.WriteEndElement();
+            WriteNumFmt(xml, "numFmt", savedId, format);
         }
 
         xml.WriteEndElement(); // numFmts
+    }
+
+    private void WriteNumFmt(XmlTreeWriter xml, string elementName, int numFmtId, string format)
+    {
+        xml.WriteStartElement(elementName, _ns);
+        xml.WriteAttribute("numFmtId", numFmtId);
+        xml.WriteAttribute("formatCode", format);
+        xml.WriteEndElement();
     }
 
     private void WriteFonts(XmlTreeWriter xml, SequentialMap<int, XLFontFormatValue> idMap)

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -70,7 +70,7 @@ internal class XLWorkbookStyles
 
     internal IReadOnlyBiDictionary<StyleId, XLCellStyleValue> CellStyles => _cellStyles;
 
-    internal IReadOnlyDictionary<int, XLDxfValue> DifferentialFormats => _differentialFormats.KeyToValue;
+    internal IReadOnlyBiDictionary<int, XLDxfValue> DifferentialFormats => _differentialFormats;
 
     internal IReadOnlyDictionary<string, XLTableTheme> TableStyles => _tableStyles;
 


### PR DESCRIPTION
Add a code to the not-yet-used WIP writer of a styles part that writes differential formatting.

Nothing is yet connected to the internal structures that use `dxf` (conditional format, table styles ect.), so write every `dxf` from `XLWorkbookStyles` (repository of all dxfs, i.e. if they were loaded, they are stored there) for now (mostly for local testing).

