### PR TITLE
Styles rework - Column

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLColumnAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLColumnAreaTests.cs
@@ -1,0 +1,49 @@
+using System;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates;
+
+[TestOf(typeof(XLColumnArea))]
+internal class XLColumnAreaTests
+{
+    [TestCase(null)]
+    [TestCase("")]
+    public void Ctor_sheet_must_be_valid(string invalidSheetName)
+    {
+        Assert.That(
+            () => new XLColumnArea(invalidSheetName, 1),
+            Throws.Exception.TypeOf<ArgumentException>());
+    }
+
+    [TestCase(-50)]
+    [TestCase(0)]
+    [TestCase(XLHelper.MaxColumnNumber + 1)]
+    [TestCase(int.MaxValue)]
+    public void Ctor_column_number_must_be_valid(int invalidColumnNumber)
+    {
+        Assert.That(
+            () => new XLColumnArea("some sheet", invalidColumnNumber),
+            Throws.Exception.TypeOf<ArgumentOutOfRangeException>());
+    }
+
+    [TestCase("name", 5, "name", 5, true)]
+    [TestCase("NAME", 5, "name", 5, true)]
+    [TestCase("NAME", 5, "name", 4, false)]
+    [TestCase("some name", 1, "other name", 1, false)]
+    public void Two_areas_are_compared_by_case_insensitive_sheet_name_and_column_number(string firstName, int firstColumn, string secondName, int secondColumn, bool areEqual)
+    {
+        var first = new XLColumnArea(firstName, firstColumn);
+        var second = new XLColumnArea(secondName, secondColumn);
+        Assert.That(first == second, Is.EqualTo(areEqual));
+        Assert.That(first.GetHashCode() == second.GetHashCode(), Is.EqualTo(areEqual));
+    }
+
+    [Test]
+    public void Area_property_returns_area_of_column()
+    {
+        var column = new XLColumnArea("name", 4);
+        var columnArea = column.Area;
+        Assert.AreEqual(columnArea, new XLBookArea("name", new XLSheetRange(1, 4, XLHelper.MaxRowNumber, 4)));
+    }
+}

--- a/ClosedXML/Excel/Cells/FormatSlice.cs
+++ b/ClosedXML/Excel/Cells/FormatSlice.cs
@@ -81,29 +81,5 @@ internal class FormatSlice : ISlice
         return _slice[point].Format;
     }
 
-    /// <summary>
-    /// Apply a deterministic format change. Deterministic = when inputs are equal, outputs must
-    /// also be equal. That is needed to cache format modifications. This method doesn't register
-    /// formats in the workbook styles, it only sets values in the slice.
-    /// </summary>
-    /// <param name="area">Area that should be modified.</param>
-    /// <param name="modification">A deterministic modification.</param>
-    /// <param name="resolver">A provider of format for non-materialized cells (e.g. column has a format and thus non-materialized cells should use column format).</param>
-    internal void ApplyDeterministic(XLSheetRange area, Func<XLCellFormatValue, XLCellFormatValue> modification, Func<XLSheetPoint, XLCellFormatValue> resolver)
-    {
-        var cache = new Dictionary<XLCellFormatValue, XLCellFormatValue>(ReferenceEqualityComparer<XLCellFormatValue>.Instance);
-        foreach (var point in area)
-        {
-            var format = GetFormat(point) ?? resolver(point);
-            if (!cache.TryGetValue(format, out var modifiedFormat))
-            {
-                modifiedFormat = modification(format);
-                cache.Add(format, modifiedFormat);
-            }
-
-            Set(point, modifiedFormat);
-        }
-    }
-
     private readonly record struct SliceValue(XLStyleValue? StyleValue, XLCellFormatValue? Format);
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -929,6 +929,19 @@ namespace ClosedXML.Excel
 
             if (options.HasFlag(XLCellsUsedOptions.NormalFormats))
             {
+#if STYLES_REWORK
+                if (FormatValue is { } format)
+                {
+                    if (format.IncludeQuotePrefix)
+                        return false;
+
+                    // TODO Styles: Think about empty detection. Original is pretty suss, document if necessary
+                    var defaultFormat = Worksheet.Workbook.Styles.DefaultFormat;
+                    if (defaultFormat != format)
+                        return false;
+                }
+#else
+
                 if (StyleValue.IncludeQuotePrefix)
                     return false;
 
@@ -943,6 +956,7 @@ namespace ClosedXML.Excel
                     if (Worksheet.Internals.ColumnsCollection.TryGetValue(_columnNumber, out XLColumn column) && !column.StyleValue.Equals(Worksheet.StyleValue))
                         return false;
                 }
+#endif
             }
 
             if (options.HasFlag(XLCellsUsedOptions.MergedRanges) && IsMerged())

--- a/ClosedXML/Excel/Cells/XLCellsCollection.cs
+++ b/ClosedXML/Excel/Cells/XLCellsCollection.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ClosedXML.Excel.Formatting;
+using ClosedXML.Utils;
 
 namespace ClosedXML.Excel
 {
@@ -370,6 +372,51 @@ namespace ClosedXML.Excel
             var valueEnumerator = ValueSlice.GetEnumerator(range);
             var formulaEnumerator = FormulaSlice.GetEnumerator(range);
             return new SlicesEnumerator(false, valueEnumerator, formulaEnumerator);
+        }
+
+        /// <summary>
+        /// Apply a deterministic format change on used cells.
+        /// </summary>
+        /// <remarks>
+        /// Deterministic = when inputs are equal, outputs must also be equal. That is needed to
+        /// cache format modifications. This method doesn't register formats in the workbook
+        /// styles, it only sets values in the slice.
+        /// </remarks>
+        /// <param name="area">Area that is used to check for used cells.</param>
+        /// <param name="modification">A deterministic modification.</param>
+        /// <param name="resolver">A provider of format for non-materialized cells (e.g. column has a format and thus non-materialized cells should use column format).</param>
+        internal void ApplyFormatOnUsed(XLSheetRange area, Func<XLCellFormatValue, XLCellFormatValue> modification, Func<XLSheetPoint, XLCellFormatValue> resolver)
+        {
+            var enumerator = new SlicesEnumerator(area, this);
+            ApplyFormat(enumerator, modification, resolver);
+        }
+
+        /// <summary>
+        /// Apply a deterministic format change on all cells in <paramref name="area"/>.
+        /// </summary>
+        /// <inheritdoc cref="ApplyFormatOnUsed"/>
+        internal void ApplyFormatOnAll(XLSheetRange area, Func<XLCellFormatValue, XLCellFormatValue> modification, Func<XLSheetPoint, XLCellFormatValue> resolver)
+        {
+            using var areaEnumerator = area.GetEnumerator();
+            var enumerator = new SlicesEnumerator(false, areaEnumerator);
+            ApplyFormat(enumerator, modification, resolver);
+        }
+
+        private void ApplyFormat(SlicesEnumerator enumerator, Func<XLCellFormatValue, XLCellFormatValue> modification, Func<XLSheetPoint, XLCellFormatValue> resolver)
+        {
+            var cache = new Dictionary<XLCellFormatValue, XLCellFormatValue>(ReferenceEqualityComparer<XLCellFormatValue>.Instance);
+            while (enumerator.MoveNext())
+            {
+                var point = enumerator.Current;
+                var format = FormatSlice.GetFormat(point) ?? resolver(point);
+                if (!cache.TryGetValue(format, out var modifiedFormat))
+                {
+                    modifiedFormat = modification(format);
+                    cache.Add(format, modifiedFormat);
+                }
+
+                FormatSlice.Set(point, modifiedFormat);
+            }
         }
 
         /// <summary>

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ClosedXML.Graphics;
+using ClosedXML.Excel.Formatting;
 
 namespace ClosedXML.Excel
 {
-    internal class XLColumn : XLRangeBase, IXLColumn
+    internal class XLColumn : XLRangeBase, IXLColumn, IXLFormatContainer
     {
         private int _outlineLevel;
 
@@ -19,6 +20,11 @@ namespace ClosedXML.Excel
 
             Width = worksheet.ColumnWidth;
         }
+
+        /// <summary>
+        /// Get area of this column.
+        /// </summary>
+        internal XLColumnArea Area => new(Worksheet.Name, ColumnNumber());
 
         public override XLRangeType RangeType
         {
@@ -447,6 +453,18 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLColumn Members
+
+        #region IXLFormatContainer
+
+        /// <remarks>
+        /// Format of the column or <c>null</c> for default format.
+        /// </remarks>
+        /// <inheritdoc cref="IXLFormatContainer.FormatValue"/>
+        public XLCellFormatValue? FormatValue { get; set; }
+
+        public XLCellFormat Format => XLCellFormat.ForColumn(this);
+
+        #endregion
 
         public override XLRange AsRange()
         {

--- a/ClosedXML/Excel/Coordinates/XLColumnArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLColumnArea.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// An immutable column address within a workbook.
+/// </summary>
+internal readonly record struct XLColumnArea
+{
+    public XLColumnArea(string name, int columnNumber)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException(nameof(name));
+
+        if (columnNumber is < XLHelper.MinColumnNumber or > XLHelper.MaxColumnNumber)
+            throw new ArgumentOutOfRangeException(nameof(columnNumber));
+
+        Name = name;
+        ColumNumber = columnNumber;
+    }
+
+    /// <summary>
+    /// Name of the sheet. Sheet may exist or not (e.g. deleted). Never null.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Column number, ranges from 1 to <see cref="XLHelper.MaxColumnNumber"/>.
+    /// </summary>
+    public int ColumNumber { get; }
+
+    public XLBookArea Area => new(Name, new XLSheetRange(XLHelper.MinRowNumber, ColumNumber, XLHelper.MaxRowNumber, ColumNumber));
+
+    public bool Equals(XLColumnArea other)
+    {
+        return ColumNumber == other.ColumNumber && XLHelper.SheetComparer.Equals(Name, other.Name);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (XLHelper.SheetComparer.GetHashCode(Name) * 397) ^ ColumNumber.GetHashCode();
+        }
+    }
+}

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -1246,11 +1246,17 @@ internal class WorksheetPartReader
         // When loading columns we must propagate style to each column but not deeper. In other cases we do not propagate at all.
         if (xlStylized is IXLColumns columns)
         {
-            columns.Cast<XLColumn>().ForEach(col => col.InnerStyle = new XLStyle(col, xlStyleKey));
+            columns.Cast<XLColumn>().ForEach(col =>
+            {
+                col.InnerStyle = new XLStyle(col, xlStyleKey);
+                col.FormatValue = styles.CellFormats[styleIndex];
+            });
         }
         else
         {
             xlStylized.InnerStyle = new XLStyle(xlStylized, xlStyleKey);
+            if (xlStylized is IXLFormatContainer formatContainer)
+                formatContainer.FormatValue = styles.CellFormats[styleIndex];
         }
     }
 }

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -421,7 +421,7 @@ namespace ClosedXML.Excel.IO
                     var outlineLevel = 0;
                     if (xlWorksheet.Internals.ColumnsCollection.TryGetValue(co, out XLColumn col))
                     {
-                        styleId = context.GetStyleId(col.StyleValue);
+                        styleId = context.GetStyleId(col.StyleValue, col.FormatValue);
                         columnWidth = GetColumnWidth(col.Width).SaveRound();
                         isHidden = col.IsHidden;
                         collapsed = col.Collapsed;

--- a/ClosedXML/Excel/Style/Api/FormatResolver.cs
+++ b/ClosedXML/Excel/Style/Api/FormatResolver.cs
@@ -9,11 +9,13 @@ namespace ClosedXML.Excel;
 /// </summary>
 internal class FormatResolver
 {
-    private readonly XLCellFormatValue _workbookFormat;
+    private readonly XLCellFormatValue _defaultFormat;
+    private readonly XLColumnsCollection _columns;
 
     public FormatResolver(XLWorksheet worksheet)
     {
-        _workbookFormat = worksheet.Workbook.Styles.DefaultFormat;
+        _defaultFormat = worksheet.Workbook.Styles.DefaultFormat;
+        _columns = worksheet.Internals.ColumnsCollection;
     }
 
     /// <summary>
@@ -23,7 +25,13 @@ internal class FormatResolver
     /// <returns>A format that is already registered in the styles.</returns>
     public XLCellFormatValue Resolve(XLSheetPoint point)
     {
-        // TODO: Add resolve from worksheet, columns and rows
-        return _workbookFormat;
+        // TODO: Add resolve from worksheet and rows
+        if (_columns.TryGetValue(point.Column, out var column) &&
+            column.FormatValue is { } columnFormat)
+        {
+            return columnFormat;
+        }
+
+        return _defaultFormat;
     }
 }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -26,7 +26,28 @@ internal class XLCellFormat
     /// </summary>
     internal IReadOnlyList<XLBookArea> Areas { get; init; } = Array.Empty<XLBookArea>();
 
+    /// <summary>
+    /// Formatting is updated for used cells within these areas. Unused cells are ignored.
+    /// </summary>
+    internal IReadOnlyList<XLBookArea> UsedAreas { get; init; } = Array.Empty<XLBookArea>();
+
+    /// <summary>
+    /// Formatting is updated for these columns. This doesn't update cells within the columns, only
+    /// the columns themselves.
+    /// </summary>
+    internal IReadOnlyList<XLColumnArea> Columns { get; init; } = Array.Empty<XLColumnArea>();
+
     internal XLFontCellFormat Font => new(this);
+
+    internal static XLCellFormat ForColumn(XLColumn column)
+    {
+        var columnArea = column.Area;
+        return new XLCellFormat(column.Worksheet.Workbook)
+        {
+            UsedAreas = new[] { columnArea.Area },
+            Columns = new[] { columnArea }
+        };
+    }
 
     internal T Resolve<T>(Func<XLCellFormatValue, T?> selector)
         where T : struct
@@ -36,23 +57,47 @@ internal class XLCellFormat
 
     internal void ModifyFont<TProperty>(Func<XLFontFormatValue, TProperty, XLFontFormatValue> modifyFont, TProperty value)
     {
+        // TODO Styles: Apply to containers and deal with cross points
         var styles = _workbook.Styles;
-        foreach (var (sheetName, area) in Areas)
+        foreach (var columnArea in Columns)
         {
-            // Worksheet could have been deleted -> skip
+            if (!_workbook.TryGetWorksheet(columnArea.Name, out XLWorksheet worksheet))
+                continue;
+
+            var column = worksheet.Column(columnArea.ColumNumber);
+            if (column.FormatValue is not { } originalFormat)
+                originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
+
+            column.FormatValue = ModifyFormat(originalFormat);
+        }
+
+        foreach (var (sheetName, area) in UsedAreas)
+        {
             if (!_workbook.TryGetWorksheet(sheetName, out XLWorksheet worksheet))
                 continue;
 
             var formatResolver = new FormatResolver(worksheet);
-            var formatSlice = worksheet.Internals.CellsCollection.FormatSlice;
-            formatSlice.ApplyDeterministic(area, format =>
-            {
-                var modifiedFont = styles.GetRegisteredFontFormat(format.Font, font => modifyFont(font, value));
-                var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Font = modifiedFont });
-                return modifiedFormat;
-            }, formatResolver.Resolve);
+            var cellsCollection = worksheet.Internals.CellsCollection;
+            cellsCollection.ApplyFormatOnUsed(area, ModifyFormat, formatResolver.Resolve);
         }
 
-        // TODO: Apply to used areas, containers and deal with cross points
+        foreach (var (sheetName, area) in Areas)
+        {
+            if (!_workbook.TryGetWorksheet(sheetName, out XLWorksheet worksheet))
+                continue;
+
+            var formatResolver = new FormatResolver(worksheet);
+            var cellsCollection = worksheet.Internals.CellsCollection;
+            cellsCollection.ApplyFormatOnAll(area, ModifyFormat, formatResolver.Resolve);
+        }
+
+        return;
+
+        XLCellFormatValue ModifyFormat(XLCellFormatValue format)
+        {
+            var modifiedFont = styles.GetRegisteredFontFormat(format.Font, font => modifyFont(font, value));
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Font = modifiedFont });
+            return modifiedFormat;
+        }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -6,12 +6,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ClosedXML.Excel.Formatting;
 using ClosedXML.Excel.InsertData;
 using static ClosedXML.Excel.XLProtectionAlgorithm;
 
 namespace ClosedXML.Excel
 {
-    internal class XLWorksheet : XLRangeBase, IXLWorksheet
+    internal class XLWorksheet : XLRangeBase, IXLWorksheet, IXLFormatContainer
     {
         #region Fields
 
@@ -187,6 +188,20 @@ namespace ClosedXML.Excel
         public XLAutoFilter AutoFilter { get; private set; }
 
         public bool IsDeleted { get; private set; }
+
+        #region IXLFormatContainer
+
+        /// <remarks>
+        /// Format of a worksheet or <c>null</c> if worksheet has no format. In OOXML, worksheet
+        /// doesn't actually has a format by itself, so this mostly virtual. During load, it
+        /// represents a style of largest group of columns that are empty other than a style
+        /// (assuming all columns have a style). In most cases it will remainder of columns,
+        /// e.g. <c><![CDATA[<col min="7" max="16384" style="5"/>]]></c>.
+        /// </remarks>
+        /// <inheritdoc cref="IXLFormatContainer.FormatValue"/>
+        public XLCellFormatValue? FormatValue { get; set; } // TODO Styles: Set during load
+
+        #endregion
 
         #region IXLWorksheet Members
 


### PR DESCRIPTION
Another part of styles rework. All is WIP. It basically adds formatting to a column. It has two practical effects (save only for now):
* It's possible to modify a format of a column
* If column has a format, a non-materialized cell will use that format

Practical example (all internals for now):
```csharp
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();
ws.Cell("A1").Format.Font.Size = 20;
ws.Column("A").Format.Font.Size = 15;
ws.Cell("A2").Format.Font.Size = 25;

// The saved workbook has column style with font size 15, including cell A1. The cell A2 though has expected size 25.
wb.SaveAs("demo-out.xlsx");
```