### PR TITLE
XLBookPoint should use sheet name

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArrayFormulaTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
@@ -152,7 +152,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
 
             Assert.That(() => _ = ws.Cell("A2").Value,
                 Throws.TypeOf<InvalidOperationException>()
-                    .With.Message.EqualTo("Formula in a cell '$Sheet1'!$A1 is part of a cycle."));
+                    .With.Message.EqualTo("Formula in a cell Sheet1!A1 is part of a cycle."));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/XLCalculationChainTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ClosedXML.Excel;
@@ -28,7 +28,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var expectedPoints = new List<XLBookPoint>();
             for (var i = 0; i < chainLength; ++i)
             {
-                var point = new XLBookPoint(1, new XLSheetPoint(1, i));
+                var point = new XLBookPoint("sheet", new XLSheetPoint(1, i));
                 chain.AddLast(point);
                 expectedPoints.Add(point);
             }
@@ -42,17 +42,17 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             var chain = new XLCalculationChain();
 
             Assert.Throws<InvalidOperationException>(
-                () => chain.Remove(new XLBookPoint(1, new XLSheetPoint(1, 1))));
+                () => chain.Remove(new XLBookPoint("sheet", new XLSheetPoint(1, 1))));
         }
 
         [Test]
         public void Remove_link_from_chain()
         {
             var chain = new XLCalculationChain();
-            var a1 = new XLBookPoint(1, new XLSheetPoint(1, 1));
-            var b1 = new XLBookPoint(1, new XLSheetPoint(1, 2));
-            var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
-            var d1 = new XLBookPoint(1, new XLSheetPoint(1, 4));
+            var a1 = new XLBookPoint("sheet", new XLSheetPoint(1, 1));
+            var b1 = new XLBookPoint("sheet", new XLSheetPoint(1, 2));
+            var c1 = new XLBookPoint("sheet", new XLSheetPoint(1, 3));
+            var d1 = new XLBookPoint("sheet", new XLSheetPoint(1, 4));
 
             chain.AddLast(a1);
             chain.AddLast(b1);
@@ -80,21 +80,21 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void AddAfter_adds_point()
         {
             var chain = new XLCalculationChain();
-            var a1 = new XLBookPoint(1, new XLSheetPoint(1, 1));
+            var a1 = new XLBookPoint("sheet", new XLSheetPoint(1, 1));
             chain.AddLast(a1);
 
             // Add as tail for single link chain
-            var b1 = new XLBookPoint(1, new XLSheetPoint(1, 2));
+            var b1 = new XLBookPoint("sheet", new XLSheetPoint(1, 2));
             chain.AddAfter(a1, b1, 0);
             CollectionAssert.AreEqual(new[] { a1, b1 }, GetPoints(chain));
 
             // Add as tail for multi link chain
-            var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
+            var c1 = new XLBookPoint("sheet", new XLSheetPoint(1, 3));
             chain.AddAfter(b1, c1, 0);
             CollectionAssert.AreEqual(new[] { a1, b1, c1 }, GetPoints(chain));
 
             // Add somewhere in the middle
-            var d1 = new XLBookPoint(1, new XLSheetPoint(1, 4));
+            var d1 = new XLBookPoint("sheet", new XLSheetPoint(1, 4));
             chain.AddAfter(b1, d1, 0);
             CollectionAssert.AreEqual(new[] { a1, b1, d1, c1 }, GetPoints(chain));
         }
@@ -103,13 +103,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void MoveToFront_moves_the_point_to_the_front()
         {
             var chain = new XLCalculationChain();
-            var a1 = new XLBookPoint(1, new XLSheetPoint(1, 1));
+            var a1 = new XLBookPoint("sheet", new XLSheetPoint(1, 1));
             chain.AddLast(a1);
-            var b1 = new XLBookPoint(1, new XLSheetPoint(1, 2));
+            var b1 = new XLBookPoint("sheet", new XLSheetPoint(1, 2));
             chain.AddLast(b1);
-            var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
+            var c1 = new XLBookPoint("sheet", new XLSheetPoint(1, 3));
             chain.AddLast(c1);
-            var d1 = new XLBookPoint(1, new XLSheetPoint(1, 4));
+            var d1 = new XLBookPoint("sheet", new XLSheetPoint(1, 4));
             chain.AddLast(d1);
 
             Assert.True(chain.MoveAhead());
@@ -171,13 +171,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         {
             var chain = new XLCalculationChain();
             // `=C1+B1`
-            var a1 = new XLBookPoint(1, new XLSheetPoint(1, 1));
+            var a1 = new XLBookPoint("sheet", new XLSheetPoint(1, 1));
             chain.AddLast(a1);
             // `=A1`
-            var b1 = new XLBookPoint(1, new XLSheetPoint(1, 2));
+            var b1 = new XLBookPoint("sheet", new XLSheetPoint(1, 2));
             chain.AddLast(b1);
             // `=A1`
-            var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
+            var c1 = new XLBookPoint("sheet", new XLSheetPoint(1, 3));
             chain.AddLast(c1);
 
             // Move to the first link.
@@ -241,11 +241,11 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Reset_clears_positions_ahead_of_current()
         {
             var chain = new XLCalculationChain();
-            var a1 = new XLBookPoint(1, new XLSheetPoint(1, 1));
+            var a1 = new XLBookPoint("sheet", new XLSheetPoint(1, 1));
             chain.AddLast(a1);
-            var b1 = new XLBookPoint(1, new XLSheetPoint(1, 2));
+            var b1 = new XLBookPoint("sheet", new XLSheetPoint(1, 2));
             chain.AddLast(b1);
-            var c1 = new XLBookPoint(1, new XLSheetPoint(1, 3));
+            var c1 = new XLBookPoint("sheet", new XLSheetPoint(1, 3));
             chain.AddLast(c1);
 
             Assert.True(chain.MoveAhead());

--- a/ClosedXML.Tests/Excel/Coordinates/XLBookPointTest.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLBookPointTest.cs
@@ -1,0 +1,39 @@
+using System;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates;
+
+internal class XLBookPointTest
+{
+    [TestCase(null)]
+    [TestCase("")]
+    public void Ctor_sheet_must_be_valid(string invalidSheetName)
+    {
+        Assert.That(
+            () => new XLBookPoint(invalidSheetName, new XLSheetPoint(1, 1)),
+            Throws.Exception.TypeOf<ArgumentException>());
+    }
+
+    [TestCase("sheet", 2, 5, "sheet", 2, 5, true)]
+    [TestCase("SHEET", 2, 5, "sheet", 2, 5, true)]
+    [TestCase("sheet", 2, 5, "sheet", 2, 6, false)]
+    [TestCase("SHEET", 2, 5, "sheet", 3, 5, false)]
+    [TestCase("some sheet", 2, 5, "other sheet", 2, 5, false)]
+    public void Two_points_are_compared_by_case_insensitive_sheet_name_and_point_coordinates(string firstName, int firstRow, int firstColumn, string secondName, int secondRow, int secondColumn, bool areEqual)
+    {
+        var first = new XLBookPoint(firstName, firstRow, firstColumn);
+        var second = new XLBookPoint(secondName, secondRow, secondColumn);
+        Assert.That(first == second, Is.EqualTo(areEqual));
+        Assert.That(first.GetHashCode() == second.GetHashCode(), Is.EqualTo(areEqual));
+    }
+
+    [TestCase("sheet", 1, 4, "sheet!D1")]
+    [TestCase("Joe's", 47, 28, "'Joe''s'!AB47")]
+    [TestCase("2025 Q1", XLHelper.MaxRowNumber, XLHelper.MaxColumnNumber, "'2025 Q1'!XFD1048576")]
+    public void ToString_returns_readable_reference(string name, int row, int column, string expected)
+    {
+        var bookPoint = new XLBookPoint(name, row, column);
+        Assert.AreEqual(expected, bookPoint.ToString());
+    }
+}

--- a/ClosedXML/Excel/CalcEngine/CalcContext.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcContext.cs
@@ -69,9 +69,9 @@ namespace ClosedXML.Excel.CalcEngine
 
         /// <summary>
         /// Sheet that is being recalculated. If set, formula can read dirty
-        /// values from other sheets, but not from this sheetId.
+        /// values from other sheets, but not from this sheet.
         /// </summary>
-        public uint? RecalculateSheetId { get; set; }
+        public string? RecalculateSheetName { get; set; }
 
         internal XLSheetPoint FormulaSheetPoint => new(FormulaAddress.RowNumber, FormulaAddress.ColumnNumber);
 
@@ -109,7 +109,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return valueSlice.GetCellValue(point);
 
             // Used when only one sheet should be recalculated, leaving other sheets with their data.
-            if (RecalculateSheetId is not null && sheet.SheetId != RecalculateSheetId.Value)
+            if (RecalculateSheetName is not null && !XLHelper.SheetComparer.Equals(sheet.Name, RecalculateSheetName))
                 return valueSlice.GetCellValue(point);
 
             // A special branch for functions out of cells (e.g. worksheet.Evaluate("A1+2")).
@@ -121,7 +121,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return cell?.Value ?? Blank.Value;
             }
 
-            throw new GettingDataException(new XLBookPoint(sheet.SheetId, new XLSheetPoint(rowNumber, columnNumber)));
+            throw new GettingDataException(new XLBookPoint(sheet.Name, new XLSheetPoint(rowNumber, columnNumber)));
         }
 
         /// <summary>

--- a/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalcEngine.cs
@@ -49,8 +49,9 @@ namespace ClosedXML.Excel.CalcEngine
         {
             if (_chain is not null && _dependencyTree is not null)
             {
-                _dependencyTree.AddFormula(new XLBookArea(sheet.Name, range), arrayFormula, sheet.Workbook);
-                _chain.AppendArea(sheet.SheetId, range);
+                var area = new XLBookArea(sheet.Name, range);
+                _dependencyTree.AddFormula(area, arrayFormula, sheet.Workbook);
+                _chain.AppendArea(area);
             }
         }
 
@@ -142,7 +143,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <summary>
         /// Recalculate a workbook or a sheet.
         /// </summary>
-        internal void Recalculate(XLWorkbook wb, uint? recalculateSheetId)
+        internal void Recalculate(XLWorkbook wb, string? recalculateSheetName)
         {
             // Lazy, so initialize chain from wb, if it is empty
             if (_chain is null || _dependencyTree is null)
@@ -151,10 +152,11 @@ namespace ClosedXML.Excel.CalcEngine
                 _dependencyTree = DependencyTree.CreateFrom(wb);
             }
 
-            var sheetIdMap = wb.WorksheetsInternal
-                .ToDictionary<XLWorksheet, uint, (XLWorksheet Sheet, ValueSlice ValueSlice, FormulaSlice FormulaSlice)>(
-                    sheet => sheet.SheetId,
-                    sheet => (sheet, sheet.Internals.CellsCollection.ValueSlice, sheet.Internals.CellsCollection.FormulaSlice));
+            var sheetMap = wb.WorksheetsInternal
+                .ToDictionary<XLWorksheet, string, (XLWorksheet Sheet, ValueSlice ValueSlice, FormulaSlice FormulaSlice)>(
+                    sheet => sheet.Name,
+                    sheet => (sheet, sheet.Internals.CellsCollection.ValueSlice, sheet.Internals.CellsCollection.FormulaSlice),
+                    XLHelper.SheetComparer);
 
             // Each outer loop moves chain one cell ahead.
             while (_chain.MoveAhead())
@@ -164,30 +166,30 @@ namespace ClosedXML.Excel.CalcEngine
                 while (true)
                 {
                     var current = _chain.Current;
-                    var sheetId = current.SheetId;
+                    var sheetName = current.SheetName;
 
                     // Skip dirty cells from sheets that are not being recalculated
-                    if (recalculateSheetId is not null && sheetId != recalculateSheetId.Value)
+                    if (recalculateSheetName is not null && !XLHelper.SheetComparer.Equals(sheetName, recalculateSheetName))
                     {
                         // Even though cell is dirty, it's in the ignored sheet and
                         // thus chain can move ahead.
                         break;
                     }
 
-                    if (!sheetIdMap.TryGetValue(sheetId, out var sheetInfo))
+                    if (!sheetMap.TryGetValue(sheetName, out var sheetInfo))
                     {
-                        throw new InvalidOperationException($"Unable to find sheet with sheetId {sheetId} for a point ${current.Point}.");
+                        throw new InvalidOperationException($"Sheet of a calc chain cell {current} doesn't exist in the workbook.");
                     }
 
                     if (_chain.IsCurrentInCycle)
                     {
-                        throw new InvalidOperationException($"Formula in a cell '${sheetInfo.Sheet.Name}'!${current.Point} is part of a cycle.");
+                        throw new InvalidOperationException($"Formula in a cell {current} is part of a cycle.");
                     }
 
                     var cellFormula = sheetInfo.FormulaSlice.Get(current.Point);
                     if (cellFormula is null)
                     {
-                        throw new InvalidOperationException($"Calculation chain contains a '${sheetInfo.Sheet.Name}'!${current.Point}, but the cell doesn't contain formula.");
+                        throw new InvalidOperationException($"Calculation chain contains a {current}, but the cell doesn't contain a formula.");
                     }
 
                     if (!cellFormula.IsDirty)
@@ -196,7 +198,7 @@ namespace ClosedXML.Excel.CalcEngine
                     try
                     {
                         ApplyFormula(cellFormula, current.Point, sheetInfo.Sheet, sheetInfo.ValueSlice,
-                            recalculateSheetId);
+                            recalculateSheetName);
                         cellFormula.IsDirty = false;
 
                         // Break out of the inner loop, a dirty cell has been
@@ -216,7 +218,7 @@ namespace ClosedXML.Excel.CalcEngine
             _chain.Reset();
         }
 
-        private void ApplyFormula(XLCellFormula formula, XLSheetPoint appliedPoint, XLWorksheet sheet, ValueSlice valueSlice, uint? recalculateSheetId)
+        private void ApplyFormula(XLCellFormula formula, XLSheetPoint appliedPoint, XLWorksheet sheet, ValueSlice valueSlice, string? recalculateSheetName)
         {
             var formulaText = formula.A1;
             if (formula.Type == FormulaType.Normal)
@@ -226,7 +228,7 @@ namespace ClosedXML.Excel.CalcEngine
                     sheet.Workbook,
                     sheet,
                     new XLAddress(sheet, appliedPoint.Row, appliedPoint.Column, true, true),
-                    recalculateSheetId: recalculateSheetId);
+                    recalculateSheetName: recalculateSheetName);
                 valueSlice.SetCellValue(appliedPoint, single.ToCellValue());
             }
             else if (formula.Type == FormulaType.Array)
@@ -235,7 +237,7 @@ namespace ClosedXML.Excel.CalcEngine
                 var range = formula.Range;
                 var leftTopCorner = range.FirstPoint;
                 var masterCell = sheet.Cell(leftTopCorner.Row, leftTopCorner.Column);
-                var array = EvaluateArrayFormula(formulaText, masterCell, recalculateSheetId);
+                var array = EvaluateArrayFormula(formulaText, masterCell, recalculateSheetName);
 
                 // The array from formula can be smaller or larger than the
                 // range of cells it should fit into. Broadcast it to the size.
@@ -268,7 +270,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// <param name="address">Address of formula.</param>
         /// <param name="recursive">Should the data necessary for this formula (not deeper ones)
         /// be calculated recursively? Used only for non-cell calculations.</param>
-        /// <param name="recalculateSheetId">
+        /// <param name="recalculateSheetName">
         /// If set, calculation  will allow dirty reads from other sheets than the passed one.
         /// </param>
         /// <returns>The value of the expression.</returns>
@@ -278,11 +280,11 @@ namespace ClosedXML.Excel.CalcEngine
         /// method and then using the Expression.Evaluate method to evaluate
         /// the parsed expression.
         /// </remarks>
-        internal ScalarValue EvaluateFormula(string expression, XLWorkbook? wb = null, XLWorksheet? ws = null, IXLAddress? address = null, bool recursive = false, uint? recalculateSheetId = null)
+        internal ScalarValue EvaluateFormula(string expression, XLWorkbook? wb = null, XLWorksheet? ws = null, IXLAddress? address = null, bool recursive = false, string? recalculateSheetName = null)
         {
             var ctx = new CalcContext(this, _culture, wb, ws, address, recursive)
             {
-                RecalculateSheetId = recalculateSheetId
+                RecalculateSheetName = recalculateSheetName
             };
             var result = EvaluateFormula(expression, ctx);
             if (ctx.UseImplicitIntersection)
@@ -300,12 +302,12 @@ namespace ClosedXML.Excel.CalcEngine
             return ToCellContentValue(result, ctx);
         }
 
-        private Array EvaluateArrayFormula(string expression, XLCell masterCell, uint? recalculateSheetId)
+        private Array EvaluateArrayFormula(string expression, XLCell masterCell, string? recalculateSheetName)
         {
             var ctx = new CalcContext(this, _culture, masterCell)
             {
                 IsArrayCalculation = true,
-                RecalculateSheetId = recalculateSheetId
+                RecalculateSheetName = recalculateSheetName
             };
             var result = EvaluateFormula(expression, ctx);
             if (result.TryPickSingleOrMultiValue(out var single, out var multi, ctx))

--- a/ClosedXML/Excel/CalcEngine/XLCalculationChain.cs
+++ b/ClosedXML/Excel/CalcEngine/XLCalculationChain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel.CalcEngine
                 var formulaSlice = sheet.Internals.CellsCollection.FormulaSlice;
                 using var e = formulaSlice.GetForwardEnumerator(XLSheetRange.Full);
                 while (e.MoveNext())
-                    chain.AddLast(new XLBookPoint(sheet.SheetId, e.Point));
+                    chain.AddLast(new XLBookPoint(sheet.Name, e.Point));
             }
 
             return chain;
@@ -111,16 +111,10 @@ namespace ClosedXML.Excel.CalcEngine
         /// <summary>
         /// Add all cells from the area to the end of the chain.
         /// </summary>
-        /// <exception cref="ArgumentException">If chain already contains a cell from the area.</exception>
-        internal void AppendArea(uint sheetId, XLSheetRange range)
+        internal void AppendArea(XLBookArea area)
         {
-            for (var row = range.TopRow; row <= range.BottomRow; ++row)
-            {
-                for (var col = range.LeftColumn; col <= range.RightColumn; ++col)
-                {
-                    AddLast(new XLBookPoint(sheetId, new XLSheetPoint(row, col)));
-                }
-            }
+            foreach (var point in area)
+                AddLast(point);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/Cells/FormulaSlice.cs
+++ b/ClosedXML/Excel/Cells/FormulaSlice.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using ClosedXML.Excel.CalcEngine;
 
 namespace ClosedXML.Excel
@@ -88,7 +88,7 @@ namespace ClosedXML.Excel
 
             // Remove first, so calc chain doesn't choke on two formulas
             // in one cell when changing a formula of a cell.
-            var bookPoint = new XLBookPoint(_sheet.SheetId, point);
+            var bookPoint = new XLBookPoint(_sheet.Name, point);
             if (original is not null)
                 _engine.RemoveFormula(bookPoint, original);
 
@@ -117,7 +117,7 @@ namespace ClosedXML.Excel
                     // (number of cells formula affects doesn't matter) and also
                     // removes point from the calc chain. Therefore, it works for
                     // array and normal formulas.
-                    var bookPoint = new XLBookPoint(_sheet.SheetId, point);
+                    var bookPoint = new XLBookPoint(_sheet.Name, point);
                     if (original is not null)
                         _engine.RemoveFormula(bookPoint, original);
                 }

--- a/ClosedXML/Excel/Coordinates/XLBookArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLBookArea.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
     /// <summary>
     /// A specification of an area (rectangular range) of a sheet.
     /// </summary>
-    internal readonly struct XLBookArea : IEquatable<XLBookArea>
+    internal readonly struct XLBookArea : IEquatable<XLBookArea>, IEnumerable<XLBookPoint>
     {
         /// <summary>
         /// Name of the sheet. Sheet may exist or not (e.g. deleted). Never null.
@@ -29,6 +31,22 @@ namespace ClosedXML.Excel
         public static bool operator ==(XLBookArea lhs, XLBookArea rhs) => lhs.Equals(rhs);
 
         public static bool operator !=(XLBookArea lhs, XLBookArea rhs) => !(lhs == rhs);
+
+        public IEnumerator<XLBookPoint> GetEnumerator()
+        {
+            for (var row = Area.TopRow; row <= Area.BottomRow; ++row)
+            {
+                for (var col = Area.LeftColumn; col <= Area.RightColumn; ++col)
+                {
+                    yield return new XLBookPoint(Name, row, col);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
         internal static XLBookArea From(IXLRange range)
         {

--- a/ClosedXML/Excel/Coordinates/XLBookPoint.cs
+++ b/ClosedXML/Excel/Coordinates/XLBookPoint.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using ClosedXML.Parser;
 
 namespace ClosedXML.Excel
 {
@@ -9,24 +10,24 @@ namespace ClosedXML.Excel
     /// </summary>
     internal readonly struct XLBookPoint : IEquatable<XLBookPoint>
     {
-        internal XLBookPoint(XLWorksheet sheet, XLSheetPoint point)
-            : this(sheet.SheetId, point)
+        internal XLBookPoint(string sheetName, int row, int col)
+            : this(sheetName, new XLSheetPoint(row, col))
         {
         }
 
-        internal XLBookPoint(uint sheetId, XLSheetPoint point)
+        internal XLBookPoint(string sheetName, XLSheetPoint point)
         {
-            SheetId = sheetId;
+            if (string.IsNullOrEmpty(sheetName))
+                throw new ArgumentException(nameof(sheetName));
+
+            SheetName = sheetName;
             Point = point;
         }
 
-        /// TODO: SheetId doesn't work nicely with renames, but will in the future.
         /// <summary>
-        /// A sheet id of a point. Id of a sheet never changes during workbook
-        /// lifecycle (<see cref="XLWorksheet.SheetId"/>), but the sheet may be
-        /// deleted, making the sheetId and thus book point invalid.
+        /// Name of the sheet. The sheet may be deleted.
         /// </summary>
-        public uint SheetId { get; }
+        public string SheetName { get; }
 
         /// <inheritdoc cref="XLSheetPoint.Row"/>
         public int Row => Point.Column;
@@ -45,7 +46,7 @@ namespace ClosedXML.Excel
 
         public bool Equals(XLBookPoint other)
         {
-            return SheetId == other.SheetId && Point.Equals(other.Point);
+            return Point.Equals(other.Point) && XLHelper.SheetComparer.Equals(SheetName, other.SheetName);
         }
 
         public override bool Equals(object? obj)
@@ -57,13 +58,16 @@ namespace ClosedXML.Excel
         {
             unchecked
             {
-                return ((int)SheetId * 397) ^ Point.GetHashCode();
+                return (XLHelper.SheetComparer.GetHashCode(SheetName) * 397) ^ Point.GetHashCode();
             }
         }
 
         public override string ToString()
         {
-            return $"[{SheetId}]{Point}";
+            var name = NameUtils.ShouldQuote(SheetName.AsSpan())
+                ? SheetName.AlwaysEscapeSheetName()
+                : SheetName;
+            return $"{name}!{Point}";
         }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1744,7 +1744,7 @@ namespace ClosedXML.Excel
         public void RecalculateAllFormulas()
         {
             Internals.CellsCollection.FormulaSlice.MarkDirty(XLSheetRange.Full);
-            Workbook.CalcEngine.Recalculate(Workbook, SheetId);
+            Workbook.CalcEngine.Recalculate(Workbook, Name);
         }
 
         public String Author { get; set; }


### PR DESCRIPTION
The `XLBookPoint` contained `SheetId` identifier of a sheet instead of a sheet name. The original intent was to be able to survive many sheet names without need to change sheet points.

This turned out not to be such a great choice. The "feature" was never actually used and internal structures using a book point still has to be updated when sheet is deleted. Also, it's kind of hard to understand in relation to other coordinate structures that use sheet name directly.

Therefore the `SheetId` is switched to `SheetName`.

I want internal components to be more self-contained and not bounded to the rest of internal structures through some arcane web of implicit dependencies and behavior. Any internal component that uses sheet name will implement the `IWorkbookListener.OnSheetRenamed` in order to deal with update itself (component might need to do other things than just updating some address, e.g., formula update).
