### PR TITLE
Fix inside border of multi-rows/columns

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using ClosedXML.Excel;
 using ClosedXML.Tests.Utils;
@@ -305,6 +306,47 @@ namespace ClosedXML.Tests.Excel.Styles
             }
         }
 
+        [TestCaseSource(nameof(BorderColorSetters))]
+        public void Color_is_set_only_when_border_is_visible(Func<IXLBorder, XLColor> getColor, Action<IXLBorder, XLColor> setColor, Action<IXLBorder, XLBorderStyleValues> setStyle)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            var cell = ws.Cell("A1");
+            var defaultBorderColor = getColor(cell.Style.Border);
+            var color = XLColor.Red;
+
+            // Try and fail to set color, when border style is None.
+            setStyle(cell.Style.Border, XLBorderStyleValues.None);
+            setColor(cell.Style.Border, color);
+            Assert.AreEqual(defaultBorderColor, getColor(cell.Style.Border));
+
+            // Set color, when border style is visible.
+            setStyle(cell.Style.Border, XLBorderStyleValues.Thin);
+            setColor(cell.Style.Border, color);
+            Assert.AreEqual(color, getColor(cell.Style.Border));
+        }
+
+        [TestCaseSource(nameof(BorderColorSetters))]
+        public void Making_border_hidden_resets_the_color_to_default(Func<IXLBorder, XLColor> getColor, Action<IXLBorder, XLColor> setColor, Action<IXLBorder, XLBorderStyleValues> setStyle)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            var cell = ws.Cell("A1");
+            var defaultBorderColor = getColor(cell.Style.Border);
+            var color = XLColor.Red;
+
+            // Set the color of visible border
+            setStyle(cell.Style.Border, XLBorderStyleValues.Thin);
+            setColor(cell.Style.Border, color);
+            Assert.AreEqual(color, getColor(cell.Style.Border));
+
+            // When the border is hidden, the color is reset to default border color
+            setStyle(cell.Style.Border, XLBorderStyleValues.None);
+            Assert.AreEqual(defaultBorderColor, getColor(cell.Style.Border));
+        }
+
         private static void AssertCellBorder(IXLWorksheet ws, string cell, int sides, XLBorderStyleValues style = XLBorderStyleValues.Thick, XLColor color = null)
         {
             var border = ws.Cell(cell).Style.Border;
@@ -389,6 +431,21 @@ namespace ClosedXML.Tests.Excel.Styles
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorder, (border, value) => border.SetDiagonalBorder(value), styleValues);
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorderColor, (border, value) => border.SetDiagonalBorder(XLBorderStyleValues.Thin).Border.DiagonalBorderColor = value, colors);
             yield return FormatTestCase<IXLBorder>.ForBorder(border => border.DiagonalBorderColor, (border, value) => border.SetDiagonalBorder(XLBorderStyleValues.Thin).Border.SetDiagonalBorderColor(value), colors);
+        }
+
+        private static IEnumerable<object> BorderColorSetters()
+        {
+            yield return MakeTestCase(border => border.LeftBorderColor, (border, value) => border.LeftBorderColor = value, (border, style) => border.LeftBorder = style);
+            yield return MakeTestCase(border => border.TopBorderColor, (border, value) => border.TopBorderColor = value, (border, style) => border.TopBorder = style);
+            yield return MakeTestCase(border => border.RightBorderColor, (border, value) => border.RightBorderColor = value, (border, style) => border.RightBorder = style);
+            yield return MakeTestCase(border => border.BottomBorderColor, (border, value) => border.BottomBorderColor = value, (border, style) => border.BottomBorder = style);
+            yield return MakeTestCase(border => border.DiagonalBorderColor, (border, value) => border.DiagonalBorderColor = value, (border, style) => border.DiagonalBorder = style);
+            yield break;
+
+            static TestCaseData MakeTestCase(Func<IXLBorder, XLColor> getColor, Action<IXLBorder, XLColor> setColor, Action<IXLBorder, XLBorderStyleValues> setStyle)
+            {
+                return new TestCaseData(getColor, setColor, setStyle);
+            }
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -168,6 +168,35 @@ namespace ClosedXML.Tests.Excel.Styles
             AssertCellBorder(ws, "B3", Top | Bottom, XLBorderStyleValues.Thick, XLColor.Red);
         }
 
+        [Test, Ignore("Fixes #2517 in styles rework")] // TODO Styles: Enable after style rework switch
+        public void InsideBorder_for_multicolumn_colspans()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Reordered B-C,E-G - It can be in any order, duplicates are allowed in column specification string
+            ws.Columns("E,G,C,F,B,E,C").Style.Border.SetInsideBorder(XLBorderStyleValues.Thin);
+
+            AssertInsideBorderLeftColumn('B');
+            AssertInsideBorderRightColumn('C');
+
+            AssertInsideBorderLeftColumn('E');
+            AssertInsideBorderCenterColumns('F');
+            AssertInsideBorderRightColumn('G');
+            return;
+
+            void AssertInsideBorderLeftColumn(char column) => AssertColumn(column, Top | Right | Bottom);
+            void AssertInsideBorderCenterColumns(char column) => AssertColumn(column, All);
+            void AssertInsideBorderRightColumn(char column) => AssertColumn(column, Left | Top | Bottom);
+
+            void AssertColumn(char column, int sides)
+            {
+                AssertCellBorder(ws, $"{column}1", sides, XLBorderStyleValues.Thin);
+                AssertCellBorder(ws, $"{column}2", sides, XLBorderStyleValues.Thin);
+                AssertCellBorder(ws, $"{column}10", sides, XLBorderStyleValues.Thin);
+            }
+        }
+
         [Test]
         public void OutsideBorder_for_rows()
         {

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -110,7 +110,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
         [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
         [Timeout(100)]
-        public void OutsideBorder_for_columns()
+        public void OutsideBorder_for_column()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -140,7 +140,7 @@ namespace ClosedXML.Tests.Excel.Styles
 
         [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
         [Timeout(100)]
-        public void InsideBorder_for_columns()
+        public void InsideBorder_for_one_column()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -200,7 +200,7 @@ namespace ClosedXML.Tests.Excel.Styles
         }
 
         [Test]
-        public void InsideBorder_for_rows()
+        public void InsideBorder_for_one_row()
         {
             using var wb = new XLWorkbook();
             var ws = wb.AddWorksheet();
@@ -228,6 +228,35 @@ namespace ClosedXML.Tests.Excel.Styles
             // TODO Styles: Enable after switch, repository makes a mess with equality
             // AssertCellBorder(ws, "A2", Left | Right, XLBorderStyleValues.Thick, XLColor.Red);
             // AssertCellBorder(ws, "C2", Left | Right, XLBorderStyleValues.Thick, XLColor.Red);
+        }
+
+        [Test, Ignore("Fixes #2517 in styles rework")] // TODO Styles: Enable after style rework switch
+        public void InsideBorder_for_multirow_rowspans()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Reordered 2-3,5-7 - It can be in any order, duplicates are allowed in row specification string
+            ws.Rows("6,2,7,6,3,5,7").Style.Border.SetInsideBorder(XLBorderStyleValues.Thin);
+
+            AssertInsideBorderTopRow(2);
+            AssertInsideBorderBottomRow(3);
+
+            AssertInsideBorderTopRow(5);
+            AssertInsideBorderCenterRow(6);
+            AssertInsideBorderBottomRow(7);
+            return;
+
+            void AssertInsideBorderTopRow(int row) => AssertRow(row, Left | Bottom | Right);
+            void AssertInsideBorderCenterRow(int row) => AssertRow(row, All);
+            void AssertInsideBorderBottomRow(int row) => AssertRow(row, Left | Top | Right);
+
+            void AssertRow(int row, int sides)
+            {
+                AssertCellBorder(ws, $"A{row}", sides, XLBorderStyleValues.Thin);
+                AssertCellBorder(ws, $"B{row}", sides, XLBorderStyleValues.Thin);
+                AssertCellBorder(ws, $"Z{row}", sides, XLBorderStyleValues.Thin);
+            }
         }
 
         [Test]

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -38,6 +38,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=codeplex/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=codepoints/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coef/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=colspans/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COMBIN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=COMBINA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
@@ -92,6 +93,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAKEARRAY/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MAXIFS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MINIFS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=multicolumn/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NEGBINOM.DIST/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PDURATION/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PERCENTRANK.EXC/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -99,6 +99,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PERMUTATIONA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=PQSOURCE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDARRAY/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=rowspans/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SORTBY/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTAFTER/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTBEFORE/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -247,8 +247,7 @@ namespace ClosedXML.Excel
                     return XLCellFormat.ForWorksheet(_worksheet);
                 }
 
-                var columns = Columns.Select(x => x.Area).ToArray();
-                return XLCellFormat.ForColumns(_workbook, _defaultStyleSheet, columns);
+                return XLCellFormat.ForColumns(_workbook, _defaultStyleSheet, Columns);
             }
         }
 

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -2100,6 +2100,7 @@ namespace ClosedXML.Excel.IO
                 return xlRow.HeightChanged ||
                     xlRow.IsHidden ||
                     xlRow.StyleValue != xlRow.Worksheet.StyleValue ||
+                    xlRow.FormatValue is not null && xlRow.FormatValue != xlRow.Worksheet.Workbook.Styles.DefaultFormat ||
                     xlRow.Collapsed ||
                     xlRow.OutlineLevel > 0;
             }

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -235,8 +235,7 @@ namespace ClosedXML.Excel
                     return XLCellFormat.ForWorksheet(_worksheet);
                 }
 
-                var rows = Rows.Select(x => x.Area).ToArray();
-                return XLCellFormat.ForRows(_workbook, _defaultStyleSheet, rows);
+                return XLCellFormat.ForRows(_workbook, _defaultStyleSheet, Rows);
 
             }
         }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -44,9 +44,10 @@ internal partial class XLCellFormat
 
     /// <summary>
     /// Formatting is updated for these columns. This doesn't update cells within the columns, only
-    /// the columns themselves.
+    /// the columns themselves. The values are unique columns, sorted by column number in ascending
+    /// order.
     /// </summary>
-    private IReadOnlyList<XLColumnArea> Columns { get; init; } = Array.Empty<XLColumnArea>();
+    private XLColumnArea[] Columns { get; init; } = Array.Empty<XLColumnArea>();
 
     /// <summary>
     /// Formatting is updated for these rows. This doesn't update cells within the rows, only
@@ -96,13 +97,14 @@ internal partial class XLCellFormat
         };
     }
 
-    internal static XLCellFormat ForColumns(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLColumnArea> columns)
+    internal static XLCellFormat ForColumns(XLWorkbook workbook, XLWorksheet? formatValueSheet, IEnumerable<XLColumn> columns)
     {
+        var columnAreas = columns.Select(x => x.Area).Distinct().OrderBy(x => x.ColumNumber).ToArray();
         var formatValue = new Hierarchy(workbook, formatValueSheet?.Name, null, null, null);
         return new XLCellFormat(workbook, formatValue)
         {
-            Columns = columns,
-            UsedAreas = columns.Select(x => x.Area).ToArray()
+            Columns = columnAreas,
+            UsedAreas = columnAreas.Select(x => x.Area).ToArray()
         };
     }
 
@@ -275,7 +277,7 @@ internal partial class XLCellFormat
             Left = modify(border.Left, value),
             Right = modify(border.Right, value),
         }, styles);
-        ModifyColumnsBorder(setLeftAndRight);
+        ModifyColumnsBorder(Columns, setLeftAndRight);
 
         // A normal path for range API object (except XLCells). Set outer border to areas.
         // Don't use UsedAreas, they are for columns/rows. Worksheet doesn't have an outer border.
@@ -317,13 +319,7 @@ internal partial class XLCellFormat
 
         var styles = _workbook.Styles;
         ModifyInsideBordersOfRows(styles, modify, value);
-
-        var setTopAndBottom = GetModifyBorderFunc(border => border with
-        {
-            Top = modify(border.Top, value),
-            Bottom = modify(border.Bottom, value)
-        }, styles);
-        ModifyColumnsBorder(setTopAndBottom);
+        ModifyInsideBordersOfColumns(styles, modify, value);
 
         var setLeft = GetModifyBorderFunc(border => border with { Left = modify(border.Left, value) }, styles);
         var setTop = GetModifyBorderFunc(border => border with { Top = modify(border.Top, value) }, styles);
@@ -441,9 +437,70 @@ internal partial class XLCellFormat
         }
     }
 
-    private void ModifyColumnsBorder(Func<XLCellFormatValue, XLCellFormatValue> modifyBorder)
+    private void ModifyInsideBordersOfColumns<TProperty>(XLWorkbookStyles styles, Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
     {
-        foreach (var columnArea in Columns)
+        // For a single column, only the top are bottom border are counted as "inside". The left and right border touch the outside.
+        var setTopAndBottom = GetModifyBorderFunc(border => border with
+        {
+            Top = modify(border.Top, value),
+            Bottom = modify(border.Bottom, value)
+        }, styles);
+
+        // For multi-column colspan, there are three different patterns:
+        // Multi-column colspan - left column
+        var setTopRightBottom = GetModifyBorderFunc(border => border with
+        {
+            Top = modify(border.Top, value),
+            Right = modify(border.Right, value),
+            Bottom = modify(border.Bottom, value),
+        }, styles);
+
+        // Multi-column colspan - center columns. There isn't a center column in 2-column colspan
+        var setAll = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Top = modify(border.Top, value),
+            Right = modify(border.Right, value),
+            Bottom = modify(border.Bottom, value),
+        }, styles);
+
+        // Multi-column colspan - right column
+        var setLeftTopBottom = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Top = modify(border.Top, value),
+            Bottom = modify(border.Bottom, value),
+        }, styles);
+
+        // Set border for each colspan
+        for (var i = 0; i < Columns.Length; ++i)
+        {
+            // Find colspan as a sequence of consecutive columns 
+            var startIndex = i;
+            var endIndex = i;
+            while (endIndex + 1 < Columns.Length && Columns[endIndex + 1].ColumNumber == Columns[endIndex].ColumNumber + 1)
+            {
+                endIndex += 1;
+            }
+
+            i = endIndex;
+            var colspanWidth = endIndex - startIndex + 1;
+            if (colspanWidth > 1)
+            {
+                ModifyColumnsBorder(Columns.AsSpan(startIndex, 1), setTopRightBottom);
+                ModifyColumnsBorder(Columns.AsSpan(startIndex + 1, colspanWidth - 2), setAll);
+                ModifyColumnsBorder(Columns.AsSpan(endIndex, 1), setLeftTopBottom);
+            }
+            else
+            {
+                ModifyColumnsBorder(Columns.AsSpan(startIndex, 1), setTopAndBottom);
+            }
+        }
+    }
+
+    private void ModifyColumnsBorder(ReadOnlySpan<XLColumnArea> columns, Func<XLCellFormatValue, XLCellFormatValue> modifyBorder)
+    {
+        foreach (var columnArea in columns)
         {
             if (!_workbook.TryGetWorksheet(columnArea.Name, out XLWorksheet worksheet))
                 continue;

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -232,12 +232,7 @@ internal partial class XLCellFormat
     internal void ModifyBorder<TProperty>(Func<XLBorderFormatValue, TProperty, XLBorderFormatValue> modifyBorder, TProperty value)
     {
         var styles = _workbook.Styles;
-        Modify(format =>
-        {
-            var modifiedBorder = styles.GetRegisteredBorderFormat(format.Border, border => modifyBorder(border, value));
-            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Border = modifiedBorder });
-            return modifiedFormat;
-        });
+        Modify(GetModifyBorderFunc(border => modifyBorder(border, value), styles));
     }
 
     internal void ModifyOuterBorder<TProperty>(Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
@@ -352,7 +347,32 @@ internal partial class XLCellFormat
     {
         return format =>
         {
-            var modifiedBorder = styles.GetRegisteredBorderFormat(format.Border, modifyBorder);
+            var modifiedBorder = styles.GetRegisteredBorderFormat(format.Border, border =>
+            {
+                var modified = modifyBorder(border);
+
+                // Per original behavior, the non-visible border can't hold color state, e.g. when
+                // a border is set to from Thin to None and later changed back to Thick, it
+                // shouldn't remember the original color.
+                // That is not how Excel behaves and it makes everything harder (e.g. user can't
+                // set the border color first and then border style), but it is what it is.
+                if (!modified.Left.IsVisible)
+                    modified = modified with { Left = XLBorderLine.None };
+
+                if (!modified.Top.IsVisible)
+                    modified = modified with { Top = XLBorderLine.None };
+
+                if (!modified.Right.IsVisible)
+                    modified = modified with { Right = XLBorderLine.None };
+
+                if (!modified.Bottom.IsVisible)
+                    modified = modified with { Bottom = XLBorderLine.None };
+
+                if (!modified.Diagonal.IsVisible)
+                    modified = modified with { Diagonal = XLBorderLine.None };
+
+                return modified;
+            });
             var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Border = modifiedBorder });
             return modifiedFormat;
         };

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -50,9 +50,9 @@ internal partial class XLCellFormat
 
     /// <summary>
     /// Formatting is updated for these rows. This doesn't update cells within the rows, only
-    /// the rows themselves.
+    /// the rows themselves. The values are unique rows, sorted by row number in ascending order.
     /// </summary>
-    private IReadOnlyList<XLRowArea> Rows { get; init; } = Array.Empty<XLRowArea>();
+    private XLRowArea[] Rows { get; init; } = Array.Empty<XLRowArea>();
 
     /// <summary>
     /// Formatting is updated for these worksheets. This doesn't update cells within the sheets, only
@@ -118,13 +118,14 @@ internal partial class XLCellFormat
         };
     }
 
-    internal static XLCellFormat ForRows(XLWorkbook workbook, XLWorksheet? formatValueSheet, IReadOnlyList<XLRowArea> rows)
+    internal static XLCellFormat ForRows(XLWorkbook workbook, XLWorksheet? formatValueSheet, IEnumerable<XLRow> rows)
     {
+        var rowAreas = rows.Select(x => x.Area).Distinct().OrderBy(x => x.RowNumber).ToArray();
         var formatValue = new Hierarchy(workbook, formatValueSheet?.Name, null, null, null);
         return new XLCellFormat(workbook, formatValue)
         {
-            Rows = rows,
-            UsedAreas = rows.Select(x => x.Area).ToArray()
+            Rows = rowAreas,
+            UsedAreas = rowAreas.Select(x => x.Area).ToArray()
         };
     }
 
@@ -267,7 +268,7 @@ internal partial class XLCellFormat
             Top = modify(border.Top, value),
             Bottom = modify(border.Bottom, value),
         }, styles);
-        ModifyRowsBorder(setTopAndBottom);
+        ModifyRowsBorder(Rows, setTopAndBottom);
 
         var setLeftAndRight = GetModifyBorderFunc(border => border with
         {
@@ -315,12 +316,7 @@ internal partial class XLCellFormat
             return;
 
         var styles = _workbook.Styles;
-        var setLeftAndRight = GetModifyBorderFunc(border => border with
-        {
-            Left = modify(border.Left, value),
-            Right = modify(border.Right, value),
-        }, styles);
-        ModifyRowsBorder(setLeftAndRight);
+        ModifyInsideBordersOfRows(styles, modify, value);
 
         var setTopAndBottom = GetModifyBorderFunc(border => border with
         {
@@ -366,9 +362,70 @@ internal partial class XLCellFormat
         };
     }
 
-    private void ModifyRowsBorder(Func<XLCellFormatValue, XLCellFormatValue> modifyBorder)
+    private void ModifyInsideBordersOfRows<TProperty>(XLWorkbookStyles styles, Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)
     {
-        foreach (var rowArea in Rows)
+        // For a single row, only the left are right border are counted as "inside". The top and bottom border touch the outside.
+        var setLeftAndRight = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Right = modify(border.Right, value),
+        }, styles);
+
+        // For multi-row rowspan, there are three different patterns:
+        // Multi-row rowspan - top row
+        var setLeftRightBottom = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Right = modify(border.Right, value),
+            Bottom = modify(border.Bottom, value),
+        }, styles);
+
+        // Multi-row rowspan - center rows. There isn't a center row in 2-row rowspan
+        var setAll = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Top = modify(border.Top, value),
+            Right = modify(border.Right, value),
+            Bottom = modify(border.Bottom, value),
+        }, styles);
+
+        // Multi-row rowspan - bottom row
+        var setLeftTopRight = GetModifyBorderFunc(border => border with
+        {
+            Left = modify(border.Left, value),
+            Top = modify(border.Top, value),
+            Right = modify(border.Right, value),
+        }, styles);
+
+        // Set border for each rowspan
+        for (var i = 0; i < Rows.Length; ++i)
+        {
+            // Find rowspan as a sequence of consecutive rows 
+            var startIndex = i;
+            var endIndex = i;
+            while (endIndex + 1 < Rows.Length && Rows[endIndex + 1].RowNumber == Rows[endIndex].RowNumber + 1)
+            {
+                endIndex += 1;
+            }
+
+            i = endIndex;
+            var rowSpanHeight = endIndex - startIndex + 1;
+            if (rowSpanHeight > 1)
+            {
+                ModifyRowsBorder(Rows.AsSpan(startIndex, 1), setLeftRightBottom);
+                ModifyRowsBorder(Rows.AsSpan(startIndex + 1, rowSpanHeight - 2), setAll);
+                ModifyRowsBorder(Rows.AsSpan(endIndex, 1), setLeftTopRight);
+            }
+            else
+            {
+                ModifyRowsBorder(Rows.AsSpan(startIndex, 1), setLeftAndRight);
+            }
+        }
+    }
+
+    private void ModifyRowsBorder(ReadOnlySpan<XLRowArea> rows, Func<XLCellFormatValue, XLCellFormatValue> modifyBorder)
+    {
+        foreach (var rowArea in rows)
         {
             if (!_workbook.TryGetWorksheet(rowArea.Name, out XLWorksheet worksheet))
                 continue;

--- a/ClosedXML/Excel/Style/Formatting/XLBorderLine.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLBorderLine.cs
@@ -6,4 +6,9 @@ namespace ClosedXML.Excel.Formatting;
 internal readonly record struct XLBorderLine(XLColor Color, XLBorderStyleValues Style)
 {
     internal static readonly XLBorderLine None = new(XLColor.Auto, XLBorderStyleValues.None);
+
+    /// <summary>
+    /// Is the border line visible?
+    /// </summary>
+    internal bool IsVisible => Style != XLBorderStyleValues.None;
 }

--- a/ClosedXML/Excel/Style/IXLBorder.cs
+++ b/ClosedXML/Excel/Style/IXLBorder.cs
@@ -22,6 +22,16 @@ namespace ClosedXML.Excel
         Thin
     }
 
+    /// <summary>
+    /// <para>
+    /// The interface is used across many different objects. The value returned by properties is
+    /// defined only for <see cref="IXLCell"/>, <see cref="IXLRow"/>, <see cref="IXLColumn"/>,
+    /// <see cref="IXLWorksheet"/> and <see cref="XLWorkbook"/>. The returned value is undefined
+    /// for other <see cref="IXLRangeBase"/> objects that can contain multiple different property
+    /// values (e.g. <see cref="IXLRange"/> can contain multiple cells, <see cref="IXLColumns"/>
+    /// can contains multiple columns).
+    /// </para>
+    /// </summary>
     public interface IXLBorder : IEquatable<IXLBorder>
     {
         XLBorderStyleValues OutsideBorder { set; }
@@ -32,28 +42,99 @@ namespace ClosedXML.Excel
 
         XLColor InsideBorderColor { set; }
 
+        /// <summary>
+        /// Get or set style of the left border.
+        /// </summary>
+        /// <remarks>
+        /// When style is set to <see cref="XLBorderStyleValues.None"/>, the <see cref="LeftBorderColor"/>
+        /// is set to the default border color.
+        /// </remarks>
         XLBorderStyleValues LeftBorder { get; set; }
 
+        /// <summary>
+        /// Get or set color of the left border.
+        /// </summary>
+        /// <remarks>
+        /// The color can be set only when the border is visible (=<see cref="LeftBorder"/>
+        /// is not <see cref="XLBorderStyleValues.None"/>). Set style first, then color.
+        /// </remarks>
         XLColor LeftBorderColor { get; set; }
 
+        /// <summary>
+        /// Get or set style of the right border.
+        /// </summary>
+        /// <remarks>
+        /// When style is set to <see cref="XLBorderStyleValues.None"/>, the <see cref="RightBorderColor"/>
+        /// is set to the default border color.
+        /// </remarks>
         XLBorderStyleValues RightBorder { get; set; }
 
+        /// <summary>
+        /// Get or set color of the right border.
+        /// </summary>
+        /// <remarks>
+        /// The color can be set only when the border is visible (=<see cref="RightBorder"/>
+        /// is not <see cref="XLBorderStyleValues.None"/>). Set style first, then color.
+        /// </remarks>
         XLColor RightBorderColor { get; set; }
 
+        /// <summary>
+        /// Get or set style of the top border.
+        /// </summary>
+        /// <remarks>
+        /// When style is set to <see cref="XLBorderStyleValues.None"/>, the <see cref="TopBorderColor"/>
+        /// is set to the default border color.
+        /// </remarks>
         XLBorderStyleValues TopBorder { get; set; }
 
+        /// <summary>
+        /// Get or set color of the top border.
+        /// </summary>
+        /// <remarks>
+        /// The color can be set only when the border is visible (=<see cref="TopBorder"/>
+        /// is not <see cref="XLBorderStyleValues.None"/>). Set style first, then color.
+        /// </remarks>
         XLColor TopBorderColor { get; set; }
 
+        /// <summary>
+        /// Get or set style of the bottom border.
+        /// </summary>
+        /// <remarks>
+        /// When style is set to <see cref="XLBorderStyleValues.None"/>, the <see cref="BottomBorderColor"/>
+        /// is set to the default border color.
+        /// </remarks>
         XLBorderStyleValues BottomBorder { get; set; }
 
+        /// <summary>
+        /// Get or set color of the bottom border.
+        /// </summary>
+        /// <remarks>
+        /// The color can be set only when the border is visible (=<see cref="BottomBorder"/>
+        /// is not <see cref="XLBorderStyleValues.None"/>). Set style first, then color.
+        /// </remarks>
         XLColor BottomBorderColor { get; set; }
 
         Boolean DiagonalUp { get; set; }
 
         Boolean DiagonalDown { get; set; }
 
+        /// <summary>
+        /// Get or set style of the diagonal border.
+        /// </summary>
+        /// <remarks>
+        /// When style is set to <see cref="XLBorderStyleValues.None"/>, the <see cref="DiagonalBorderColor"/>
+        /// is set to the default border color.
+        /// </remarks>
         XLBorderStyleValues DiagonalBorder { get; set; }
 
+        /// <summary>
+        /// Get or set color of the diagonal border.
+        /// </summary>
+        /// <remarks>
+        /// The color can be set only when the border line is can be visible
+        /// (=<see cref="DiagonalBorder"/> is not <see cref="XLBorderStyleValues.None"/>).
+        /// Set style first, then color.
+        /// </remarks>
         XLColor DiagonalBorderColor { get; set; }
 
         IXLStyle SetOutsideBorder(XLBorderStyleValues value);
@@ -64,28 +145,68 @@ namespace ClosedXML.Excel
 
         IXLStyle SetInsideBorderColor(XLColor value);
 
+        /// <summary>
+        /// Set style of the left border.
+        /// </summary>
+        /// <inheritdoc cref="LeftBorder"/>
         IXLStyle SetLeftBorder(XLBorderStyleValues value);
 
+        /// <summary>
+        /// Set color of the left border.
+        /// </summary>
+        /// <inheritdoc cref="LeftBorderColor"/>
         IXLStyle SetLeftBorderColor(XLColor value);
 
+        /// <summary>
+        /// Set style of the right border.
+        /// </summary>
+        /// <inheritdoc cref="RightBorder"/>
         IXLStyle SetRightBorder(XLBorderStyleValues value);
 
+        /// <summary>
+        /// Set color of the right border.
+        /// </summary>
+        /// <inheritdoc cref="RightBorderColor"/>
         IXLStyle SetRightBorderColor(XLColor value);
 
+        /// <summary>
+        /// Set style of the top border.
+        /// </summary>
+        /// <inheritdoc cref="TopBorder"/>
         IXLStyle SetTopBorder(XLBorderStyleValues value);
 
+        /// <summary>
+        /// Set color of the top border.
+        /// </summary>
+        /// <inheritdoc cref="TopBorderColor"/>
         IXLStyle SetTopBorderColor(XLColor value);
 
+        /// <summary>
+        /// Set style of the bottom border.
+        /// </summary>
+        /// <inheritdoc cref="BottomBorder"/>
         IXLStyle SetBottomBorder(XLBorderStyleValues value);
 
+        /// <summary>
+        /// Set color of the bottom border.
+        /// </summary>
+        /// <inheritdoc cref="BottomBorderColor"/>
         IXLStyle SetBottomBorderColor(XLColor value);
 
         IXLStyle SetDiagonalUp(); IXLStyle SetDiagonalUp(Boolean value);
 
         IXLStyle SetDiagonalDown(); IXLStyle SetDiagonalDown(Boolean value);
 
+        /// <summary>
+        /// Set style of the diagonal border.
+        /// </summary>
+        /// <inheritdoc cref="DiagonalBorder"/>
         IXLStyle SetDiagonalBorder(XLBorderStyleValues value);
 
+        /// <summary>
+        /// Set color of the diagonal border.
+        /// </summary>
+        /// <inheritdoc cref="DiagonalBorderColor"/>
         IXLStyle SetDiagonalBorderColor(XLColor value);
     }
 }


### PR DESCRIPTION
`IXLBorder.InsideBorder` property doesn't work properly when used on a multi-row rowspans or multi-column colspans. It should set every border that doesn't touch "outside." Instead it only sets top/bottom border for columns and left/right border for rows. That behavior is correct only when there is *one* column. When there are multiple consecutive rows/columns, it needs to set also additional borders (vertical for columns, horizontal for rows).

This PR fixes that problem in style-rework (i.e. hidden behind compilation constant and is still WIP).

Example:
|Original | Fixed |
|------|-----|
|<img width="353" height="433" alt="image" src="https://github.com/user-attachments/assets/e2309d72-6ade-4fc6-b35b-48f30de802a8" />|<img width="427" height="584" alt="image" src="https://github.com/user-attachments/assets/b3e9a152-3742-4246-aecc-f4ecf018f1d4" />|

Related to #2517. That issue is mostly about performance, but also that multi-column  is incorrect.


