### PR TITLE
Style rework - format value getter

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLBookPointTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLBookPointTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.Coordinates;
 
-internal class XLBookPointTest
+internal class XLBookPointTests
 {
     [TestCase(null)]
     [TestCase("")]

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -12,10 +12,12 @@ namespace ClosedXML.Excel;
 internal class XLCellFormat
 {
     private readonly XLWorkbook _workbook;
+    private readonly Hierarchy _formatValue;
 
-    private XLCellFormat(XLWorkbook workbook)
+    private XLCellFormat(XLWorkbook workbook, Hierarchy formatValue)
     {
         _workbook = workbook;
+        _formatValue = formatValue;
     }
 
     internal XLFontCellFormat Font => new XLFontCellFormat(this);
@@ -59,16 +61,22 @@ internal class XLCellFormat
 
     internal static XLCellFormat ForCell(XLCell cell)
     {
-        return new XLCellFormat(cell.Worksheet.Workbook)
+        var workbook = cell.Worksheet.Workbook;
+        var sheetName = cell.Worksheet.Name;
+        var cellPoint = cell.SheetPoint;
+        var formatValue = new Hierarchy(workbook, sheetName, cellPoint.Column, cellPoint.Row, cellPoint);
+        return new XLCellFormat(workbook, formatValue)
         {
-            Areas = new[] { new XLBookArea(cell.Worksheet.Name, new XLSheetRange(cell.SheetPoint)) }
+            Areas = new[] { new XLBookArea(sheetName, new XLSheetRange(cellPoint)) }
         };
     }
 
     internal static XLCellFormat ForColumn(XLColumn column)
     {
+        var workbook = column.Worksheet.Workbook;
         var columnArea = column.Area;
-        return new XLCellFormat(column.Worksheet.Workbook)
+        var formatValue = new Hierarchy(workbook, columnArea.Name, columnArea.ColumNumber, null, null);
+        return new XLCellFormat(workbook, formatValue)
         {
             UsedAreas = new[] { columnArea.Area },
             Columns = new[] { columnArea }
@@ -77,8 +85,10 @@ internal class XLCellFormat
 
     internal static XLCellFormat ForRow(XLRow row)
     {
+        var workbook = row.Worksheet.Workbook;
         var rowArea = row.Area;
-        return new XLCellFormat(row.Worksheet.Workbook)
+        var formatValue = new Hierarchy(workbook, rowArea.Name, null, rowArea.RowNumber, null);
+        return new XLCellFormat(workbook, formatValue)
         {
             UsedAreas = new[] { rowArea.Area },
             Rows = new[] { rowArea }
@@ -87,7 +97,9 @@ internal class XLCellFormat
 
     internal static XLCellFormat ForWorksheet(XLWorksheet worksheet)
     {
-        return new XLCellFormat(worksheet.Workbook)
+        var workbook = worksheet.Workbook;
+        var formatValue = new Hierarchy(workbook, worksheet.Name, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
         {
             UsedAreas = new[] { worksheet.Area },
             Worksheets = new[] { worksheet.Name }
@@ -96,16 +108,17 @@ internal class XLCellFormat
 
     internal static XLCellFormat ForWorkbook(XLWorkbook workbook)
     {
-        return new XLCellFormat(workbook)
+        var formatValue = new Hierarchy(workbook, null, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
         {
             DefaultFormat = true
         };
     }
 
-    internal T Resolve<T>(Func<XLCellFormatValue, T?> selector)
-        where T : struct
+    internal T Resolve<T>(Func<XLCellFormatValue, T> selector)
     {
-        throw new NotImplementedException();
+        var format = _formatValue.Resolve();
+        return selector(format);
     }
 
     internal void ModifyFont<TProperty>(Func<XLFontFormatValue, TProperty, XLFontFormatValue> modifyFont, TProperty value)
@@ -208,5 +221,73 @@ internal class XLCellFormat
         var formatResolver = new FormatResolver(worksheet);
         var cellsCollection = worksheet.Internals.CellsCollection;
         cellsCollection.ApplyFormatOnAll(area, modifyFormat, formatResolver.Resolve);
+    }
+
+    /// <summary>
+    /// A format value resolution hierarchy for a range API object. Each range API type needs
+    /// to set proper fallbacks through ctor.
+    /// </summary>
+    private readonly record struct Hierarchy
+    {
+        private readonly XLWorkbook _workbook;
+        private readonly string? _sheetName;
+        private readonly int? _columnNumber;
+        private readonly int? _rowNumber;
+        private readonly XLSheetPoint? _point;
+
+        public Hierarchy(XLWorkbook workbook, string? sheetName, int? columnNumber, int? rowNumber, XLSheetPoint? point)
+        {
+            _workbook = workbook;
+            _sheetName = sheetName;
+            _columnNumber = columnNumber;
+            _rowNumber = rowNumber;
+            _point = point;
+        }
+
+        private XLCellFormatValue DefaultFormat => _workbook.Styles.DefaultCellFormat;
+
+        internal XLCellFormatValue Resolve()
+        {
+            var isForWorkbook = _sheetName is null;
+            if (isForWorkbook)
+                return DefaultFormat;
+
+            // First, make sure the sheet exists
+            if (!_workbook.TryGetWorksheet(_sheetName, out XLWorksheet sheet))
+                return DefaultFormat;
+
+            if (_point is { } point)
+            {
+                var formatSlice = sheet.Internals.CellsCollection.FormatSlice;
+                var cellFormat = formatSlice.GetFormat(point);
+                if (cellFormat is not null)
+                    return cellFormat;
+            }
+
+            if (_rowNumber is { } rowNumber)
+            {
+                var rowsCollection = sheet.Internals.RowsCollection;
+                if (rowsCollection.TryGetValue(rowNumber, out var row) &&
+                    row.FormatValue is { } rowFormat)
+                {
+                    return rowFormat;
+                }
+            }
+
+            if (_columnNumber is { } columnNumber)
+            {
+                var columnsCollection = sheet.Internals.ColumnsCollection;
+                if (columnsCollection.TryGetValue(columnNumber, out var column) &&
+                    column.FormatValue is { } columnFormat)
+                {
+                    return columnFormat;
+                }
+            }
+
+            if (sheet.FormatValue is { } sheetFormat)
+                return sheetFormat;
+
+            return DefaultFormat;
+        }
     }
 }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -18,6 +18,8 @@ internal class XLCellFormat
         _workbook = workbook;
     }
 
+    internal XLFontCellFormat Font => new XLFontCellFormat(this);
+
     /// <summary>
     /// Cell areas in a workbook that should be updated when format is changed, e.g. when we have
     /// a format API object for a row container, the area are all cells of the row. It must be
@@ -54,8 +56,6 @@ internal class XLCellFormat
     /// formats below, containers and areas).
     /// </summary>
     private bool DefaultFormat { get; init; }
-
-    internal XLFontCellFormat Font => new(this);
 
     internal static XLCellFormat ForCell(XLCell cell)
     {

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -24,36 +24,36 @@ internal class XLCellFormat
     /// an area, so we can satisfy the <see cref="IXLBorder.OutsideBorder"/> and
     /// <see cref="IXLBorder.InsideBorder"/> property setters.
     /// </summary>
-    internal IReadOnlyList<XLBookArea> Areas { get; init; } = Array.Empty<XLBookArea>();
+    private IReadOnlyList<XLBookArea> Areas { get; init; } = Array.Empty<XLBookArea>();
 
     /// <summary>
     /// Formatting is updated for used cells within these areas. Unused cells are ignored.
     /// </summary>
-    internal IReadOnlyList<XLBookArea> UsedAreas { get; init; } = Array.Empty<XLBookArea>();
+    private IReadOnlyList<XLBookArea> UsedAreas { get; init; } = Array.Empty<XLBookArea>();
 
     /// <summary>
     /// Formatting is updated for these columns. This doesn't update cells within the columns, only
     /// the columns themselves.
     /// </summary>
-    internal IReadOnlyList<XLColumnArea> Columns { get; init; } = Array.Empty<XLColumnArea>();
+    private IReadOnlyList<XLColumnArea> Columns { get; init; } = Array.Empty<XLColumnArea>();
 
     /// <summary>
     /// Formatting is updated for these rows. This doesn't update cells within the rows, only
     /// the rows themselves.
     /// </summary>
-    internal IReadOnlyList<XLRowArea> Rows { get; init; } = Array.Empty<XLRowArea>();
+    private IReadOnlyList<XLRowArea> Rows { get; init; } = Array.Empty<XLRowArea>();
 
     /// <summary>
     /// Formatting is updated for these worksheets. This doesn't update cells within the sheets, only
     /// the sheets and materialized rows and columns of the sheets.
     /// </summary>
-    internal IReadOnlyList<string> Worksheets { get; init; } = Array.Empty<string>();
+    private IReadOnlyList<string> Worksheets { get; init; } = Array.Empty<string>();
 
     /// <summary>
     /// Should the formatting be updated for the default format of a workbook (plus cascade to all
     /// formats below, containers and areas).
     /// </summary>
-    internal bool DefaultFormat { get; init; }
+    private bool DefaultFormat { get; init; }
 
     internal XLFontCellFormat Font => new(this);
 

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
@@ -17,19 +17,19 @@ internal class XLFontCellFormat
 
     public XLFontName Name
     {
-        get => Resolve(static x => x.Font?.Name);
+        get => Resolve(static x => x.Font.Name);
         set => Modify(static (font, fontName) => font with { Name = fontName }, value);
     }
 
     public bool Bold
     {
-        get => Resolve(static x => x.Font?.Bold);
+        get => Resolve(static x => x.Font.Bold);
         set => Modify(static (font, bold) => font with { Bold = bold }, value);
     }
 
     public bool Italic
     {
-        get => Resolve(static x => x.Font?.Italic);
+        get => Resolve(static x => x.Font.Italic);
         set => Modify(static (font, italic) => font with { Italic = italic }, value);
     }
 
@@ -38,12 +38,11 @@ internal class XLFontCellFormat
     /// </summary>
     public double Size
     {
-        get => Resolve(static x => x.Font?.Size).Points;
+        get => Resolve(static x => x.Font.Size).Points;
         set => Modify(static (font, size) => font with { Size = size }, XLFontSize.FromPoints(value));
     }
 
-    private T Resolve<T>(Func<XLCellFormatValue, T?> selector)
-        where T : struct
+    private T Resolve<T>(Func<XLCellFormatValue, T> selector)
     {
         return _parent.Resolve(selector);
     }


### PR DESCRIPTION
Another step in WIP styles rework, unused code. It basically adds ability to resolve format (font) value. Next step is to add add `IXLStyle` interface to `XLCellFormat` and finally write some tests.

Essentially, this allows to use Font getters of a `Format` property.
```csharp
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();

wb.Format.Font.Bold = true;
((XLColumn)ws.Column("B")).Format.Font.Size = 6;

// This is now possible, resolved through set format values
Assert.IsTrue(((XLColumn)ws.Column("B")).Format.Font.Bold);
Assert.IsTrue(((XLRow)ws.Row(100)).Format.Font.Bold);
Assert.IsTrue(((XLCell)ws.Cell("B10")).Format.Font.Bold);
Assert.AreEqual(6, ((XLCell)ws.Cell("B10")).Format.Font.Size);
```
