### PR TITLE
Style rework - Add IXLFont implementation

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -34,7 +34,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
         [Test]
         [TestCaseSource(nameof(FontProperties))]
-        public void Font_property_can_be_set(IFormatTestCase<IXLFont> testCase)
+        public void Font_property_can_be_individually_set(IFormatTestCase<IXLFont> testCase)
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -47,6 +47,45 @@ namespace ClosedXML.Tests.Excel.Styles
                 var setValue = testCase.GetPropertyValue(cellFormat.Font);
                 Assert.AreEqual(testValue, setValue);
             }
+        }
+
+        [Test]
+        public void Font_can_be_set_by_assigning_font()
+        {
+            // Arrange
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Style
+                .Font.SetBold()
+                .Font.SetItalic()
+                .Font.SetUnderline(XLFontUnderlineValues.DoubleAccounting)
+                .Font.SetStrikethrough()
+                .Font.SetVerticalAlignment(XLFontVerticalTextAlignmentValues.Superscript)
+                .Font.SetShadow()
+                .Font.SetFontSize(25)
+                .Font.SetFontColor(XLColor.Red)
+                .Font.SetFontName("Arial")
+                .Font.SetFontFamilyNumbering(XLFontFamilyNumberingValues.Decorative)
+                .Font.SetFontCharSet(XLFontCharSet.Hangul)
+                .Font.SetFontScheme(XLFontScheme.Minor);
+
+            // Act
+            ws.Cell("A2").Style.Font = ws.Cell("A1").Style.Font;
+
+            // Assert
+            var copiedFont = ws.Cell("A2").Style.Font;
+            Assert.IsTrue(copiedFont.Bold);
+            Assert.IsTrue(copiedFont.Italic);
+            Assert.AreEqual(XLFontUnderlineValues.DoubleAccounting, copiedFont.Underline);
+            Assert.IsTrue(copiedFont.Strikethrough);
+            Assert.AreEqual(XLFontVerticalTextAlignmentValues.Superscript, copiedFont.VerticalAlignment);
+            Assert.IsTrue(copiedFont.Shadow);
+            Assert.AreEqual(25, copiedFont.FontSize);
+            Assert.AreEqual(XLColor.Red, copiedFont.FontColor);
+            Assert.AreEqual("Arial", copiedFont.FontName);
+            Assert.AreEqual(XLFontFamilyNumberingValues.Decorative, copiedFont.FontFamilyNumbering);
+            Assert.AreEqual(XLFontCharSet.Hangul, copiedFont.FontCharSet);
+            Assert.AreEqual(XLFontScheme.Minor, copiedFont.FontScheme);
         }
 
         private static IEnumerable<object> FontProperties()

--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -59,11 +59,50 @@ namespace ClosedXML.Tests.Excel.Styles
             yield return new FontTestCase<bool>(font => font.Italic, (font, value) => font.SetItalic(value), true, false);
             yield return new FontTestCase<bool>(font => font.Italic, (font, _) => font.SetItalic(), true);
 
-            yield return new FontTestCase<string>(font => font.FontName, (font, value) => font.FontName = value, "Calibri", "Arial", "Consolas");
-            yield return new FontTestCase<string>(font => font.FontName, (font, value) => font.SetFontName(value), "Calibri", "Arial", "Consolas");
+            var underlineValues = GetEnumValues<XLFontUnderlineValues>();
+            yield return new FontTestCase<XLFontUnderlineValues>(font => font.Underline, (font, value) => font.Underline = value, underlineValues);
+            yield return new FontTestCase<XLFontUnderlineValues>(font => font.Underline, (font, value) => font.SetUnderline(value), underlineValues);
+            yield return new FontTestCase<XLFontUnderlineValues>(font => font.Underline, (font, _) => font.SetUnderline(), XLFontUnderlineValues.Single);
+
+            yield return new FontTestCase<bool>(font => font.Strikethrough, (font, value) => font.Strikethrough = value, true, false);
+            yield return new FontTestCase<bool>(font => font.Strikethrough, (font, value) => font.SetStrikethrough(value), true, false);
+            yield return new FontTestCase<bool>(font => font.Strikethrough, (font, _) => font.SetStrikethrough(), true);
+
+            var valignValues = GetEnumValues<XLFontVerticalTextAlignmentValues>();
+            yield return new FontTestCase<XLFontVerticalTextAlignmentValues>(font => font.VerticalAlignment, (font, value) => font.VerticalAlignment = value, valignValues);
+            yield return new FontTestCase<XLFontVerticalTextAlignmentValues>(font => font.VerticalAlignment, (font, value) => font.SetVerticalAlignment(value), valignValues);
+
+            yield return new FontTestCase<bool>(font => font.Shadow, (font, value) => font.Shadow = value, true, false);
+            yield return new FontTestCase<bool>(font => font.Shadow, (font, value) => font.SetShadow(value), true, false);
+            yield return new FontTestCase<bool>(font => font.Shadow, (font, _) => font.SetShadow(), true);
 
             yield return new FontTestCase<double>(font => font.FontSize, (font, value) => font.FontSize = value, 1, 15, 409.55);
             yield return new FontTestCase<double>(font => font.FontSize, (font, value) => font.SetFontSize(value), 1, 15, 409.55);
+
+            yield return new FontTestCase<XLColor>(font => font.FontColor, (font, value) => font.FontColor = value, XLColor.Black, XLColor.Red, XLColor.Auto);
+            yield return new FontTestCase<XLColor>(font => font.FontColor, (font, value) => font.SetFontColor(value), XLColor.Black, XLColor.Red, XLColor.Auto);
+
+            yield return new FontTestCase<string>(font => font.FontName, (font, value) => font.FontName = value, "Calibri", "Arial", "Consolas");
+            yield return new FontTestCase<string>(font => font.FontName, (font, value) => font.SetFontName(value), "Calibri", "Arial", "Consolas");
+
+            var familyValues = GetEnumValues<XLFontFamilyNumberingValues>();
+            yield return new FontTestCase<XLFontFamilyNumberingValues>(font => font.FontFamilyNumbering, (font, value) => font.FontFamilyNumbering = value, familyValues);
+            yield return new FontTestCase<XLFontFamilyNumberingValues>(font => font.FontFamilyNumbering, (font, value) => font.SetFontFamilyNumbering(value), familyValues);
+
+            var charsetValues = GetEnumValues<XLFontCharSet>();
+            yield return new FontTestCase<XLFontCharSet>(font => font.FontCharSet, (font, value) => font.FontCharSet = value, charsetValues);
+            yield return new FontTestCase<XLFontCharSet>(font => font.FontCharSet, (font, value) => font.SetFontCharSet(value), charsetValues);
+
+            var schemeValues = GetEnumValues<XLFontScheme>();
+            yield return new FontTestCase<XLFontScheme>(font => font.FontScheme, (font, value) => font.FontScheme = value, schemeValues);
+            yield return new FontTestCase<XLFontScheme>(font => font.FontScheme, (font, value) => font.SetFontScheme(value), schemeValues);
+        }
+
+        // TODO: Replace with EnumPolyfill once Polyfill is updated
+        private static T[] GetEnumValues<T>()
+            where T : struct, Enum
+        {
+            return Enum.GetValues(typeof(T)).Cast<T>().ToArray();
         }
 
         private class FontTestCase<T> : IFormatTestCase<IXLFont>

--- a/ClosedXML.Tests/Excel/Styles/FontTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/FontTests.cs
@@ -88,6 +88,39 @@ namespace ClosedXML.Tests.Excel.Styles
             Assert.AreEqual(XLFontScheme.Minor, copiedFont.FontScheme);
         }
 
+        [Test]
+        public void Font_can_be_checked_for_equality()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var testFont = ws.Cell("A1").Style.Font;
+            var equalFont = ws.Cell("A2").Style.Font;
+
+            Assert.AreEqual(testFont, equalFont);
+            var makeDifferentFont = new Action<IXLFont>[]
+            {
+                x => x.Bold = !x.Bold,
+                x => x.Italic = !x.Italic,
+                x => x.Underline = XLFontUnderlineValues.DoubleAccounting,
+                x => x.Strikethrough = !x.Strikethrough,
+                x => x.VerticalAlignment = XLFontVerticalTextAlignmentValues.Superscript,
+                x => x.Shadow = !x.Shadow,
+                x => x.FontSize = 25,
+                x => x.FontColor = XLColor.Blue,
+                x => x.FontName = "Arial",
+                x => x.FontFamilyNumbering = XLFontFamilyNumberingValues.Decorative,
+                x => x.FontCharSet = XLFontCharSet.Arabic,
+                x => x.FontScheme = XLFontScheme.Minor,
+            };
+            var cell = ws.Cell("A3");
+            foreach (var modify in makeDifferentFont)
+            {
+                modify(cell.Style.Font);
+                Assert.AreNotEqual(testFont, cell.Style.Font);
+                cell = cell.CellRight();
+            }
+        }
+
         private static IEnumerable<object> FontProperties()
         {
             yield return new FontTestCase<bool>(font => font.Bold, (font, value) => font.Bold = value, true, false);

--- a/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/NumberFormatTests.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 
-namespace ClosedXML.Tests.Excel
+namespace ClosedXML.Tests.Excel.Styles
 {
     public class NumberFormatTests
     {
@@ -126,6 +126,65 @@ namespace ClosedXML.Tests.Excel
                     return wb;
                 }, @"Other\NumberFormats\NonSequentialNumberFormatsIds-Output.xlsx");
             }
+        }
+
+        [Test]
+        public void NumberFormatId_sets_format_to_predefined_format()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var cellFormat = ws.Cell("A1").Style;
+            const int predefinedFormatId = (int)XLPredefinedFormat.Number.Precision2;
+
+            cellFormat.NumberFormat.NumberFormatId = predefinedFormatId;
+
+            Assert.AreEqual(predefinedFormatId, cellFormat.NumberFormat.NumberFormatId);
+            Assert.AreEqual("0.00", cellFormat.NumberFormat.Format);
+        }
+
+        [Test]
+        public void NumberFormatId_throws_on_non_predefined_formats()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ws.Cell("A1").Style.NumberFormat.NumberFormatId = 160);
+        }
+
+        [TestCase("0.000000 Cute", -1)]
+        [TestCase("0.00", XLPredefinedFormat.Number.Precision2)]
+        public void Format_sets_number_format(string numberFormat, int numFmtId)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Cell("A1").Style.NumberFormat.Format = numberFormat;
+
+            Assert.AreEqual(numberFormat, ws.Cell("A1").Style.NumberFormat.Format);
+            Assert.AreEqual(numFmtId, ws.Cell("A1").Style.NumberFormat.NumberFormatId);
+        }
+
+        [Test]
+        public void Number_format_can_be_set_by_assigning()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Style.NumberFormat.Format = "0.000";
+
+            ws.Cell("A2").Style.NumberFormat = ws.Cell("A1").Style.NumberFormat;
+
+            Assert.AreEqual("0.000", ws.Cell("A2").Style.NumberFormat.Format);
+        }
+
+        [Test]
+        public void Equal_compares_formats()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").Style.NumberFormat.Format = "0.000";
+            ws.Cell("A2").Style.NumberFormat.Format = "0.000";
+
+            Assert.AreEqual(ws.Cell("A2").Style.NumberFormat, ws.Cell("A1").Style.NumberFormat);
         }
     }
 }

--- a/ClosedXML/Excel/Columns/XLColumn.cs
+++ b/ClosedXML/Excel/Columns/XLColumn.cs
@@ -608,9 +608,9 @@ namespace ClosedXML.Excel
         // TODO Styles: Replace with FormatValue during cut-over
         internal XLStyleValue StyleValue
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
+            get;
+            set;
+        } = null!;
 #endif
     }
 }

--- a/ClosedXML/Excel/Rows/XLRow.cs
+++ b/ClosedXML/Excel/Rows/XLRow.cs
@@ -678,11 +678,11 @@ namespace ClosedXML.Excel
 
 #if STYLES_REWORK
         // TODO Styles: Replace with FormatValue during cut-over
-        public XLStyleValue StyleValue
+        internal XLStyleValue StyleValue
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
+            get;
+            set;
+        } = null!;
 #endif
 
         /// <summary>

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -43,8 +43,8 @@ internal partial class XLCellFormat : IXLStyle
 
     IXLNumberFormat IXLStyle.NumberFormat
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => NumberFormat;
+        set => NumberFormat.SetNumberFormat(value.Format);
     }
 
     IXLProtection IXLStyle.Protection

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -21,7 +21,9 @@ internal partial class XLCellFormat
         _formatValue = formatValue;
     }
 
-    internal XLFontCellFormat Font => new XLFontCellFormat(this);
+    internal XLNumberCellFormat NumberFormat => new(this);
+
+    internal XLFontCellFormat Font => new(this);
 
     /// <summary>
     /// Cell areas in a workbook that should be updated when format is changed, e.g. when we have
@@ -171,17 +173,32 @@ internal partial class XLCellFormat
         return selector(format);
     }
 
+    internal void ModifyNumberFormat(string numberFormat)
+    {
+        var styles = _workbook.Styles;
+        Modify(format =>
+        {
+            var modifiedNumberFormat = styles.GetRegisteredNumberFormat(numberFormat);
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { NumberFormat = modifiedNumberFormat });
+            return modifiedFormat;
+        });
+    }
+
     internal void ModifyFont<TProperty>(Func<XLFontFormatValue, TProperty, XLFontFormatValue> modifyFont, TProperty value)
     {
-        // TODO Styles: Deal with cross points
         var styles = _workbook.Styles;
-        var modifyFormat = (XLCellFormatValue format) =>
+        Modify(format =>
         {
             var modifiedFont = styles.GetRegisteredFontFormat(format.Font, font => modifyFont(font, value));
             var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Font = modifiedFont });
             return modifiedFormat;
-        };
+        });
+    }
 
+    private void Modify(Func<XLCellFormatValue, XLCellFormatValue> modifyFormat)
+    {
+        // TODO Styles: Deal with cross points
+        var styles = _workbook.Styles;
         if (DefaultFormat)
         {
             styles.DefaultFormat = modifyFormat(styles.DefaultFormat);

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
@@ -2,31 +2,42 @@ using System;
 
 namespace ClosedXML.Excel;
 
-internal partial class XLFontCellFormat : IXLFont
+internal sealed partial class XLFontCellFormat : IXLFont
 {
-    // TODO Styles: Implement remaining format properties by using IXLFont contract
+    bool IXLFontBase.Bold
+    {
+        get => Bold;
+        set => Bold = value;
+    }
+
+    bool IXLFontBase.Italic
+    {
+        get => Italic;
+        set => Italic = value;
+    }
+
     XLFontUnderlineValues IXLFontBase.Underline
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Underline;
+        set => Underline = value;
     }
 
     bool IXLFontBase.Strikethrough
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Strikethrough;
+        set => Strikethrough = value;
     }
 
     XLFontVerticalTextAlignmentValues IXLFontBase.VerticalAlignment
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => VerticalAlignment;
+        set => VerticalAlignment = value;
     }
 
     bool IXLFontBase.Shadow
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Shadow;
+        set => Shadow = value;
     }
 
     double IXLFontBase.FontSize
@@ -37,8 +48,8 @@ internal partial class XLFontCellFormat : IXLFont
 
     XLColor IXLFontBase.FontColor
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Color;
+        set => Color = value;
     }
 
     string IXLFontBase.FontName
@@ -49,30 +60,31 @@ internal partial class XLFontCellFormat : IXLFont
 
     XLFontFamilyNumberingValues IXLFontBase.FontFamilyNumbering
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Family;
+        set => Family = value;
     }
 
     XLFontCharSet IXLFontBase.FontCharSet
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Charset;
+        set => Charset = value;
     }
 
     XLFontScheme IXLFontBase.FontScheme
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Scheme;
+        set => Scheme = value;
     }
 
     bool IEquatable<IXLFont>.Equals(IXLFont? other)
     {
+        // TODO Styles: Implement remaining format properties by using IXLFont contract. Deal somehow with Extend and Condense.
         throw new NotImplementedException();
     }
 
     IXLStyle IXLFont.SetBold()
     {
-        return ((IXLFont)this).SetBold(true);
+        return (this as IXLFont).SetBold(true);
     }
 
     IXLStyle IXLFont.SetBold(bool value)
@@ -83,7 +95,7 @@ internal partial class XLFontCellFormat : IXLFont
 
     IXLStyle IXLFont.SetItalic()
     {
-        return ((IXLFont)this).SetItalic(true);
+        return (this as IXLFont).SetItalic(true);
     }
 
     IXLStyle IXLFont.SetItalic(bool value)
@@ -94,48 +106,53 @@ internal partial class XLFontCellFormat : IXLFont
 
     IXLStyle IXLFont.SetUnderline()
     {
-        throw new NotImplementedException();
+        return (this as IXLFont).SetUnderline(XLFontUnderlineValues.Single);
     }
 
     IXLStyle IXLFont.SetUnderline(XLFontUnderlineValues value)
     {
-        throw new NotImplementedException();
+        Underline = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetStrikethrough()
     {
-        throw new NotImplementedException();
+        return (this as IXLFont).SetStrikethrough(true);
     }
 
     IXLStyle IXLFont.SetStrikethrough(bool value)
     {
-        throw new NotImplementedException();
+        Strikethrough = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetVerticalAlignment(XLFontVerticalTextAlignmentValues value)
     {
-        throw new NotImplementedException();
+        VerticalAlignment = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetShadow()
     {
-        throw new NotImplementedException();
+        return (this as IXLFont).SetShadow(true);
     }
 
     IXLStyle IXLFont.SetShadow(bool value)
     {
-        throw new NotImplementedException();
+        Shadow = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetFontSize(double value)
     {
-        ((IXLFont)this).FontSize = value;
+        (this as IXLFont).FontSize = value;
         return _parent;
     }
 
     IXLStyle IXLFont.SetFontColor(XLColor value)
     {
-        throw new NotImplementedException();
+        Color = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetFontName(string value)
@@ -146,17 +163,20 @@ internal partial class XLFontCellFormat : IXLFont
 
     IXLStyle IXLFont.SetFontFamilyNumbering(XLFontFamilyNumberingValues value)
     {
-        throw new NotImplementedException();
+        Family = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetFontCharSet(XLFontCharSet value)
     {
-        throw new NotImplementedException();
+        Charset = value;
+        return _parent;
     }
 
     IXLStyle IXLFont.SetFontScheme(XLFontScheme value)
     {
-        throw new NotImplementedException();
+        Scheme = value;
+        return _parent;
     }
 
     /// <summary>
@@ -164,6 +184,7 @@ internal partial class XLFontCellFormat : IXLFont
     /// </summary>
     internal void SetFont(IXLFont value)
     {
+        // TODO Styles: Implement remaining format properties by using IXLFont contract. Remember outline and extend
         throw new NotImplementedException();
     }
 }

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
@@ -178,13 +178,4 @@ internal sealed partial class XLFontCellFormat : IXLFont
         Scheme = value;
         return _parent;
     }
-
-    /// <summary>
-    /// A helper method to set all font properties at once (e.g, <c>someStyle.Font = otherStyle.Font</c>).
-    /// </summary>
-    internal void SetFont(IXLFont value)
-    {
-        // TODO Styles: Implement remaining format properties by using IXLFont contract. Remember outline and extend
-        throw new NotImplementedException();
-    }
 }

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.IXLFont.cs
@@ -78,8 +78,46 @@ internal sealed partial class XLFontCellFormat : IXLFont
 
     bool IEquatable<IXLFont>.Equals(IXLFont? other)
     {
-        // TODO Styles: Implement remaining format properties by using IXLFont contract. Deal somehow with Extend and Condense.
-        throw new NotImplementedException();
+        if (other is null)
+            return false;
+
+        if (Bold != other.Bold)
+            return false;
+
+        if (Italic != other.Italic)
+            return false;
+
+        if (Underline != other.Underline)
+            return false;
+
+        if (Strikethrough != other.Strikethrough)
+            return false;
+
+        if (VerticalAlignment != other.VerticalAlignment)
+            return false;
+
+        if (Shadow != other.Shadow)
+            return false;
+
+        if (!Size.Points.Equals(other.FontSize))
+            return false;
+
+        if (Color != other.FontColor)
+            return false;
+
+        if (Name != other.FontName)
+            return false;
+
+        if (Family != other.FontFamilyNumbering)
+            return false;
+
+        if (Charset != other.FontCharSet)
+            return false;
+
+        if (Scheme != other.FontScheme)
+            return false;
+
+        return true;
     }
 
     IXLStyle IXLFont.SetBold()

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
@@ -102,4 +102,26 @@ internal sealed partial class XLFontCellFormat
     {
         _parent.ModifyFont(modifyFont, value);
     }
+
+    /// <summary>
+    /// A helper method to set all font properties at once (e.g, <c>someStyle.Font = otherStyle.Font</c>).
+    /// </summary>
+    internal void SetFont(IXLFont value)
+    {
+        _parent.ModifyFont(static (font, value) => font with
+        {
+            Bold = value.Bold,
+            Italic = value.Italic,
+            Underline = value.Underline,
+            Strikethrough = value.Strikethrough,
+            VerticalAlignment = value.VerticalAlignment,
+            Shadow = value.Shadow,
+            Size = XLFontSize.FromPoints(value.FontSize),
+            Color = value.FontColor,
+            Name = value.FontName,
+            Family = value.FontFamilyNumbering,
+            Charset = value.FontCharSet,
+            Scheme = value.FontScheme
+        }, value);
+    }
 }

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
@@ -6,7 +6,7 @@ namespace ClosedXML.Excel;
 /// <summary>
 /// API object to modify font properties of a cell format of a <see cref="IXLFormatContainer"/>.
 /// </summary>
-internal partial class XLFontCellFormat
+internal sealed partial class XLFontCellFormat
 {
     private readonly XLCellFormat _parent;
 
@@ -15,28 +15,82 @@ internal partial class XLFontCellFormat
         _parent = parent;
     }
 
-    public XLFontName Name
+    internal XLFontName Name
     {
         get => Resolve(static x => x.Font.Name);
         set => Modify(static (font, fontName) => font with { Name = fontName }, value);
     }
 
-    public bool Bold
+    internal XLFontCharSet Charset
+    {
+        get => Resolve(static x => x.Font.Charset);
+        set => Modify(static (font, charset) => font with { Charset = charset }, value);
+    }
+
+    internal XLFontFamilyNumberingValues Family
+    {
+        get => Resolve(static x => x.Font.Family);
+        set => Modify(static (font, family) => font with { Family = family }, value);
+    }
+
+    internal bool Bold
     {
         get => Resolve(static x => x.Font.Bold);
         set => Modify(static (font, bold) => font with { Bold = bold }, value);
     }
 
-    public bool Italic
+    internal bool Italic
     {
         get => Resolve(static x => x.Font.Italic);
         set => Modify(static (font, italic) => font with { Italic = italic }, value);
     }
 
-    public XLFontSize Size
+    internal bool Strikethrough
+    {
+        get => Resolve(static x => x.Font.Strikethrough);
+        set => Modify(static (font, strikethrough) => font with { Strikethrough = strikethrough }, value);
+    }
+
+    internal bool Outline
+    {
+        get => Resolve(static x => x.Font.Outline);
+        set => Modify(static (font, outline) => font with { Outline = outline }, value);
+    }
+
+    internal bool Shadow
+    {
+        get => Resolve(static x => x.Font.Shadow);
+        set => Modify(static (font, shadow) => font with { Shadow = shadow }, value);
+    }
+
+    internal XLColor Color
+    {
+        get => Resolve(static x => x.Font.Color);
+        set => Modify(static (font, color) => font with { Color = color }, value);
+    }
+
+    internal XLFontSize Size
     {
         get => Resolve(static x => x.Font.Size);
         set => Modify(static (font, size) => font with { Size = size }, value);
+    }
+
+    internal XLFontUnderlineValues Underline
+    {
+        get => Resolve(static x => x.Font.Underline);
+        set => Modify(static (font, underline) => font with { Underline = underline }, value);
+    }
+
+    internal XLFontVerticalTextAlignmentValues VerticalAlignment
+    {
+        get => Resolve(static x => x.Font.VerticalAlignment);
+        set => Modify(static (font, verticalAlignment) => font with { VerticalAlignment = verticalAlignment }, value);
+    }
+
+    internal XLFontScheme Scheme
+    {
+        get => Resolve(static x => x.Font.Scheme);
+        set => Modify(static (font, scheme) => font with { Scheme = scheme }, value);
     }
 
     private T Resolve<T>(Func<XLCellFormatValue, T> selector)

--- a/ClosedXML/Excel/Style/Api/XLNumberCellFormat.IXLNumberFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLNumberCellFormat.IXLNumberFormat.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+internal sealed partial class XLNumberCellFormat : IXLNumberFormat
+{
+    int IXLNumberFormatBase.NumberFormatId
+    {
+        get => NumberFormatId;
+        set => NumberFormatId = value;
+    }
+
+    string IXLNumberFormatBase.Format
+    {
+        get => Format;
+        set => Format = value;
+    }
+
+    bool IEquatable<IXLNumberFormatBase>.Equals(IXLNumberFormatBase? other)
+    {
+        if (other is null)
+            return false;
+
+        return other.Format == Format;
+    }
+
+    IXLStyle IXLNumberFormat.SetNumberFormatId(int value)
+    {
+        NumberFormatId = value;
+        return _parent;
+    }
+
+    IXLStyle IXLNumberFormat.SetFormat(string value)
+    {
+        Format = value;
+        return _parent;
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLNumberCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLNumberCellFormat.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+internal sealed partial class XLNumberCellFormat
+{
+    private readonly XLCellFormat _parent;
+
+    internal XLNumberCellFormat(XLCellFormat parent)
+    {
+        _parent = parent;
+    }
+
+    private int NumberFormatId
+    {
+        get
+        {
+            var numberFormat = _parent.Resolve(static x => x.NumberFormat);
+            return XLPredefinedFormat.NumberFormatIds.GetValueOrDefault(numberFormat, -1);
+        }
+        set
+        {
+            if (!XLPredefinedFormat.FormatCodes.TryGetValue(value, out var format))
+                throw new ArgumentOutOfRangeException($"Only predefined format is permitted. Use nested enums/members of {nameof(XLPredefinedFormat)}.");
+
+            Format = format;
+        }
+    }
+
+    private string Format
+    {
+        get => _parent.Resolve(static x => x.NumberFormat);
+        set => _parent.ModifyNumberFormat(value);
+    }
+
+    internal void SetNumberFormat(string numberFormat)
+    {
+        Format = numberFormat;
+    }
+}

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -293,6 +293,15 @@ internal class XLWorkbookStyles
         _mruColors = mruColors;
     }
 
+    internal string GetRegisteredNumberFormat(string numberFormat)
+    {
+        if (_numberFormats.TryGetValue(numberFormat, out var existingFormat))
+            return existingFormat;
+
+        AddUserDefinedNumberFormat(numberFormat);
+        return numberFormat;
+    }
+
     /// <summary>
     /// Get a font format that is stored in the internal structures of the styles class. The font
     /// format is created by modification of existing font format. This is essential for saving,

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -2142,9 +2142,9 @@ namespace ClosedXML.Excel
         // TODO Styles: Replace with FormatValue during cut-over
         internal XLStyleValue StyleValue
         {
-            get => throw new NotImplementedException();
-            set => throw new NotImplementedException();
-        }
+            get;
+            set;
+        } = null!;
 #endif
     }
 }


### PR DESCRIPTION
Continuation of styles rework. It adds implementation of `IXLFont` properties and methods to reworked `XLCellFormat` API object.

Since some formatting things finally work, I tried to check performance comparison from original to reworked version, inspired by #2718. It sets format of 1.8 million cells ([gist](https://gist.github.com/jahav/3d497e57d79e2f14961934f7c0dd73ec)) .
| Step | Old duration | New duration |
|-----|-----|-----|
| 1. Dummy styles (1000 styles) | 17ms | 20ms |
| 2. Set font size (1.8 mil cells) | 61'232ms| 458ms |
| 3. Set number format (1.8 mil cells) | 58'374ms | 112ms |

Although it's a very naive test, results are encouraging. The step 2 also allocates all memory to hold formats, that is the reason for extra 346ms in comparison with step 3.

