### PR TITLE
Ensure workbook reference in cell range objects

### DIFF
--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System.Linq;
 
@@ -155,7 +155,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             IXLWorksheet ws = wb.Worksheets.Add("Sheet");
 
             var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>();
-            var cf = new XLConditionalFormat(ranges);
+            var cf = new XLConditionalFormat((XLWorksheet)ws, ranges);
             cf.Values.Add(new XLFormula("=A3=$D3"));
             cf.Style.Fill.SetBackgroundColor(XLColor.Red);
             ws.ConditionalFormats.Add(cf);
@@ -176,13 +176,13 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             {
                 var ws = wb.Worksheets.Add("Sheet");
 
-                var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>();
-                var cf1 = new XLConditionalFormat(ranges);
+                var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>().ToList();
+                var cf1 = new XLConditionalFormat((XLWorksheet)ws, ranges);
                 cf1.ColorScale()
                     .LowestValue(XLColor.Red)
                     .HighestValue(XLColor.Green);
 
-                var cf2 = new XLConditionalFormat(ranges);
+                var cf2 = new XLConditionalFormat((XLWorksheet)ws, ranges);
                 cf2.ColorScale()
                     .LowestValue(XLColor.Red)
                     .HighestValue(XLColor.Green);

--- a/ClosedXML.Tests/Excel/DefinedNames/DefinedNamesTests.cs
+++ b/ClosedXML.Tests/Excel/DefinedNames/DefinedNamesTests.cs
@@ -76,7 +76,7 @@ namespace ClosedXML.Tests.Excel
                 ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
                 ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
                 ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
-                wb.DefinedNames.Add("Named range 5", new XLRanges
+                wb.DefinedNames.Add("Named range 5", new XLRanges(wb)
                 {
                     ws1.Range("A5:D5"),
                     ws3.Range("A5:D5")
@@ -179,10 +179,10 @@ namespace ClosedXML.Tests.Excel
         [Test]
         public void CopyNamedRangeDifferentWorksheets()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws1 = wb.Worksheets.Add("Sheet1");
             var ws2 = wb.Worksheets.Add("Sheet2");
-            var ranges = new XLRanges();
+            var ranges = new XLRanges(wb);
             ranges.Add(ws1.Range("B2:E6"));
             ranges.Add(ws2.Range("D1:E2"));
             var original = ws1.DefinedNames.Add("Named range", ranges);
@@ -392,7 +392,7 @@ namespace ClosedXML.Tests.Excel
                 {
                     var ws = wb.Worksheets.Add("Sheet 1");
 
-                    wb.DefinedNames.Add("Multirange named range", new XLRanges
+                    wb.DefinedNames.Add("Multirange named range", new XLRanges(wb)
                     {
                         ws.Range("A5:D5"),
                         ws.Range("A15:D15")
@@ -429,7 +429,7 @@ namespace ClosedXML.Tests.Excel
                 ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
                 ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
                 ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
-                wb.DefinedNames.Add("Named range 5", new XLRanges
+                wb.DefinedNames.Add("Named range 5", new XLRanges(wb)
                 {
                     ws1.Range("A5:D5"),
                     ws3.Range("A5:D5")
@@ -540,7 +540,7 @@ namespace ClosedXML.Tests.Excel
                     ws1.Range("A2:D2").AddToNamed("Named range 2", XLScope.Workbook);
                     ws2.Range("A3:D3").AddToNamed("Named range 3", XLScope.Worksheet);
                     ws2.Range("A4:D4").AddToNamed("Named range 4", XLScope.Workbook);
-                    wb.DefinedNames.Add("Named range 5", new XLRanges
+                    wb.DefinedNames.Add("Named range 5", new XLRanges(wb)
                     {
                         ws1.Range("A5:D5"),
                         ws3.Range("A5:D5")

--- a/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using ClosedXML.Excel.Patterns;
 using ClosedXML.Excel.Ranges.Index;
 using NUnit.Framework;
@@ -230,7 +230,7 @@ namespace ClosedXML.Tests.Excel.Ranges
                 var range2 = ws.Range("A2:B3");
                 var range3 = ws.Range("A1:B2"); // same as range1
 
-                var ranges = new XLRanges();
+                var ranges = new XLRanges(wb);
                 ranges.Add(range1);
                 Assert.AreEqual(1, ranges.Count);
                 ranges.Add(range2);

--- a/ClosedXML.Tests/Excel/Ranges/RangesConsolidationTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangesConsolidationTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System.Linq;
 
@@ -10,9 +10,9 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void ConsolidateRangesSameWorksheet()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("Sheet1");
-            var ranges = new XLRanges();
+            var ranges = new XLRanges(wb);
             ranges.Add(ws.Range("A1:E3"));
             ranges.Add(ws.Range("A4:B10"));
             ranges.Add(ws.Range("E2:F12"));
@@ -37,9 +37,9 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void ConsolidateWideRangesSameWorksheet()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("Sheet1");
-            var ranges = new XLRanges();
+            var ranges = new XLRanges(wb);
             ranges.Add(ws.Row(5));
             ranges.Add(ws.Row(7));
             ranges.Add(ws.Row(6));
@@ -62,10 +62,10 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void ConsolidateRangesDifferentWorksheets()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws1 = wb.Worksheets.Add("Sheet1");
             var ws2 = wb.Worksheets.Add("Sheet2");
-            var ranges = new XLRanges();
+            var ranges = new XLRanges(wb);
             ranges.Add(ws1.Range("A1:E3"));
             ranges.Add(ws1.Range("A4:B10"));
             ranges.Add(ws1.Range("E2:F12"));
@@ -106,9 +106,9 @@ namespace ClosedXML.Tests.Excel.Ranges
         [Test]
         public void ConsolidateSparsedRanges()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("Sheet1");
-            var ranges = new XLRanges();
+            var ranges = new XLRanges(wb);
             ranges.Add(ws.Range("A1:C1"));
             ranges.Add(ws.Range("E1:G1"));
             ranges.Add(ws.Range("A3:C3"));

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -399,8 +399,9 @@ namespace ClosedXML.Tests
         [Test]
         public void RangesRemoveAllWithoutDispose()
         {
-            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            var ranges = new XLRanges();
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var ranges = new XLRanges(wb);
             ranges.Add(ws.Range("A1:A2"));
             ranges.Add(ws.Range("B1:B2"));
             var rangesCopy = ranges.ToList();
@@ -417,8 +418,9 @@ namespace ClosedXML.Tests
         [Test]
         public void RangesRemoveAllByCriteria()
         {
-            var ws = new XLWorkbook().Worksheets.Add("Sheet1");
-            var ranges = new XLRanges();
+            using var wb = new XLWorkbook();
+            var ws = wb.Worksheets.Add("Sheet1");
+            var ranges = new XLRanges(wb);
             ranges.Add(ws.Range("A1:A2"));
             ranges.Add(ws.Range("B1:B3"));
             ranges.Add(ws.Range("C1:C4"));
@@ -433,11 +435,11 @@ namespace ClosedXML.Tests
         [Test]
         public void XLRangesReturnsRangesInDeterministicOrder()
         {
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws1 = wb.Worksheets.Add("Sheet1");
             var ws2 = wb.Worksheets.Add("Another sheet");
 
-            var ranges = new XLRanges();
+            var ranges = new XLRanges(wb);
             ranges.Add(ws2.Range("F1:F12"));
             ranges.Add(ws1.Range("F12:F16"));
             ranges.Add(ws1.Range("B1:F2"));

--- a/ClosedXML/Excel/CalcEngine/Visitors/FormulaReferences.cs
+++ b/ClosedXML/Excel/CalcEngine/Visitors/FormulaReferences.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Parser;
+using ClosedXML.Parser;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,7 +49,7 @@ internal class FormulaReferences
 
     internal XLRanges GetExternalRanges(XLWorkbook workbook, XLSheetPoint anchor)
     {
-        var list = new XLRanges();
+        var list = new XLRanges(workbook);
         foreach (var reference in SheetReferences)
         {
             if (workbook.TryGetWorksheet(reference.Sheet, out XLWorksheet sheet))

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -19,7 +19,7 @@ using ClosedXML.Excel.Formatting;
 namespace ClosedXML.Excel
 {
     [DebuggerDisplay("{Address}")]
-    internal sealed class XLCell : XLStylizedBase, IXLCell, IXLStylized, IXLFormatContainer
+    internal sealed class XLCell : XLStylizedBase, IXLCell, IXLFormatContainer, IXLStylized
     {
         public static readonly Regex A1SimpleRegex = new Regex(
             //  @"(?<=\W)" // Start with non word

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1111,11 +1111,11 @@ namespace ClosedXML.Excel
             get { yield break; }
         }
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges { AsRange() };
+                var retVal = new XLRanges(Worksheet) { AsRange() };
                 return retVal;
             }
         }
@@ -1310,7 +1310,7 @@ namespace ClosedXML.Excel
                     .Select(r => r.RangeAddress.Intersection(fromRange.RangeAddress).Relative(fromRange.RangeAddress, toRange.RangeAddress).AsRange() as XLRange)
                     .ToList();
 
-                var c = new XLConditionalFormat(fmtRanges, true);
+                var c = new XLConditionalFormat(Worksheet, fmtRanges, true);
                 c.CopyFrom(cf);
                 c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), fmtRanges.First().FirstCell());
 

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Excel
 {
     using System.Linq;
 
-    internal class XLCells : XLStylizedBase, IXLCells, IXLStylized, IEnumerable<XLCell>
+    internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
     {
         #region Fields
 

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -8,27 +8,26 @@ namespace ClosedXML.Excel
 
     internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
     {
-        #region Fields
-
+        private readonly XLWorkbook _workbook;
         private readonly List<XLRangeAddress> _rangeAddresses = new List<XLRangeAddress>();
         private readonly bool _usedCellsOnly;
         private readonly Func<IXLCell, Boolean> _predicate;
         private readonly XLCellsUsedOptions _options;
         private bool _styleInitialized = false;
 
-        #endregion Fields
+        public XLCells(XLWorksheet worksheet, bool usedCellsOnly, XLCellsUsedOptions options, Func<IXLCell, Boolean>? predicate = null)
+            : this(worksheet.Workbook, usedCellsOnly, options, predicate)
+        {
+        }
 
-        #region Constructor
-
-        public XLCells(bool usedCellsOnly, XLCellsUsedOptions options, Func<IXLCell, Boolean>? predicate = null)
+        public XLCells(XLWorkbook workbook, bool usedCellsOnly, XLCellsUsedOptions options, Func<IXLCell, Boolean>? predicate = null)
             : base(XLStyle.Default.Value)
         {
+            _workbook = workbook;
             _usedCellsOnly = usedCellsOnly;
             _options = options;
             _predicate = predicate ?? (_ => true);
         }
-
-        #endregion Constructor
 
         #region IEnumerable<XLCell> Members
 
@@ -222,11 +221,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges();
+                var retVal = new XLRanges(_workbook);
                 this.ForEach<XLCell>(c => retVal.Add(c.AsRange()));
                 return retVal;
             }

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -7,13 +7,7 @@ namespace ClosedXML.Excel
 {
     internal class XLColumn : XLRangeBase, IXLColumn
     {
-        #region Private fields
-
         private int _outlineLevel;
-
-        #endregion Private fields
-
-        #region Constructor
 
         /// <summary>
         /// The direct constructor should only be used in <see cref="XLWorksheet.RangeFactory"/>.
@@ -25,8 +19,6 @@ namespace ClosedXML.Excel
 
             Width = worksheet.ColumnWidth;
         }
-
-        #endregion Constructor
 
         public override XLRangeType RangeType
         {
@@ -73,7 +65,7 @@ namespace ClosedXML.Excel
 
         public override XLCells Cells(String cellsInColumn)
         {
-            var retVal = new XLCells(false, XLCellsUsedOptions.All);
+            var retVal = new XLCells(Worksheet, false, XLCellsUsedOptions.All);
             var rangePairs = cellsInColumn.Split(',');
             foreach (string pair in rangePairs)
                 retVal.Add(Range(pair.Trim()).RangeAddress);
@@ -432,7 +424,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeColumns Columns(String columns)
         {
-            var retVal = new XLRangeColumns();
+            var retVal = new XLRangeColumns(Worksheet);
             var columnPairs = columns.Split(',');
             foreach (string pair in columnPairs)
                 AsRange().Columns(pair.Trim()).ForEach(retVal.Add);

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -9,6 +9,8 @@ namespace ClosedXML.Excel
     internal class XLColumns : XLStylizedBase, IXLColumns
     {
         private readonly List<XLColumn> _columnsCollection = new List<XLColumn>();
+
+        private readonly XLWorkbook _workbook;
         private readonly XLWorksheet? _worksheet;
 
         /// <summary>
@@ -26,13 +28,15 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Create a new instance of <see cref="XLColumns"/>.
         /// </summary>
+        /// <param name="workbook">Workbook to which all columns belong.</param>
         /// <param name="worksheet">If worksheet is specified it means that the created instance represents
         /// all columns on a worksheet so changing its width will affect all columns.</param>
         /// <param name="defaultStyle">Default style to use when initializing child entries.</param>
         /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLColumn"/> to support lazy initialization.</param>
-        public XLColumns(XLWorksheet? worksheet, XLStyleValue? defaultStyle = null, IEnumerable<XLColumn>? lazyEnumerable = null)
+        public XLColumns(XLWorkbook workbook, XLWorksheet? worksheet, XLStyleValue? defaultStyle = null, IEnumerable<XLColumn>? lazyEnumerable = null)
             : base(defaultStyle)
         {
+            _workbook = workbook;
             _worksheet = worksheet;
             _lazyEnumerable = lazyEnumerable;
         }

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Excel
 {
     using System.Collections;
 
-    internal class XLColumns : XLStylizedBase, IXLColumns, IXLStylized
+    internal class XLColumns : XLStylizedBase, IXLColumns
     {
         private readonly List<XLColumn> _columnsCollection = new List<XLColumn>();
         private readonly XLWorksheet? _worksheet;

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -1,18 +1,26 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    using System.Collections;
-
     internal class XLColumns : XLStylizedBase, IXLColumns
     {
         private readonly List<XLColumn> _columnsCollection = new List<XLColumn>();
         private readonly XLWorksheet? _worksheet;
+
+        /// <summary>
+        /// This object represents all columns of the worksheet, even non-materialized ones.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(_worksheet))]
+        private bool AllColumnsOfSheet => _worksheet is not null;
+
         private bool IsMaterialized => _lazyEnumerable == null;
 
         private IEnumerable<XLColumn>? _lazyEnumerable;
+
         private IEnumerable<XLColumn> Columns => _lazyEnumerable ?? _columnsCollection.AsEnumerable();
 
         /// <summary>
@@ -47,7 +55,7 @@ namespace ClosedXML.Excel
             {
                 Columns.ForEach(c => c.Width = value);
 
-                if (_worksheet == null) return;
+                if (!AllColumnsOfSheet) return;
 
                 _worksheet.ColumnWidth = value;
                 _worksheet.Internals.ColumnsCollection.ForEach(c => c.Value.Width = value);
@@ -56,7 +64,7 @@ namespace ClosedXML.Excel
 
         public void Delete()
         {
-            if (_worksheet != null)
+            if (AllColumnsOfSheet)
             {
                 _worksheet.Internals.ColumnsCollection.Clear();
                 _worksheet.Internals.CellsCollection.Clear();
@@ -218,7 +226,7 @@ namespace ClosedXML.Excel
         {
             get
             {
-                if (_worksheet != null)
+                if (AllColumnsOfSheet)
                     yield return _worksheet;
                 else
                 {

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -183,7 +183,7 @@ namespace ClosedXML.Excel
 
         public IXLCells Cells()
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.All);
+            var cells = new XLCells(_workbook, false, XLCellsUsedOptions.All);
             foreach (XLColumn container in Columns)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -191,7 +191,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed()
         {
-            var cells = new XLCells(true, XLCellsUsedOptions.All);
+            var cells = new XLCells(_workbook, true, XLCellsUsedOptions.All);
             foreach (XLColumn container in Columns)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -206,7 +206,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(true, options);
+            var cells = new XLCells(_workbook, true, options);
             foreach (XLColumn container in Columns)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -240,11 +240,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges();
+                var retVal = new XLRanges(_workbook);
                 this.ForEach(c => retVal.Add(c.AsRange()));
                 return retVal;
             }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    internal class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat, IXLStylized
+    internal class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     {
         private sealed class FullEqualityComparer : IEqualityComparer<IXLConditionalFormat>
         {

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -8,6 +8,8 @@ namespace ClosedXML.Excel
 {
     internal class XLConditionalFormat : XLStylizedBase, IXLConditionalFormat
     {
+        private readonly XLWorksheet _worksheet;
+
         private sealed class FullEqualityComparer : IEqualityComparer<IXLConditionalFormat>
         {
             private readonly bool _compareRange;
@@ -121,34 +123,35 @@ namespace ClosedXML.Excel
 
         #region Constructors
 
-        private XLConditionalFormat(XLStyleValue style)
+        private XLConditionalFormat(XLWorksheet worksheet)
             : base(XLStyle.Default.Value)
         {
+            _worksheet = worksheet;
             Id = Guid.NewGuid();
-            Ranges = new XLRanges();
+            Ranges = new XLRanges(worksheet);
             Values = new XLDictionary<XLFormula>();
             Colors = new XLDictionary<XLColor>();
             ContentTypes = new XLDictionary<XLCFContentType>();
             IconSetOperators = new XLDictionary<XLCFIconSetOperator>();
         }
 
-        public XLConditionalFormat(XLRange range, Boolean copyDefaultModify = false)
-            : this(XLStyle.Default.Value)
+        public XLConditionalFormat(XLWorksheet worksheet, XLRange range, Boolean copyDefaultModify = false)
+            : this(worksheet)
         {
             if (range != null)
                 Ranges.Add(range);
             CopyDefaultModify = copyDefaultModify;
         }
 
-        public XLConditionalFormat(IEnumerable<XLRange> ranges, Boolean copyDefaultModify = false)
-            : this(XLStyle.Default.Value)
+        public XLConditionalFormat(XLWorksheet worksheet, IEnumerable<XLRange> ranges, Boolean copyDefaultModify = false)
+            : this(worksheet)
         {
             ranges?.ForEach(range => Ranges.Add(range));
             CopyDefaultModify = copyDefaultModify;
         }
 
         public XLConditionalFormat(XLConditionalFormat conditionalFormat, IEnumerable<IXLRange> targetRanges)
-            : this(conditionalFormat.StyleValue)
+            : this(conditionalFormat._worksheet)
         {
             targetRanges?.ForEach(range => Ranges.Add(range));
             CopyFrom(conditionalFormat);
@@ -171,10 +174,7 @@ namespace ClosedXML.Excel
             get { yield break; }
         }
 
-        public override IXLRanges RangesUsed
-        {
-            get { return new XLRanges(); }
-        }
+        public override IEnumerable<IXLRange> RangesUsed => Array.Empty<IXLRange>();
 
         public XLDictionary<XLFormula> Values { get; private set; }
 

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -11,6 +11,7 @@ namespace ClosedXML.Excel
     /// </summary>
     internal class XLConditionalFormats : IXLConditionalFormats
     {
+        private readonly XLWorksheet _worksheet;
         private readonly List<IXLConditionalFormat> _conditionalFormats = new();
 
         private static readonly List<XLConditionalFormatType> CFTypesExcludedFromConsolidation = new()
@@ -23,6 +24,11 @@ namespace ClosedXML.Excel
             XLConditionalFormatType.IsDuplicate,
             XLConditionalFormatType.IsUnique
         };
+
+        public XLConditionalFormats(XLWorksheet worksheet)
+        {
+            _worksheet = worksheet;
+        }
 
         public void Add(IXLConditionalFormat conditionalFormat)
         {
@@ -60,10 +66,10 @@ namespace ClosedXML.Excel
 
                 if (!CFTypesExcludedFromConsolidation.Contains(item.ConditionalFormatType))
                 {
-                    var rangesToJoin = new XLRanges();
+                    var rangesToJoin = new XLRanges(_worksheet);
                     item.Ranges.ForEach(r => rangesToJoin.Add(r));
                     var firstRange = item.Ranges.First();
-                    var skippedRanges = new XLRanges();
+                    var skippedRanges = new XLRanges(_worksheet);
                     Func<IXLConditionalFormat, bool> IsSameFormat = f =>
                         f != item && f.Ranges.First().Worksheet.Position == firstRange.Worksheet.Position &&
                         XLConditionalFormat.NoRangeComparer.Equals(f, item);

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -40,7 +40,7 @@ namespace ClosedXML.Excel
         private XLDataValidation(XLWorksheet worksheet)
         {
             _worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
-            _ranges = new XLRanges();
+            _ranges = new XLRanges(worksheet);
             Initialize();
         }
 

--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -197,7 +197,7 @@ namespace ClosedXML.Excel
                 var consRule = similarRules.First();
                 var ranges = similarRules.SelectMany(dv => dv.Ranges).ToList();
 
-                IXLRanges consolidatedRanges = new XLRanges();
+                IXLRanges consolidatedRanges = new XLRanges(_worksheet);
                 ranges.ForEach(r => consolidatedRanges.Add(r));
                 consolidatedRanges = consolidatedRanges.Consolidate();
 

--- a/ClosedXML/Excel/DefinedNames/XLDefinedName.cs
+++ b/ClosedXML/Excel/DefinedNames/XLDefinedName.cs
@@ -156,7 +156,7 @@ internal class XLDefinedName : IXLDefinedName, IWorkbookListener
         var rng = byExclamation[1];
         var rangeToAdd = _container.Workbook.WorksheetsInternal.Worksheet(wsName).Range(rng);
 
-        var ranges = new XLRanges { rangeToAdd };
+        var ranges = new XLRanges(_container.Workbook) { rangeToAdd };
         RefersTo = _formula + "," + string.Join(",", ranges.Select(RangeToFixed));
     }
 

--- a/ClosedXML/Excel/DefinedNames/XLDefinedNames.cs
+++ b/ClosedXML/Excel/DefinedNames/XLDefinedNames.cs
@@ -14,9 +14,9 @@ namespace ClosedXML.Excel
     {
         private readonly Dictionary<String, XLDefinedName> _namedRanges = new(XLHelper.NameComparer);
 
-        internal XLWorkbook Workbook { get; set; }
+        internal XLWorkbook Workbook { get; }
 
-        internal XLWorksheet? Worksheet { get; set; }
+        internal XLWorksheet? Worksheet { get; }
 
         internal XLNamedRangeScope Scope { get; }
 
@@ -120,7 +120,7 @@ namespace ClosedXML.Excel
 
         public IXLDefinedName Add(String name, IXLRange range, String? comment)
         {
-            var ranges = new XLRanges { range };
+            var ranges = new XLRanges(Workbook) { range };
             return Add(name, ranges, comment);
         }
 

--- a/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorkbookStylesPartWriter.cs
@@ -248,7 +248,6 @@ namespace ClosedXML.Excel.IO
             {
                 var emptyContainer = new XLStylizedEmpty(DefaultStyle);
 
-                var style = new XLStyle(emptyContainer, DefaultStyle);
                 OpenXmlHelper.LoadFont(df.Font, emptyContainer.Style.Font);
                 OpenXmlHelper.LoadBorder(df.Border, emptyContainer.Style.Border);
                 OpenXmlHelper.LoadNumberFormat(df.NumberingFormat, emptyContainer.Style.NumberFormat);

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -794,7 +794,7 @@ internal class WorksheetPartReader
         {
             var ranges = conditionalFormatting.SequenceOfReferences.Items
                 .Select(sor => ws.Range(sor.Value));
-            var conditionalFormat = new XLConditionalFormat(ranges);
+            var conditionalFormat = new XLConditionalFormat(ws, ranges);
 
             conditionalFormat.StopIfTrue = OpenXmlHelper.GetBooleanValueAsBool(fr.StopIfTrue, false);
 

--- a/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatBase.cs
+++ b/ClosedXML/Excel/PivotTables/PivotStyleFormats/XLPivotStyleFormatBase.cs
@@ -47,7 +47,8 @@ internal abstract class XLPivotStyleFormatBase : IXLPivotStyleFormat, IXLStylize
             StyleValue = XLStyleValue.FromKey(ref styleKey);
         }
     }
-    public IXLRanges RangesUsed { get; } = new XLRanges();
+
+    public IEnumerable<IXLRange> RangesUsed => Array.Empty<IXLRange>();
 
     public XLStyleValue StyleValue
     {

--- a/ClosedXML/Excel/PivotTables/XLPivotTable.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotTable.cs
@@ -32,7 +32,6 @@ namespace ClosedXML.Excel
         internal XLPivotTable(XLWorksheet worksheet, XLPivotCache cache)
         {
             _worksheet = worksheet;
-
             Filters = new XLPivotTableFilters(this);
             RowAxis = new XLPivotTableAxis(this, XLPivotAxis.AxisRow);
             ColumnAxis = new XLPivotTableAxis(this, XLPivotAxis.AxisCol);
@@ -234,7 +233,7 @@ namespace ClosedXML.Excel
 
                 var oldname = _name ?? string.Empty;
 
-                if (!XLHelper.ValidateName("pivot table", value, oldname, Worksheet.PivotTables.Select(pvt => pvt.Name), out String message))
+                if (!XLHelper.ValidateName("pivot table", value, oldname, _worksheet.PivotTables.Select<XLPivotTable, string>(pvt => pvt.Name), out var message))
                     throw new ArgumentException(message, nameof(value));
 
                 _name = value;

--- a/ClosedXML/Excel/Ranges/XLRange.cs
+++ b/ClosedXML/Excel/Ranges/XLRange.cs
@@ -8,14 +8,10 @@ namespace ClosedXML.Excel
 {
     internal class XLRange : XLRangeBase, IXLRange
     {
-        #region Constructor
-
         public XLRange(XLRangeParameters xlRangeParameters)
             : base(xlRangeParameters.RangeAddress, (xlRangeParameters.DefaultStyle as XLStyle).Value)
         {
         }
-
-        #endregion Constructor
 
         public override XLRangeType RangeType
         {
@@ -41,7 +37,7 @@ namespace ClosedXML.Excel
 
         public virtual IXLRangeColumns Columns(Func<IXLRangeColumn, Boolean> predicate = null)
         {
-            var retVal = new XLRangeColumns();
+            var retVal = new XLRangeColumns(Worksheet);
             Int32 columnCount = ColumnCount();
             for (Int32 c = 1; c <= columnCount; c++)
             {
@@ -54,7 +50,7 @@ namespace ClosedXML.Excel
 
         public virtual IXLRangeColumns Columns(Int32 firstColumn, Int32 lastColumn)
         {
-            var retVal = new XLRangeColumns();
+            var retVal = new XLRangeColumns(Worksheet);
 
             for (int co = firstColumn; co <= lastColumn; co++)
                 retVal.Add(Column(co));
@@ -69,7 +65,7 @@ namespace ClosedXML.Excel
 
         public virtual IXLRangeColumns Columns(String columns)
         {
-            var retVal = new XLRangeColumns();
+            var retVal = new XLRangeColumns(Worksheet);
             var columnPairs = columns.Split(',');
             foreach (string tPair in columnPairs.Select(pair => pair.Trim()))
             {
@@ -156,7 +152,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeRows Rows(Func<IXLRangeRow, Boolean> predicate = null)
         {
-            var retVal = new XLRangeRows();
+            var retVal = new XLRangeRows(Worksheet);
             Int32 rowCount = RowCount();
             for (Int32 r = 1; r <= rowCount; r++)
             {
@@ -169,7 +165,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeRows Rows(Int32 firstRow, Int32 lastRow)
         {
-            var retVal = new XLRangeRows();
+            var retVal = new XLRangeRows(Worksheet);
 
             for (int ro = firstRow; ro <= lastRow; ro++)
                 retVal.Add(Row(ro));
@@ -178,7 +174,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeRows Rows(String rows)
         {
-            var retVal = new XLRangeRows();
+            var retVal = new XLRangeRows(Worksheet);
             var rowPairs = rows.Split(',');
             foreach (string tPair in rowPairs.Select(pair => pair.Trim()))
             {
@@ -588,7 +584,7 @@ namespace ClosedXML.Excel
 
         internal XLRangeRows RowsUsed(XLCellsUsedOptions options, Func<IXLRangeRow, Boolean> predicate = null)
         {
-            XLRangeRows rows = new XLRangeRows();
+            XLRangeRows rows = new XLRangeRows(Worksheet);
             Int32 rowCount = RowCount(options);
 
             for (Int32 ro = 1; ro <= rowCount; ro++)
@@ -618,7 +614,7 @@ namespace ClosedXML.Excel
 
         internal virtual XLRangeColumns ColumnsUsed(XLCellsUsedOptions options, Func<IXLRangeColumn, Boolean> predicate = null)
         {
-            XLRangeColumns columns = new XLRangeColumns();
+            XLRangeColumns columns = new XLRangeColumns(Worksheet);
             Int32 columnCount = ColumnCount(options);
 
             for (Int32 co = 1; co <= columnCount; co++)

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -11,20 +11,8 @@ namespace ClosedXML.Excel
 {
     internal abstract class XLRangeBase : XLStylizedBase, IXLRangeBase, IXLStylized
     {
-        #region Fields
-
         private XLSortElements _sortRows;
         private XLSortElements _sortColumns;
-
-        #endregion Fields
-
-        protected IXLStyle GetStyle()
-        {
-            return Style;
-        }
-
-        #region Constructor
-
         private static Int32 IdCounter = 0;
         private readonly Int32 Id;
 
@@ -35,8 +23,6 @@ namespace ClosedXML.Excel
 
             _rangeAddress = rangeAddress;
         }
-
-        #endregion Constructor
 
         protected virtual void OnRangeAddressChanged(XLRangeAddress oldAddress, XLRangeAddress newAddress)
         {
@@ -179,14 +165,7 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        public override IXLRanges RangesUsed
-        {
-            get
-            {
-                var retVal = new XLRanges { AsRange() };
-                return retVal;
-            }
-        }
+        public override IEnumerable<IXLRange> RangesUsed => new XLRanges(Worksheet) { AsRange() };
 
         protected override IEnumerable<XLStylizedBase> Children
         {
@@ -271,7 +250,7 @@ namespace ClosedXML.Excel
 
         public XLCells Cells(Boolean usedCellsOnly, XLCellsUsedOptions options)
         {
-            var cells = new XLCells(usedCellsOnly, options) { RangeAddress };
+            var cells = new XLCells(Worksheet, usedCellsOnly, options) { RangeAddress };
             return cells;
         }
 
@@ -282,7 +261,7 @@ namespace ClosedXML.Excel
 
         public IXLCells Cells(Func<IXLCell, Boolean> predicate)
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents, predicate) { RangeAddress };
+            var cells = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents, predicate) { RangeAddress };
             return cells;
         }
 
@@ -917,7 +896,7 @@ namespace ClosedXML.Excel
 
         public virtual XLRanges Ranges(String ranges)
         {
-            var retVal = new XLRanges();
+            var retVal = new XLRanges(Worksheet);
             var rangePairs = ranges.Split(',');
             foreach (string pair in rangePairs)
                 retVal.Add(Range(pair.Trim()));
@@ -926,7 +905,7 @@ namespace ClosedXML.Excel
 
         public IXLRanges Ranges(params String[] ranges)
         {
-            var retVal = new XLRanges();
+            var retVal = new XLRanges(Worksheet);
             foreach (string pair in ranges)
                 retVal.Add(Range(pair));
             return retVal;
@@ -948,19 +927,19 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(true, options) { RangeAddress };
+            var cells = new XLCells(Worksheet,true, options) { RangeAddress };
             return cells;
         }
 
         public IXLCells CellsUsed(Func<IXLCell, Boolean> predicate)
         {
-            var cells = new XLCells(true, XLCellsUsedOptions.AllContents, predicate) { RangeAddress };
+            var cells = new XLCells(Worksheet,true, XLCellsUsedOptions.AllContents, predicate) { RangeAddress };
             return cells;
         }
 
         public IXLCells CellsUsed(XLCellsUsedOptions options, Func<IXLCell, Boolean> predicate)
         {
-            var cells = new XLCells(true, options, predicate) { RangeAddress };
+            var cells = new XLCells(Worksheet, true, options, predicate) { RangeAddress };
             return cells;
         }
 
@@ -1785,15 +1764,7 @@ namespace ClosedXML.Excel
 
         public IXLConditionalFormat AddConditionalFormat()
         {
-            var cf = new XLConditionalFormat(AsRange());
-            Worksheet.ConditionalFormats.Add(cf);
-            return cf;
-        }
-
-        internal IXLConditionalFormat AddConditionalFormat(IXLConditionalFormat source)
-        {
-            var cf = new XLConditionalFormat(AsRange());
-            cf.CopyFrom(source);
+            var cf = new XLConditionalFormat(Worksheet, AsRange());
             Worksheet.ConditionalFormats.Add(cf);
             return cf;
         }
@@ -1877,7 +1848,7 @@ namespace ClosedXML.Excel
 
         public IXLCells SurroundingCells(Func<IXLCell, Boolean> predicate = null)
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents, predicate);
+            var cells = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents, predicate);
             this.Grow().Cells(c => !this.Contains(c)).ForEach(c => cells.Add(c as XLCell));
             return cells;
         }
@@ -1887,7 +1858,7 @@ namespace ClosedXML.Excel
             if (otherRange == null)
                 return this.Cells(thisRangePredicate);
 
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents);
             if (!this.Worksheet.Equals(otherRange.Worksheet))
                 return cells;
 
@@ -1903,7 +1874,7 @@ namespace ClosedXML.Excel
             if (otherRange == null)
                 return this.Cells(thisRangePredicate);
 
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents);
             if (!this.Worksheet.Equals(otherRange.Worksheet))
                 return cells;
 

--- a/ClosedXML/Excel/Ranges/XLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumn.cs
@@ -7,8 +7,6 @@ namespace ClosedXML.Excel
 {
     internal class XLRangeColumn : XLRangeBase, IXLRangeColumn
     {
-        #region Constructor
-
         /// <summary>
         /// The direct constructor should only be used in <see cref="XLWorksheet.RangeFactory"/>.
         /// </summary>
@@ -16,8 +14,6 @@ namespace ClosedXML.Excel
             : base(rangeParameters.RangeAddress, (rangeParameters.DefaultStyle as XLStyle).Value)
         {
         }
-
-        #endregion Constructor
 
         #region IXLRangeColumn Members
 
@@ -30,7 +26,7 @@ namespace ClosedXML.Excel
 
         public override XLCells Cells(string cellsInColumn)
         {
-            var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var retVal = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents);
             var rangePairs = cellsInColumn.Split(',');
             foreach (string pair in rangePairs)
                 retVal.Add(Range(pair.Trim()).RangeAddress);
@@ -146,7 +142,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeColumns Columns(string columns)
         {
-            var retVal = new XLRangeColumns();
+            var retVal = new XLRangeColumns(Worksheet);
             var rowPairs = columns.Split(',');
             foreach (string trimmedPair in rowPairs.Select(pair => pair.Trim()))
             {

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -7,7 +7,7 @@ namespace ClosedXML.Excel
 {
     using System.Collections;
 
-    internal class XLRangeColumns : XLStylizedBase, IXLRangeColumns, IXLStylized
+    internal class XLRangeColumns : XLStylizedBase, IXLRangeColumns
     {
         private readonly List<XLRangeColumn> _ranges = new List<XLRangeColumn>();
 

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -9,10 +9,12 @@ namespace ClosedXML.Excel
 
     internal class XLRangeColumns : XLStylizedBase, IXLRangeColumns
     {
+        private readonly XLWorksheet _worksheet;
         private readonly List<XLRangeColumn> _ranges = new List<XLRangeColumn>();
 
-        public XLRangeColumns() : base(XLWorkbook.DefaultStyleValue)
+        public XLRangeColumns(XLWorksheet worksheet) : base(XLWorkbook.DefaultStyleValue)
         {
+            _worksheet = worksheet;
         }
 
         #region IXLRangeColumns Members
@@ -49,7 +51,7 @@ namespace ClosedXML.Excel
 
         public IXLCells Cells()
         {
-            var cells = new XLCells(usedCellsOnly: false, options: XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_worksheet, usedCellsOnly: false, options: XLCellsUsedOptions.AllContents);
             foreach (XLRangeColumn container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -57,7 +59,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed()
         {
-            var cells = new XLCells(usedCellsOnly: true, options: XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_worksheet, usedCellsOnly: true, options: XLCellsUsedOptions.AllContents);
             foreach (XLRangeColumn container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -66,7 +68,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(usedCellsOnly: true, options: options);
+            var cells = new XLCells(_worksheet, usedCellsOnly: true, options: options);
             foreach (XLRangeColumn container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -85,11 +87,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges();
+                var retVal = new XLRanges(_worksheet);
                 this.ForEach(c => retVal.Add(c.AsRange()));
                 return retVal;
             }

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -12,18 +12,14 @@ namespace ClosedXML.Excel
     /// </summary>
     internal class XLRangeConsolidationEngine
     {
-        #region Public Constructors
+        private readonly XLWorkbook _workbook;
+        private readonly XLRanges _allRanges;
 
-        public XLRangeConsolidationEngine(IXLRanges ranges)
+        public XLRangeConsolidationEngine(XLWorkbook workbook, XLRanges ranges)
         {
-            if (ranges == null)
-                throw new ArgumentNullException(nameof(ranges));
-            _allRanges = ranges;
+            _workbook = workbook;
+            _allRanges = ranges ?? throw new ArgumentNullException(nameof(ranges));
         }
-
-        #endregion Public Constructors
-
-        #region Public Methods
 
         public IXLRanges Consolidate()
         {
@@ -32,7 +28,7 @@ namespace ClosedXML.Excel
 
             var worksheets = _allRanges.Select(r => r.Worksheet).Distinct().OrderBy(ws => ws.Position);
 
-            IXLRanges retVal = new XLRanges();
+            IXLRanges retVal = new XLRanges(_workbook);
             foreach (var ws in worksheets)
             {
                 var matrix = new XLRangeConsolidationMatrix(ws, _allRanges.Where(r => r.Worksheet == ws).ToList());
@@ -45,14 +41,6 @@ namespace ClosedXML.Excel
 
             return retVal;
         }
-
-        #endregion Public Methods
-
-        #region Private Fields
-
-        private readonly IXLRanges _allRanges;
-
-        #endregion Private Fields
 
         #region Private Classes
 

--- a/ClosedXML/Excel/Ranges/XLRangeFactory.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeFactory.cs
@@ -1,27 +1,15 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel
 {
     internal class XLRangeFactory
     {
-        #region Properties
-
-        public XLWorksheet Worksheet { get; private set; }
-
-        #endregion Properties
-
-        #region Constructors
+        private readonly XLWorksheet _worksheet;
 
         public XLRangeFactory(XLWorksheet worksheet)
         {
-            if (worksheet == null)
-                throw new ArgumentNullException(nameof(worksheet));
-            Worksheet = worksheet;
+            _worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
         }
-
-        #endregion Constructors
 
         #region Methods
 
@@ -55,35 +43,35 @@ namespace ClosedXML.Excel
 
         public XLRange CreateRange(XLRangeAddress rangeAddress)
         {
-            var xlRangeParameters = new XLRangeParameters(rangeAddress, Worksheet.Style);
+            var xlRangeParameters = new XLRangeParameters(rangeAddress, _worksheet.Style);
             return new XLRange(xlRangeParameters);
         }
 
         public XLColumn CreateColumn(int columnNumber)
         {
-            return new XLColumn(Worksheet, columnNumber);
+            return new XLColumn(_worksheet, columnNumber);
         }
 
         public XLRow CreateRow(int rowNumber)
         {
-            return new XLRow(Worksheet, rowNumber);
+            return new XLRow(_worksheet, rowNumber);
         }
 
         public XLRangeColumn CreateRangeColumn(XLRangeAddress rangeAddress)
         {
-            var xlRangeParameters = new XLRangeParameters(rangeAddress, Worksheet.Style);
+            var xlRangeParameters = new XLRangeParameters(rangeAddress, _worksheet.Style);
             return new XLRangeColumn(xlRangeParameters);
         }
 
         public XLRangeRow CreateRangeRow(XLRangeAddress rangeAddress)
         {
-            var xlRangeParameters = new XLRangeParameters(rangeAddress, Worksheet.Style);
+            var xlRangeParameters = new XLRangeParameters(rangeAddress, _worksheet.Style);
             return new XLRangeRow(xlRangeParameters);
         }
 
         public XLTable CreateTable(XLRangeAddress rangeAddress)
         {
-            return new XLTable(new XLRangeParameters(rangeAddress, Worksheet.Style));
+            return new XLTable(new XLRangeParameters(rangeAddress, _worksheet.Style));
         }
 
         #endregion Methods

--- a/ClosedXML/Excel/Ranges/XLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRow.cs
@@ -5,8 +5,6 @@ namespace ClosedXML.Excel
 
     internal class XLRangeRow : XLRangeBase, IXLRangeRow
     {
-        #region Constructor
-
         /// <summary>
         /// The direct constructor should only be used in <see cref="XLWorksheet.RangeFactory"/>.
         /// </summary>
@@ -14,8 +12,6 @@ namespace ClosedXML.Excel
             : base(rangeParameters.RangeAddress, ((XLStyle)rangeParameters.DefaultStyle).Value)
         {
         }
-
-        #endregion Constructor
 
         #region IXLRangeRow Members
 
@@ -63,7 +59,7 @@ namespace ClosedXML.Excel
 
         public override XLCells Cells(string cellsInRow)
         {
-            var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var retVal = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents);
             var rangePairs = cellsInRow.Split(',');
             foreach (string pair in rangePairs)
                 retVal.Add(Range(pair.Trim()).RangeAddress);
@@ -146,7 +142,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeRows Rows(string rows)
         {
-            var retVal = new XLRangeRows();
+            var retVal = new XLRangeRows(Worksheet);
             var columnPairs = rows.Split(',');
             foreach (string trimmedPair in columnPairs.Select(pair => pair.Trim()))
             {

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -7,7 +7,7 @@ namespace ClosedXML.Excel
 {
     using System.Collections;
 
-    internal class XLRangeRows : XLStylizedBase, IXLRangeRows, IXLStylized
+    internal class XLRangeRows : XLStylizedBase, IXLRangeRows
     {
         private readonly List<XLRangeRow> _ranges = new List<XLRangeRow>();
 

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -9,10 +9,12 @@ namespace ClosedXML.Excel
 
     internal class XLRangeRows : XLStylizedBase, IXLRangeRows
     {
+        private readonly XLWorksheet _worksheet;
         private readonly List<XLRangeRow> _ranges = new List<XLRangeRow>();
 
-        public XLRangeRows() : base(XLStyle.Default.Value)
+        public XLRangeRows(XLWorksheet worksheet) : base(XLStyle.Default.Value)
         {
+            _worksheet = worksheet;
         }
 
         #region IXLRangeRows Members
@@ -49,7 +51,7 @@ namespace ClosedXML.Excel
 
         public IXLCells Cells()
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_worksheet, false, XLCellsUsedOptions.AllContents);
             foreach (XLRangeRow container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -57,7 +59,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed()
         {
-            var cells = new XLCells(true, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_worksheet, true, XLCellsUsedOptions.AllContents);
             foreach (XLRangeRow container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -66,7 +68,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(true, options);
+            var cells = new XLCells(_worksheet, true, options);
             foreach (XLRangeRow container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -86,11 +88,11 @@ namespace ClosedXML.Excel
         }
 
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges();
+                var retVal = new XLRanges(_worksheet);
                 this.ForEach(c => retVal.Add(c.AsRange()));
                 return retVal;
             }

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -7,7 +7,7 @@ namespace ClosedXML.Excel
 {
     using System.Collections;
 
-    internal class XLRanges : XLStylizedBase, IXLRanges, IXLStylized
+    internal class XLRanges : XLStylizedBase, IXLRanges
     {
         /// <summary>
         /// Normally, XLRanges collection includes ranges from a single worksheet, but not necessarily.

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -9,6 +9,8 @@ namespace ClosedXML.Excel
 
     internal class XLRanges : XLStylizedBase, IXLRanges
     {
+        private readonly XLWorkbook _workbook;
+
         /// <summary>
         /// Normally, XLRanges collection includes ranges from a single worksheet, but not necessarily.
         /// </summary>
@@ -27,8 +29,15 @@ namespace ClosedXML.Excel
             return rangeIndex;
         }
 
-        public XLRanges() : base(XLWorkbook.DefaultStyleValue)
+        public XLRanges(XLWorksheet worksheet)
+            : this(worksheet.Workbook)
         {
+        }
+
+        public XLRanges(XLWorkbook workbook)
+            : base(XLWorkbook.DefaultStyleValue)
+        {
+            _workbook = workbook;
             _indexes = new Dictionary<IXLWorksheet, IXLRangeIndex<XLRange>>();
         }
 
@@ -193,7 +202,7 @@ namespace ClosedXML.Excel
 
         public XLCells Cells()
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_workbook, false, XLCellsUsedOptions.AllContents);
             foreach (XLRange container in Ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -201,7 +210,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed()
         {
-            var cells = new XLCells(true, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_workbook, true, XLCellsUsedOptions.AllContents);
             foreach (XLRange container in Ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -209,7 +218,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(true, options);
+            var cells = new XLCells(_workbook, true, options);
             foreach (XLRange container in Ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -219,19 +228,9 @@ namespace ClosedXML.Excel
 
         #region IXLStylized Members
 
-        protected override IEnumerable<XLStylizedBase> Children
-        {
-            get
-            {
-                foreach (XLRange rng in Ranges)
-                    yield return rng;
-            }
-        }
+        protected override IEnumerable<XLStylizedBase> Children => Ranges;
 
-        public override IXLRanges RangesUsed
-        {
-            get { return this; }
-        }
+        public override IEnumerable<IXLRange> RangesUsed => this;
 
         #endregion IXLStylized Members
 
@@ -288,7 +287,7 @@ namespace ClosedXML.Excel
 
         public IXLRanges Consolidate()
         {
-            var engine = new XLRangeConsolidationEngine(this);
+            var engine = new XLRangeConsolidationEngine(_workbook, this);
             return engine.Consolidate();
         }
     }

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -7,18 +7,12 @@ namespace ClosedXML.Excel
 {
     internal sealed class XLRow : XLRangeBase, IXLRow
     {
-        #region Private fields
-
         /// <summary>
         /// Don't use directly, use properties.
         /// </summary>
         private XlRowFlags _flags;
         private Double _height;
         private Int32 _outlineLevel;
-
-        #endregion Private fields
-
-        #region Constructor
 
         /// <summary>
         /// The direct constructor should only be used in <see cref="XLWorksheet.RangeFactory"/>.
@@ -30,8 +24,6 @@ namespace ClosedXML.Excel
 
             _height = worksheet.RowHeight;
         }
-
-        #endregion Constructor
 
         public override XLRangeType RangeType
         {
@@ -228,7 +220,7 @@ namespace ClosedXML.Excel
 
         public override XLCells Cells(String cellsInRow)
         {
-            var retVal = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var retVal = new XLCells(Worksheet, false, XLCellsUsedOptions.AllContents);
             var rangePairs = cellsInRow.Split(',');
             foreach (string pair in rangePairs)
                 retVal.Add(Range(pair.Trim()).RangeAddress);
@@ -491,7 +483,7 @@ namespace ClosedXML.Excel
             var newRow = (XLRow)row;
             newRow._height = _height;
             newRow.HeightChanged = HeightChanged;
-            newRow.InnerStyle = GetStyle();
+            newRow.InnerStyle = Style;
             newRow.IsHidden = IsHidden;
 
             AsRange().CopyTo(row);
@@ -511,7 +503,7 @@ namespace ClosedXML.Excel
 
         public IXLRangeRows Rows(String rows)
         {
-            var retVal = new XLRangeRows();
+            var retVal = new XLRangeRows(Worksheet);
             var rowPairs = rows.Split(',');
             foreach (string pair in rowPairs)
                 AsRange().Rows(pair.Trim()).ForEach(retVal.Add);

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Excel
 {
     using System.Collections;
 
-    internal class XLRows : XLStylizedBase, IXLRows, IXLStylized
+    internal class XLRows : XLStylizedBase, IXLRows
     {
         private readonly List<XLRow> _rowsCollection = new List<XLRow>();
         private readonly XLWorksheet? _worksheet;

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -9,6 +9,7 @@ namespace ClosedXML.Excel
     internal class XLRows : XLStylizedBase, IXLRows
     {
         private readonly List<XLRow> _rowsCollection = new List<XLRow>();
+        private readonly XLWorkbook _workbook;
         private readonly XLWorksheet? _worksheet;
 
         /// <summary>
@@ -25,13 +26,15 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Create a new instance of <see cref="XLRows"/>.
         /// </summary>
+        /// <param name="workbook">Workbook of the rows.</param>
         /// <param name="worksheet">If worksheet is specified it means that the created instance represents
         /// all rows on a worksheet so changing its height will affect all rows.</param>
         /// <param name="defaultStyle">Default style to use when initializing child entries.</param>
         /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLRow"/> to support lazy initialization.</param>
-        public XLRows(XLWorksheet? worksheet, XLStyleValue? defaultStyle = null, IEnumerable<XLRow>? lazyEnumerable = null)
+        public XLRows(XLWorkbook workbook, XLWorksheet? worksheet, XLStyleValue? defaultStyle = null, IEnumerable<XLRow>? lazyEnumerable = null)
             : base(defaultStyle)
         {
+            _workbook = workbook;
             _worksheet = worksheet;
             _lazyEnumerable = lazyEnumerable;
         }
@@ -178,7 +181,7 @@ namespace ClosedXML.Excel
 
         public IXLCells Cells()
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_workbook, false, XLCellsUsedOptions.AllContents);
             foreach (XLRow container in Rows)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -186,7 +189,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed()
         {
-            var cells = new XLCells(true, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_workbook, true, XLCellsUsedOptions.AllContents);
             foreach (XLRow container in Rows)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -194,7 +197,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(true, options);
+            var cells = new XLCells(_workbook, true, options);
             foreach (XLRow container in Rows)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -225,11 +228,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges();
+                var retVal = new XLRanges(_workbook);
                 this.ForEach(c => retVal.Add(c.AsRange()));
                 return retVal;
             }

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -1,15 +1,21 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    using System.Collections;
-
     internal class XLRows : XLStylizedBase, IXLRows
     {
         private readonly List<XLRow> _rowsCollection = new List<XLRow>();
         private readonly XLWorksheet? _worksheet;
+
+        /// <summary>
+        /// This object represents all rows of the worksheet, even non-materialized ones.
+        /// </summary>
+        [MemberNotNullWhen(true, nameof(_worksheet))]
+        private bool AllRowsOfSheet => _worksheet is not null;
 
         private bool IsMaterialized => _lazyEnumerable == null;
 
@@ -47,7 +53,9 @@ namespace ClosedXML.Excel
             set
             {
                 Rows.ForEach(c => c.Height = value);
-                if (_worksheet == null) return;
+                if (!AllRowsOfSheet)
+                    return;
+
                 _worksheet.RowHeight = value;
                 _worksheet.Internals.RowsCollection.ForEach(r => r.Value.Height = value);
             }
@@ -55,7 +63,7 @@ namespace ClosedXML.Excel
 
         public void Delete()
         {
-            if (_worksheet != null)
+            if (AllRowsOfSheet)
             {
                 _worksheet.Internals.RowsCollection.Clear();
                 _worksheet.Internals.CellsCollection.Clear();
@@ -207,7 +215,7 @@ namespace ClosedXML.Excel
         {
             get
             {
-                if (_worksheet != null)
+                if (AllRowsOfSheet)
                     yield return _worksheet;
                 else
                 {

--- a/ClosedXML/Excel/Style/IXLStylized.cs
+++ b/ClosedXML/Excel/Style/IXLStylized.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
@@ -33,7 +34,7 @@ namespace ClosedXML.Excel
         /// <see cref="XLCells"/>, it should return range for each element in the collection.
         /// </para>
         /// </summary>
-        IXLRanges RangesUsed { get; }
+        IEnumerable<IXLRange> RangesUsed { get; }
 
         /// <summary>
         /// Style value representing the current style of the stylized element.

--- a/ClosedXML/Excel/Style/XLStylizedBase.cs
+++ b/ClosedXML/Excel/Style/XLStylizedBase.cs
@@ -44,7 +44,7 @@ namespace ClosedXML.Excel
         /// </summary>
         protected abstract IEnumerable<XLStylizedBase> Children { get; }
 
-        public abstract IXLRanges RangesUsed { get; }
+        public abstract IEnumerable<IXLRange> RangesUsed { get; }
 
         #endregion Properties
 

--- a/ClosedXML/Excel/Style/XLStylizedEmpty.cs
+++ b/ClosedXML/Excel/Style/XLStylizedEmpty.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
-    internal class XLStylizedEmpty : XLStylizedBase, IXLStylized
+    internal class XLStylizedEmpty : XLStylizedBase
     {
         public XLStylizedEmpty(IXLStyle? defaultStyle)
             : base((defaultStyle as XLStyle)?.Value)

--- a/ClosedXML/Excel/Style/XLStylizedEmpty.cs
+++ b/ClosedXML/Excel/Style/XLStylizedEmpty.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace ClosedXML.Excel
@@ -9,14 +10,8 @@ namespace ClosedXML.Excel
         {
         }
 
-        public override IXLRanges RangesUsed
-        {
-            get { return new XLRanges(); }
-        }
+        public override IEnumerable<IXLRange> RangesUsed => Array.Empty<IXLRange>();
 
-        protected override IEnumerable<XLStylizedBase> Children
-        {
-            get { yield break; }
-        }
+        protected override IEnumerable<XLStylizedBase> Children => Array.Empty<XLStylizedBase>();
     }
 }

--- a/ClosedXML/Excel/Tables/XLTableRange.cs
+++ b/ClosedXML/Excel/Tables/XLTableRange.cs
@@ -145,7 +145,7 @@ namespace ClosedXML.Excel
 
         public IXLTableRows Rows(Func<IXLTableRow, Boolean> predicate = null)
         {
-            var retVal = new XLTableRows(Worksheet.Style);
+            var retVal = new XLTableRows(Worksheet);
             Int32 rowCount = _range.RowCount();
 
             for (int r = 1; r <= rowCount; r++)
@@ -159,7 +159,7 @@ namespace ClosedXML.Excel
 
         public new IXLTableRows Rows(int firstRow, int lastRow)
         {
-            var retVal = new XLTableRows(Worksheet.Style);
+            var retVal = new XLTableRows(Worksheet);
 
             for (int rowNumber = firstRow; rowNumber <= lastRow; rowNumber++)
                 retVal.Add(Row(rowNumber));
@@ -169,7 +169,7 @@ namespace ClosedXML.Excel
 
         public new IXLTableRows Rows(string rows)
         {
-            var retVal = new XLTableRows(Worksheet.Style);
+            var retVal = new XLTableRows(Worksheet);
             var rowPairs = rows.Split(',');
             foreach (string tPair in rowPairs.Select(pair => pair.Trim()))
             {
@@ -200,7 +200,7 @@ namespace ClosedXML.Excel
 
         internal XLTableRows RowsUsed(XLCellsUsedOptions options, Func<IXLTableRow, Boolean> predicate = null)
         {
-            var rows = new XLTableRows(Worksheet.Style);
+            var rows = new XLTableRows(Worksheet);
             Int32 rowCount = RowCount();
 
             for (Int32 ro = 1; ro <= rowCount; ro++)

--- a/ClosedXML/Excel/Tables/XLTableRows.cs
+++ b/ClosedXML/Excel/Tables/XLTableRows.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    internal class XLTableRows : XLStylizedBase, IXLTableRows, IXLStylized
+    internal class XLTableRows : XLStylizedBase, IXLTableRows
     {
         private readonly List<XLTableRow> _ranges = new List<XLTableRow>();
 

--- a/ClosedXML/Excel/Tables/XLTableRows.cs
+++ b/ClosedXML/Excel/Tables/XLTableRows.cs
@@ -7,10 +7,12 @@ namespace ClosedXML.Excel
 {
     internal class XLTableRows : XLStylizedBase, IXLTableRows
     {
+        private readonly XLWorksheet _worksheet;
         private readonly List<XLTableRow> _ranges = new List<XLTableRow>();
 
-        public XLTableRows(IXLStyle defaultStyle) : base(((XLStyle)defaultStyle).Value)
+        public XLTableRows(XLWorksheet worksheet) : base(((XLStyle)worksheet.Style).Value)
         {
+            _worksheet = worksheet;
         }
 
         #region IXLStylized Members
@@ -26,11 +28,11 @@ namespace ClosedXML.Excel
             }
         }
 
-        public override IXLRanges RangesUsed
+        public override IEnumerable<IXLRange> RangesUsed
         {
             get
             {
-                var retVal = new XLRanges();
+                var retVal = new XLRanges(_worksheet);
                 this.ForEach(c => retVal.Add(c.AsRange()));
                 return retVal;
             }
@@ -71,7 +73,7 @@ namespace ClosedXML.Excel
 
         public IXLCells Cells()
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_worksheet, false, XLCellsUsedOptions.AllContents);
             foreach (XLTableRow container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -79,7 +81,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed()
         {
-            var cells = new XLCells(true, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(_worksheet, true, XLCellsUsedOptions.AllContents);
             foreach (XLTableRow container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;
@@ -94,7 +96,7 @@ namespace ClosedXML.Excel
 
         public IXLCells CellsUsed(XLCellsUsedOptions options)
         {
-            var cells = new XLCells(false, options);
+            var cells = new XLCells(_worksheet, false, options);
             foreach (XLTableRow container in _ranges)
                 cells.Add(container.RangeAddress);
             return cells;

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -695,7 +695,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns FindColumns(Func<IXLColumn, Boolean> predicate)
         {
-            var columns = new XLColumns(worksheet: null);
+            var columns = new XLColumns(this, worksheet: null);
             foreach (XLWorksheet ws in WorksheetsInternal)
             {
                 foreach (IXLColumn column in ws.Columns().Where(predicate))

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -670,7 +670,7 @@ namespace ClosedXML.Excel
 
         public IXLCells FindCells(Func<IXLCell, Boolean> predicate)
         {
-            var cells = new XLCells(false, XLCellsUsedOptions.AllContents);
+            var cells = new XLCells(this, false, XLCellsUsedOptions.AllContents);
             foreach (XLWorksheet ws in WorksheetsInternal)
             {
                 foreach (XLCell cell in ws.CellsUsed(XLCellsUsedOptions.All))
@@ -684,7 +684,7 @@ namespace ClosedXML.Excel
 
         public IXLRows FindRows(Func<IXLRow, Boolean> predicate)
         {
-            var rows = new XLRows(worksheet: null);
+            var rows = new XLRows(this, worksheet: null);
             foreach (XLWorksheet ws in WorksheetsInternal)
             {
                 foreach (IXLRow row in ws.Rows().Where(predicate))
@@ -866,7 +866,7 @@ namespace ClosedXML.Excel
 
         public IXLRanges Ranges(String ranges)
         {
-            var retVal = new XLRanges();
+            var retVal = new XLRanges(this);
             var rangePairs = ranges.Split(',');
             foreach (var range in rangePairs.Select(r => Range(r.Trim())).Where(range => range != null))
             {

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -323,13 +323,13 @@ namespace ClosedXML.Excel
             columnMap.UnionWith(Internals.CellsCollection.ColumnsUsedKeys);
             columnMap.UnionWith(Internals.ColumnsCollection.Keys);
 
-            var retVal = new XLColumns(this, StyleValue, columnMap.Select(Column));
+            var retVal = new XLColumns(Workbook, this, StyleValue, columnMap.Select(Column));
             return retVal;
         }
 
         public IXLColumns Columns(String columns)
         {
-            var retVal = new XLColumns(null, StyleValue);
+            var retVal = new XLColumns(Workbook, null, StyleValue);
             var columnPairs = columns.Split(',');
             foreach (string tPair in columnPairs.Select(pair => pair.Trim()))
             {
@@ -369,7 +369,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns Columns(Int32 firstColumn, Int32 lastColumn)
         {
-            var retVal = new XLColumns(null, StyleValue);
+            var retVal = new XLColumns(Workbook, null, StyleValue);
 
             for (int co = firstColumn; co <= lastColumn; co++)
                 retVal.Add(Column(co));
@@ -986,7 +986,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns ColumnsUsed(XLCellsUsedOptions options = XLCellsUsedOptions.AllContents, Func<IXLColumn, Boolean>? predicate = null)
         {
-            var columns = new XLColumns(worksheet: null, StyleValue);
+            var columns = new XLColumns(Workbook, worksheet: null, StyleValue);
             var columnsUsed = new HashSet<Int32>();
             Internals.ColumnsCollection.Keys.ForEach(r => columnsUsed.Add(r));
             Internals.CellsCollection.ColumnsUsedKeys.ForEach(r => columnsUsed.Add(r));

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -68,10 +68,10 @@ namespace ClosedXML.Excel
             PivotTables = new XLPivotTables(this);
             _protection = new XLSheetProtection(DefaultProtectionAlgorithm);
             AutoFilter = new XLAutoFilter();
-            ConditionalFormats = new XLConditionalFormats();
+            ConditionalFormats = new XLConditionalFormats(this);
             SparklineGroupsInternal = new XLSparklineGroups(this);
             Internals = new XLWorksheetInternals(new XLCellsCollection(this), new XLColumnsCollection(),
-                                                 new XLRowsCollection(), new XLRanges());
+                                                 new XLRowsCollection(), new XLRanges(this));
             PageSetup = new XLPageSetup((XLPageSetup)workbook.PageOptions, this);
             Outline = new XLOutline(workbook.Outline);
             _columnWidth = workbook.ColumnWidth;
@@ -90,7 +90,7 @@ namespace ClosedXML.Excel
             ShowZeros = workbook.ShowZeros;
             RightToLeft = workbook.RightToLeft;
             TabColor = XLColor.NoColor;
-            _selectedRanges = new XLRanges();
+            _selectedRanges = new XLRanges(this);
 
             Author = workbook.Author;
         }
@@ -190,7 +190,7 @@ namespace ClosedXML.Excel
 
         #region IXLWorksheet Members
 
-        public XLWorkbook Workbook { get; private set; }
+        public XLWorkbook Workbook { get; }
 
         public Double ColumnWidth
         {
@@ -383,13 +383,13 @@ namespace ClosedXML.Excel
             rowMap.UnionWith(Internals.CellsCollection.RowsUsedKeys);
             rowMap.UnionWith(Internals.RowsCollection.Keys);
 
-            var retVal = new XLRows(this, StyleValue, rowMap.Select(Row));
+            var retVal = new XLRows(Workbook, this, StyleValue, rowMap.Select(Row));
             return retVal;
         }
 
         public IXLRows Rows(String rows)
         {
-            var retVal = new XLRows(null, StyleValue);
+            var retVal = new XLRows(Workbook, null, StyleValue);
             var rowPairs = rows.Split(',');
             foreach (string tPair in rowPairs.Select(pair => pair.Trim()))
             {
@@ -415,7 +415,7 @@ namespace ClosedXML.Excel
 
         public IXLRows Rows(Int32 firstRow, Int32 lastRow)
         {
-            var retVal = new XLRows(null, StyleValue);
+            var retVal = new XLRows(Workbook, null, StyleValue);
 
             for (int ro = firstRow; ro <= lastRow; ro++)
                 retVal.Add(Row(ro));
@@ -933,7 +933,7 @@ namespace ClosedXML.Excel
 
         public override XLRanges Ranges(String ranges)
         {
-            var retVal = new XLRanges();
+            var retVal = new XLRanges(Workbook);
             foreach (string rangeAddressStr in ranges.Split(',').Select(s => s.Trim()))
             {
                 if (rangeAddressStr.StartsWith("#REF!"))
@@ -964,7 +964,7 @@ namespace ClosedXML.Excel
 
         public IXLRows RowsUsed(XLCellsUsedOptions options = XLCellsUsedOptions.AllContents, Func<IXLRow, Boolean>? predicate = null)
         {
-            var rows = new XLRows(worksheet: null, StyleValue);
+            var rows = new XLRows(Workbook, worksheet: null, StyleValue);
             var rowsUsed = new HashSet<Int32>();
             foreach (var rowNum in Internals.RowsCollection.Keys.Concat(Internals.CellsCollection.RowsUsedKeys))
             {

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -258,7 +258,7 @@ namespace ClosedXML.Excel
                                                              Boolean expandTable)
         {
             var ws = tableRange.Worksheet;
-            var rows = new XLTableRows(ws.Style);
+            var rows = new XLTableRows(ws);
             var inserted = insertFunc(numberOfRows, false);
             inserted.ForEach(r => rows.Add(new XLTableRow(tableRange, (XLRangeRow)r)));
 


### PR DESCRIPTION
Add workbook reference to every cell range class (`XLColumns`, `XLRangeBase`, `XLCells`...). 

There are two key reasons:
* **Styles** - I need access to `XLWorkbookStyles` to modify a style (e.g. through `IXLCells.Style`). That is a property on a `XLWorkbook`. So basically a prerequisite for styles rework.
* **Performance** - basically all ranges are using `XLCell` to modify the values of a cell. That was fine when it was actual object that contained all the data (massive 158 bytes per cell), but now it is basically a proxy into a sparse array of slices. With access to workbook, it will be possible to skip `XLCell` proxy creation and work directly with cell collection/slices. That means possibility of bulk operations and significantly less pressure on GC.

Additionally, it makes life easier. Cell range lists (`XLCells`, `XLColumns`, `XLRows`, `XLRanges`...) can be empty under certain circumstances. In such cases, there is usually no connection to rest of workbook. E.g. if user tries to add a range to empty range list, there would be no way to check if it is from same workbook (not that I do that, but I should).