### PR TITLE
Styles rework - set row and worksheet format

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLColumnAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLColumnAreaTests.cs
@@ -46,4 +46,14 @@ internal class XLColumnAreaTests
         var columnArea = column.Area;
         Assert.AreEqual(columnArea, new XLBookArea("name", new XLSheetRange(1, 4, XLHelper.MaxRowNumber, 4)));
     }
+
+    [TestCase("name", 4, "name!D:D")]
+    [TestCase("some name", 26, "'some name'!Z:Z")]
+    [TestCase("Joe's", 27, "'Joe''s'!AA:AA")]
+    [TestCase("Joe", XLHelper.MaxColumnNumber, "Joe!XFD:XFD")]
+    public void ToString_returns_readable_reference(string name, int columnNumber, string expected)
+    {
+        var columnArea = new XLColumnArea(name, columnNumber);
+        Assert.AreEqual(expected, columnArea.ToString());
+    }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLRowAreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLRowAreaTests.cs
@@ -1,0 +1,59 @@
+using System;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates;
+
+[TestOf(typeof(XLRowArea))]
+internal class XLRowAreaTests
+{
+    [TestCase(null)]
+    [TestCase("")]
+    public void Ctor_sheet_must_be_valid(string invalidSheetName)
+    {
+        Assert.That(
+            () => new XLRowArea(invalidSheetName, 1),
+            Throws.Exception.TypeOf<ArgumentException>());
+    }
+
+    [TestCase(-50)]
+    [TestCase(0)]
+    [TestCase(XLHelper.MaxRowNumber + 1)]
+    [TestCase(int.MaxValue)]
+    public void Ctor_row_number_must_be_valid(int invalidRowNumber)
+    {
+        Assert.That(
+            () => new XLRowArea("some sheet", invalidRowNumber),
+            Throws.Exception.TypeOf<ArgumentOutOfRangeException>());
+    }
+
+    [TestCase("name", 5, "name", 5, true)]
+    [TestCase("NAME", 5, "name", 5, true)]
+    [TestCase("NAME", 5, "name", 4, false)]
+    [TestCase("some name", 1, "other name", 1, false)]
+    public void Two_areas_are_compared_by_case_insensitive_sheet_name_and_row_number(string firstName, int firstRow, string secondName, int secondRow, bool areEqual)
+    {
+        var first = new XLRowArea(firstName, firstRow);
+        var second = new XLRowArea(secondName, secondRow);
+        Assert.That(first == second, Is.EqualTo(areEqual));
+        Assert.That(first.GetHashCode() == second.GetHashCode(), Is.EqualTo(areEqual));
+    }
+
+    [Test]
+    public void Area_property_returns_area_of_row()
+    {
+        var row = new XLRowArea("name", 4);
+        var rowArea = row.Area;
+        Assert.AreEqual(rowArea, new XLBookArea("name", new XLSheetRange(4, XLHelper.MinColumnNumber, 4, XLHelper.MaxColumnNumber)));
+    }
+
+    [TestCase("name", 4, "name!4:4")]
+    [TestCase("some name", 4, "'some name'!4:4")]
+    [TestCase("Joe's", 4, "'Joe''s'!4:4")]
+    [TestCase("Joe", XLHelper.MaxRowNumber, "Joe!1048576:1048576")]
+    public void ToString_returns_readable_reference(string name, int rowNumber, string expected)
+    {
+        var rowArea = new XLRowArea(name, rowNumber);
+        Assert.AreEqual(expected, rowArea.ToString());
+    }
+}

--- a/ClosedXML/Excel/Coordinates/XLColumnArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLColumnArea.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Text;
+using ClosedXML.Parser;
 
 namespace ClosedXML.Excel;
 
@@ -42,5 +44,14 @@ internal readonly record struct XLColumnArea
         {
             return (XLHelper.SheetComparer.GetHashCode(Name) * 397) ^ ColumNumber.GetHashCode();
         }
+    }
+
+    public override string ToString()
+    {
+        var name = NameUtils.ShouldQuote(Name.AsSpan()) ? Name.AlwaysEscapeSheetName() : Name;
+        var column = XLHelper.GetColumnLetterFromNumber(ColumNumber);
+        return new StringBuilder(name.Length + 2 + 2 * column.Length)
+            .Append(name).Append('!').Append(column).Append(':').Append(column)
+            .ToString();
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLRowArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLRowArea.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text;
+using ClosedXML.Parser;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// An immutable row address within a workbook.
+/// </summary>
+internal readonly record struct XLRowArea
+{
+    public XLRowArea(string name, int rowNumber)
+    {
+        if (string.IsNullOrEmpty(name))
+            throw new ArgumentException(nameof(name));
+
+        if (rowNumber is < XLHelper.MinRowNumber or > XLHelper.MaxRowNumber)
+            throw new ArgumentOutOfRangeException(nameof(rowNumber));
+
+        Name = name;
+        RowNumber = rowNumber;
+    }
+
+    /// <summary>
+    /// Name of the sheet. Sheet may exist or not (e.g. deleted). Never null.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Row number, ranges from 1 to <see cref="XLHelper.MaxRowNumber"/>.
+    /// </summary>
+    public int RowNumber { get; }
+
+    /// <summary>
+    /// Get the area of the row.
+    /// </summary>
+    public XLBookArea Area => new(Name, new XLSheetRange(RowNumber, XLHelper.MinColumnNumber, RowNumber, XLHelper.MaxColumnNumber));
+
+    public bool Equals(XLRowArea other)
+    {
+        return RowNumber == other.RowNumber && XLHelper.SheetComparer.Equals(Name, other.Name);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (XLHelper.SheetComparer.GetHashCode(Name) * 397) ^ RowNumber.GetHashCode();
+        }
+    }
+
+    public override string ToString()
+    {
+        var name = NameUtils.ShouldQuote(Name.AsSpan()) ? Name.AlwaysEscapeSheetName() : Name;
+        return new StringBuilder(name.Length + 1 + 7 + 1 + 7)
+            .Append(name).Append('!').Append(RowNumber).Append(':').Append(RowNumber)
+            .ToString();
+    }
+}

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -152,11 +152,16 @@ internal class WorksheetPartReader
         if (wsDefaultColumn != null && wsDefaultColumn.Width != null)
             ws.ColumnWidth = wsDefaultColumn.Width - XLConstants.ColumnWidthOffset;
 
-        Int32 styleIndexDefault = wsDefaultColumn != null && wsDefaultColumn.Style != null
-                                      ? Int32.Parse(wsDefaultColumn.Style.InnerText)
-                                      : -1;
-        if (styleIndexDefault >= 0)
-            ApplyStyle(ws, styleIndexDefault, ws.Workbook.Styles);
+        // Sheet doesn't have a format, only column spans have format. When whole sheet is selected
+        // to change format, Excel will mark all cols spans as having a particular format. Format
+        // is considered a sheet format when all columns have a format and it's in the last column.
+        var colSpanFormats = columns.Elements<Column>().Select(c => (MinColumn: c.Min?.Value, MaxColumn: c.Max?.Value, XfId: c.Style?.Value ?? 0)).ToArray();
+        var allColsHaveFormat = colSpanFormats.Sum(x => x.MaxColumn - x.MinColumn + 1) == XLHelper.MaxColumnNumber;
+        if (allColsHaveFormat)
+        {
+            var lastColumnXfId = colSpanFormats.Single(x => x.MaxColumn == XLHelper.MaxColumnNumber).XfId;
+            ApplyStyle(ws, checked((int)lastColumnXfId), ws.Workbook.Styles);
+        }
 
         foreach (Column col in columns.Elements<Column>())
         {

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -360,7 +360,7 @@ namespace ClosedXML.Excel.IO
 
             #region Columns
 
-            var worksheetStyleId = context.GetStyleId(xlWorksheet.StyleValue);
+            var worksheetStyleId = context.GetStyleId(xlWorksheet.StyleValue, xlWorksheet.FormatValue);
             if (xlWorksheet.Internals.CellsCollection.IsEmpty &&
                 xlWorksheet.Internals.ColumnsCollection.Count == 0
                 && worksheetStyleId == 0)
@@ -429,7 +429,7 @@ namespace ClosedXML.Excel.IO
                     }
                     else
                     {
-                        styleId = context.GetStyleId(xlWorksheet.StyleValue);
+                        styleId = worksheetStyleId;
                         columnWidth = worksheetColumnWidth;
                     }
 

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -2060,7 +2060,7 @@ namespace ClosedXML.Excel.IO
                     if (xlWorksheet.Internals.RowsCollection.TryGetValue(currentRowNumber, out var row))
                     {
                         rowPropIndex++;
-                        rowStyleId = context.GetStyleId(row.StyleValue);
+                        rowStyleId = context.GetStyleId(row.StyleValue, row.FormatValue);
                     }
                     else
                     {
@@ -2139,10 +2139,17 @@ namespace ClosedXML.Excel.IO
                     w.WriteAttributeString("hidden", TrueValue);
                 }
 
-                if (xlRow.StyleValue != xlRow.Worksheet.StyleValue)
+                var rowHasCustomFormat =
+#if STYLES_REWORK
+                    xlRow.FormatValue is not null && xlRow.FormatValue != xlRow.Worksheet.Workbook.Styles.DefaultFormat;
+#else
+                    xlRow.StyleValue != xlRow.Worksheet.StyleValue;
+#endif
+
+                if (rowHasCustomFormat)
                 {
-                    var styleIndex = context.GetStyleId(xlRow.StyleValue);
-                    w.WriteAttribute("s", styleIndex);
+                    var formatIndex = context.GetStyleId(xlRow.StyleValue, xlRow.FormatValue);
+                    w.WriteAttribute("s", formatIndex);
                     w.WriteAttributeString("customFormat", TrueValue);
                 }
 

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -2,10 +2,11 @@ using ClosedXML.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ClosedXML.Excel.Formatting;
 
 namespace ClosedXML.Excel
 {
-    internal sealed class XLRow : XLRangeBase, IXLRow
+    internal sealed class XLRow : XLRangeBase, IXLRow, IXLFormatContainer
     {
         /// <summary>
         /// Don't use directly, use properties.
@@ -24,6 +25,8 @@ namespace ClosedXML.Excel
 
             _height = worksheet.RowHeight;
         }
+
+        internal XLRowArea Area => new XLRowArea(Worksheet.Name, RowNumber());
 
         public override XLRangeType RangeType
         {
@@ -524,6 +527,19 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLRow Members
+
+
+        #region IXLFormatContainer
+
+        /// <remarks>
+        /// Format of a row or <c>null</c> for not defined format.
+        /// </remarks>
+        /// <inheritdoc cref="IXLFormatContainer.FormatValue"/>
+        public XLCellFormatValue? FormatValue { get; set; }
+
+        public XLCellFormat Format => XLCellFormat.ForRow(this);
+
+        #endregion
 
         public override XLRange AsRange()
         {

--- a/ClosedXML/Excel/Style/Api/FormatResolver.cs
+++ b/ClosedXML/Excel/Style/Api/FormatResolver.cs
@@ -10,12 +10,14 @@ namespace ClosedXML.Excel;
 internal class FormatResolver
 {
     private readonly XLCellFormatValue _defaultFormat;
+    private readonly XLWorksheet _worksheet;
     private readonly XLColumnsCollection _columns;
     private readonly XLRowsCollection _rows;
 
     public FormatResolver(XLWorksheet worksheet)
     {
         _defaultFormat = worksheet.Workbook.Styles.DefaultFormat;
+        _worksheet = worksheet;
         _columns = worksheet.Internals.ColumnsCollection;
         _rows = worksheet.Internals.RowsCollection;
     }
@@ -39,6 +41,9 @@ internal class FormatResolver
         {
             return columnFormat;
         }
+
+        if (_worksheet.FormatValue is { } worksheetFormat)
+            return worksheetFormat;
 
         return _defaultFormat;
     }

--- a/ClosedXML/Excel/Style/Api/FormatResolver.cs
+++ b/ClosedXML/Excel/Style/Api/FormatResolver.cs
@@ -11,11 +11,13 @@ internal class FormatResolver
 {
     private readonly XLCellFormatValue _defaultFormat;
     private readonly XLColumnsCollection _columns;
+    private readonly XLRowsCollection _rows;
 
     public FormatResolver(XLWorksheet worksheet)
     {
         _defaultFormat = worksheet.Workbook.Styles.DefaultFormat;
         _columns = worksheet.Internals.ColumnsCollection;
+        _rows = worksheet.Internals.RowsCollection;
     }
 
     /// <summary>
@@ -25,7 +27,13 @@ internal class FormatResolver
     /// <returns>A format that is already registered in the styles.</returns>
     public XLCellFormatValue Resolve(XLSheetPoint point)
     {
-        // TODO: Add resolve from worksheet and rows
+        // TODO: Add resolve from worksheet
+        if (_rows.TryGetValue(point.Row, out var row) &&
+            row.FormatValue is { } rowFormat)
+        {
+            return rowFormat;
+        }
+
         if (_columns.TryGetValue(point.Column, out var column) &&
             column.FormatValue is { } columnFormat)
         {

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -43,6 +43,12 @@ internal class XLCellFormat
     /// </summary>
     internal IReadOnlyList<XLRowArea> Rows { get; init; } = Array.Empty<XLRowArea>();
 
+    /// <summary>
+    /// Formatting is updated for these worksheets. This doesn't update cells within the sheets, only
+    /// the sheets and materialized rows and columns of the sheets.
+    /// </summary>
+    internal IReadOnlyList<string> Worksheets { get; init; } = Array.Empty<string>();
+
     internal XLFontCellFormat Font => new(this);
 
     internal static XLCellFormat ForColumn(XLColumn column)
@@ -65,6 +71,15 @@ internal class XLCellFormat
         };
     }
 
+    internal static XLCellFormat ForWorksheet(XLWorksheet worksheet)
+    {
+        return new XLCellFormat(worksheet.Workbook)
+        {
+            UsedAreas = new[] { worksheet.Area },
+            Worksheets = new[] { worksheet.Name }
+        };
+    }
+
     internal T Resolve<T>(Func<XLCellFormatValue, T?> selector)
         where T : struct
     {
@@ -75,16 +90,32 @@ internal class XLCellFormat
     {
         // TODO Styles: Apply to containers and deal with cross points
         var styles = _workbook.Styles;
+
+        foreach (var sheetName in Worksheets)
+        {
+            if (!_workbook.TryGetWorksheet(sheetName, out XLWorksheet worksheet))
+                continue;
+
+            var originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
+            var modifiedFormat = ModifyFormat(originalFormat);
+            worksheet.FormatValue = modifiedFormat;
+
+            var columns = worksheet.Internals.ColumnsCollection.Values;
+            foreach (var column in columns)
+                ApplyColRowFormat(column, worksheet);
+
+            var rows = worksheet.Internals.RowsCollection.Values;
+            foreach (var row in rows)
+                ApplyColRowFormat(row, worksheet);
+        }
+
         foreach (var columnArea in Columns)
         {
             if (!_workbook.TryGetWorksheet(columnArea.Name, out XLWorksheet worksheet))
                 continue;
 
             var column = worksheet.Column(columnArea.ColumNumber);
-            if (column.FormatValue is not { } originalFormat)
-                originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
-
-            column.FormatValue = ModifyFormat(originalFormat);
+            ApplyColRowFormat(column, worksheet);
         }
 
         foreach (var rowArea in Rows)
@@ -93,10 +124,7 @@ internal class XLCellFormat
                 continue;
 
             var row = worksheet.Row(rowArea.RowNumber);
-            if (row.FormatValue is not { } originalFormat)
-                originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
-
-            row.FormatValue = ModifyFormat(originalFormat);
+            ApplyColRowFormat(row, worksheet);
         }
 
         foreach (var (sheetName, area) in UsedAreas)
@@ -126,6 +154,14 @@ internal class XLCellFormat
             var modifiedFont = styles.GetRegisteredFontFormat(format.Font, font => modifyFont(font, value));
             var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Font = modifiedFont });
             return modifiedFormat;
+        }
+
+        void ApplyColRowFormat(IXLFormatContainer rowOrCol, XLWorksheet worksheet)
+        {
+            if (rowOrCol.FormatValue is not { } originalFormat)
+                originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
+
+            rowOrCol.FormatValue = ModifyFormat(originalFormat);
         }
     }
 }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -37,6 +37,12 @@ internal class XLCellFormat
     /// </summary>
     internal IReadOnlyList<XLColumnArea> Columns { get; init; } = Array.Empty<XLColumnArea>();
 
+    /// <summary>
+    /// Formatting is updated for these rows. This doesn't update cells within the rows, only
+    /// the rows themselves.
+    /// </summary>
+    internal IReadOnlyList<XLRowArea> Rows { get; init; } = Array.Empty<XLRowArea>();
+
     internal XLFontCellFormat Font => new(this);
 
     internal static XLCellFormat ForColumn(XLColumn column)
@@ -46,6 +52,16 @@ internal class XLCellFormat
         {
             UsedAreas = new[] { columnArea.Area },
             Columns = new[] { columnArea }
+        };
+    }
+
+    internal static XLCellFormat ForRow(XLRow row)
+    {
+        var rowArea = row.Area;
+        return new XLCellFormat(row.Worksheet.Workbook)
+        {
+            UsedAreas = new[] { rowArea.Area },
+            Rows = new[] { rowArea }
         };
     }
 
@@ -69,6 +85,18 @@ internal class XLCellFormat
                 originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
 
             column.FormatValue = ModifyFormat(originalFormat);
+        }
+
+        foreach (var rowArea in Rows)
+        {
+            if (!_workbook.TryGetWorksheet(rowArea.Name, out XLWorksheet worksheet))
+                continue;
+
+            var row = worksheet.Row(rowArea.RowNumber);
+            if (row.FormatValue is not { } originalFormat)
+                originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
+
+            row.FormatValue = ModifyFormat(originalFormat);
         }
 
         foreach (var (sheetName, area) in UsedAreas)

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -90,6 +90,12 @@ internal class XLCellFormat
     {
         // TODO Styles: Apply to containers and deal with cross points
         var styles = _workbook.Styles;
+        var modifyFormat = (XLCellFormatValue format) =>
+        {
+            var modifiedFont = styles.GetRegisteredFontFormat(format.Font, font => modifyFont(font, value));
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Font = modifiedFont });
+            return modifiedFormat;
+        };
 
         foreach (var sheetName in Worksheets)
         {
@@ -97,16 +103,16 @@ internal class XLCellFormat
                 continue;
 
             var originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
-            var modifiedFormat = ModifyFormat(originalFormat);
+            var modifiedFormat = modifyFormat(originalFormat);
             worksheet.FormatValue = modifiedFormat;
 
             var columns = worksheet.Internals.ColumnsCollection.Values;
             foreach (var column in columns)
-                ApplyColRowFormat(column, worksheet);
+                ApplyColRowFormat(column, modifyFormat, worksheet);
 
             var rows = worksheet.Internals.RowsCollection.Values;
             foreach (var row in rows)
-                ApplyColRowFormat(row, worksheet);
+                ApplyColRowFormat(row, modifyFormat, worksheet);
         }
 
         foreach (var columnArea in Columns)
@@ -115,7 +121,7 @@ internal class XLCellFormat
                 continue;
 
             var column = worksheet.Column(columnArea.ColumNumber);
-            ApplyColRowFormat(column, worksheet);
+            ApplyColRowFormat(column, modifyFormat, worksheet);
         }
 
         foreach (var rowArea in Rows)
@@ -124,7 +130,7 @@ internal class XLCellFormat
                 continue;
 
             var row = worksheet.Row(rowArea.RowNumber);
-            ApplyColRowFormat(row, worksheet);
+            ApplyColRowFormat(row, modifyFormat, worksheet);
         }
 
         foreach (var (sheetName, area) in UsedAreas)
@@ -134,7 +140,7 @@ internal class XLCellFormat
 
             var formatResolver = new FormatResolver(worksheet);
             var cellsCollection = worksheet.Internals.CellsCollection;
-            cellsCollection.ApplyFormatOnUsed(area, ModifyFormat, formatResolver.Resolve);
+            cellsCollection.ApplyFormatOnUsed(area, modifyFormat, formatResolver.Resolve);
         }
 
         foreach (var (sheetName, area) in Areas)
@@ -144,24 +150,17 @@ internal class XLCellFormat
 
             var formatResolver = new FormatResolver(worksheet);
             var cellsCollection = worksheet.Internals.CellsCollection;
-            cellsCollection.ApplyFormatOnAll(area, ModifyFormat, formatResolver.Resolve);
+            cellsCollection.ApplyFormatOnAll(area, modifyFormat, formatResolver.Resolve);
         }
 
         return;
 
-        XLCellFormatValue ModifyFormat(XLCellFormatValue format)
-        {
-            var modifiedFont = styles.GetRegisteredFontFormat(format.Font, font => modifyFont(font, value));
-            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Font = modifiedFont });
-            return modifiedFormat;
-        }
-
-        void ApplyColRowFormat(IXLFormatContainer rowOrCol, XLWorksheet worksheet)
+        static void ApplyColRowFormat(IXLFormatContainer rowOrCol, Func<XLCellFormatValue, XLCellFormatValue> modifyFormat, XLWorksheet worksheet)
         {
             if (rowOrCol.FormatValue is not { } originalFormat)
-                originalFormat = worksheet.FormatValue ?? styles.DefaultFormat;
+                originalFormat = worksheet.FormatValue ?? worksheet.Workbook.Styles.DefaultFormat;
 
-            rowOrCol.FormatValue = ModifyFormat(originalFormat);
+            rowOrCol.FormatValue = modifyFormat(originalFormat);
         }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
+++ b/ClosedXML/Excel/XLWorkbook_Save.NestedTypes.cs
@@ -118,15 +118,6 @@ namespace ClosedXML.Excel
 #endif
             }
 
-            internal UInt32 GetStyleId(XLStyleValue style)
-            {
-#if STYLES_REWORK
-                return 0; // TODO: Map to real format id
-#else
-                return _sharedStyles[style].StyleId;
-#endif
-            }
-
             internal uint GetStyleId(XLStyleValue style, XLCellFormatValue? format)
             {
 #if STYLES_REWORK

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -98,6 +98,8 @@ namespace ClosedXML.Excel
 
         #endregion Constructor
 
+        internal XLBookArea Area => new(Name, XLSheetRange.Full);
+
         [Obsolete($"Use {nameof(DefinedNames)} instead.")]
         IXLDefinedNames IXLWorksheet.NamedRanges => DefinedNames;
 
@@ -193,13 +195,13 @@ namespace ClosedXML.Excel
 
         /// <remarks>
         /// Format of a worksheet or <c>null</c> if worksheet has no format. In OOXML, worksheet
-        /// doesn't actually has a format by itself, so this mostly virtual. During load, it
-        /// represents a style of largest group of columns that are empty other than a style
-        /// (assuming all columns have a style). In most cases it will remainder of columns,
-        /// e.g. <c><![CDATA[<col min="7" max="16384" style="5"/>]]></c>.
+        /// doesn't actually has a format by itself, so this is mostly virtual. If all columns have
+        /// format during the load, it is set to the format of the last column in a sheet (XFD).
         /// </remarks>
         /// <inheritdoc cref="IXLFormatContainer.FormatValue"/>
-        public XLCellFormatValue? FormatValue { get; set; } // TODO Styles: Set during load
+        public XLCellFormatValue? FormatValue { get; set; }
+
+        public XLCellFormat Format => XLCellFormat.ForWorksheet(this);
 
         #endregion
 


### PR DESCRIPTION
Part of styles rework. Another improvement in format setting. It allows to set format of a row and worksheet.

The end of style rework is near :D 
* Add format setter to a workbook (the last big missing container)
* Add format getters so it's possible to read the formatting values, not just write
* Add `IXLStyle` interface to `XLCellFormat` so it can be used instead of `XLStyle`.
* Switch Style props to `XLCellFormat`.
* Review/fix all broken tests after switch (and that will be all of them, xfIds and many other things will differ)
* Review/add tests 
* ... and another 20 things

Anyway, this now works as expected.
```csharp
using (var wb = new XLWorkbook())
{
	var ws = wb.AddWorksheet();

	((XLWorksheet)ws).Format.Font.Size = 6;
	((XLCell)ws.Cell("B3")).Format.Font.Size = 20;
	((XLRow)ws.Row(3)).Format.Font.Size = 15;
	((XLCell)ws.Cell("C3")).Format.Font.Size = 25;
	wb.SaveAs("demo.xlsx");
}

using (var wb = new XLWorkbook("demo.xlsx"))
{
	var ws = wb.Worksheet("Sheet1");

	((XLCell)ws.Cell("B3")).Format.Font.Size = 20;
	((XLWorksheet)ws).Format.Font.Size = 8;
	((XLCell)ws.Cell("D3")).Format.Font.Size = 30;
	wb.SaveAs("demo-out.xlsx");
}
```