### PR TITLE
Styles rework - add temporary switch between old and new infrastructure

### DIFF
--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFCellIsConverter.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.Operator = cf.Operator.ToOpenXml();
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFContainsConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFContainsConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.ContainsText;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFDatesOccuringConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFDatesOccuringConverter.cs
@@ -25,7 +25,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.TimePeriod = cf.TimePeriod.ToOpenXml();
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFEndsWithConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFEndsWithConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.EndsWith;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsBlankConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsBlankConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             var formula = new Formula { Text = "LEN(TRIM(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + "))=0" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsErrorConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFIsErrorConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             var formula = new Formula { Text = "ISERROR(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + ")" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotBlankConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotBlankConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             var formula = new Formula { Text = "LEN(TRIM(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + "))>0" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotContainsConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotContainsConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.NotContains;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotErrorConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFNotErrorConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             var formula = new Formula { Text = "NOT(ISERROR(" + cf.Range.RangeAddress.FirstAddress.ToStringRelative(false) + "))" };
 

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFStartsWithConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFStartsWithConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.Operator = ConditionalFormattingOperatorValues.BeginsWith;
             conditionalFormattingRule.Text = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFTopConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFTopConverter.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             conditionalFormattingRule.Percent = cf.Percent;
             conditionalFormattingRule.Rank = val;

--- a/ClosedXML/Excel/ConditionalFormats/Save/XLCFUniqueConverter.cs
+++ b/ClosedXML/Excel/ConditionalFormats/Save/XLCFUniqueConverter.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
             var conditionalFormattingRule = XLCFBaseConverter.Convert(cf, priority);
             var cfStyle = ((XLStyle)cf.Style).Value;
             if (!cfStyle.Equals(XLWorkbook.DefaultStyleValue))
-                conditionalFormattingRule.FormatId = (UInt32)context.DifferentialFormats[cfStyle];
+                conditionalFormattingRule.FormatId = context.GetDxfId(cfStyle);
 
             return conditionalFormattingRule;
         }

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -334,7 +334,7 @@ internal class PivotTableDefinitionPartWriter2
                 // DxfId is optional.
                 if (format.DxfStyleValue != XLStyleValue.Default)
                 {
-                    var dxfId = context.DifferentialFormats[format.DxfStyleValue];
+                    var dxfId = context.GetDxfId(format.DxfStyleValue);
                     xml.WriteAttribute("dxfId", dxfId);
                 }
 

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -390,17 +390,20 @@ internal class StylesWriter
         xml.WriteStartElement("borders", _ns);
         xml.WriteAttribute("count", idMap.Count);
         foreach (var (_, border) in idMap.GetActual())
-            WriteBorder(xml, "border", border);
+            WriteBorder(xml, "border", border, false);
 
         xml.WriteEndElement();
     }
 
-    private void WriteBorder(XmlTreeWriter xml, string elementName, XLBorderFormatValue border)
+    private void WriteBorder(XmlTreeWriter xml, string elementName, XLBorderFormatValue border, bool isDxf)
     {
         xml.WriteStartElement(elementName, _ns);
         xml.WriteAttributeDefault("diagonalUp", border.DiagonalUp, false);
         xml.WriteAttributeDefault("diagonalDown", border.DiagonalDown, false);
-        xml.WriteAttributeDefault("outline", border.Outline, true);
+
+        // Outline has no meaning for cell styles, it is only for dxf - tables and such.
+        if (isDxf)
+            xml.WriteAttributeDefault("outline", border.Outline, true);
 
         // ISO should be "start"+"end", but Excel uses "left"+"right"
         WriteBorderPr("left", border.Left);
@@ -623,7 +626,7 @@ internal class StylesWriter
                 WriteAlignment(xml, "alignment", alignment);
 
             if (dxf.Border is { } border)
-                WriteBorder(xml, "border", border);
+                WriteBorder(xml, "border", border, true);
 
             if (dxf.Protection is { } protection)
                 WriteProtection(xml, "protection", protection);

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -550,6 +550,9 @@ internal class StylesWriter
 
     private void WriteProtection(XmlTreeWriter xml, string elementName, XLProtectionFormatValue protection)
     {
+        if (protection.Locked && !protection.Hidden)
+            return;
+
         xml.WriteStartElement(elementName, _ns);
         xml.WriteAttributeDefault("locked", protection.Locked, true);
         xml.WriteAttributeDefault("hidden", protection.Hidden, false);

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -244,35 +244,22 @@ internal class StylesWriter
         // MS-OI29500 dictates font elements order.
         xml.WriteStartElement(elementName, _ns);
 
-        if (font.Bold is { } bold)
-            xml.WriteBooleanProperty("b", bold, _ns);
+        WriteFlag("b", font.Bold);
+        WriteFlag("i", font.Italic);
+        WriteFlag("strike", font.Strikethrough);
+        WriteFlag("condense", font.Condense);
+        WriteFlag("extend", font.Extend);
+        WriteFlag("outline", font.Outline);
+        WriteFlag("shadow", font.Shadow);
 
-        if (font.Italic is { } italic)
-            xml.WriteBooleanProperty("i", italic, _ns);
-
-        if (font.Strikethrough is { } strikethrough)
-            xml.WriteBooleanProperty("strike", strikethrough, _ns);
-
-        if (font.Condense is { } condense)
-            xml.WriteBooleanProperty("condense", condense, _ns);
-
-        if (font.Extend is { } extend)
-            xml.WriteBooleanProperty("extend", extend, _ns);
-
-        if (font.Outline is { } outline)
-            xml.WriteBooleanProperty("outline", outline, _ns);
-
-        if (font.Shadow is { } shadow)
-            xml.WriteBooleanProperty("shadow", shadow, _ns);
-
-        if (font.Underline is { } underline)
+        if (font.Underline is { } underline && underline != XLFontUnderlineValues.None)
         {
             xml.WriteStartElement("u", _ns);
             xml.WriteAttributeDefault("val", underline, XLFontUnderlineValues.Single);
             xml.WriteEndElement();
         }
 
-        if (font.VerticalAlignment is { } verticalAlignment)
+        if (font.VerticalAlignment is { } verticalAlignment && verticalAlignment != XLFontVerticalTextAlignmentValues.Baseline)
         {
             xml.WriteStartElement("vertAlign", _ns);
             xml.WriteAttribute("val", verticalAlignment);
@@ -298,14 +285,14 @@ internal class StylesWriter
             xml.WriteEndElement();
         }
 
-        if (font.Family is { } family)
+        if (font.Family is { } family && family != XLFontFamilyNumberingValues.NotApplicable)
         {
             xml.WriteStartElement("family", _ns);
             xml.WriteAttribute("val", (int)family);
             xml.WriteEndElement();
         }
 
-        if (font.Charset is { } charset)
+        if (font.Charset is { } charset && charset != XLFontCharSet.Ansi)
         {
             // Charset is stored as an CT_IntProperty
             xml.WriteStartElement("charset", _ns);
@@ -313,7 +300,7 @@ internal class StylesWriter
             xml.WriteEndElement();
         }
 
-        if (font.Scheme is { } scheme)
+        if (font.Scheme is { } scheme && scheme != XLFontScheme.None)
         {
             xml.WriteStartElement("scheme", _ns);
             xml.WriteAttribute("val", scheme);
@@ -321,6 +308,13 @@ internal class StylesWriter
         }
 
         xml.WriteEndElement();
+        return;
+
+        void WriteFlag(string flagName, bool? flag)
+        {
+            if (flag == true)
+                xml.WriteBooleanProperty(flagName, true, _ns);
+        }
     }
 
     private void WriteFills(XmlTreeWriter xml, SequentialMap<int, XLFillFormatValue> idMap)

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -417,7 +417,9 @@ internal class StylesWriter
 
             xml.WriteStartElement(name, _ns);
             xml.WriteAttributeDefault("style", borderLine.Value.Style, XLBorderStyleValues.None);
-            xml.WriteColor("color", _ns, borderLine.Value.Color);
+            if (borderLine.Value.Style != XLBorderStyleValues.None)
+                xml.WriteColor("color", _ns, borderLine.Value.Color);
+
             xml.WriteEndElement();
         }
     }

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -19,20 +19,6 @@ internal class StylesWriter
 {
     private const int FirstUserDefinedFormatIndex = 164;
 
-    private static readonly XLFillFormatValue FillNone = new(new XLPatternFill
-    {
-        PatternType = XLFillPatternValues.None,
-        BackgroundColor = XLColor.NoColor,
-        PatternColor = XLColor.NoColor
-    });
-
-    private static readonly XLFillFormatValue FillGray125 = new(new XLPatternFill
-    {
-        PatternType = XLFillPatternValues.Gray125,
-        BackgroundColor = XLColor.NoColor,
-        PatternColor = XLColor.NoColor
-    });
-
     private static readonly List<(string Type, TableRegion? TableRegion, PivotRegion? PivotRegion)> TableRegionsMap = new()
     {
         ("wholeTable", TableRegion.WholeTable, PivotRegion.WholeTable),
@@ -149,9 +135,9 @@ internal class StylesWriter
         // Fill 0 must be None and fill 1 must be Gray125, that is just an immutable fact of the universe.
         // Excel will ignore fills at 0/1 and will use None/Gray125. Write both fills whether they are used
         // or not.
-        AddFillAsUsed(FillNone);
-        AddFillAsUsed(FillGray125);
-        var fillsFormatsMap = SequentialMap<int, XLFillFormatValue>.Create(usedFills, styles.Fills, 0, FillNone, FillGray125);
+        AddFillAsUsed(XLFillFormatValue.None);
+        AddFillAsUsed(XLFillFormatValue.Gray125);
+        var fillsFormatsMap = SequentialMap<int, XLFillFormatValue>.Create(usedFills, styles.Fills, 0, XLFillFormatValue.None, XLFillFormatValue.Gray125);
         WriteFills(xml, fillsFormatsMap);
 
         var borderFormatsMap = SequentialMap<int, XLBorderFormatValue>.Create(usedBorders, styles.Borders);

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -169,8 +169,7 @@ internal class StylesWriter
 
         dxfMap.Sort();
 
-        if (dxfMap.Count > 0)
-            WriteDxfs(xml, dxfMap, numberFormatMap.Count);
+        WriteDxfs(xml, dxfMap, numberFormatMap.Count);
 
         var hasTableStyles = styles.TableStyles.Count > 0 ||
                              styles.PivotStyles.Count > 0 ||

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -172,7 +172,11 @@ internal class StylesWriter
         if (dxfMap.Count > 0)
             WriteDxfs(xml, dxfMap, numberFormatMap.Count);
 
-        if (styles.TableStyles.Count > 0 || styles.PivotStyles.Count > 0)
+        var hasTableStyles = styles.TableStyles.Count > 0 ||
+                             styles.PivotStyles.Count > 0 ||
+                             styles.DefaultTableStyle is not null ||
+                             styles.DefaultPivotStyle is not null;
+        if (hasTableStyles)
             WriteTableStyles(xml, dxfMap, styles);
 
         WriteColors(xml, styles);

--- a/ClosedXML/Excel/IO/TablePartWriter.cs
+++ b/ClosedXML/Excel/IO/TablePartWriter.cs
@@ -1,4 +1,3 @@
-﻿using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using System;
@@ -87,8 +86,8 @@ namespace ClosedXML.Excel.IO
                         .First()
                         .Style).Value;
 
-                    if (!DefaultStyleValue.Equals(style) && context.DifferentialFormats.TryGetValue(style, out Int32 id))
-                        tableColumn.DataFormatId = UInt32Value.FromUInt32(Convert.ToUInt32(id));
+                    if (!DefaultStyleValue.Equals(style) && context.TryGetDxfId(style, out var dxfId))
+                        tableColumn.DataFormatId = dxfId;
                 }
                 else
                     tableColumn.DataFormatId = null;

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel.IO
             else
                 defaultFormatId = 0;
 
-            context.SharedStyles.Add(defaultStyle,
+            context.AddSharedStyle(defaultStyle,
                 new StyleInfo
                 {
                     StyleId = defaultFormatId,
@@ -121,7 +121,7 @@ namespace ClosedXML.Excel.IO
                 var numberFormatId = context.SavedNumberFormats[xlStyle.NumberFormat.Format];
 
                 if (!context.SharedStyles.ContainsKey(xlStyle))
-                    context.SharedStyles.Add(xlStyle,
+                    context.AddSharedStyle(xlStyle,
                         new StyleInfo
                         {
                             StyleId = styleCount++,
@@ -158,8 +158,8 @@ namespace ClosedXML.Excel.IO
                 si.StyleId = (UInt32)styleId;
                 newSharedStyles.Add(ss.Key, si);
             }
-            context.SharedStyles.Clear();
-            newSharedStyles.ForEach(kp => context.SharedStyles.Add(kp.Key, kp.Value));
+            context.ClearSharedStyles();
+            newSharedStyles.ForEach(kp => context.AddSharedStyle(kp.Key, kp.Value));
 
             AddDifferentialFormats(workbookStylesPart, workbook, context);
         }

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -1,3 +1,4 @@
+#if !STYLES_REWORK
 #nullable disable
 
 using ClosedXML.Utils;
@@ -931,3 +932,4 @@ namespace ClosedXML.Excel.IO
         }
     }
 }
+#endif

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -29,7 +29,7 @@ internal class WorksheetPartReader
     private Int32 _lastRow;
     private Int32 _lastColumnNumber;
 
-    internal void LoadWorksheet(XLWorksheet ws, Stylesheet s, WorksheetPart worksheetPart, SharedStringItem[] sharedStrings, LoadContext context)
+    internal void LoadWorksheet(XLWorksheet ws, WorksheetPart worksheetPart, SharedStringItem[] sharedStrings, LoadContext context)
     {
         var styleList = new Dictionary<int, IXLStyle>();// {{0, ws.Style}};
         PageSetupProperties pageSetupProperties = null;

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -360,7 +360,7 @@ namespace ClosedXML.Excel.IO
 
             #region Columns
 
-            var worksheetStyleId = context.SharedStyles[xlWorksheet.StyleValue].StyleId;
+            var worksheetStyleId = context.GetStyleId(xlWorksheet.StyleValue);
             if (xlWorksheet.Internals.CellsCollection.IsEmpty &&
                 xlWorksheet.Internals.ColumnsCollection.Count == 0
                 && worksheetStyleId == 0)
@@ -421,7 +421,7 @@ namespace ClosedXML.Excel.IO
                     var outlineLevel = 0;
                     if (xlWorksheet.Internals.ColumnsCollection.TryGetValue(co, out XLColumn col))
                     {
-                        styleId = context.SharedStyles[col.StyleValue].StyleId;
+                        styleId = context.GetStyleId(col.StyleValue);
                         columnWidth = GetColumnWidth(col.Width).SaveRound();
                         isHidden = col.IsHidden;
                         collapsed = col.Collapsed;
@@ -429,7 +429,7 @@ namespace ClosedXML.Excel.IO
                     }
                     else
                     {
-                        styleId = context.SharedStyles[xlWorksheet.StyleValue].StyleId;
+                        styleId = context.GetStyleId(xlWorksheet.StyleValue);
                         columnWidth = worksheetColumnWidth;
                     }
 
@@ -2060,7 +2060,7 @@ namespace ClosedXML.Excel.IO
                     if (xlWorksheet.Internals.RowsCollection.TryGetValue(currentRowNumber, out var row))
                     {
                         rowPropIndex++;
-                        rowStyleId = context.SharedStyles[row.StyleValue].StyleId;
+                        rowStyleId = context.GetStyleId(row.StyleValue);
                     }
                     else
                     {
@@ -2141,7 +2141,7 @@ namespace ClosedXML.Excel.IO
 
                 if (xlRow.StyleValue != xlRow.Worksheet.StyleValue)
                 {
-                    var styleIndex = context.SharedStyles[xlRow.StyleValue].StyleId;
+                    var styleIndex = context.GetStyleId(xlRow.StyleValue);
                     w.WriteAttribute("s", styleIndex);
                     w.WriteAttributeString("customFormat", TrueValue);
                 }
@@ -2198,7 +2198,7 @@ namespace ClosedXML.Excel.IO
 
             static void WriteCell(XmlWriter xml, XLCell xlCell, char[] cellRef, SaveContext context, SaveOptions options, HashSet<IXLAddress> tableTotalCells, uint rowStyleId)
             {
-                var styleId = context.SharedStyles[xlCell.StyleValue].StyleId;
+                var styleId = context.GetStyleId(xlCell.StyleValue);
 
                 Span<Char> cellRefSpan = cellRef;
                 var cellRefLen = xlCell.SheetPoint.Format(cellRefSpan);

--- a/ClosedXML/Excel/Style/Formatting/TextRotation.cs
+++ b/ClosedXML/Excel/Style/Formatting/TextRotation.cs
@@ -7,6 +7,8 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal readonly record struct TextRotation
 {
+    public static readonly TextRotation None = new(0);
+
     public static readonly TextRotation VerticalText = new(255);
 
     public TextRotation(int value)

--- a/ClosedXML/Excel/Style/Formatting/XLBorderFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderFormatValue.cs
@@ -5,6 +5,20 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal record XLBorderFormatValue
 {
+    internal static readonly XLBorderFormatValue None = new()
+    {
+        Left = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Right = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Top = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Bottom = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Diagonal = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Vertical = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Horizontal = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        DiagonalUp = false,
+        DiagonalDown = false,
+        Outline = false
+    };
+
     public required XLBorderLine? Left { get; init; }
 
     public required XLBorderLine? Right { get; init; }

--- a/ClosedXML/Excel/Style/Formatting/XLCellFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLCellFormatValue.cs
@@ -70,4 +70,21 @@ internal record XLCellFormatValue
     /// </para>
     /// </summary>
     public required CellFormatComponents CustomFormat { get; init; }
+
+    internal static XLCellFormatValue FromStyle(StyleId styleId, XLCellStyleValue style)
+    {
+        return new XLCellFormatValue
+        {
+            NumberFormat = style.NumberFormat,
+            Alignment = style.Alignment,
+            Protection = style.Protection,
+            Font = style.Font,
+            Fill = style.Fill,
+            Border = style.Border,
+            CellStyleId = styleId,
+            IncludeQuotePrefix = false,
+            PivotButton = false,
+            CustomFormat = CellFormatComponents.None
+        };
+    }
 }

--- a/ClosedXML/Excel/Style/Formatting/XLFillFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLFillFormatValue.cs
@@ -5,7 +5,21 @@ namespace ClosedXML.Excel.Formatting;
 /// </summary>
 internal record XLFillFormatValue
 {
-    public static readonly XLFillFormatValue Empty = new(null, null, null);
+    internal static readonly XLFillFormatValue Empty = new(null, null, null);
+
+    internal static readonly XLFillFormatValue None = new(new XLPatternFill
+    {
+        PatternType = XLFillPatternValues.None,
+        BackgroundColor = XLColor.NoColor,
+        PatternColor = XLColor.NoColor
+    });
+
+    internal static readonly XLFillFormatValue Gray125 = new(new XLPatternFill
+    {
+        PatternType = XLFillPatternValues.Gray125,
+        BackgroundColor = XLColor.NoColor,
+        PatternColor = XLColor.NoColor
+    });
 
     public XLFillFormatValue(XLPatternFill pattern)
         : this(pattern, null, null)

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -1,7 +1,7 @@
 using System;
-using ClosedXML.Excel.Formatting;
 using System.Collections.Generic;
 using System.Diagnostics;
+using ClosedXML.Excel.Formatting;
 using ClosedXML.Utils;
 
 namespace ClosedXML.Excel;

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -45,6 +45,63 @@ internal class XLWorkbookStyles
 
     private List<XLColor> _mruColors = new();
 
+    /// <summary>
+    /// A normal style that is used for newly create workbooks or loaded workbooks without a normal style.
+    /// </summary>
+    private static readonly XLCellStyleValue DefaultNormalStyle = new()
+    {
+        Name = "Normal",
+        BuiltInStyle = BuiltInStyleValues.Normal,
+        Hidden = false,
+        Alignment = new XLAlignmentFormatValue
+        {
+            Horizontal = XLAlignmentHorizontalValues.General,
+            Vertical = XLAlignmentVerticalValues.Center,
+            TextRotation = TextRotation.None,
+            WrapText = false,
+            Indent = 0,
+            RelativeIndent = 0,
+            JustifyLastLine = false,
+            ShrinkToFit = false,
+            ReadingOrder = XLAlignmentReadingOrderValues.ContextDependent
+        },
+        Protection = new XLProtectionFormatValue
+        {
+            Locked = true,
+            Hidden = false,
+        },
+        NumberFormat = XLPredefinedFormat.FormatCodes[XLPredefinedFormat.General],
+        Font = new XLFontFormatValue
+        {
+            Name = "Calibri",
+            Charset = XLFontCharSet.ShiftJIS,
+            Family = XLFontFamilyNumberingValues.Swiss,
+            Bold = false,
+            Italic = false,
+            Strikethrough = false,
+            Outline = false,
+            Shadow = false,
+            Condense = false,
+            Extend = false,
+            Color = XLColor.FromArgb(0x00000000),
+            Size = XLFontSize.FromPoints(11),
+            Underline = XLFontUnderlineValues.None,
+            VerticalAlignment = XLFontVerticalTextAlignmentValues.Baseline,
+            Scheme = XLFontScheme.None
+        },
+        Fill = XLFillFormatValue.None,
+        Border = XLBorderFormatValue.None,
+        IncludedComponents = CellFormatComponents.All
+    };
+
+    /// <summary>
+    /// A cell format that is used when an element doesn't explicitly define formatting. This
+    /// format must be saved at index 0 in a file. The likely reason is that when an element
+    /// (e.g., a cell) in a XML doesn't explicitly define index of a format, the default value
+    /// is 0 = this format.
+    /// </summary>
+    internal XLCellFormatValue DefaultCellFormat => _cellFormats[0];
+
     internal XLWorkbookStyles()
     {
         _numberFormats = new BiDictionary<int, string>();
@@ -250,5 +307,30 @@ internal class XLWorkbookStyles
     internal T GetDefaultFormat<T>(Func<XLCellFormatValue, T?> selector)
     {
         return selector(DefaultFormat) ?? throw new UnreachableException("Default value doesn't contain a format property.");
+    }
+
+    /// <summary>
+    /// Create a workbook styles component suitable for a new workbook.
+    /// </summary>
+    internal static XLWorkbookStyles CreateInitialized()
+    {
+        var styles = new XLWorkbookStyles
+        {
+            DefaultTableStyle = XLTableTheme.TableStyleMedium2.ToString(),
+            DefaultPivotStyle = XLPivotTableTheme.PivotStyleLight16.ToString()
+        };
+
+        foreach (var (numFmtId, formatCode) in XLPredefinedFormat.FormatCodes)
+            styles.AddNumberFormat(numFmtId, formatCode);
+
+        var normalStyle = DefaultNormalStyle;
+        styles.AddFontFormat(normalStyle.Font!);
+        styles.AddFillFormat(XLFillFormatValue.None);
+        styles.AddFillFormat(XLFillFormatValue.Gray125);
+        styles.AddBorderFormat(XLBorderFormatValue.None);
+        styles.AddCellStyle(0, normalStyle);
+        styles.AddFormat(XLCellFormatValue.FromStyle(0, normalStyle));
+
+        return styles;
     }
 }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -134,7 +134,7 @@ namespace ClosedXML.Excel
 
         internal SharedStringTable SharedStringTable { get; } = new();
 
-        internal XLWorkbookStyles Styles { get; set; } = new();
+        internal XLWorkbookStyles Styles { get; }
 
         #region Nested Type : XLLoadSource
 
@@ -741,6 +741,7 @@ namespace ClosedXML.Excel
         internal XLWorkbook(String file, Boolean asTemplate)
             : this(new LoadOptions())
         {
+            Styles = new XLWorkbookStyles();
             LoadSheetsFromTemplate(file);
         }
 
@@ -759,6 +760,7 @@ namespace ClosedXML.Excel
             _loadSource = XLLoadSource.File;
             _originalFile = file;
             _spreadsheetDocumentType = GetSpreadsheetDocumentType(_originalFile);
+            Styles = new XLWorkbookStyles();
             Load(file);
 
             if (loadOptions.RecalculateAllFormulas)
@@ -779,6 +781,7 @@ namespace ClosedXML.Excel
         {
             _loadSource = XLLoadSource.Stream;
             _originalStream = stream;
+            Styles = new XLWorkbookStyles();
             Load(stream);
 
             if (loadOptions.RecalculateAllFormulas)
@@ -797,6 +800,7 @@ namespace ClosedXML.Excel
             Protection = new XLWorkbookProtection(DefaultProtectionAlgorithm);
             DefaultRowHeight = 15;
             DefaultColumnWidth = 8.43;
+            Styles = XLWorkbookStyles.CreateInitialized();
             Style = new XLStyle(null, DefaultStyle);
             RowHeight = DefaultRowHeight;
             ColumnWidth = DefaultColumnWidth;

--- a/ClosedXML/Excel/XLWorkbook_Load.cs
+++ b/ClosedXML/Excel/XLWorkbook_Load.cs
@@ -265,7 +265,7 @@ namespace ClosedXML.Excel
                 }
 
                 var worksheetPartReader = new WorksheetPartReader();
-                worksheetPartReader.LoadWorksheet(ws, s, worksheetPart, sharedStrings, context);
+                worksheetPartReader.LoadWorksheet(ws, worksheetPart, sharedStrings, context);
 
                 ws.ConditionalFormats.ReorderAccordingToOriginalPriority();
 

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -14,21 +14,24 @@ namespace ClosedXML.Excel
 
         internal sealed class SaveContext
         {
+#if !STYLES_REWORK
             private readonly Dictionary<XLStyleValue, StyleInfo> _sharedStyles;
+#endif
 
             public SaveContext()
             {
-                DifferentialFormats = new Dictionary<XLStyleValue, int>();
                 RelIdGenerator = new RelIdGenerator();
                 SharedFonts = new Dictionary<XLFontValue, FontInfo>();
                 SavedNumberFormats = new Dictionary<string, int>();
+#if !STYLES_REWORK
+                DifferentialFormats = new Dictionary<XLStyleValue, int>();
                 _sharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
+#endif
                 TableId = 0;
                 TableNames = new HashSet<String>();
                 PivotSourceCacheId = 0;
             }
 
-            public Dictionary<XLStyleValue, Int32> DifferentialFormats { get; }
             public RelIdGenerator RelIdGenerator { get; private set; }
             public Dictionary<XLFontValue, FontInfo> SharedFonts { get; private set; }
 
@@ -39,7 +42,11 @@ namespace ClosedXML.Excel
             /// </summary>
             public Dictionary<string, int> SavedNumberFormats { get; }
 
+#if !STYLES_REWORK
             public IReadOnlyDictionary<XLStyleValue, StyleInfo> SharedStyles => _sharedStyles;
+
+            public Dictionary<XLStyleValue, Int32> DifferentialFormats { get; }
+#endif
 
             public uint TableId { get; set; }
             public HashSet<string> TableNames { get; private set; }
@@ -85,11 +92,18 @@ namespace ClosedXML.Excel
 
             internal UInt32 GetDxfId(XLStyleValue dxf)
             {
+#if STYLES_REWORK
+                throw new NotImplementedException();
+#else
                 return (UInt32)DifferentialFormats[dxf];
+#endif
             }
 
             internal bool TryGetDxfId(XLStyleValue dxf, out uint dxfId)
             {
+#if STYLES_REWORK
+                throw new NotImplementedException();
+#else
                 if (DifferentialFormats.TryGetValue(dxf, out var differentialFormatId))
                 {
                     dxfId = (uint)differentialFormatId;
@@ -98,22 +112,29 @@ namespace ClosedXML.Excel
 
                 dxfId = default;
                 return false;
-            }
-
-            internal void AddSharedStyle(XLStyleValue style, StyleInfo info)
-            {
-                _sharedStyles.Add(style, info);
+#endif
             }
 
             internal UInt32 GetStyleId(XLStyleValue style)
             {
+#if STYLES_REWORK
+                return 0; // TODO: Map to real format id
+#else
                 return _sharedStyles[style].StyleId;
+#endif
+            }
+
+#if !STYLES_REWORK
+            internal void AddSharedStyle(XLStyleValue style, StyleInfo info)
+            {
+                _sharedStyles.Add(style, info);
             }
 
             internal void ClearSharedStyles()
             {
                 _sharedStyles.Clear();
             }
+#endif
 #nullable disable
         }
 
@@ -207,6 +228,7 @@ namespace ClosedXML.Excel
 
         #endregion Nested type: FontInfo
 
+#if !STYLES_REWORK
         #region Nested type: FillInfo
 
         internal struct FillInfo
@@ -241,5 +263,6 @@ namespace ClosedXML.Excel
         }
 
         #endregion Nested type: StyleInfo
+#endif
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel
                 PivotSourceCacheId = 0;
             }
 
-            public Dictionary<XLStyleValue, Int32> DifferentialFormats { get; private set; }
+            public Dictionary<XLStyleValue, Int32> DifferentialFormats { get; }
             public RelIdGenerator RelIdGenerator { get; private set; }
             public Dictionary<XLFontValue, FontInfo> SharedFonts { get; private set; }
 
@@ -81,6 +81,23 @@ namespace ClosedXML.Excel
                     return null;
 
                 return SavedNumberFormats[numberFormat.Format];
+            }
+
+            internal UInt32 GetDxfId(XLStyleValue dxf)
+            {
+                return (UInt32)DifferentialFormats[dxf];
+            }
+
+            internal bool TryGetDxfId(XLStyleValue dxf, out uint dxfId)
+            {
+                if (DifferentialFormats.TryGetValue(dxf, out var differentialFormatId))
+                {
+                    dxfId = (uint)differentialFormatId;
+                    return true;
+                }
+
+                dxfId = default;
+                return false;
             }
 
             internal void AddSharedStyle(XLStyleValue style, StyleInfo info)

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -14,13 +14,15 @@ namespace ClosedXML.Excel
 
         internal sealed class SaveContext
         {
+            private readonly Dictionary<XLStyleValue, StyleInfo> _sharedStyles;
+
             public SaveContext()
             {
                 DifferentialFormats = new Dictionary<XLStyleValue, int>();
                 RelIdGenerator = new RelIdGenerator();
                 SharedFonts = new Dictionary<XLFontValue, FontInfo>();
                 SavedNumberFormats = new Dictionary<string, int>();
-                SharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
+                _sharedStyles = new Dictionary<XLStyleValue, StyleInfo>();
                 TableId = 0;
                 TableNames = new HashSet<String>();
                 PivotSourceCacheId = 0;
@@ -37,7 +39,8 @@ namespace ClosedXML.Excel
             /// </summary>
             public Dictionary<string, int> SavedNumberFormats { get; }
 
-            public Dictionary<XLStyleValue, StyleInfo> SharedStyles { get; private set; }
+            public IReadOnlyDictionary<XLStyleValue, StyleInfo> SharedStyles => _sharedStyles;
+
             public uint TableId { get; set; }
             public HashSet<string> TableNames { get; private set; }
 
@@ -79,7 +82,22 @@ namespace ClosedXML.Excel
 
                 return SavedNumberFormats[numberFormat.Format];
             }
-            #nullable disable
+
+            internal void AddSharedStyle(XLStyleValue style, StyleInfo info)
+            {
+                _sharedStyles.Add(style, info);
+            }
+
+            internal UInt32 GetStyleId(XLStyleValue style)
+            {
+                return _sharedStyles[style].StyleId;
+            }
+
+            internal void ClearSharedStyles()
+            {
+                _sharedStyles.Clear();
+            }
+#nullable disable
         }
 
         #endregion Nested type: SaveContext

--- a/ClosedXML/Excel/XLWorkbook_Save.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.cs
@@ -194,7 +194,11 @@ namespace ClosedXML.Excel
                                      workbookPart.AddNewPart<WorkbookStylesPart>(
                                          context.RelIdGenerator.GetNext(RelType.Workbook));
 
+#if STYLES_REWORK
+            new StylesWriter().WriteContent(workbookStylesPart, XmlToEnumMapper.Instance, Styles, context);
+#else
             WorkbookStylesPartWriter.GenerateContent(workbookStylesPart, this, context);
+#endif
 
             var cacheRelIds = PivotCachesInternal
                   .Select<XLPivotCache, String>(ps => ps.WorkbookCacheRelId)
@@ -463,7 +467,7 @@ namespace ClosedXML.Excel
                 {
                     orphanPart.DeletePart(orphanPart.PivotTableCacheRecordsPart);
                     workbookPart.DeletePart(orphanPart);
-                };
+                }
 
                 // Remove deleted pivot cache parts
                 if (workbookPart.Workbook.PivotCaches is not null)


### PR DESCRIPTION
Allow change of styles saving code between old one and new one.

Styles rework is about changing reader, internal structure and writer to something that will properly represent styles part of a workbook. Since it's not possible to do it at once, it is done piecemeal, but code is not really used. Tests and everything is still using old reader.

But switch can't happen, until reworked styles work correctly and pass tests. That means I need a way to switch between them old and reworked one, so I can test the reworked one. The added constant `STYLES_REWORK` basically switches writer to the reworked one and through `#if` preprocessor directives hides old writer.

The only thing I can do through rework is to save a blank workbook, but I can finally start improving it without being blind.