### PR TITLE
XLComment.SetVisible: the parameter is called 'hidden' but implemented as 'visible'

### DIFF
--- a/ClosedXML/Excel/Comments/XLComment.cs
+++ b/ClosedXML/Excel/Comments/XLComment.cs
@@ -68,9 +68,9 @@ namespace ClosedXML.Excel
             return Container;
         }
 
-        public IXLComment SetVisible(Boolean hidden)
+        public IXLComment SetVisible(Boolean visible)
         {
-            Visible = hidden;
+            Visible = visible;
             return Container;
         }
 

--- a/ClosedXML/Excel/Drawings/IXLDrawing.cs
+++ b/ClosedXML/Excel/Drawings/IXLDrawing.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
 
         Boolean Visible { get; set; }
         T SetVisible();
-        T SetVisible(Boolean hidden);
+        T SetVisible(Boolean visible);
                 
         ////String Name { get; set; }
         ////T SetName(String name);

--- a/ClosedXML/Excel/Drawings/XLDrawing.cs
+++ b/ClosedXML/Excel/Drawings/XLDrawing.cs
@@ -21,9 +21,9 @@ namespace ClosedXML.Excel
             Visible = true;
             return Container;
         }
-        public T SetVisible(Boolean hidden)
+        public T SetVisible(Boolean visible)
         {
-            Visible = hidden;
+            Visible = visible;
             return Container;
         }
 


### PR DESCRIPTION
This just makes it a little clearer that the "hidden" parameter actually means "visible".