### PR TITLE
Style rework - Add IXLStyle to XLCellFormat

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -1,4 +1,7 @@
-﻿using ClosedXML.Excel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.Styles
@@ -27,6 +30,66 @@ namespace ClosedXML.Tests.Excel.Styles
 
             Assert.IsFalse(fontKey1.Equals(fontKey2));
             Assert.IsTrue(fontKey2.Equals(fontKey3));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(FontProperties))]
+        public void Font_property_can_be_set(IFormatTestCase<IXLFont> testCase)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var cellsFormat = ((XLCells)ws.Cells("A1:C4")).Format;
+            var cellFormat = ((XLCell)ws.Cell("B2")).Format;
+
+            foreach (var testValue in testCase.Values)
+            {
+                testCase.SetPropertyValue(cellsFormat.Font, testValue);
+                var setValue = testCase.GetPropertyValue(cellFormat.Font);
+                Assert.AreEqual(testValue, setValue);
+            }
+        }
+
+        private static IEnumerable<object> FontProperties()
+        {
+            yield return new FontTestCase<bool>(font => font.Bold, (font, value) => font.Bold = value, true, false);
+            yield return new FontTestCase<bool>(font => font.Bold, (font, value) => font.SetBold(value), true, false);
+            yield return new FontTestCase<bool>(font => font.Bold, (font, _) => font.SetBold(), true);
+
+            yield return new FontTestCase<bool>(font => font.Italic, (font, value) => font.Italic = value, true, false);
+            yield return new FontTestCase<bool>(font => font.Italic, (font, value) => font.SetItalic(value), true, false);
+            yield return new FontTestCase<bool>(font => font.Italic, (font, _) => font.SetItalic(), true);
+
+            yield return new FontTestCase<string>(font => font.FontName, (font, value) => font.FontName = value, "Calibri", "Arial", "Consolas");
+            yield return new FontTestCase<string>(font => font.FontName, (font, value) => font.SetFontName(value), "Calibri", "Arial", "Consolas");
+
+            yield return new FontTestCase<double>(font => font.FontSize, (font, value) => font.FontSize = value, 1, 15, 409.55);
+            yield return new FontTestCase<double>(font => font.FontSize, (font, value) => font.SetFontSize(value), 1, 15, 409.55);
+        }
+
+        private class FontTestCase<T> : IFormatTestCase<IXLFont>
+        {
+            private readonly Func<IXLFont, T> _getter;
+            private readonly Action<IXLFont, T> _setter;
+            private readonly IReadOnlyList<T> _testValues;
+
+            public FontTestCase(Func<IXLFont, T> getter, Action<IXLFont, T> setter, params T[] testValues)
+            {
+                _getter = getter;
+                _setter = setter;
+                _testValues = testValues;
+            }
+
+            public IEnumerable<object> Values => _testValues.Cast<object>();
+
+            public object GetPropertyValue(IXLFont font)
+            {
+                return _getter(font);
+            }
+
+            public void SetPropertyValue(IXLFont font, object value)
+            {
+                _setter(font, (T)value);
+            }
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/IFormatTestCase.cs
+++ b/ClosedXML.Tests/Excel/Styles/IFormatTestCase.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace ClosedXML.Tests.Excel.Styles;
+
+/// <summary>
+/// A test case for setting a format property.
+/// </summary>
+/// <typeparam name="T">Type of property that is being set.</typeparam>
+public interface IFormatTestCase<in T>
+{
+    /// <summary>
+    /// Test values.
+    /// </summary>
+    IEnumerable<object> Values { get; }
+
+    object GetPropertyValue(T font);
+
+    void SetPropertyValue(T font, object value);
+}

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -5,14 +5,20 @@ using System.Linq;
 
 namespace ClosedXML.Excel;
 
-internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
+internal class XLCells :
+#if !STYLES_REWORK
+    XLStylizedBase,
+#endif
+    IXLCells, IEnumerable<XLCell>
 {
     private readonly XLWorkbook _workbook;
     private readonly List<XLRangeAddress> _rangeAddresses = new();
     private readonly bool _usedCellsOnly;
     private readonly Func<IXLCell, Boolean> _predicate;
     private readonly XLCellsUsedOptions _options;
+#if !STYLES_REWORK
     private bool _styleInitialized = false;
+#endif
 
     public XLCells(XLWorksheet worksheet, bool usedCellsOnly, XLCellsUsedOptions options, Func<IXLCell, Boolean>? predicate = null)
         : this(worksheet.Workbook, usedCellsOnly, options, predicate)
@@ -20,7 +26,9 @@ internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
     }
 
     public XLCells(XLWorkbook workbook, bool usedCellsOnly, XLCellsUsedOptions options, Func<IXLCell, Boolean>? predicate = null)
+#if !STYLES_REWORK
         : base(XLStyle.Default.Value)
+#endif
     {
         _workbook = workbook;
         _usedCellsOnly = usedCellsOnly;
@@ -207,8 +215,28 @@ internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
         set { this.ForEach<XLCell>(c => c.FormulaR1C1 = value); }
     }
 
-    #endregion IXLCells Members
+#if STYLES_REWORK
+    public IXLStyle Style
+    {
+        get => Format;
+        set => Format.SetStyle(value);
+    }
 
+#endif
+    internal XLCellFormat Format
+    {
+        get
+        {
+            // For backwards compatibility, the sheet is considered the inner style. A terrible
+            // choice, but it is what it is.
+            var sheet = _rangeAddresses.Select(x => x.Worksheet).FirstOrDefault(x => x is not null);
+            var areas = _rangeAddresses.Select(XLBookArea.From).ToArray();
+            return XLCellFormat.ForCells(_workbook, areas, sheet);
+        }
+    }
+#endregion IXLCells Members
+
+#if !STYLES_REWORK
     #region IXLStylized Members
 
     protected override IEnumerable<XLStylizedBase> Children
@@ -231,11 +259,12 @@ internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
     }
 
     #endregion IXLStylized Members
-
+#endif
     public void Add(XLRangeAddress rangeAddress)
     {
         _rangeAddresses.Add(rangeAddress);
 
+#if !STYLES_REWORK
         if (_styleInitialized)
             return;
 
@@ -245,6 +274,7 @@ internal class XLCells : XLStylizedBase, IXLCells, IEnumerable<XLCell>
 
         InnerStyle = worksheetStyle;
         _styleInitialized = true;
+#endif
     }
 
     public void Add(XLCell cell)

--- a/ClosedXML/Excel/Coordinates/XLBookArea.cs
+++ b/ClosedXML/Excel/Coordinates/XLBookArea.cs
@@ -56,6 +56,14 @@ namespace ClosedXML.Excel
             return new XLBookArea(range.Worksheet.Name, XLSheetRange.FromRangeAddress(range.RangeAddress));
         }
 
+        internal static XLBookArea From(XLRangeAddress address)
+        {
+            if (address.Worksheet is null)
+                throw new ArgumentException("Range doesn't contain sheet.", nameof(address));
+
+            return new XLBookArea(address.Worksheet.Name, XLSheetRange.FromRangeAddress(address));
+        }
+
         public bool Equals(XLBookArea other)
         {
             return Area == other.Area && XLHelper.SheetComparer.Equals(Name, other.Name);

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -150,6 +150,7 @@ internal class StylesWriter
         foreach (var styleId in styles.CellStyles.Keys)
             cellStylesMap.Add(styleId);
 
+        cellStylesMap.Sort();
         if (cellStylesMap.Count > 0)
             WriteCellStyleXfs(xml, cellStylesMap, numberFormatMap, fontFormatsMap, fillsFormatsMap, borderFormatsMap);
 

--- a/ClosedXML/Excel/IO/StylesWriter.cs
+++ b/ClosedXML/Excel/IO/StylesWriter.cs
@@ -102,28 +102,12 @@ internal class StylesWriter
         xml.WriteStartDocument("styleSheet", _ns);
 
         // Number formats
-        var numberFormatMap = new SequentialMap<int, string>(styles.NumberFormats);
+        // The map has predefined formats from index 0 and the user defined ones from 164 onward.
+        // There is a gap between predefined formats.
+        var predefinedNumberFormats = XLPredefinedFormat.FormatCodes.OrderBy(x => x.Key).Select(x => x.Value).ToArray();
+        var numberFormatMap = SequentialMap<int, string>.Create(usedNumberFormats, styles.NumberFormats, FirstUserDefinedFormatIndex, predefinedNumberFormats);
 
-        // Add identity map for predefined formats. That way they can be always be mapped. If there
-        // is a workbook that uses predefined ids for a different format (e.g., numId=0 with format
-        // "0.00"), it should be dealt in the loading code.
-        for (var i = 0; i < FirstUserDefinedFormatIndex; ++i)
-            numberFormatMap.Add(i);
-
-        foreach (var (actualId, format) in styles.NumberFormats)
-        {
-            if (!usedNumberFormats.Contains(format))
-                continue;
-
-            // Predefined formats were already added in the identity map and don't need to be written.
-            if (XLPredefinedFormat.NumberFormatIds.ContainsKey(format))
-                continue;
-
-            numberFormatMap.Add(actualId);
-        }
-
-        numberFormatMap.Sort();
-        if (numberFormatMap.Count > FirstUserDefinedFormatIndex)
+        if (numberFormatMap.Count > predefinedNumberFormats.Length)
             WriteNumberFormats(xml, numberFormatMap);
 
         // Fonts. Register default format font as font zero. The font zero is used for font name and size.
@@ -143,7 +127,7 @@ internal class StylesWriter
         if (borderFormatsMap.Count > 0)
             WriteBorders(xml, borderFormatsMap);
 
-        // TODO: Ensure normal style is written, though that should be done during initialization/loading
+        // TODO Styles: Ensure normal style is written, though that should be done during initialization/loading
         var cellStylesMap = new SequentialMap<StyleId, XLCellStyleValue>(styles.CellStyles);
 
         // All cell styles, regardless if they are used or not should be written to the file
@@ -476,17 +460,10 @@ internal class StylesWriter
         foreach (var (_, cellStyle) in cellStylesMap.GetActual())
         {
             xml.WriteStartElement("xf", _ns);
-            if (cellStyle.NumberFormat is not null)
-                xml.WriteAttributeOptional("numFmtId", numFmtIdMap.GetSavedId(cellStyle.NumberFormat));
-
-            if (cellStyle.Font is not null)
-                xml.WriteAttributeOptional("fontId", fontIdMap.GetSavedId(cellStyle.Font));
-
-            if (cellStyle.Fill is not null)
-                xml.WriteAttributeOptional("fillId", fillIdMap.GetSavedId(cellStyle.Fill));
-
-            if (cellStyle.Border is not null)
-                xml.WriteAttributeOptional("borderId", borderIdMap.GetSavedId(cellStyle.Border));
+            xml.WriteAttributeOptional("numFmtId", numFmtIdMap.GetSavedId(cellStyle.NumberFormat));
+            xml.WriteAttributeOptional("fontId", fontIdMap.GetSavedId(cellStyle.Font));
+            xml.WriteAttributeOptional("fillId", fillIdMap.GetSavedId(cellStyle.Fill));
+            xml.WriteAttributeOptional("borderId", borderIdMap.GetSavedId(cellStyle.Border));
 
             // cellStyleXf doesn't use quote, pivot button or xfId -> skip those attributes
             xml.WriteAttributeDefault("applyNumberFormat", cellStyle.IncludedComponents.HasFlag(CellFormatComponents.NumberFormat), true);
@@ -524,22 +501,10 @@ internal class StylesWriter
         {
             xml.WriteStartElement("xf", _ns);
 
-            if (cellXf.NumberFormat is not null)
-            {
-                if (!XLPredefinedFormat.NumberFormatIds.TryGetValue(cellXf.NumberFormat, out var numFmtId))
-                    numFmtId = numFmtIdMap.GetSavedId(cellXf.NumberFormat);
-
-                xml.WriteAttributeOptional("numFmtId", numFmtId);
-            }
-
-            if (cellXf.Font is not null)
-                xml.WriteAttributeOptional("fontId", fontIdMap.GetSavedId(cellXf.Font));
-
-            if (cellXf.Fill is not null)
-                xml.WriteAttributeOptional("fillId", fillIdMap.GetSavedId(cellXf.Fill));
-
-            if (cellXf.Border is not null)
-                xml.WriteAttributeOptional("borderId", borderIdMap.GetSavedId(cellXf.Border));
+            xml.WriteAttributeOptional("numFmtId", numFmtIdMap.GetSavedId(cellXf.NumberFormat));
+            xml.WriteAttributeOptional("fontId", fontIdMap.GetSavedId(cellXf.Font));
+            xml.WriteAttributeOptional("fillId", fillIdMap.GetSavedId(cellXf.Fill));
+            xml.WriteAttributeOptional("borderId", borderIdMap.GetSavedId(cellXf.Border));
 
             if (cellXf.CellStyleId is not null)
                 xml.WriteAttributeDefault("xfId", cellStyleIdMap.GetSavedId(cellXf.CellStyleId.Value), 0);
@@ -811,9 +776,7 @@ internal class StylesWriter
         /// <summary>
         /// The index is the one that is used to save the <typeparamref name="T"/> while value is an index to the <c>_fullMap</c>.
         /// </summary>
-        private readonly List<TKey> _savedIdToActualId = new();
-
-        private readonly int _offset;
+        private readonly Dictionary<int, TKey> _savedIdToActualId = new();
 
         private readonly IReadOnlyBiDictionary<TKey, T> _fullMap;
 
@@ -823,10 +786,9 @@ internal class StylesWriter
         /// </summary>
         private List<(int SaveId, T Actual)>? _saveTable;
 
-        public SequentialMap(IReadOnlyBiDictionary<TKey, T> fullMap, int offset = 0)
+        public SequentialMap(IReadOnlyBiDictionary<TKey, T> fullMap)
         {
             _fullMap = fullMap;
-            _offset = offset;
         }
 
         /// <summary>
@@ -834,15 +796,19 @@ internal class StylesWriter
         /// </summary>
         public int Count => _savedIdToActualId.Count;
 
-        internal static SequentialMap<TKey, T> Create(HashSet<T> usedValues, IReadOnlyBiDictionary<TKey, T> allValuesMap, int offset = 0, params T[] firstValues)
+        internal static SequentialMap<TKey, T> Create(HashSet<T> usedValues, IReadOnlyBiDictionary<TKey, T> allValuesMap, int usedStart = 0, params T[] firstValues)
         {
-            var map = new SequentialMap<TKey, T>(allValuesMap, offset);
+            var map = new SequentialMap<TKey, T>(allValuesMap);
             foreach (var firstValue in firstValues)
             {
                 var actualId = allValuesMap[firstValue];
                 map.Add(actualId);
             }
 
+            // This is here basically for number formats. It ensures that user defined number
+            // formats start at 164 and the 0-164 is reserved for predefined formats.
+            // Number formats is the only table that can have gaps in the ids.
+            var usedSaveId = Math.Max(map.Count, usedStart);
             foreach (var (actualId, value) in allValuesMap)
             {
                 if (firstValues.Contains(value))
@@ -851,7 +817,7 @@ internal class StylesWriter
                 if (!usedValues.Contains(value))
                     continue;
 
-                map.Add(actualId);
+                map.Add(actualId, usedSaveId++);
             }
 
             map.Sort();
@@ -860,13 +826,18 @@ internal class StylesWriter
 
         public void Add(TKey actualId)
         {
-            _savedIdToActualId.Add(actualId);
+            _savedIdToActualId.Add(_savedIdToActualId.Count, actualId);
+        }
+
+        private void Add(TKey actualId, int saveId)
+        {
+            _savedIdToActualId.Add(saveId, actualId);
         }
 
         public void Sort()
         {
             _saveTable = _savedIdToActualId
-                .Select((actualId, saveId) => (saveId + _offset, _fullMap[actualId]))
+                .Select(x => (x.Key, _fullMap[x.Value]))
                 .OrderBy(x => x.Item1)
                 .ToList();
         }
@@ -884,8 +855,14 @@ internal class StylesWriter
 
         public int GetSavedId(TKey actualId)
         {
-            // TODO: make another identity map, plus this returns -1 on error
-            return _savedIdToActualId.IndexOf(actualId);
+            // TODO Styles: Use a better better internal structure
+            foreach (var (mapSaveId, mapActualId) in _savedIdToActualId)
+            {
+                if (mapActualId.Equals(actualId))
+                    return mapSaveId;
+            }
+
+            throw new InvalidOperationException($"Unable to find saveId for {actualId} of {typeof(T).Name}.");
         }
     }
 }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Methods and properties of <see cref="IXLStyle"/>. The <see cref="XLCellFormat"/> has many
+/// properties with same name, but different type, so the interface is explicitly implemented.
+/// </summary>
+internal partial class XLCellFormat : IXLStyle
+{
+    // TODO Styles: Implement remaining format properties by using IXLStyle contract
+    IXLAlignment IXLStyle.Alignment
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    IXLBorder IXLStyle.Border
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    IXLNumberFormat IXLStyle.DateFormat => throw new NotImplementedException();
+
+    IXLFill IXLStyle.Fill
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    IXLFont IXLStyle.Font
+    {
+        get => Font;
+        set => Font.SetFont(value);
+    }
+
+    bool IXLStyle.IncludeQuotePrefix
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    IXLNumberFormat IXLStyle.NumberFormat
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    IXLProtection IXLStyle.Protection
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    IXLStyle IXLStyle.SetIncludeQuotePrefix(bool includeQuotePrefix)
+    {
+        throw new NotImplementedException();
+    }
+
+    bool IEquatable<IXLStyle>.Equals(IXLStyle? other)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// A helper method that is used when a style if copied from one object to another.
+    /// For example, <c>rangeApi.Style = someOtherApi.Style</c>.
+    /// </summary>
+    internal void SetStyle(IXLStyle value)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -9,7 +9,7 @@ namespace ClosedXML.Excel;
 /// Unlike the <see cref="XLStyle"/>, the <see cref="XLCellFormat"/> one modifies formatting
 /// in a <see cref="XLWorkbookStyles"/>.
 /// </summary>
-internal class XLCellFormat
+internal partial class XLCellFormat
 {
     private readonly XLWorkbook _workbook;
     private readonly Hierarchy _formatValue;
@@ -112,6 +112,15 @@ internal class XLCellFormat
         return new XLCellFormat(workbook, formatValue)
         {
             DefaultFormat = true
+        };
+    }
+
+    internal static XLCellFormat ForCells(XLWorkbook workbook, IReadOnlyList<XLBookArea> areas, XLWorksheet? sheet)
+    {
+        var formatValue = new Hierarchy(workbook, sheet?.Name, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
+        {
+            Areas = areas
         };
     }
 

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
@@ -1,0 +1,169 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+internal partial class XLFontCellFormat : IXLFont
+{
+    // TODO Styles: Implement remaining format properties by using IXLFont contract
+    XLFontUnderlineValues IXLFontBase.Underline
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    bool IXLFontBase.Strikethrough
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    XLFontVerticalTextAlignmentValues IXLFontBase.VerticalAlignment
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    bool IXLFontBase.Shadow
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    double IXLFontBase.FontSize
+    {
+        get => Size.Points;
+        set => Size = XLFontSize.FromPoints(value);
+    }
+
+    XLColor IXLFontBase.FontColor
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    string IXLFontBase.FontName
+    {
+        get => Name.Text;
+        set => Name = value;
+    }
+
+    XLFontFamilyNumberingValues IXLFontBase.FontFamilyNumbering
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    XLFontCharSet IXLFontBase.FontCharSet
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    XLFontScheme IXLFontBase.FontScheme
+    {
+        get => throw new NotImplementedException();
+        set => throw new NotImplementedException();
+    }
+
+    bool IEquatable<IXLFont>.Equals(IXLFont? other)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetBold()
+    {
+        return ((IXLFont)this).SetBold(true);
+    }
+
+    IXLStyle IXLFont.SetBold(bool value)
+    {
+        Bold = value;
+        return _parent;
+    }
+
+    IXLStyle IXLFont.SetItalic()
+    {
+        return ((IXLFont)this).SetItalic(true);
+    }
+
+    IXLStyle IXLFont.SetItalic(bool value)
+    {
+        Italic = value;
+        return _parent;
+    }
+
+    IXLStyle IXLFont.SetUnderline()
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetUnderline(XLFontUnderlineValues value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetStrikethrough()
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetStrikethrough(bool value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetVerticalAlignment(XLFontVerticalTextAlignmentValues value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetShadow()
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetShadow(bool value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetFontSize(double value)
+    {
+        ((IXLFont)this).FontSize = value;
+        return _parent;
+    }
+
+    IXLStyle IXLFont.SetFontColor(XLColor value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetFontName(string value)
+    {
+        Name = value;
+        return _parent;
+    }
+
+    IXLStyle IXLFont.SetFontFamilyNumbering(XLFontFamilyNumberingValues value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetFontCharSet(XLFontCharSet value)
+    {
+        throw new NotImplementedException();
+    }
+
+    IXLStyle IXLFont.SetFontScheme(XLFontScheme value)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// A helper method to set all font properties at once (e.g, <c>someStyle.Font = otherStyle.Font</c>).
+    /// </summary>
+    internal void SetFont(IXLFont value)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Excel;
 /// <summary>
 /// API object to modify font properties of a cell format of a <see cref="IXLFormatContainer"/>.
 /// </summary>
-internal class XLFontCellFormat
+internal partial class XLFontCellFormat
 {
     private readonly XLCellFormat _parent;
 
@@ -33,13 +33,10 @@ internal class XLFontCellFormat
         set => Modify(static (font, italic) => font with { Italic = italic }, value);
     }
 
-    /// <summary>
-    /// Size in points.
-    /// </summary>
-    public double Size
+    public XLFontSize Size
     {
-        get => Resolve(static x => x.Font.Size).Points;
-        set => Modify(static (font, size) => font with { Size = size }, XLFontSize.FromPoints(value));
+        get => Resolve(static x => x.Font.Size);
+        set => Modify(static (font, size) => font with { Size = size }, value);
     }
 
     private T Resolve<T>(Func<XLCellFormatValue, T> selector)

--- a/ClosedXML/Excel/Style/IXLFont.cs
+++ b/ClosedXML/Excel/Style/IXLFont.cs
@@ -193,6 +193,10 @@ namespace ClosedXML.Excel
 
         IXLStyle SetShadow(); IXLStyle SetShadow(Boolean value);
 
+        /// <summary>
+        /// Set font size in points.
+        /// </summary>
+        /// <inheritdoc cref="IXLFontBase.FontSize"/>
         IXLStyle SetFontSize(Double value);
 
         IXLStyle SetFontColor(XLColor value);

--- a/ClosedXML/Excel/Style/IXLFontBase.cs
+++ b/ClosedXML/Excel/Style/IXLFontBase.cs
@@ -18,6 +18,14 @@ namespace ClosedXML.Excel
 
         Boolean Shadow { get; set; }
 
+        /// <summary>
+        /// Get or set font size in points.
+        /// </summary>
+        /// <value>
+        /// Font size is defined in twips and the passed value is rounded to nearest twips. Allowed
+        /// values are from 1pt to 409.55pt.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">Value is outside of allowed values 1pt to 409.55pt.</exception>
         Double FontSize { get; set; }
 
         XLColor FontColor { get; set; }

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -353,7 +353,10 @@ internal class XLWorkbookStyles
         styles.AddFillFormat(XLFillFormatValue.Gray125);
         styles.AddBorderFormat(XLBorderFormatValue.None);
         styles.AddCellStyle(0, normalStyle);
-        styles.AddFormat(XLCellFormatValue.FromStyle(0, normalStyle));
+
+        var defaultFormat = XLCellFormatValue.FromStyle(0, normalStyle);
+        styles.AddFormat(defaultFormat);
+        styles.DefaultFormat = defaultFormat;
 
         return styles;
     }


### PR DESCRIPTION
Part of WIP styles rework. Adds the `IXLStyle` interface to the `XLCellFormat`. Basically it allows for selected range API objects (currently `XLCells`) to use `XLCellFormat` instead of `XLStyle`, when `STYLES_REWORK` constant is defined. This is the key for the switch from current `XLStyle` to `XLCellFormat`.

The `XLCellFormat` implements only 4 font `IXLFont` interface properties for now (name, size, bold, italic), so not super useful, but others will be simple to add.

```csharp
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();
ws.Cells("B3:Z10000").Style.Font.FontSize = 20; // Set through XLCellFormat and bulk cell format apply 
wb.SaveAs("demo.xlsx"); // Styles part is saved through new StylesWriter
```
