### PR TITLE
Style rework - Add IXLBorder api

### DIFF
--- a/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
+++ b/ClosedXML.Tests/Excel/IO/StylesReaderTests.cs
@@ -392,7 +392,7 @@ internal class StylesReaderTests
             Assert.AreEqual(XLFillPatternValues.LightGrid, style.Fill.Pattern?.PatternType);
 
             Assert.AreSame(styles.Borders[0], style.Border);
-            Assert.AreEqual(XLBorderStyleValues.Double, style.Border.Bottom?.Style);
+            Assert.AreEqual(XLBorderStyleValues.Double, style.Border.Bottom.Style);
 
             // All apply* are true or default (true) -> everything should be overwritten
             Assert.AreEqual(CellFormatComponents.All, style.IncludedComponents);
@@ -564,11 +564,11 @@ internal class StylesReaderTests
                 Assert.AreEqual(XLFillPatternValues.LightGrid, dxf.Fill?.Pattern?.PatternType);
                 Assert.AreEqual(XLColor.FromRgb(0x0000FF), dxf.Fill.Pattern.PatternColor);
                 Assert.AreEqual(XLColor.FromRgb(0x00FF00), dxf.Fill.Pattern.BackgroundColor);
-                Assert.AreEqual(XLBorderStyleValues.Thin, dxf.Border?.Right?.Style);
-                Assert.AreEqual(XLColor.FromRgb(0x00FF00), dxf.Border?.Right?.Color);
-                Assert.IsNull(dxf.Border.Left);
-                Assert.IsNull(dxf.Border.Top);
-                Assert.IsNull(dxf.Border.Bottom);
+                Assert.AreEqual(XLBorderStyleValues.Thin, dxf.Border?.Right.Style);
+                Assert.AreEqual(XLColor.FromRgb(0x00FF00), dxf.Border?.Right.Color);
+                Assert.AreEqual(XLBorderLine.None, dxf.Border.Left);
+                Assert.AreEqual(XLBorderLine.None, dxf.Border.Top);
+                Assert.AreEqual(XLBorderLine.None, dxf.Border.Bottom);
             });
     }
 

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -109,6 +109,7 @@ namespace ClosedXML.Tests.Excel.Styles
         }
 
         [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
+        [Timeout(100)]
         public void OutsideBorder_for_columns()
         {
             using var wb = new XLWorkbook();
@@ -138,6 +139,7 @@ namespace ClosedXML.Tests.Excel.Styles
         }
 
         [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
+        [Timeout(100)]
         public void InsideBorder_for_columns()
         {
             using var wb = new XLWorkbook();

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -15,7 +15,7 @@ namespace ClosedXML.Tests.Excel.Styles
         private const int All = Left | Top | Right | Bottom;
 
         [Test]
-        public void InsideBorders_preserves_outside_borders()
+        public void InsideBorders_preserve_outside_borders()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -279,7 +279,7 @@ namespace ClosedXML.Tests.Excel.Styles
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorder, (border, value) => border.SetOutsideBorder(value), styleValues);
 
             // Outside border color - check that once set, all outer borders are set to the color
-            // Because of hash key adn repos, we must first set style other than none
+            // Because of hash key and repos, we must first set style other than none
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -31,7 +31,7 @@ namespace ClosedXML.Tests.Excel.Styles
             ws.Range("B2:C2").Style.Border.SetInsideBorder(XLBorderStyleValues.None);
 
             AssertCellBorder(ws, "B2", Left | Top | Bottom, XLBorderStyleValues.Thin);
-            AssertCellBorder(ws, "C2", Right| Top | Bottom, XLBorderStyleValues.Thin);
+            AssertCellBorder(ws, "C2", Right | Top | Bottom, XLBorderStyleValues.Thin);
             Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor);
             Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("C2").Style.Border.RightBorderColor.ThemeColor);
         }

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -1,36 +1,334 @@
-﻿using ClosedXML.Excel;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using ClosedXML.Tests.Utils;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.Styles
 {
     public class BorderTests
     {
+        private const int None = 0x0;
+        private const int Left = 0x1;
+        private const int Right = 0x2;
+        private const int Top = 0x4;
+        private const int Bottom = 0x8;
+        private const int All = Left | Top | Right | Bottom;
+
         [Test]
-        public void SetInsideBorderPreservesOutsideBorders()
+        public void InsideBorders_preserves_outside_borders()
         {
-            using (var wb = new XLWorkbook())
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var halfAccent1Color = XLColor.FromTheme(XLThemeColor.Accent1, 0.5);
+            ws.Cells("B2:C2").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetOutsideBorderColor(halfAccent1Color);
+
+            // Check pre-conditions
+            AssertCellBorder(ws, "B2", Left | Right | Top | Bottom, XLBorderStyleValues.Thin, halfAccent1Color);
+            AssertCellBorder(ws, "C2", Left | Right | Top | Bottom, XLBorderStyleValues.Thin, halfAccent1Color);
+
+            ws.Range("B2:C2").Style.Border.SetInsideBorder(XLBorderStyleValues.None);
+
+            AssertCellBorder(ws, "B2", Left | Top | Bottom, XLBorderStyleValues.Thin);
+            AssertCellBorder(ws, "C2", Right| Top | Bottom, XLBorderStyleValues.Thin);
+            Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor);
+            Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("C2").Style.Border.RightBorderColor.ThemeColor);
+        }
+
+        [Test]
+        public void InsideBorder_sets_border_that_is_not_on_edge()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Range("B2:D4").Style
+                .Border.SetInsideBorderColor(XLColor.Red)
+                .Border.SetInsideBorder(XLBorderStyleValues.Thick);
+
+            AssertCellBorder(ws, "B2", Bottom | Right);
+            AssertCellBorder(ws, "C2", Left | Bottom | Right);
+            AssertCellBorder(ws, "D2", Bottom | Left);
+            AssertCellBorder(ws, "B3", Top | Right | Bottom);
+            AssertCellBorder(ws, "C3", Left | Top | Right | Bottom);
+            AssertCellBorder(ws, "D3", Top | Left | Bottom);
+            AssertCellBorder(ws, "B4", Top | Right);
+            AssertCellBorder(ws, "C4", Left | Top | Right);
+            AssertCellBorder(ws, "D4", Left | Top);
+        }
+
+        [Test]
+        public void OutsideBorder_sets_only_borders_on_edge()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Range("B2:D4").Style
+                .Border.SetOutsideBorderColor(XLColor.Red)
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thick);
+
+            AssertCellBorder(ws, "B2", Top | Left);
+            AssertCellBorder(ws, "C2", Top);
+            AssertCellBorder(ws, "D2", Top | Right);
+            AssertCellBorder(ws, "B3", Left);
+            AssertCellBorder(ws, "C3", None);
+            AssertCellBorder(ws, "D3", Right);
+            AssertCellBorder(ws, "B4", Bottom | Left);
+            AssertCellBorder(ws, "C4", Bottom);
+            AssertCellBorder(ws, "D4", Bottom | Right);
+        }
+
+        [Test]
+        public void OutsideBorder_used_for_cells_will_make_outside_border_around_each_cell()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Cells("B2:C3").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetOutsideBorderColor(XLColor.Red);
+
+            AssertCellBorder(ws, "B2", All, XLBorderStyleValues.Thick, XLColor.Red);
+            AssertCellBorder(ws, "C2", All, XLBorderStyleValues.Thick, XLColor.Red);
+            AssertCellBorder(ws, "B3", All, XLBorderStyleValues.Thick, XLColor.Red);
+            AssertCellBorder(ws, "C3", All, XLBorderStyleValues.Thick, XLColor.Red);
+        }
+
+        [Test]
+        public void InsideBorder_used_for_cells_is_ignored_because_individual_cells_have_no_inside()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            ws.Cells("B2:C3").Style
+                .Border.SetInsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetInsideBorderColor(XLColor.Red);
+
+            AssertCellBorder(ws, "B2", None, XLBorderStyleValues.None);
+            AssertCellBorder(ws, "C2", None, XLBorderStyleValues.None);
+            AssertCellBorder(ws, "B3", None, XLBorderStyleValues.None);
+            AssertCellBorder(ws, "C3", None, XLBorderStyleValues.None);
+        }
+
+        [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
+        public void OutsideBorder_for_columns()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Materialize a cell with style to test interactions between column and materialized cell
+            ws.Cell("B2").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetOutsideBorderColor(XLColor.Blue);
+
+            // Set border for a whole column
+            ws.Column("B").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetOutsideBorderColor(XLColor.Red);
+
+            var b2 = ws.Cell("B2").Style.Border;
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.TopBorder);
+            Assert.AreEqual(XLColor.Blue, b2.TopBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.BottomBorder);
+            Assert.AreEqual(XLColor.Blue, b2.BottomBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.LeftBorder);
+            Assert.AreEqual(XLColor.Red, b2.LeftBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.RightBorder);
+            Assert.AreEqual(XLColor.Red, b2.RightBorderColor);
+            AssertCellBorder(ws, "B1", Left | Right, XLBorderStyleValues.Thick, XLColor.Red);
+            AssertCellBorder(ws, "B3", Left | Right, XLBorderStyleValues.Thick, XLColor.Red);
+        }
+
+        [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
+        public void InsideBorder_for_columns()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Materialize a cell with style to test interactions between column and materialized cell
+            ws.Cell("B2").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetOutsideBorderColor(XLColor.Blue);
+
+            // Set border for a whole column
+            ws.Column("B").Style
+                .Border.SetInsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetInsideBorderColor(XLColor.Red);
+
+            var b2 = ws.Cell("B2").Style.Border;
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.TopBorder);
+            Assert.AreEqual(XLColor.Red, b2.TopBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.BottomBorder);
+            Assert.AreEqual(XLColor.Red, b2.BottomBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.LeftBorder);
+            Assert.AreEqual(XLColor.Blue, b2.LeftBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.RightBorder);
+            Assert.AreEqual(XLColor.Blue, b2.RightBorderColor);
+            AssertCellBorder(ws, "B1", Top | Bottom, XLBorderStyleValues.Thick, XLColor.Red);
+            AssertCellBorder(ws, "B3", Top | Bottom, XLBorderStyleValues.Thick, XLColor.Red);
+        }
+
+        [Test]
+        public void OutsideBorder_for_rows()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Materialize a cell with style to test interactions between row and materialized cell
+            ws.Cell("B2").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetOutsideBorderColor(XLColor.Blue);
+
+            // Set border for a whole row
+            ws.Row(2).Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetOutsideBorderColor(XLColor.Red);
+
+            var b2 = ws.Cell("B2").Style.Border;
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.LeftBorder);
+            Assert.AreEqual(XLColor.Blue, b2.LeftBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.RightBorder);
+            Assert.AreEqual(XLColor.Blue, b2.RightBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.TopBorder);
+            Assert.AreEqual(XLColor.Red, b2.TopBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.BottomBorder);
+            Assert.AreEqual(XLColor.Red, b2.BottomBorderColor);
+
+            // TODO Styles: Enable after switch, repository makes a mess with equality
+            // AssertCellBorder(ws, "A2", Top | Bottom, XLBorderStyleValues.Thick, XLColor.Red);
+            // AssertCellBorder(ws, "C2", Top | Bottom, XLBorderStyleValues.Thick, XLColor.Red);
+        }
+
+        [Test]
+        public void InsideBorder_for_rows()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Materialize a cell with style to test interactions between row and materialized cell
+            ws.Cell("B2").Style
+                .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
+                .Border.SetOutsideBorderColor(XLColor.Blue);
+
+            // Set border for a whole row
+            ws.Row(2).Style
+                .Border.SetInsideBorder(XLBorderStyleValues.Thick)
+                .Border.SetInsideBorderColor(XLColor.Red);
+
+            var b2 = ws.Cell("B2").Style.Border;
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.LeftBorder);
+            Assert.AreEqual(XLColor.Red, b2.LeftBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thick, b2.RightBorder);
+            Assert.AreEqual(XLColor.Red, b2.RightBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.TopBorder);
+            Assert.AreEqual(XLColor.Blue, b2.TopBorderColor);
+            Assert.AreEqual(XLBorderStyleValues.Thin, b2.BottomBorder);
+            Assert.AreEqual(XLColor.Blue, b2.BottomBorderColor);
+
+            // TODO Styles: Enable after switch, repository makes a mess with equality
+            // AssertCellBorder(ws, "A2", Left | Right, XLBorderStyleValues.Thick, XLColor.Red);
+            // AssertCellBorder(ws, "C2", Left | Right, XLBorderStyleValues.Thick, XLColor.Red);
+        }
+
+        [Test]
+        [TestCaseSource(nameof(BorderApiSetters))]
+        public void Border_property_can_be_individually_set(FormatTestCase<IXLBorder> testCase)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var cell = ws.Cell("B2");
+
+            foreach (var testValue in testCase.Values)
             {
-                var ws = wb.AddWorksheet();
-
-                ws.Cells("B2:C2").Style
-                    .Border.SetOutsideBorder(XLBorderStyleValues.Thin)
-                    .Border.SetOutsideBorderColor(XLColor.FromTheme(XLThemeColor.Accent1, 0.5));
-
-                //Check pre-conditions
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("B2").Style.Border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("B2").Style.Border.RightBorder);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.RightBorderColor.ThemeColor);
-
-                ws.Range("B2:C2").Style.Border.SetInsideBorder(XLBorderStyleValues.None);
-
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("B2").Style.Border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("B2").Style.Border.RightBorder);
-                Assert.AreEqual(XLBorderStyleValues.None, ws.Cell("C2").Style.Border.LeftBorder);
-                Assert.AreEqual(XLBorderStyleValues.Thin, ws.Cell("C2").Style.Border.RightBorder);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("B2").Style.Border.LeftBorderColor.ThemeColor);
-                Assert.AreEqual(XLThemeColor.Accent1, ws.Cell("C2").Style.Border.RightBorderColor.ThemeColor);
+                testCase.SetPropertyValue(cell.Style.Border, testValue);
+                var setValue = testCase.GetPropertyValue(cell.Style.Border);
+                Assert.AreEqual(testValue, setValue);
+                cell = cell.CellRight();
             }
+        }
+
+        private static void AssertCellBorder(IXLWorksheet ws, string cell, int sides, XLBorderStyleValues style = XLBorderStyleValues.Thick, XLColor color = null)
+        {
+            var border = ws.Cell(cell).Style.Border;
+            Assert.AreEqual((sides & Left) != 0 ? style : XLBorderStyleValues.None, border.LeftBorder);
+            Assert.AreEqual((sides & Right) != 0 ? style : XLBorderStyleValues.None, border.RightBorder);
+            Assert.AreEqual((sides & Top) != 0 ? style : XLBorderStyleValues.None, border.TopBorder);
+            Assert.AreEqual((sides & Bottom) != 0 ? style : XLBorderStyleValues.None, border.BottomBorder);
+
+            if (color is not null)
+            {
+                Assert.AreEqual((sides & Left) != 0 ? color : XLColor.Auto, border.LeftBorderColor);
+                Assert.AreEqual((sides & Right) != 0 ? color : XLColor.Auto, border.RightBorderColor);
+                Assert.AreEqual((sides & Top) != 0 ? color : XLColor.Auto, border.TopBorderColor);
+                Assert.AreEqual((sides & Bottom) != 0 ? color : XLColor.Auto, border.BottomBorderColor);
+            }
+        }
+
+        private static IEnumerable<object> BorderApiSetters()
+        {
+            var styleValues = EnumPolyfill.GetValues<XLBorderStyleValues>();
+            var colors = new[] { XLColor.Red, XLColor.Black, XLColor.Auto };
+
+            // Outside border style - check that once set, all outer borders are set to the style
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorder, (border, value) => border.OutsideBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorder, (border, value) => border.OutsideBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorder, (border, value) => border.OutsideBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorder, (border, value) => border.OutsideBorder = value, styleValues);
+
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorder, (border, value) => border.SetOutsideBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorder, (border, value) => border.SetOutsideBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorder, (border, value) => border.SetOutsideBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorder, (border, value) => border.SetOutsideBorder(value), styleValues);
+
+            // Outside border color - check that once set, all outer borders are set to the color
+            // Because of hash key adn repos, we must first set style other than none
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.OutsideBorderColor = value, colors);
+
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.SetOutsideBorderColor(value), colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.SetOutsideBorderColor(value), colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.SetOutsideBorderColor(value), colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorderColor, (border, value) => border.SetOutsideBorder(XLBorderStyleValues.Thin).Border.SetOutsideBorderColor(value), colors);
+
+            // Left border
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorder, (border, value) => border.LeftBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorder, (border, value) => border.SetLeftBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorderColor, (border, value) => border.SetLeftBorder(XLBorderStyleValues.Thin).Border.LeftBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.LeftBorderColor, (border, value) => border.SetLeftBorder(XLBorderStyleValues.Thin).Border.SetLeftBorderColor(value), colors);
+
+            // Right border
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorder, (border, value) => border.RightBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorder, (border, value) => border.SetRightBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorderColor, (border, value) => border.SetRightBorder(XLBorderStyleValues.Thin).Border.RightBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.RightBorderColor, (border, value) => border.SetRightBorder(XLBorderStyleValues.Thin).Border.SetRightBorderColor(value), colors);
+
+            // Top border
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorder, (border, value) => border.TopBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorder, (border, value) => border.SetTopBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorderColor, (border, value) => border.SetTopBorder(XLBorderStyleValues.Thin).Border.TopBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.TopBorderColor, (border, value) => border.SetTopBorder(XLBorderStyleValues.Thin).Border.SetTopBorderColor(value), colors);
+
+            // Bottom border
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorder, (border, value) => border.BottomBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorder, (border, value) => border.SetBottomBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorderColor, (border, value) => border.SetBottomBorder(XLBorderStyleValues.Thin).Border.BottomBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.BottomBorderColor, (border, value) => border.SetBottomBorder(XLBorderStyleValues.Thin).Border.SetBottomBorderColor(value), colors);
+
+            // Diagonal up
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalUp, (border, value) => border.DiagonalUp = value, true, false);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalUp, (border, value) => border.SetDiagonalUp(value), true, false);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalUp, (border, _) => border.SetDiagonalUp(), true);
+
+            // Diagonal down
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalDown, (border, value) => border.DiagonalDown = value, true, false);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalDown, (border, value) => border.SetDiagonalDown(value), true, false);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalDown, (border, _) => border.SetDiagonalDown(), true);
+
+            // Diagonal border
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorder, (border, value) => border.DiagonalBorder = value, styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorder, (border, value) => border.SetDiagonalBorder(value), styleValues);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorderColor, (border, value) => border.SetDiagonalBorder(XLBorderStyleValues.Thin).Border.DiagonalBorderColor = value, colors);
+            yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorderColor, (border, value) => border.SetDiagonalBorder(XLBorderStyleValues.Thin).Border.SetDiagonalBorderColor(value), colors);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/FormatTestCase.cs
+++ b/ClosedXML.Tests/Excel/Styles/FormatTestCase.cs
@@ -28,6 +28,11 @@ public class FormatTestCase<TApi>
         return new FormatTestCase<IXLFill>(fill => getter(fill), (fill, value) => setter(fill, (T)value), testValues.Cast<object>().ToArray());
     }
 
+    public static FormatTestCase<IXLBorder> ForBorder<T>(Func<IXLBorder, T> getter, Action<IXLBorder, T> setter, params T[] testValues)
+    {
+        return new FormatTestCase<IXLBorder>(border => getter(border), (border, value) => setter(border, (T)value), testValues.Cast<object>().ToArray());
+    }
+
     public IEnumerable<object> Values => _testValues;
 
     public object GetPropertyValue(TApi font)

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -228,15 +228,9 @@ internal class XLCells :
         get
         {
             // For backwards compatibility, the sheet is considered the inner style. A terrible
-            // choice, but it is what it is. We have to deal with individual cells, only because
-            // of borders. Original code considered each cell as an individual region and
-            // outside/inside borders should treat it as such.
-            // TODO Styles: Make a custom factory and adjust Inside/OutsideBorder code
+            // choice, but it is what it is.
             var sheet = _rangeAddresses.Select(x => x.Worksheet).FirstOrDefault(x => x is not null);
-            var areas = _rangeAddresses.Select(XLBookArea.From)
-                .SelectMany(x => x)
-                .Select(point => new XLBookArea(point.SheetName, new XLSheetRange(point.Point)))
-                .ToArray();
+            var areas = _rangeAddresses.Select(XLBookArea.From).ToArray();
             return XLCellFormat.ForCells(_workbook, areas, sheet);
         }
     }

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -228,9 +228,15 @@ internal class XLCells :
         get
         {
             // For backwards compatibility, the sheet is considered the inner style. A terrible
-            // choice, but it is what it is.
+            // choice, but it is what it is. We have to deal with individual cells, only because
+            // of borders. Original code considered each cell as an individual region and
+            // outside/inside borders should treat it as such.
+            // TODO Styles: Make a custom factory and adjust Inside/OutsideBorder code
             var sheet = _rangeAddresses.Select(x => x.Worksheet).FirstOrDefault(x => x is not null);
-            var areas = _rangeAddresses.Select(XLBookArea.From).ToArray();
+            var areas = _rangeAddresses.Select(XLBookArea.From)
+                .SelectMany(x => x)
+                .Select(point => new XLBookArea(point.SheetName, new XLSheetRange(point.Point)))
+                .ToArray();
             return XLCellFormat.ForCells(_workbook, areas, sheet);
         }
     }

--- a/ClosedXML/Excel/IO/StylesReader.cs
+++ b/ClosedXML/Excel/IO/StylesReader.cs
@@ -509,13 +509,13 @@ internal partial class StylesReader
     {
         var borderFormat = new XLBorderFormatValue
         {
-            Left = left,
-            Right = right,
-            Top = top,
-            Bottom = bottom,
-            Diagonal = diagonal,
-            Vertical = vertical,
-            Horizontal = horizontal,
+            Left = left ?? XLBorderLine.None,
+            Right = right ?? XLBorderLine.None,
+            Top = top ?? XLBorderLine.None,
+            Bottom = bottom ?? XLBorderLine.None,
+            Diagonal = diagonal ?? XLBorderLine.None,
+            Vertical = vertical ?? XLBorderLine.None,
+            Horizontal = horizontal ?? XLBorderLine.None,
             DiagonalUp = diagonalUp ?? false, // OI-29500: Excel uses false as default value
             DiagonalDown = diagonalDown ?? false, // OI-29500: Excel uses false as default value
             Outline = outline

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel
             get
             {
                 var columns = _ranges.Select(x => XLBookArea.From(x.RangeAddress)).ToArray();
-                return XLCellFormat.ForCells(_worksheet.Workbook, columns, null);
+                return XLCellFormat.ForAreas(_worksheet.Workbook, columns, null);
             }
         }
 

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -28,7 +28,7 @@ namespace ClosedXML.Excel
             get
             {
                 var areas = _ranges.Select(x => XLBookArea.From(x.RangeAddress)).ToArray();
-                return XLCellFormat.ForCells(_worksheet.Workbook, areas, null);
+                return XLCellFormat.ForAreas(_worksheet.Workbook, areas, null);
             }
         }
 

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -55,7 +55,7 @@ namespace ClosedXML.Excel
             {
                 var sheet = Ranges.FirstOrDefault()?.Worksheet;
                 var areas = Ranges.Select(x => XLBookArea.From(x.RangeAddress)).ToArray();
-                return XLCellFormat.ForCells(_workbook, areas, sheet);
+                return XLCellFormat.ForAreas(_workbook, areas, sheet);
             }
         }
 

--- a/ClosedXML/Excel/Style/Api/XLBorderCellFormat.IXLBorder.cs
+++ b/ClosedXML/Excel/Style/Api/XLBorderCellFormat.IXLBorder.cs
@@ -1,0 +1,261 @@
+using System;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+internal sealed partial class XLBorderCellFormat : IXLBorder
+{
+    XLBorderStyleValues IXLBorder.OutsideBorder
+    {
+        set => _parent.ModifyOuterBorder(static (borderLine, style) => borderLine with { Style = style }, value);
+    }
+
+    XLColor IXLBorder.OutsideBorderColor
+    {
+        set => _parent.ModifyOuterBorder(static (borderLine, color) => borderLine with { Color = color }, value);
+    }
+
+    XLBorderStyleValues IXLBorder.InsideBorder
+    {
+        set => _parent.ModifyInnerBorder(static (borderLine, style) => borderLine with { Style = style }, value);
+    }
+
+    XLColor IXLBorder.InsideBorderColor
+    {
+        set => _parent.ModifyInnerBorder(static (borderLine, color) => borderLine with { Color = color }, value);
+    }
+
+    XLBorderStyleValues IXLBorder.LeftBorder
+    {
+        get => LeftBorder;
+        set => LeftBorder = value;
+    }
+
+    XLColor IXLBorder.LeftBorderColor
+    {
+        get => LeftBorderColor;
+        set => LeftBorderColor = value;
+    }
+
+    XLBorderStyleValues IXLBorder.RightBorder
+    {
+        get => RightBorder;
+        set => RightBorder = value;
+    }
+
+    XLColor IXLBorder.RightBorderColor
+    {
+        get => RightBorderColor;
+        set => RightBorderColor = value;
+    }
+
+    XLBorderStyleValues IXLBorder.TopBorder
+    {
+        get => TopBorder;
+        set => TopBorder = value;
+    }
+
+    XLColor IXLBorder.TopBorderColor
+    {
+        get => TopBorderColor;
+        set => TopBorderColor = value;
+    }
+
+    XLBorderStyleValues IXLBorder.BottomBorder
+    {
+        get => BottomBorder;
+        set => BottomBorder = value;
+    }
+
+    XLColor IXLBorder.BottomBorderColor
+    {
+        get => BottomBorderColor;
+        set => BottomBorderColor = value;
+    }
+
+    bool IXLBorder.DiagonalUp
+    {
+        get => DiagonalUp;
+        set => DiagonalUp = value;
+    }
+
+    bool IXLBorder.DiagonalDown
+    {
+        get => DiagonalDown;
+        set => DiagonalDown = value;
+    }
+
+    XLBorderStyleValues IXLBorder.DiagonalBorder
+    {
+        get => DiagonalBorder;
+        set => DiagonalBorder = value;
+    }
+
+    XLColor IXLBorder.DiagonalBorderColor
+    {
+        get => DiagonalBorderColor;
+        set => DiagonalBorderColor = value;
+    }
+
+    IXLStyle IXLBorder.SetOutsideBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).OutsideBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetOutsideBorderColor(XLColor value)
+    {
+        (this as IXLBorder).OutsideBorderColor = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetInsideBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).InsideBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetInsideBorderColor(XLColor value)
+    {
+        (this as IXLBorder).InsideBorderColor = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetLeftBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).LeftBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetLeftBorderColor(XLColor value)
+    {
+        (this as IXLBorder).LeftBorderColor = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetRightBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).RightBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetRightBorderColor(XLColor value)
+    {
+        (this as IXLBorder).RightBorderColor = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetTopBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).TopBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetTopBorderColor(XLColor value)
+    {
+        (this as IXLBorder).TopBorderColor = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetBottomBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).BottomBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetBottomBorderColor(XLColor value)
+    {
+        (this as IXLBorder).BottomBorderColor = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetDiagonalUp()
+    {
+        return (this as IXLBorder).SetDiagonalUp(true);
+    }
+
+    IXLStyle IXLBorder.SetDiagonalUp(bool value)
+    {
+        (this as IXLBorder).DiagonalUp = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetDiagonalDown()
+    {
+        return (this as IXLBorder).SetDiagonalDown(true);
+    }
+
+    IXLStyle IXLBorder.SetDiagonalDown(bool value)
+    {
+        (this as IXLBorder).DiagonalDown = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetDiagonalBorder(XLBorderStyleValues value)
+    {
+        (this as IXLBorder).DiagonalBorder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLBorder.SetDiagonalBorderColor(XLColor value)
+    {
+        (this as IXLBorder).DiagonalBorderColor = value;
+        return _parent;
+    }
+
+    bool IEquatable<IXLBorder>.Equals(IXLBorder? other)
+    {
+        // A "business" equals, when borders are visually same, they are considered equals.
+        if (other is null)
+            return false;
+
+        var thisBorder = _parent.Resolve(static x => x.Border);
+        var otherLeft = new XLBorderLine(other.LeftBorderColor, other.LeftBorder);
+        if (!IsSameLine(thisBorder.Left, otherLeft))
+            return false;
+
+        var otherTop = new XLBorderLine(other.TopBorderColor, other.TopBorder);
+        if (!IsSameLine(thisBorder.Top, otherTop))
+            return false;
+
+        var otherRight = new XLBorderLine(other.RightBorderColor, other.RightBorder);
+        if (!IsSameLine(thisBorder.Right, otherRight))
+            return false;
+
+        var otherBottom = new XLBorderLine(other.BottomBorderColor, other.BottomBorder);
+        if (!IsSameLine(thisBorder.Bottom, otherBottom))
+            return false;
+
+        // Check diagonals. If the diagonal flag is not set, the diagonal is not displayed. Normalize them to take into the account the direction flag
+        var thisDiagonalUp = MakeThisDiagonal(thisBorder.Diagonal, thisBorder.DiagonalUp);
+        var otherDiagonalUp = MakeOtherDiagonal(other, other.DiagonalUp);
+        if (!IsSameLine(thisDiagonalUp, otherDiagonalUp))
+            return false;
+
+        var thisDiagonalDown = MakeThisDiagonal(thisBorder.Diagonal, thisBorder.DiagonalDown);
+        var otherDiagonalDown = MakeOtherDiagonal(other, other.DiagonalDown);
+        if (!IsSameLine(thisDiagonalDown, otherDiagonalDown))
+            return false;
+
+        return true;
+
+        static bool IsSameLine(XLBorderLine lhs, XLBorderLine rhs)
+        {
+            if (lhs.Style == XLBorderStyleValues.None && rhs.Style == XLBorderStyleValues.None)
+                return true;
+
+            // Auto color in context of border is black, not transparent.
+            return lhs.Style == rhs.Style && lhs.Color == rhs.Color;
+        }
+
+        static XLBorderLine MakeThisDiagonal(XLBorderLine diagonal, bool diagonalDirection)
+        {
+            return diagonal with { Style = diagonalDirection ? diagonal.Style : XLBorderStyleValues.None };
+        }
+
+        static XLBorderLine MakeOtherDiagonal(IXLBorder border, bool diagonalDirection)
+        {
+            return new XLBorderLine(border.DiagonalBorderColor, diagonalDirection ? border.DiagonalBorder : XLBorderStyleValues.None);
+        }
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLBorderCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLBorderCellFormat.cs
@@ -1,0 +1,99 @@
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+internal sealed partial class XLBorderCellFormat
+{
+    private readonly XLCellFormat _parent;
+
+    internal XLBorderCellFormat(XLCellFormat parent)
+    {
+        _parent = parent;
+    }
+
+    internal XLBorderStyleValues LeftBorder
+    {
+        get => _parent.Resolve(static x => x.Border.Left.Style);
+        set => _parent.ModifyBorder(static (border, leftStyle) => border with { Left = border.Left with { Style = leftStyle } }, value);
+    }
+
+    internal XLColor LeftBorderColor
+    {
+        get => _parent.Resolve(static x => x.Border.Left.Color);
+        set => _parent.ModifyBorder(static (border, leftColor) => border with { Left = border.Left with { Color = leftColor } }, value);
+    }
+
+    internal XLBorderStyleValues RightBorder
+    {
+        get => _parent.Resolve(static x => x.Border.Right.Style);
+        set => _parent.ModifyBorder(static (border, rightStyle) => border with { Right = border.Right with { Style = rightStyle } }, value);
+    }
+
+    internal XLColor RightBorderColor
+    {
+        get => _parent.Resolve(static x => x.Border.Right.Color);
+        set => _parent.ModifyBorder(static (border, rightColor) => border with { Right = border.Right with { Color = rightColor } }, value);
+    }
+
+    internal XLBorderStyleValues TopBorder
+    {
+        get => _parent.Resolve(static x => x.Border.Top.Style);
+        set => _parent.ModifyBorder(static (border, topStyle) => border with { Top = border.Top with { Style = topStyle } }, value);
+    }
+
+    internal XLColor TopBorderColor
+    {
+        get => _parent.Resolve(static x => x.Border.Top.Color);
+        set => _parent.ModifyBorder(static (border, topColor) => border with { Top = border.Top with { Color = topColor } }, value);
+    }
+
+    internal XLBorderStyleValues BottomBorder
+    {
+        get => _parent.Resolve(static x => x.Border.Bottom.Style);
+        set => _parent.ModifyBorder(static (border, bottomStyle) => border with { Bottom = border.Bottom with { Style = bottomStyle } }, value);
+    }
+
+    internal XLColor BottomBorderColor
+    {
+        get => _parent.Resolve(static x => x.Border.Bottom.Color);
+        set => _parent.ModifyBorder(static (border, bottomColor) => border with { Bottom = border.Bottom with { Color = bottomColor } }, value);
+    }
+
+    internal bool DiagonalUp
+    {
+        get => _parent.Resolve(static x => x.Border.DiagonalUp);
+        set => _parent.ModifyBorder(static (border, diagonalUp) => border with { DiagonalUp = diagonalUp }, value);
+    }
+
+    internal bool DiagonalDown
+    {
+        get => _parent.Resolve(static x => x.Border.DiagonalDown);
+        set => _parent.ModifyBorder(static (border, diagonalDown) => border with { DiagonalDown = diagonalDown }, value);
+    }
+
+    internal XLBorderStyleValues DiagonalBorder
+    {
+        get => _parent.Resolve(static x => x.Border.Diagonal.Style);
+        set => _parent.ModifyBorder(static (border, diagonalStyle) => border with { Diagonal = border.Diagonal with { Style = diagonalStyle } }, value);
+    }
+
+    internal XLColor DiagonalBorderColor
+    {
+        get => _parent.Resolve(static x => x.Border.Diagonal.Color);
+        set => _parent.ModifyBorder(static (border, diagonalColor) => border with { Diagonal = border.Diagonal with { Color = diagonalColor } }, value);
+    }
+
+    internal void SetValue(IXLBorder value)
+    {
+        _parent.ModifyBorder((border, other) => border with
+        {
+            Left = new XLBorderLine(other.LeftBorderColor, other.LeftBorder),
+            Right = new XLBorderLine(other.RightBorderColor, other.RightBorder),
+            Top = new XLBorderLine(other.TopBorderColor, other.TopBorder),
+            Bottom = new XLBorderLine(other.BottomBorderColor, other.BottomBorder),
+            DiagonalUp = other.DiagonalUp,
+            DiagonalDown = other.DiagonalDown,
+            Diagonal = new XLBorderLine(other.DiagonalBorderColor, other.DiagonalBorder),
+        }, value);
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -17,8 +17,8 @@ internal partial class XLCellFormat : IXLStyle
 
     IXLBorder IXLStyle.Border
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Border;
+        set => Border.SetValue(value);
     }
 
     IXLNumberFormat IXLStyle.DateFormat => throw new NotImplementedException();

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -67,7 +67,8 @@ internal partial class XLCellFormat
     private bool DefaultFormat { get; init; }
 
     /// <summary>
-    /// A flag indicating API object is for XLCells. It has custom outside/inside borders behavior.
+    /// A flag indicating API object is for XLCells. Unlike other range API objects, the XLCells
+    /// has a non-standard outside/inside borders behavior.
     /// </summary>
     private bool IsCells { get; init; }
 
@@ -276,7 +277,7 @@ internal partial class XLCellFormat
         ModifyColumnsBorder(setLeftAndRight);
 
         // A normal path for range API object (except XLCells). Set outer border to areas.
-        // Don't use UsedAreas, they are for columns/rows. Worksheet doesn't have outer border.
+        // Don't use UsedAreas, they are for columns/rows. Worksheet doesn't have an outer border.
         var setLeft = GetModifyBorderFunc(border => border with { Left = modify(border.Left, value) }, styles);
         var setTop = GetModifyBorderFunc(border => border with { Top = modify(border.Top, value) }, styles);
         var setRight = GetModifyBorderFunc(border => border with { Right = modify(border.Right, value) }, styles);

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -66,6 +66,11 @@ internal partial class XLCellFormat
     /// </summary>
     private bool DefaultFormat { get; init; }
 
+    /// <summary>
+    /// A flag indicating API object is for XLCells. It has custom outside/inside borders behavior.
+    /// </summary>
+    private bool IsCells { get; init; }
+
     internal static XLCellFormat ForCell(XLCell cell)
     {
         var workbook = cell.Worksheet.Workbook;
@@ -142,12 +147,22 @@ internal partial class XLCellFormat
         };
     }
 
-    internal static XLCellFormat ForCells(XLWorkbook workbook, IReadOnlyList<XLBookArea> areas, XLWorksheet? sheet)
+    internal static XLCellFormat ForAreas(XLWorkbook workbook, IReadOnlyList<XLBookArea> areas, XLWorksheet? sheet)
     {
         var formatValue = new Hierarchy(workbook, sheet?.Name, null, null, null);
         return new XLCellFormat(workbook, formatValue)
         {
             Areas = areas
+        };
+    }
+
+    internal static XLCellFormat ForCells(XLWorkbook workbook, IReadOnlyList<XLBookArea> areas, XLWorksheet? sheet)
+    {
+        var formatValue = new Hierarchy(workbook, sheet?.Name, null, null, null);
+        return new XLCellFormat(workbook, formatValue)
+        {
+            Areas = areas,
+            IsCells = true
         };
     }
 
@@ -223,9 +238,29 @@ internal partial class XLCellFormat
 
     internal void ModifyOuterBorder<TProperty>(Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
     {
+        var styles = _workbook.Styles;
+        if (IsCells)
+        {
+            var setAll = GetModifyBorderFunc(border => border with
+            {
+                Left = modify(border.Left, value),
+                Top = modify(border.Top, value),
+                Right = modify(border.Right, value),
+                Bottom = modify(border.Bottom, value),
+            }, styles);
+            foreach (var (sheetName, area) in Areas)
+            {
+                if (!_workbook.TryGetWorksheet(sheetName, out XLWorksheet worksheet))
+                    continue;
+
+                ApplyToAll(area, setAll, worksheet);
+            }
+
+            return;
+        }
+
         // Change only top and bottom border of a row. The style is used by non-materialized cells
         // in a row and will be used by non-materialized cells in a row. Same applies to columns.
-        var styles = _workbook.Styles;
         var setTopAndBottom = GetModifyBorderFunc(border => border with
         {
             Top = modify(border.Top, value),
@@ -240,8 +275,8 @@ internal partial class XLCellFormat
         }, styles);
         ModifyColumnsBorder(setLeftAndRight);
 
-        // Set outer border to areas. Don't use UsedAreas, they are for columns/rows. Worksheet
-        // doesn't have outer border.
+        // A normal path for range API object (except XLCells). Set outer border to areas.
+        // Don't use UsedAreas, they are for columns/rows. Worksheet doesn't have outer border.
         var setLeft = GetModifyBorderFunc(border => border with { Left = modify(border.Left, value) }, styles);
         var setTop = GetModifyBorderFunc(border => border with { Top = modify(border.Top, value) }, styles);
         var setRight = GetModifyBorderFunc(border => border with { Right = modify(border.Right, value) }, styles);
@@ -274,6 +309,10 @@ internal partial class XLCellFormat
 
     internal void ModifyInnerBorder<TProperty>(Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
     {
+        // Shortcut for XLCells - it has no inner borders
+        if (IsCells)
+            return;
+
         var styles = _workbook.Styles;
         var setLeftAndRight = GetModifyBorderFunc(border => border with
         {

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -26,7 +26,9 @@ internal partial class XLCellFormat
     internal XLFontCellFormat Font => new(this);
 
     internal XLFillCellFormat Fill => new(this);
-    
+
+    internal XLBorderCellFormat Border => new(this);
+
     /// <summary>
     /// Cell areas in a workbook that should be updated when format is changed, e.g. when we have
     /// a format API object for a row container, the area are all cells of the row. It must be
@@ -206,6 +208,158 @@ internal partial class XLCellFormat
             var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Fill = modifiedFill });
             return modifiedFormat;
         });
+    }
+
+    internal void ModifyBorder<TProperty>(Func<XLBorderFormatValue, TProperty, XLBorderFormatValue> modifyBorder, TProperty value)
+    {
+        var styles = _workbook.Styles;
+        Modify(format =>
+        {
+            var modifiedBorder = styles.GetRegisteredBorderFormat(format.Border, border => modifyBorder(border, value));
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Border = modifiedBorder });
+            return modifiedFormat;
+        });
+    }
+
+    internal void ModifyOuterBorder<TProperty>(Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
+    {
+        // Change only top and bottom border of a row. The style is used by non-materialized cells
+        // in a row and will be used by non-materialized cells in a row. Same applies to columns.
+        var styles = _workbook.Styles;
+        var setTopAndBottom = GetModifyBorderFunc(border => border with
+        {
+            Top = modify(border.Top, value),
+            Bottom = modify(border.Bottom, value),
+        }, styles);
+        ModifyRowsBorder(setTopAndBottom);
+
+        var setLeftAndRight = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Right = modify(border.Right, value),
+        }, styles);
+        ModifyColumnsBorder(setLeftAndRight);
+
+        // Set outer border to areas. Don't use UsedAreas, they are for columns/rows. Worksheet
+        // doesn't have outer border.
+        var setLeft = GetModifyBorderFunc(border => border with { Left = modify(border.Left, value) }, styles);
+        var setTop = GetModifyBorderFunc(border => border with { Top = modify(border.Top, value) }, styles);
+        var setRight = GetModifyBorderFunc(border => border with { Right = modify(border.Right, value) }, styles);
+        var setBottom = GetModifyBorderFunc(border => border with { Bottom = modify(border.Bottom, value) }, styles);
+        foreach (var area in Areas)
+        {
+            if (!_workbook.TryGetWorksheet(area.Name, out XLWorksheet worksheet))
+                continue;
+
+            var formatResolver = new FormatResolver(worksheet);
+            var cellsCollection = worksheet.Internals.CellsCollection;
+
+            // Left side
+            var left = area.Area.SliceFromLeft(1);
+            cellsCollection.ApplyFormatOnAll(left, setLeft, formatResolver.Resolve);
+
+            // Top side
+            var top = area.Area.SliceFromTop(1);
+            cellsCollection.ApplyFormatOnAll(top, setTop, formatResolver.Resolve);
+
+            // Right side
+            var right = area.Area.SliceFromRight(1);
+            cellsCollection.ApplyFormatOnAll(right, setRight, formatResolver.Resolve);
+
+            // Bottom side
+            var bottom = area.Area.SliceFromBottom(1);
+            cellsCollection.ApplyFormatOnAll(bottom, setBottom, formatResolver.Resolve);
+        }
+    }
+
+    internal void ModifyInnerBorder<TProperty>(Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
+    {
+        var styles = _workbook.Styles;
+        var setLeftAndRight = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Right = modify(border.Right, value),
+        }, styles);
+        ModifyRowsBorder(setLeftAndRight);
+
+        var setTopAndBottom = GetModifyBorderFunc(border => border with
+        {
+            Top = modify(border.Top, value),
+            Bottom = modify(border.Bottom, value)
+        }, styles);
+        ModifyColumnsBorder(setTopAndBottom);
+
+        var setLeft = GetModifyBorderFunc(border => border with { Left = modify(border.Left, value) }, styles);
+        var setTop = GetModifyBorderFunc(border => border with { Top = modify(border.Top, value) }, styles);
+        var setRight = GetModifyBorderFunc(border => border with { Right = modify(border.Right, value) }, styles);
+        var setBottom = GetModifyBorderFunc(border => border with { Bottom = modify(border.Bottom, value) }, styles);
+        foreach (var (sheetName, area) in Areas)
+        {
+            if (!_workbook.TryGetWorksheet(sheetName, out XLWorksheet worksheet))
+                continue;
+
+            var formatResolver = new FormatResolver(worksheet);
+            var cellsCollection = worksheet.Internals.CellsCollection;
+
+            // Setting line from both sides is not super useful, but keeps internal state consistent.
+            if (area.Width > 1)
+            {
+                cellsCollection.ApplyFormatOnAll(area.SliceFromLeft(area.Width - 1), setRight, formatResolver.Resolve);
+                cellsCollection.ApplyFormatOnAll(area.SliceFromRight(area.Width - 1), setLeft, formatResolver.Resolve);
+            }
+
+            if (area.Height > 1)
+            {
+                cellsCollection.ApplyFormatOnAll(area.SliceFromTop(area.Height - 1), setBottom, formatResolver.Resolve);
+                cellsCollection.ApplyFormatOnAll(area.SliceFromBottom(area.Height - 1), setTop, formatResolver.Resolve);
+            }
+        }
+    }
+
+    private static Func<XLCellFormatValue, XLCellFormatValue> GetModifyBorderFunc(Func<XLBorderFormatValue, XLBorderFormatValue> modifyBorder, XLWorkbookStyles styles)
+    {
+        return format =>
+        {
+            var modifiedBorder = styles.GetRegisteredBorderFormat(format.Border, modifyBorder);
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Border = modifiedBorder });
+            return modifiedFormat;
+        };
+    }
+
+    private void ModifyRowsBorder(Func<XLCellFormatValue, XLCellFormatValue> modifyBorder)
+    {
+        foreach (var rowArea in Rows)
+        {
+            if (!_workbook.TryGetWorksheet(rowArea.Name, out XLWorksheet worksheet))
+                continue;
+
+            // Row style is used by non-materialized cells in a row...
+            var row = worksheet.Row(rowArea.RowNumber);
+            ApplyColRowFormat(row, modifyBorder, worksheet);
+
+            // ... and materialized cells in a row have format explicitly set.
+            var formatResolver = new FormatResolver(worksheet);
+            var cellsCollection = worksheet.Internals.CellsCollection;
+            cellsCollection.ApplyFormatOnUsed(rowArea.Area.Area, modifyBorder, formatResolver.Resolve);
+        }
+    }
+
+    private void ModifyColumnsBorder(Func<XLCellFormatValue, XLCellFormatValue> modifyBorder)
+    {
+        foreach (var columnArea in Columns)
+        {
+            if (!_workbook.TryGetWorksheet(columnArea.Name, out XLWorksheet worksheet))
+                continue;
+
+            // Column style is used by non-materialized cells in a column...
+            var column = worksheet.Column(columnArea.ColumNumber);
+            ApplyColRowFormat(column, modifyBorder, worksheet);
+
+            // ... and materialized cells in a column have format explicitly set.
+            var formatResolver = new FormatResolver(worksheet);
+            var cellsCollection = worksheet.Internals.CellsCollection;
+            cellsCollection.ApplyFormatOnUsed(columnArea.Area.Area, modifyBorder, formatResolver.Resolve);
+        }
     }
 
     private void Modify(Func<XLCellFormatValue, XLCellFormatValue> modifyFormat)

--- a/ClosedXML/Excel/Style/Formatting/XLBorderFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderFormatValue.cs
@@ -7,41 +7,41 @@ internal record XLBorderFormatValue
 {
     internal static readonly XLBorderFormatValue None = new()
     {
-        Left = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
-        Right = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
-        Top = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
-        Bottom = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
-        Diagonal = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
-        Vertical = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
-        Horizontal = new XLBorderLine(XLColor.NoColor, XLBorderStyleValues.None),
+        Left = XLBorderLine.None,
+        Right = XLBorderLine.None,
+        Top = XLBorderLine.None,
+        Bottom = XLBorderLine.None,
+        Diagonal = XLBorderLine.None,
+        Vertical = XLBorderLine.None,
+        Horizontal = XLBorderLine.None,
         DiagonalUp = false,
         DiagonalDown = false,
         Outline = false
     };
 
-    public required XLBorderLine? Left { get; init; }
+    public required XLBorderLine Left { get; init; }
 
-    public required XLBorderLine? Right { get; init; }
+    public required XLBorderLine Right { get; init; }
 
-    public required XLBorderLine? Top { get; init; }
+    public required XLBorderLine Top { get; init; }
 
-    public required XLBorderLine? Bottom { get; init; }
+    public required XLBorderLine Bottom { get; init; }
 
     /// <summary>
     /// Used when <see cref="DiagonalUp"/> or <see cref="DiagonalDown"/> are set. It's not possible
     /// to have different style for up/down diagonal.
     /// </summary>
-    public required XLBorderLine? Diagonal { get; init; }
+    public required XLBorderLine Diagonal { get; init; }
 
     /// <summary>
     /// For pivot tables only.
     /// </summary>
-    public required XLBorderLine? Vertical { get; init; }
+    public required XLBorderLine Vertical { get; init; }
 
     /// <summary>
     /// For pivot tables only.
     /// </summary>
-    public required XLBorderLine? Horizontal { get; init; }
+    public required XLBorderLine Horizontal { get; init; }
 
     public required bool DiagonalUp { get; init; }
 
@@ -51,28 +51,21 @@ internal record XLBorderFormatValue
 
     internal XLBorderKey ApplyTo(XLBorderKey borderKey)
     {
-        if (Left is not null)
-            borderKey = borderKey with { LeftBorder = Left.Value.Style, LeftBorderColor = Left.Value.Color.Key };
-
-        if (Right is not null)
-            borderKey = borderKey with { RightBorder = Right.Value.Style, RightBorderColor = Right.Value.Color.Key };
-
-        if (Top is not null)
-            borderKey = borderKey with { TopBorder = Top.Value.Style, TopBorderColor = Top.Value.Color.Key };
-
-        if (Bottom is not null)
-            borderKey = borderKey with { BottomBorder = Bottom.Value.Style, BottomBorderColor = Bottom.Value.Color.Key };
-
-        if (Diagonal is not null)
+        borderKey = new XLBorderKey
         {
-            borderKey = borderKey with
-            {
-                DiagonalBorder = Diagonal.Value.Style,
-                DiagonalBorderColor = Diagonal.Value.Color.Key,
-                DiagonalUp = DiagonalUp,
-                DiagonalDown = DiagonalDown
-            };
-        }
+            LeftBorder = Left.Style,
+            LeftBorderColor = Left.Color.Key,
+            RightBorder = Right.Style,
+            RightBorderColor = Right.Color.Key,
+            TopBorder = Top.Style,
+            TopBorderColor = Top.Color.Key,
+            BottomBorder = Bottom.Style,
+            BottomBorderColor = Bottom.Color.Key,
+            DiagonalBorder = Diagonal.Style,
+            DiagonalBorderColor = Diagonal.Color.Key,
+            DiagonalUp = DiagonalUp,
+            DiagonalDown = DiagonalDown
+        };
 
         return borderKey;
     }

--- a/ClosedXML/Excel/Style/Formatting/XLBorderLine.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderLine.cs
@@ -3,4 +3,7 @@ namespace ClosedXML.Excel.Formatting;
 /// <summary>
 /// Border line properties.
 /// </summary>
-internal readonly record struct XLBorderLine(XLColor Color, XLBorderStyleValues Style);
+internal readonly record struct XLBorderLine(XLColor Color, XLBorderStyleValues Style)
+{
+    internal static readonly XLBorderLine None = new(XLColor.Auto, XLBorderStyleValues.None);
+}

--- a/ClosedXML/Excel/Style/XLWorkbookStyles.cs
+++ b/ClosedXML/Excel/Style/XLWorkbookStyles.cs
@@ -326,6 +326,16 @@ internal class XLWorkbookStyles
         return modified;
     }
 
+    internal XLBorderFormatValue GetRegisteredBorderFormat(XLBorderFormatValue original, Func<XLBorderFormatValue, XLBorderFormatValue> modify)
+    {
+        var modified = modify(original);
+        if (_borderFormats.TryGetValue(modified, out var existingFill))
+            return existingFill;
+
+        AddBorderFormat(modified);
+        return modified;
+    }
+
     internal XLCellFormatValue GetRegisteredCellFormat(XLCellFormatValue original, Func<XLCellFormatValue, XLCellFormatValue> modify)
     {
         var modified = modify(original);


### PR DESCRIPTION
Another part of style rework. It implements a `Border` property of `XLCellFormat` API object to modify the `IXLBorder` of a `IXLStyle` interface. Everything is hidden behind STYLES_REWORK constant.

Setting border only sets format of a column and of of used cells in column - solves the #2517. 