### PR TITLE
Styles writer - write none and gray125 fills as first fills

### DIFF
--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -19,6 +19,20 @@ internal class StylesWriter
 {
     private const int FirstUserDefinedFormatIndex = 164;
 
+    private static readonly XLFillFormatValue FillNone = new(new XLPatternFill
+    {
+        PatternType = XLFillPatternValues.None,
+        BackgroundColor = XLColor.NoColor,
+        PatternColor = XLColor.NoColor
+    });
+
+    private static readonly XLFillFormatValue FillGray125 = new(new XLPatternFill
+    {
+        PatternType = XLFillPatternValues.Gray125,
+        BackgroundColor = XLColor.NoColor,
+        PatternColor = XLColor.NoColor
+    });
+
     private static readonly List<(string Type, TableRegion? TableRegion, PivotRegion? PivotRegion)> TableRegionsMap = new()
     {
         ("wholeTable", TableRegion.WholeTable, PivotRegion.WholeTable),
@@ -132,10 +146,13 @@ internal class StylesWriter
         if (fontFormatsMap.Count > 0)
             WriteFonts(xml, fontFormatsMap);
 
-        // TODO: Add the fixed fills (none+gray125) at the start
-        var fillsFormatsMap = SequentialMap<int, XLFillFormatValue>.Create(usedFills, styles.Fills);
-        if (fillsFormatsMap.Count > 0)
-            WriteFills(xml, fillsFormatsMap);
+        // Fill 0 must be None and fill 1 must be Gray125, that is just an immutable fact of the universe.
+        // Excel will ignore fills at 0/1 and will use None/Gray125. Write both fills whether they are used
+        // or not.
+        AddFillAsUsed(FillNone);
+        AddFillAsUsed(FillGray125);
+        var fillsFormatsMap = SequentialMap<int, XLFillFormatValue>.Create(usedFills, styles.Fills, 0, FillNone, FillGray125);
+        WriteFills(xml, fillsFormatsMap);
 
         var borderFormatsMap = SequentialMap<int, XLBorderFormatValue>.Create(usedBorders, styles.Borders);
         if (borderFormatsMap.Count > 0)
@@ -171,6 +188,15 @@ internal class StylesWriter
         WriteColors(xml, styles);
 
         xml.WriteEndElement();
+        return;
+
+        void AddFillAsUsed(XLFillFormatValue format)
+        {
+            if (!styles.Fills.ContainsValue(format))
+                styles.AddFillFormat(format);
+
+            usedFills.Add(format);
+        }
     }
 
     private void WriteNumberFormats(XmlTreeWriter xml, SequentialMap<int, string> idMap)
@@ -776,11 +802,20 @@ internal class StylesWriter
         /// </summary>
         public int Count => _savedIdToActualId.Count;
 
-        internal static SequentialMap<TKey, T> Create(HashSet<T> usedValues, IReadOnlyBiDictionary<TKey, T> allValuesMap, int offset = 0)
+        internal static SequentialMap<TKey, T> Create(HashSet<T> usedValues, IReadOnlyBiDictionary<TKey, T> allValuesMap, int offset = 0, params T[] firstValues)
         {
             var map = new SequentialMap<TKey, T>(allValuesMap, offset);
+            foreach (var firstValue in firstValues)
+            {
+                var actualId = allValuesMap[firstValue];
+                map.Add(actualId);
+            }
+
             foreach (var (actualId, value) in allValuesMap)
             {
+                if (firstValues.Contains(value))
+                    continue;
+
                 if (!usedValues.Contains(value))
                     continue;
 

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -165,13 +165,16 @@ internal class StylesWriter
         foreach (var styleId in styles.CellStyles.Keys)
             cellStylesMap.Add(styleId);
 
-        WriteCellStyleXfs(xml, cellStylesMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap);
+        if (cellStylesMap.Count > 0)
+            WriteCellStyleXfs(xml, cellStylesMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap);
 
         // TODO: Ensure the normal style cellXfs has index 0
         var cellXfsMap = SequentialMap<int, XLCellFormatValue>.Create(usedCellFormats, styles.CellFormats);
-        WriteCellXfs(xml, cellXfsMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap, cellStylesMap);
+        if (cellXfsMap.Count > 0)
+            WriteCellXfs(xml, cellXfsMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap, cellStylesMap);
 
-        WriteCellStyles(xml, cellStylesMap);
+        if (cellStylesMap.Count > 0)
+            WriteCellStyles(xml, cellStylesMap);
 
         // TODO: Create dxfMap from used dxfs in tables, pivot tables and so on
         var dxfMap = new SequentialMap<int, XLDxfValue>(styles.DifferentialFormats);
@@ -183,7 +186,8 @@ internal class StylesWriter
         if (dxfMap.Count > 0)
             WriteDxfs(xml, dxfMap, numberFormatMap.Count);
 
-        WriteTableStyles(xml, dxfMap, styles);
+        if (styles.TableStyles.Count > 0 || styles.PivotStyles.Count > 0)
+            WriteTableStyles(xml, dxfMap, styles);
 
         WriteColors(xml, styles);
 

--- a/ClosedXML/Utils/BiDictionary.cs
+++ b/ClosedXML/Utils/BiDictionary.cs
@@ -65,6 +65,11 @@ internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
         return _keyToValue.ContainsKey(key);
     }
 
+    public bool ContainsValue(TValue value)
+    {
+        return _entryToKey.ContainsKey(value);
+    }
+
     internal IReadOnlyDictionary<TKey, TValue> KeyToValue => _keyToValue;
 
     internal IReadOnlyDictionary<TValue, TKey> ValueToKey => _entryToKey;

--- a/ClosedXML/Utils/IReadOnlyBiDictionary.cs
+++ b/ClosedXML/Utils/IReadOnlyBiDictionary.cs
@@ -10,4 +10,9 @@ internal interface IReadOnlyBiDictionary<TKey, TValue> : IReadOnlyDictionary<TKe
     /// In case of duplicates, the earliest added entry will be returned.
     /// </summary>
     TKey this[TValue value] { get; }
+
+    /// <summary>
+    /// Does the dictionary contain the value?
+    /// </summary>
+    bool ContainsValue(TValue value);
 }


### PR DESCRIPTION
Excel will always interpret fills at index 0 and 1 as None and Gray125, regardless of what is actually written in the file. This PR adjusts new styles writer to reflect this fact and write them as first fills, regardless if they are used or not.

It's not technically necessary to write them for empty workbooks, but it will make comparison between Excel and generated workbooks easier.