### PR TITLE
Style rework - XLStylizedBase removal from ranges

### DIFF
--- a/ClosedXML.Tests/Excel/Columns/XLColumnsTests.cs
+++ b/ClosedXML.Tests/Excel/Columns/XLColumnsTests.cs
@@ -1,0 +1,37 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Columns;
+
+internal class XLColumnsTests
+{
+    [Test]
+    public void Style_sets_format_of_columns()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Columns("B-C,E").Style.Font.FontSize = 5;
+        ws.Range("A1:F1").Style.Font.Bold = true; // Materialize formats in row 1
+
+        var expected = new[]
+        {
+            (Column: "A", FontSize: 11),
+            (Column: "B", FontSize: 5),
+            (Column: "C", FontSize: 5),
+            (Column: "D", FontSize: 11),
+            (Column: "E", FontSize: 5),
+            (Column: "F", FontSize: 11),
+        };
+        foreach (var (column, fontSize) in expected)
+        {
+            Assert.AreEqual(fontSize, ws.Column(column).Style.Font.FontSize);
+
+            var cellWithFormat = ws.Cell(column + "1");
+            Assert.AreEqual(fontSize, cellWithFormat.Style.Font.FontSize);
+            Assert.True(cellWithFormat.Style.Font.Bold);
+
+            var nonMaterializedCell = ws.Cell(column + "2");
+            Assert.AreEqual(fontSize, nonMaterializedCell.Style.Font.FontSize);
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeColumnsTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeColumnsTests.cs
@@ -1,0 +1,26 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Ranges;
+
+internal class XLRangeColumnsTests
+{
+    [Test]
+    public void Style_sets_format_of_range_columns()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var range = ws.Range("B3:E4");
+        var rangeColumns = range.Columns("A,C-D");
+
+        rangeColumns.Style.Font.FontSize = 20;
+
+        var expectedChangedCells = new[] { "B3", "B4", "D3", "D4", "E3", "E4" }.ToHashSet();
+        foreach (var cell in range.Grow().Cells())
+        {
+            var address = cell.Address.ToString();
+            var fontSize = expectedChangedCells.Contains(address) ? 20 : 11;
+            Assert.AreEqual(fontSize, cell.Style.Font.FontSize);
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeRowsTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeRowsTests.cs
@@ -1,0 +1,26 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Ranges;
+
+internal class XLRangeRowsTests
+{
+    [Test]
+    public void Style_sets_format_of_range_rows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var range = ws.Range("B3:C7");
+        var rangeRows = range.Rows("1,3-4");
+
+        rangeRows.Style.Font.FontSize = 20;
+
+        var expectedChangedCells = new[] { "B3", "C3", "B5", "C5", "B6", "C6" }.ToHashSet();
+        foreach (var cell in range.Grow().Cells())
+        {
+            var address = cell.Address.ToString();
+            var fontSize = expectedChangedCells.Contains(address) ? 20 : 11;
+            Assert.AreEqual(fontSize, cell.Style.Font.FontSize, 0 , address);
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Rows/XLRowsTests.cs
+++ b/ClosedXML.Tests/Excel/Rows/XLRowsTests.cs
@@ -1,0 +1,37 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Rows;
+
+internal class XLRowsTests
+{
+    [Test]
+    public void Style_sets_format_of_rows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Rows("2,4-5").Style.Font.FontSize = 5;
+        ws.Range("A1:A6").Style.Font.Bold = true; // Materialize formats in column A
+
+        var expected = new[]
+        {
+            (Row: 1, FontSize: 11),
+            (Row: 2, FontSize: 5),
+            (Row: 3, FontSize: 11),
+            (Row: 4, FontSize: 5),
+            (Row: 5, FontSize: 5),
+            (Row: 6, FontSize: 11),
+        };
+        foreach (var (row, fontSize) in expected)
+        {
+            Assert.AreEqual(fontSize, ws.Row(row).Style.Font.FontSize);
+
+            var cellWithFormat = ws.Cell("A" + row);
+            Assert.AreEqual(fontSize, cellWithFormat.Style.Font.FontSize);
+            Assert.True(cellWithFormat.Style.Font.Bold);
+
+            var nonMaterializedCell = ws.Cell("B" + row);
+            Assert.AreEqual(fontSize, nonMaterializedCell.Style.Font.FontSize);
+        }
+    }
+}

--- a/ClosedXML.Tests/Excel/Tables/XLTableRowsTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/XLTableRowsTests.cs
@@ -1,0 +1,40 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Tables;
+
+internal class XLTableRowsTests
+{
+    [Test]
+    public void Style_sets_format_of_rows()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var table = ws.Cell("B3").InsertTable(new[]
+        {
+            new { Name = "Cake", Price = 7},
+            new { Name = "Waffle", Price = 4},
+            new { Name = "Croissant", Price = 5},
+            new { Name = "Pie", Price = 9 },
+        });
+        var rows = table.Rows(x => x.Cell(1).GetText().StartsWith("C"));
+
+        // Act
+        rows.Style.Font.FontSize = 20;
+
+        // Assert
+        var expectedChangedCells = new[]
+        {
+            "B4", "C4", // Cake row
+            "B6", "C6", // Croissant row
+        }.ToHashSet();
+
+        foreach (var cell in ws.Range("A2:D7").Cells())
+        {
+            var address = cell.Address.ToString();
+            var expectedFontSize = expectedChangedCells.Contains(address) ? 20 : 11;
+            Assert.AreEqual(expectedFontSize, cell.Style.Font.FontSize);
+        }
+    }
+}

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1160,11 +1160,6 @@ namespace ClosedXML.Excel
             Style = styleToUse;
         }
 
-        public Boolean IsDefaultWorksheetStyle()
-        {
-            return StyleValue == Worksheet.StyleValue;
-        }
-
         #endregion Styles
 
         public void DeleteComment()

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -6,12 +6,17 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    internal class XLColumns : XLStylizedBase, IXLColumns
+    internal class XLColumns :
+#if !STYLES_REWORK
+        XLStylizedBase,
+#endif
+        IXLColumns
     {
         private readonly List<XLColumn> _columnsCollection = new List<XLColumn>();
 
         private readonly XLWorkbook _workbook;
         private readonly XLWorksheet? _worksheet;
+        private readonly XLWorksheet? _defaultStyleSheet;
 
         /// <summary>
         /// This object represents all columns of the worksheet, even non-materialized ones.
@@ -34,10 +39,13 @@ namespace ClosedXML.Excel
         /// <param name="defaultStyleSheet">A sheet with a default style to use when initializing child entries.</param>
         /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLColumn"/> to support lazy initialization.</param>
         public XLColumns(XLWorkbook workbook, XLWorksheet? worksheet, XLWorksheet? defaultStyleSheet = null, IEnumerable<XLColumn>? lazyEnumerable = null)
+#if !STYLES_REWORK
             : base(defaultStyleSheet?.StyleValue)
+#endif
         {
             _workbook = workbook;
             _worksheet = worksheet;
+            _defaultStyleSheet = defaultStyleSheet;
             _lazyEnumerable = lazyEnumerable;
         }
 
@@ -222,8 +230,31 @@ namespace ClosedXML.Excel
             return this;
         }
 
+#if STYLES_REWORK
+        public IXLStyle Style
+        {
+            get => Format;
+            set => Format.SetStyle(value);
+        }
+#endif
+
+        internal XLCellFormat Format
+        {
+            get
+            {
+                if (AllColumnsOfSheet)
+                {
+                    return XLCellFormat.ForWorksheet(_worksheet);
+                }
+
+                var columns = Columns.Select(x => x.Area).ToArray();
+                return XLCellFormat.ForColumns(_workbook, _defaultStyleSheet, columns);
+            }
+        }
+
         #endregion IXLColumns Members
 
+#if !STYLES_REWORK
         #region IXLStylized Members
 
         protected override IEnumerable<XLStylizedBase> Children
@@ -251,7 +282,7 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
-
+#endif
         public void Add(XLColumn column)
         {
             Materialize();

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -31,10 +31,10 @@ namespace ClosedXML.Excel
         /// <param name="workbook">Workbook to which all columns belong.</param>
         /// <param name="worksheet">If worksheet is specified it means that the created instance represents
         /// all columns on a worksheet so changing its width will affect all columns.</param>
-        /// <param name="defaultStyle">Default style to use when initializing child entries.</param>
+        /// <param name="defaultStyleSheet">A sheet with a default style to use when initializing child entries.</param>
         /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLColumn"/> to support lazy initialization.</param>
-        public XLColumns(XLWorkbook workbook, XLWorksheet? worksheet, XLStyleValue? defaultStyle = null, IEnumerable<XLColumn>? lazyEnumerable = null)
-            : base(defaultStyle)
+        public XLColumns(XLWorkbook workbook, XLWorksheet? worksheet, XLWorksheet? defaultStyleSheet = null, IEnumerable<XLColumn>? lazyEnumerable = null)
+            : base(defaultStyleSheet?.StyleValue)
         {
             _workbook = workbook;
             _worksheet = worksheet;

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -1243,25 +1243,26 @@ internal class WorksheetPartReader
         }
     }
 
-    private static void ApplyStyle(IXLStylized xlStylized, Int32 styleIndex, XLWorkbookStyles styles)
+    private static void ApplyStyle<T>(T container, Int32 styleIndex, XLWorkbookStyles styles)
+        where T : IXLStylized, IXLFormatContainer
+    {
+        var xlStyleKey = XLStyle.Default.Key;
+        XLWorkbook.LoadStyle(ref xlStyleKey, styleIndex, styles);
+
+        container.InnerStyle = new XLStyle(container, xlStyleKey);
+        container.FormatValue = styles.CellFormats[styleIndex];
+    }
+
+    private static void ApplyStyle(XLColumns columns, Int32 styleIndex, XLWorkbookStyles styles)
     {
         var xlStyleKey = XLStyle.Default.Key;
         XLWorkbook.LoadStyle(ref xlStyleKey, styleIndex, styles);
 
         // When loading columns we must propagate style to each column but not deeper. In other cases we do not propagate at all.
-        if (xlStylized is IXLColumns columns)
+        columns.Cast<XLColumn>().ForEach(col =>
         {
-            columns.Cast<XLColumn>().ForEach(col =>
-            {
-                col.InnerStyle = new XLStyle(col, xlStyleKey);
-                col.FormatValue = styles.CellFormats[styleIndex];
-            });
-        }
-        else
-        {
-            xlStylized.InnerStyle = new XLStyle(xlStylized, xlStyleKey);
-            if (xlStylized is IXLFormatContainer formatContainer)
-                formatContainer.FormatValue = styles.CellFormats[styleIndex];
-        }
+            col.InnerStyle = new XLStyle(col, xlStyleKey);
+            col.FormatValue = styles.CellFormats[styleIndex];
+        });
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -1,23 +1,46 @@
 #nullable disable
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    using System.Collections;
-
-    internal class XLRangeColumns : XLStylizedBase, IXLRangeColumns
+    internal class XLRangeColumns :
+#if !STYLES_REWORK
+        XLStylizedBase,
+#endif
+        IXLRangeColumns
     {
         private readonly XLWorksheet _worksheet;
         private readonly List<XLRangeColumn> _ranges = new List<XLRangeColumn>();
 
-        public XLRangeColumns(XLWorksheet worksheet) : base(XLWorkbook.DefaultStyleValue)
+        public XLRangeColumns(XLWorksheet worksheet)
+#if !STYLES_REWORK
+            : base(XLWorkbook.DefaultStyleValue)
+#endif
         {
             _worksheet = worksheet;
         }
 
+        internal XLCellFormat Format
+        {
+            get
+            {
+                var columns = _ranges.Select(x => XLBookArea.From(x.RangeAddress)).ToArray();
+                return XLCellFormat.ForCells(_worksheet.Workbook, columns, null);
+            }
+        }
+
         #region IXLRangeColumns Members
+
+#if STYLES_REWORK
+        public IXLStyle Style
+        {
+            get => Format;
+            set => Format.SetStyle(value);
+        }
+#endif
 
         public IXLRangeColumns Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
@@ -82,8 +105,9 @@ namespace ClosedXML.Excel
 
         #endregion IXLRangeColumns Members
 
+#if !STYLES_REWORK
         #region IXLStylized Members
-        
+
         protected override IEnumerable<XLStylizedBase> Children
         {
             get
@@ -104,5 +128,6 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
+#endif
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -74,6 +74,12 @@ namespace ClosedXML.Excel
             return cells;
         }
 
+        public void Select()
+        {
+            foreach (var range in this)
+                range.Select();
+        }
+
         #endregion IXLRangeColumns Members
 
         #region IXLStylized Members
@@ -98,11 +104,5 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
-
-        public void Select()
-        {
-            foreach (var range in this)
-                range.Select();
-        }
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -74,6 +74,12 @@ namespace ClosedXML.Excel
             return cells;
         }
 
+        public void Select()
+        {
+            foreach (var range in this)
+                range.Select();
+        }
+
         #endregion IXLRangeRows Members
 
         #region IXLStylized Members
@@ -99,11 +105,5 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
-
-        public void Select()
-        {
-            foreach (var range in this)
-                range.Select();
-        }
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -1,23 +1,46 @@
 #nullable disable
 
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    using System.Collections;
-
-    internal class XLRangeRows : XLStylizedBase, IXLRangeRows
+    internal class XLRangeRows :
+#if !STYLES_REWORK
+        XLStylizedBase,
+#endif
+        IXLRangeRows
     {
         private readonly XLWorksheet _worksheet;
         private readonly List<XLRangeRow> _ranges = new List<XLRangeRow>();
 
-        public XLRangeRows(XLWorksheet worksheet) : base(XLStyle.Default.Value)
+        public XLRangeRows(XLWorksheet worksheet)
+#if !STYLES_REWORK
+            : base(XLStyle.Default.Value)
+#endif
         {
             _worksheet = worksheet;
         }
 
+        internal XLCellFormat Format
+        {
+            get
+            {
+                var areas = _ranges.Select(x => XLBookArea.From(x.RangeAddress)).ToArray();
+                return XLCellFormat.ForCells(_worksheet.Workbook, areas, null);
+            }
+        }
+
         #region IXLRangeRows Members
+
+#if STYLES_REWORK
+        public IXLStyle Style
+        {
+            get => Format;
+            set => Format.SetStyle(value);
+        }
+#endif
 
         public IXLRangeRows Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
@@ -82,6 +105,7 @@ namespace ClosedXML.Excel
 
         #endregion IXLRangeRows Members
 
+#if !STYLES_REWORK
         #region IXLStylized Members
 
         protected override IEnumerable<XLStylizedBase> Children
@@ -92,7 +116,6 @@ namespace ClosedXML.Excel
                     yield return range;
             }
         }
-
 
         public override IEnumerable<IXLRange> RangesUsed
         {
@@ -105,5 +128,6 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
+#endif
     }
 }

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -593,15 +593,6 @@ namespace ClosedXML.Excel
             return AdjustToContents(1);
         }
 
-        internal void SetStyleNoColumns(IXLStyle value)
-        {
-            InnerStyle = value;
-
-            int row = RowNumber();
-            foreach (XLCell c in Worksheet.Internals.CellsCollection.GetCellsInRow(row))
-                c.InnerStyle = value;
-        }
-
         private XLRow RowShift(Int32 rowsToShift)
         {
             return Worksheet.Row(RowNumber() + rowsToShift);

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -6,11 +6,16 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    internal class XLRows : XLStylizedBase, IXLRows
+    internal class XLRows :
+#if !STYLES_REWORK
+        XLStylizedBase,
+#endif
+        IXLRows
     {
         private readonly List<XLRow> _rowsCollection = new List<XLRow>();
         private readonly XLWorkbook _workbook;
         private readonly XLWorksheet? _worksheet;
+        private readonly XLWorksheet? _defaultStyleSheet;
 
         /// <summary>
         /// This object represents all rows of the worksheet, even non-materialized ones.
@@ -32,10 +37,13 @@ namespace ClosedXML.Excel
         /// <param name="defaultStyleSheet">A sheet with a default style to use when initializing child entries.</param>
         /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLRow"/> to support lazy initialization.</param>
         public XLRows(XLWorkbook workbook, XLWorksheet? worksheet, XLWorksheet? defaultStyleSheet = null, IEnumerable<XLRow>? lazyEnumerable = null)
+#if !STYLES_REWORK
             : base(defaultStyleSheet?.StyleValue)
+#endif
         {
             _workbook = workbook;
             _worksheet = worksheet;
+            _defaultStyleSheet = defaultStyleSheet;
             _lazyEnumerable = lazyEnumerable;
         }
 
@@ -210,8 +218,32 @@ namespace ClosedXML.Excel
             return this;
         }
 
+#if STYLES_REWORK
+        public IXLStyle Style
+        {
+            get => Format;
+            set => Format.SetStyle(value);
+        }
+#endif
+
+        internal XLCellFormat Format
+        {
+            get
+            {
+                if (AllRowsOfSheet)
+                {
+                    return XLCellFormat.ForWorksheet(_worksheet);
+                }
+
+                var rows = Rows.Select(x => x.Area).ToArray();
+                return XLCellFormat.ForRows(_workbook, _defaultStyleSheet, rows);
+
+            }
+        }
+
         #endregion IXLRows Members
 
+#if !STYLES_REWORK
         #region IXLStylized Members
 
         protected override IEnumerable<XLStylizedBase> Children
@@ -239,6 +271,7 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
+#endif
 
         public void Add(XLRow row)
         {

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -29,10 +29,10 @@ namespace ClosedXML.Excel
         /// <param name="workbook">Workbook of the rows.</param>
         /// <param name="worksheet">If worksheet is specified it means that the created instance represents
         /// all rows on a worksheet so changing its height will affect all rows.</param>
-        /// <param name="defaultStyle">Default style to use when initializing child entries.</param>
+        /// <param name="defaultStyleSheet">A sheet with a default style to use when initializing child entries.</param>
         /// <param name="lazyEnumerable">A predefined enumerator of <see cref="XLRow"/> to support lazy initialization.</param>
-        public XLRows(XLWorkbook workbook, XLWorksheet? worksheet, XLStyleValue? defaultStyle = null, IEnumerable<XLRow>? lazyEnumerable = null)
-            : base(defaultStyle)
+        public XLRows(XLWorkbook workbook, XLWorksheet? worksheet, XLWorksheet? defaultStyleSheet = null, IEnumerable<XLRow>? lazyEnumerable = null)
+            : base(defaultStyleSheet?.StyleValue)
         {
             _workbook = workbook;
             _worksheet = worksheet;

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -84,7 +84,7 @@ internal partial class XLCellFormat
         };
     }
 
-    public static XLCellFormat ForColumns(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLColumnArea> columns)
+    internal static XLCellFormat ForColumns(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLColumnArea> columns)
     {
         var formatValue = new Hierarchy(workbook, formatValueSheet?.Name, null, null, null);
         return new XLCellFormat(workbook, formatValue)
@@ -106,7 +106,7 @@ internal partial class XLCellFormat
         };
     }
 
-    public static XLCellFormat ForRows(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLRowArea> rows)
+    internal static XLCellFormat ForRows(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLRowArea> rows)
     {
         var formatValue = new Hierarchy(workbook, formatValueSheet?.Name, null, null, null);
         return new XLCellFormat(workbook, formatValue)

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using ClosedXML.Excel.Formatting;
 
 namespace ClosedXML.Excel;
@@ -83,6 +84,16 @@ internal partial class XLCellFormat
         };
     }
 
+    public static XLCellFormat ForColumns(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLColumnArea> columns)
+    {
+        var formatValue = new Hierarchy(workbook, formatValueSheet?.Name, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
+        {
+            Columns = columns,
+            UsedAreas = columns.Select(x => x.Area).ToArray()
+        };
+    }
+
     internal static XLCellFormat ForRow(XLRow row)
     {
         var workbook = row.Worksheet.Workbook;
@@ -92,6 +103,16 @@ internal partial class XLCellFormat
         {
             UsedAreas = new[] { rowArea.Area },
             Rows = new[] { rowArea }
+        };
+    }
+
+    public static XLCellFormat ForRows(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLRowArea> rows)
+    {
+        var formatValue = new Hierarchy(workbook, formatValueSheet?.Name, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
+        {
+            Rows = rows,
+            UsedAreas = rows.Select(x => x.Area).ToArray()
         };
     }
 

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -145,6 +145,16 @@ internal partial class XLCellFormat
         };
     }
 
+    internal static XLCellFormat ForTableRows(XLWorksheet sheet, XLBookArea[] rowAreas)
+    {
+        var workbook = sheet.Workbook;
+        var formatValue = new Hierarchy(workbook, sheet.Name, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
+        {
+            Areas = rowAreas
+        };
+    }
+
     internal T Resolve<T>(Func<XLCellFormatValue, T> selector)
     {
         var format = _formatValue.Resolve();

--- a/ClosedXML/Excel/Tables/XLTableRows.cs
+++ b/ClosedXML/Excel/Tables/XLTableRows.cs
@@ -5,16 +5,24 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    internal class XLTableRows : XLStylizedBase, IXLTableRows
+    internal class XLTableRows :
+#if !STYLES_REWORK
+        XLStylizedBase,
+#endif
+        IXLTableRows
     {
         private readonly XLWorksheet _worksheet;
         private readonly List<XLTableRow> _ranges = new List<XLTableRow>();
 
-        public XLTableRows(XLWorksheet worksheet) : base(((XLStyle)worksheet.Style).Value)
+        public XLTableRows(XLWorksheet worksheet)
+#if !STYLES_REWORK
+            : base(((XLStyle)worksheet.Style).Value)
+#endif
         {
             _worksheet = worksheet;
         }
 
+#if !STYLES_REWORK
         #region IXLStylized Members
 
         protected override IEnumerable<XLStylizedBase> Children
@@ -39,8 +47,17 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLStylized Members
+#endif
 
         #region IXLTableRows Members
+
+#if STYLES_REWORK
+        public IXLStyle Style
+        {
+            get => Format;
+            set => Format.SetStyle(value);
+        }
+#endif
 
         public IXLTableRows Clear(XLClearOptions clearOptions = XLClearOptions.All)
         {
@@ -102,12 +119,21 @@ namespace ClosedXML.Excel
             return cells;
         }
 
-        #endregion IXLTableRows Members
-
         public void Select()
         {
             foreach (var range in this)
                 range.Select();
+        }
+
+        #endregion IXLTableRows Members
+
+        internal XLCellFormat Format
+        {
+            get
+            {
+                var rowAreas = _ranges.Select(x => XLBookArea.From(x.RangeAddress)).ToArray();
+                return XLCellFormat.ForTableRows(_worksheet, rowAreas);
+            }
         }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -683,7 +683,7 @@ namespace ClosedXML.Excel
 
         public IXLRows FindRows(Func<IXLRow, Boolean> predicate)
         {
-            var rows = new XLRows(this, worksheet: null);
+            var rows = new XLRows(this, worksheet: null, defaultStyleSheet: null);
             foreach (XLWorksheet ws in WorksheetsInternal)
             {
                 foreach (IXLRow row in ws.Rows().Where(predicate))
@@ -694,7 +694,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns FindColumns(Func<IXLColumn, Boolean> predicate)
         {
-            var columns = new XLColumns(this, worksheet: null);
+            var columns = new XLColumns(this, worksheet: null, defaultStyleSheet: null);
             foreach (XLWorksheet ws in WorksheetsInternal)
             {
                 foreach (IXLColumn column in ws.Columns().Where(predicate))

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -340,13 +340,13 @@ namespace ClosedXML.Excel
             columnMap.UnionWith(Internals.CellsCollection.ColumnsUsedKeys);
             columnMap.UnionWith(Internals.ColumnsCollection.Keys);
 
-            var retVal = new XLColumns(Workbook, this, StyleValue, columnMap.Select(Column));
+            var retVal = new XLColumns(Workbook, this, this, columnMap.Select(Column));
             return retVal;
         }
 
         public IXLColumns Columns(String columns)
         {
-            var retVal = new XLColumns(Workbook, null, StyleValue);
+            var retVal = new XLColumns(Workbook, null, this);
             var columnPairs = columns.Split(',');
             foreach (string tPair in columnPairs.Select(pair => pair.Trim()))
             {
@@ -386,7 +386,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns Columns(Int32 firstColumn, Int32 lastColumn)
         {
-            var retVal = new XLColumns(Workbook, null, StyleValue);
+            var retVal = new XLColumns(Workbook, null, this);
 
             for (int co = firstColumn; co <= lastColumn; co++)
                 retVal.Add(Column(co));
@@ -400,13 +400,13 @@ namespace ClosedXML.Excel
             rowMap.UnionWith(Internals.CellsCollection.RowsUsedKeys);
             rowMap.UnionWith(Internals.RowsCollection.Keys);
 
-            var retVal = new XLRows(Workbook, this, StyleValue, rowMap.Select(Row));
+            var retVal = new XLRows(Workbook, this, this, rowMap.Select(Row));
             return retVal;
         }
 
         public IXLRows Rows(String rows)
         {
-            var retVal = new XLRows(Workbook, null, StyleValue);
+            var retVal = new XLRows(Workbook, null, this);
             var rowPairs = rows.Split(',');
             foreach (string tPair in rowPairs.Select(pair => pair.Trim()))
             {
@@ -432,7 +432,7 @@ namespace ClosedXML.Excel
 
         public IXLRows Rows(Int32 firstRow, Int32 lastRow)
         {
-            var retVal = new XLRows(Workbook, null, StyleValue);
+            var retVal = new XLRows(Workbook, null, this);
 
             for (int ro = firstRow; ro <= lastRow; ro++)
                 retVal.Add(Row(ro));
@@ -981,7 +981,7 @@ namespace ClosedXML.Excel
 
         public IXLRows RowsUsed(XLCellsUsedOptions options = XLCellsUsedOptions.AllContents, Func<IXLRow, Boolean>? predicate = null)
         {
-            var rows = new XLRows(Workbook, worksheet: null, StyleValue);
+            var rows = new XLRows(Workbook, worksheet: null, this);
             var rowsUsed = new HashSet<Int32>();
             foreach (var rowNum in Internals.RowsCollection.Keys.Concat(Internals.CellsCollection.RowsUsedKeys))
             {
@@ -1003,7 +1003,7 @@ namespace ClosedXML.Excel
 
         public IXLColumns ColumnsUsed(XLCellsUsedOptions options = XLCellsUsedOptions.AllContents, Func<IXLColumn, Boolean>? predicate = null)
         {
-            var columns = new XLColumns(Workbook, worksheet: null, StyleValue);
+            var columns = new XLColumns(Workbook, worksheet: null, defaultStyleSheet: this);
             var columnsUsed = new HashSet<Int32>();
             Internals.ColumnsCollection.Keys.ForEach(r => columnsUsed.Add(r));
             Internals.CellsCollection.ColumnsUsedKeys.ForEach(r => columnsUsed.Add(r));


### PR DESCRIPTION
Continuation of a style rework. Several range API objects (`IXLRangeColumns`, `IXLRangeRows`, `IXLColumns`, `IXLRows`, `IXLTableRows` and few others) were derived from the `XLStylizedBase` and this PR removes that inheritance.

The part of styles rework architecture is to replace the inheritance with composition (derivation from `XLStylizedBase` with creation of a new format API proxy object `XLCellFormat`). In order to do it in phases, there is `STYLES_REWORK` constant that is used to switch between the current implementation and the reworked one.

Because it must compile in both, there are sometimes some weird intermediate changes. In this PR it is change of `XLRows`/`XLColumns` ctor parameter from `StyleValue` (going way of the dodo) to `XLWorksheet`.
