### PR TITLE
Style Rework: IXLAlignment

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/AlignmentTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/AlignmentTests.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using ClosedXML.Excel;
+using ClosedXML.Tests.Utils;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.Styles
@@ -35,7 +37,7 @@ namespace ClosedXML.Tests.Excel.Styles
             TestHelper.LoadAndAssert(wb =>
             {
                 var ws = wb.Worksheets.Single();
-                Assert.AreEqual(255, ws.Cell(1,1).Style.Alignment.TextRotation);
+                Assert.AreEqual(255, ws.Cell(1, 1).Style.Alignment.TextRotation);
                 for (var column = 2; column < 21; ++column)
                 {
                     var expectedAngle = (column - 2) * 10 - 90;
@@ -50,12 +52,175 @@ namespace ClosedXML.Tests.Excel.Styles
         [TestCase(256)]
         public void TextRotationOutsideBoundsThrowsException(int textRotation)
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 using var wb = new XLWorkbook();
                 var ws = wb.AddWorksheet();
                 ws.FirstCell().Style.Alignment.TextRotation = textRotation;
             });
+        }
+
+        [Test]
+        [TestCaseSource(nameof(AlignmentApiSetters))]
+        public void Alignment_property_can_be_individually_set(FormatTestCase<IXLAlignment> testCase)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            var cellFormat = ws.Cell("B2").Style;
+            foreach (var testValue in testCase.Values)
+            {
+                testCase.SetPropertyValue(cellFormat.Alignment, testValue);
+                var setValue = testCase.GetPropertyValue(cellFormat.Alignment);
+                Assert.AreEqual(testValue, setValue);
+            }
+        }
+
+        [Test]
+        [TestCaseSource(nameof(AlignmentApiSettersLimits))]
+        public void Alignment_property_limits_throw_exception<T>(Action<IXLAlignment, T> setter, params T[] invalidValues)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var alignment = ws.Cell("A1").Style.Alignment;
+
+            foreach (var invalidValue in invalidValues)
+            {
+                Assert.That(() => setter(alignment, invalidValue), Throws.TypeOf<ArgumentOutOfRangeException>());
+            }
+        }
+
+        [Test]
+        public void TextRotation_is_connected_with_TopToBottom()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var alignment = ws.Cell("A1").Style.Alignment;
+
+            alignment.TopToBottom = true;
+            Assert.AreEqual(255, alignment.TextRotation);
+
+            alignment.TopToBottom = false;
+            Assert.AreEqual(0, alignment.TextRotation);
+
+            alignment.TextRotation = 0;
+            Assert.IsFalse(alignment.TopToBottom);
+
+            alignment.TextRotation = 10;
+            Assert.IsFalse(alignment.TopToBottom);
+
+            alignment.TextRotation = 255;
+            Assert.IsTrue(alignment.TopToBottom);
+        }
+
+        [Test]
+        public void Alignment_can_be_copied()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var source = ws.Cell("A1").Style
+                .Alignment.SetHorizontal(XLAlignmentHorizontalValues.Right)
+                .Alignment.SetVertical(XLAlignmentVerticalValues.Top)
+                .Alignment.SetIndent(2)
+                .Alignment.SetJustifyLastLine()
+                .Alignment.SetReadingOrder(XLAlignmentReadingOrderValues.LeftToRight)
+                .Alignment.SetRelativeIndent(3)
+                .Alignment.SetShrinkToFit()
+                .Alignment.SetTextRotation(12)
+                .Alignment.SetWrapText();
+
+            ws.Cell("A2").Style.Alignment = source.Alignment;
+
+            var targetAlignment = ws.Cell("A2").Style.Alignment;
+            Assert.AreEqual(XLAlignmentHorizontalValues.Right, targetAlignment.Horizontal);
+            Assert.AreEqual(XLAlignmentVerticalValues.Top, targetAlignment.Vertical);
+            Assert.AreEqual(2, targetAlignment.Indent);
+            Assert.IsTrue(targetAlignment.JustifyLastLine);
+            Assert.AreEqual(XLAlignmentReadingOrderValues.LeftToRight, targetAlignment.ReadingOrder);
+            Assert.AreEqual(3, targetAlignment.RelativeIndent);
+            Assert.IsTrue(targetAlignment.ShrinkToFit);
+            Assert.AreEqual(12, targetAlignment.TextRotation);
+            Assert.IsTrue(targetAlignment.WrapText);
+        }
+
+        [Test]
+        public void Alignment_has_equality_comparison()
+        {
+            Action<IXLAlignment>[] changePropertyToNonDefault =
+            {
+                x => x.SetHorizontal(XLAlignmentHorizontalValues.Right),
+                x => x.SetVertical(XLAlignmentVerticalValues.Top),
+                x => x.SetIndent(2),
+                x => x.SetJustifyLastLine(),
+                x => x.SetReadingOrder(XLAlignmentReadingOrderValues.LeftToRight),
+                x => x.SetRelativeIndent(3),
+                x => x.SetShrinkToFit(),
+                x => x.SetTextRotation(12),
+                x => x.SetWrapText()
+            };
+
+            using var wb = new XLWorkbook();
+            foreach (var changeProperty in changePropertyToNonDefault)
+            {
+                var ws = wb.AddWorksheet();
+                var source = ws.Cell("A1").Style.Alignment;
+                var target = ws.Cell("A2").Style.Alignment;
+
+                Assert.AreEqual(source, target);
+                changeProperty(source);
+                Assert.AreNotEqual(source, target);
+            }
+        }
+
+        private static IEnumerable<FormatTestCase<IXLAlignment>> AlignmentApiSetters()
+        {
+            var hAlignValues = EnumPolyfill.GetValues<XLAlignmentHorizontalValues>();
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.Horizontal, (align, value) => align.Horizontal = value, hAlignValues);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.Horizontal, (align, value) => align.SetHorizontal(value), hAlignValues);
+
+            var vAlignValues = EnumPolyfill.GetValues<XLAlignmentVerticalValues>();
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.Vertical, (align, value) => align.Vertical = value, vAlignValues);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.Vertical, (align, value) => align.SetVertical(value), vAlignValues);
+
+            var testIndentValues = new[] { 0, 1, 5, 255 };
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.Indent, (align, value) => align.Indent = value, testIndentValues);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.Indent, (align, value) => align.SetIndent(value), testIndentValues);
+
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.JustifyLastLine, (align, value) => align.JustifyLastLine = value, false, true);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.JustifyLastLine, (align, value) => align.SetJustifyLastLine(value), false, true);
+
+            var readingOrderValues = EnumPolyfill.GetValues<XLAlignmentReadingOrderValues>();
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.ReadingOrder, (align, value) => align.ReadingOrder = value, readingOrderValues);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.ReadingOrder, (align, value) => align.SetReadingOrder(value), readingOrderValues);
+
+            // This is likely a property slated for deletion, but at least test for now
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.RelativeIndent, (align, value) => align.RelativeIndent = value, -10, 0, 10);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.RelativeIndent, (align, value) => align.SetRelativeIndent(value), -10, 0, 10);
+
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.ShrinkToFit, (align, value) => align.ShrinkToFit = value, false, true);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.ShrinkToFit, (align, value) => align.SetShrinkToFit(value), false, true);
+
+            var testTextRotationValues = new[] { -90, -5, 0, 5, 90, 255 };
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.TextRotation, (align, value) => align.TextRotation = value, testTextRotationValues);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.TextRotation, (align, value) => align.SetTextRotation(value), testTextRotationValues);
+
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.WrapText, (align, value) => align.WrapText = value, false, true);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.WrapText, (align, value) => align.SetWrapText(value), false, true);
+
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.TopToBottom, (align, value) => align.TopToBottom = value, false, true);
+            yield return FormatTestCase<IXLAlignment>.ForAlignment(align => align.TopToBottom, (align, value) => align.SetTopToBottom(value), false, true);
+        }
+
+        private static IEnumerable<TestCaseData> AlignmentApiSettersLimits()
+        {
+            yield return MakeCase((align, value) => align.Indent = value, -1, 256);
+            yield return MakeCase((align, value) => align.TextRotation = value, -91, 91, 254, 256);
+            yield break;
+
+            static TestCaseData MakeCase<T>(Action<IXLAlignment, T> setter, params T[] invalidValues)
+            {
+                return new TestCaseData(setter, invalidValues);
+            }
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Styles/FormatTestCase.cs
+++ b/ClosedXML.Tests/Excel/Styles/FormatTestCase.cs
@@ -18,29 +18,34 @@ public class FormatTestCase<TApi>
         _testValues = testValues;
     }
 
-    public static FormatTestCase<IXLFont> ForFont<T>(Func<IXLFont, T> getter, Action<IXLFont, T> setter, params T[] testValues)
+    internal static FormatTestCase<IXLFont> ForFont<T>(Func<IXLFont, T> getter, Action<IXLFont, T> setter, params T[] testValues)
     {
         return new FormatTestCase<IXLFont>(font => getter(font), (font, value) => setter(font, (T)value), testValues.Cast<object>().ToArray());
     }
 
-    public static FormatTestCase<IXLFill> ForFill<T>(Func<IXLFill, T> getter, Action<IXLFill, T> setter, params T[] testValues)
+    internal static FormatTestCase<IXLFill> ForFill<T>(Func<IXLFill, T> getter, Action<IXLFill, T> setter, params T[] testValues)
     {
         return new FormatTestCase<IXLFill>(fill => getter(fill), (fill, value) => setter(fill, (T)value), testValues.Cast<object>().ToArray());
     }
 
-    public static FormatTestCase<IXLBorder> ForBorder<T>(Func<IXLBorder, T> getter, Action<IXLBorder, T> setter, params T[] testValues)
+    internal static FormatTestCase<IXLBorder> ForBorder<T>(Func<IXLBorder, T> getter, Action<IXLBorder, T> setter, params T[] testValues)
     {
         return new FormatTestCase<IXLBorder>(border => getter(border), (border, value) => setter(border, (T)value), testValues.Cast<object>().ToArray());
     }
 
-    public IEnumerable<object> Values => _testValues;
+    internal static FormatTestCase<IXLAlignment> ForAlignment<T>(Func<IXLAlignment, T> getter, Action<IXLAlignment, T> setter, params T[] testValues)
+    {
+        return new FormatTestCase<IXLAlignment>(align => getter(align), (align, value) => setter(align, (T)value), testValues.Cast<object>().ToArray());
+    }
 
-    public object GetPropertyValue(TApi font)
+    internal IEnumerable<object> Values => _testValues;
+
+    internal object GetPropertyValue(TApi font)
     {
         return _getter(font);
     }
 
-    public void SetPropertyValue(TApi font, object value)
+    internal void SetPropertyValue(TApi font, object value)
     {
         _setter(font, value);
     }

--- a/ClosedXML/Excel/Style/Api/XLAlignmentCellFormat.IXLAlignment.cs
+++ b/ClosedXML/Excel/Style/Api/XLAlignmentCellFormat.IXLAlignment.cs
@@ -1,0 +1,186 @@
+using System;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// Explicit implementation of the <see cref="IXLAlignment"/> interface.
+/// </summary>
+internal sealed partial class XLAlignmentCellFormat : IXLAlignment
+{
+    XLAlignmentHorizontalValues IXLAlignment.Horizontal
+    {
+        get => Resolve(static format => format.Alignment.Horizontal);
+        set => Modify(static (alignment, hAlign) => alignment with { Horizontal = hAlign }, value);
+    }
+
+    XLAlignmentVerticalValues IXLAlignment.Vertical
+    {
+        get => Resolve(static format => format.Alignment.Vertical);
+        set => Modify(static (alignment, vAlign) => alignment with { Vertical = vAlign }, value);
+    }
+
+    int IXLAlignment.Indent
+    {
+        get => Resolve(static format => format.Alignment.Indent);
+        set => Modify(static (alignment, indent) => alignment with { Indent = indent }, value);
+    }
+
+    bool IXLAlignment.JustifyLastLine
+    {
+        get => Resolve(static format => format.Alignment.JustifyLastLine);
+        set => Modify(static (alignment, justifyLastLine) => alignment with { JustifyLastLine = justifyLastLine }, value);
+    }
+
+    XLAlignmentReadingOrderValues IXLAlignment.ReadingOrder
+    {
+        get => Resolve(static format => format.Alignment.ReadingOrder);
+        set => Modify(static (alignment, readingOrder) => alignment with { ReadingOrder = readingOrder }, value);
+    }
+
+    int IXLAlignment.RelativeIndent
+    {
+        get => Resolve(static format => format.Alignment.RelativeIndent);
+        set => Modify(static (alignment, relativeIndent) => alignment with { RelativeIndent = relativeIndent }, value);
+    }
+
+    bool IXLAlignment.ShrinkToFit
+    {
+        get => Resolve(static format => format.Alignment.ShrinkToFit);
+        set => Modify(static (alignment, shrinkToFit) => alignment with { ShrinkToFit = shrinkToFit }, value);
+    }
+
+    int IXLAlignment.TextRotation
+    {
+        get => Resolve(static format => format.Alignment.TextRotation.Value);
+        set => Modify(static (alignment, textRotation) => alignment with { TextRotation = new TextRotation(textRotation) }, value);
+    }
+
+    bool IXLAlignment.WrapText
+    {
+        get => Resolve(static format => format.Alignment.WrapText);
+        set => Modify(static (alignment, wrapText) => alignment with { WrapText = wrapText }, value);
+    }
+
+    bool IXLAlignment.TopToBottom
+    {
+        get => Resolve(static format => format.Alignment.TextRotation == TextRotation.VerticalText);
+        set => Modify(static (alignment, topToBottom) => alignment with { TextRotation = topToBottom ? TextRotation.VerticalText : TextRotation.None }, value);
+    }
+
+    IXLStyle IXLAlignment.SetHorizontal(XLAlignmentHorizontalValues value)
+    {
+        (this as IXLAlignment).Horizontal = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetVertical(XLAlignmentVerticalValues value)
+    {
+        (this as IXLAlignment).Vertical = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetIndent(int value)
+    {
+        (this as IXLAlignment).Indent = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetJustifyLastLine()
+    {
+        return (this as IXLAlignment).SetJustifyLastLine(true);
+    }
+
+    IXLStyle IXLAlignment.SetJustifyLastLine(bool value)
+    {
+        (this as IXLAlignment).JustifyLastLine = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetReadingOrder(XLAlignmentReadingOrderValues value)
+    {
+        (this as IXLAlignment).ReadingOrder = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetRelativeIndent(int value)
+    {
+        (this as IXLAlignment).RelativeIndent = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetShrinkToFit()
+    {
+        return (this as IXLAlignment).SetShrinkToFit(true);
+    }
+
+    IXLStyle IXLAlignment.SetShrinkToFit(bool value)
+    {
+        (this as IXLAlignment).ShrinkToFit = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetTextRotation(int value)
+    {
+        (this as IXLAlignment).TextRotation = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetWrapText()
+    {
+        return (this as IXLAlignment).SetWrapText(true);
+    }
+
+    IXLStyle IXLAlignment.SetWrapText(bool value)
+    {
+        (this as IXLAlignment).WrapText = value;
+        return _parent;
+    }
+
+    IXLStyle IXLAlignment.SetTopToBottom()
+    {
+        return (this as IXLAlignment).SetTopToBottom(true);
+    }
+
+    IXLStyle IXLAlignment.SetTopToBottom(bool value)
+    {
+        (this as IXLAlignment).TopToBottom = value;
+        return _parent;
+    }
+
+    bool IEquatable<IXLAlignment>.Equals(IXLAlignment? other)
+    {
+        if (other == null)
+            return false;
+
+        var align = Resolve(static x => x.Alignment);
+        if (align.Horizontal != other.Horizontal)
+            return false;
+
+        if (align.Vertical != other.Vertical)
+            return false;
+
+        if (align.Indent != other.Indent)
+            return false;
+
+        if (align.JustifyLastLine != other.JustifyLastLine)
+            return false;
+
+        if (align.ReadingOrder != other.ReadingOrder)
+            return false;
+
+        if (align.RelativeIndent != other.RelativeIndent)
+            return false;
+
+        if (align.ShrinkToFit != other.ShrinkToFit)
+            return false;
+
+        if (align.TextRotation.Value != other.TextRotation)
+            return false;
+
+        if (align.WrapText != other.WrapText)
+            return false;
+
+        return true;
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLAlignmentCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLAlignmentCellFormat.cs
@@ -1,0 +1,40 @@
+using System;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+internal partial class XLAlignmentCellFormat
+{
+    private readonly XLCellFormat _parent;
+
+    internal XLAlignmentCellFormat(XLCellFormat parent)
+    {
+        _parent = parent;
+    }
+
+    internal void SetValue(IXLAlignment value)
+    {
+        Modify(static (alignment, other) => alignment with
+        {
+            Horizontal = other.Horizontal,
+            Vertical = other.Vertical,
+            TextRotation = new TextRotation(other.TextRotation),
+            WrapText = other.WrapText,
+            Indent = other.Indent,
+            RelativeIndent = other.RelativeIndent,
+            JustifyLastLine = other.JustifyLastLine,
+            ShrinkToFit = other.ShrinkToFit,
+            ReadingOrder = other.ReadingOrder
+        }, value);
+    }
+
+    private T Resolve<T>(Func<XLCellFormatValue, T> selector)
+    {
+        return _parent.Resolve(selector);
+    }
+
+    private void Modify<TProperty>(Func<XLAlignmentFormatValue, TProperty, XLAlignmentFormatValue> modifyAlignment, TProperty value)
+    {
+        _parent.ModifyAlignment(modifyAlignment, value);
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -11,8 +11,8 @@ internal partial class XLCellFormat : IXLStyle
     // TODO Styles: Implement remaining format properties by using IXLStyle contract
     IXLAlignment IXLStyle.Alignment
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Alignment;
+        set => Alignment.SetValue(value);
     }
 
     IXLBorder IXLStyle.Border

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -29,6 +29,8 @@ internal partial class XLCellFormat
 
     internal XLBorderCellFormat Border => new(this);
 
+    internal XLAlignmentCellFormat Alignment => new(this);
+
     /// <summary>
     /// Cell areas in a workbook that should be updated when format is changed, e.g. when we have
     /// a format API object for a row container, the area are all cells of the row. It must be
@@ -233,6 +235,17 @@ internal partial class XLCellFormat
     {
         var styles = _workbook.Styles;
         Modify(GetModifyBorderFunc(border => modifyBorder(border, value), styles));
+    }
+
+    internal void ModifyAlignment<TProperty>(Func<XLAlignmentFormatValue, TProperty, XLAlignmentFormatValue> modifyAlignment, TProperty value)
+    {
+        var styles = _workbook.Styles;
+        Modify(format =>
+        {
+            var modifiedAlignment = modifyAlignment(format.Alignment, value);
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Alignment = modifiedAlignment });
+            return modifiedFormat;
+        });
     }
 
     internal void ModifyOuterBorder<TProperty>(Func<XLBorderLine, TProperty, XLBorderLine> modify, TProperty value)

--- a/ClosedXML/Excel/Style/Formatting/TextRotation.cs
+++ b/ClosedXML/Excel/Style/Formatting/TextRotation.cs
@@ -14,7 +14,7 @@ internal readonly record struct TextRotation
     public TextRotation(int value)
     {
         if (value is not (>= -90 and <= 90 or 255))
-            throw new ArgumentOutOfRangeException();
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Rotation must be between [-90,90] or 255 for vertical text.");
 
         Value = value;
     }

--- a/ClosedXML/Excel/Style/Formatting/XLAlignmentFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLAlignmentFormatValue.cs
@@ -1,7 +1,11 @@
+using System;
+
 namespace ClosedXML.Excel.Formatting;
 
 internal record XLAlignmentFormatValue
 {
+    private readonly int _indent;
+
     public required XLAlignmentHorizontalValues Horizontal { get; init; }
 
     public required XLAlignmentVerticalValues Vertical { get; init; }
@@ -16,7 +20,17 @@ internal record XLAlignmentFormatValue
     /// <summary>
     /// Indicates number of 3*spaces (of the normal style font) of indentation for text in a cell.
     /// </summary>
-    public required int Indent { get; init; }
+    public required int Indent
+    {
+        get => _indent;
+        init
+        {
+            if (value is < 0 or > 255)
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Indent must be between 0 and 255.");
+
+            _indent = value;
+        }
+    }
 
     /// <summary>
     /// Relative indentation for dxf. Indicates number of spaces to indent text in a cell.

--- a/ClosedXML/Excel/Style/IXLAlignment.cs
+++ b/ClosedXML/Excel/Style/IXLAlignment.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 
 namespace ClosedXML.Excel
@@ -15,9 +13,34 @@ namespace ClosedXML.Excel
     {
         Center,
         CenterContinuous,
+
+        /// <summary>
+        /// <para>
+        /// If <see cref="IXLAlignment.JustifyLastLine"/> is <c>false</c>, each line is justified
+        /// (flushed left and right), regardless of whether line has explicit line break or not.
+        /// This is a difference from <see cref="Justify"/> that only justifies automatically
+        /// wrapped lines and doesn't justify last line.
+        /// </para>
+        /// <para>
+        /// If <see cref="IXLAlignment.JustifyLastLine"/> is <c>true</c>, the words of each line
+        /// are distributed along the line, so the gap on the left and right side of each word has
+        /// same width. The gap is also on between word and left and right side of a cell.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// This alignment implicitly turns on <see cref="IXLAlignment.WrapText"/>, regardless of
+        /// actual value.
+        /// </remarks>
         Distributed,
         Fill,
         General,
+
+        /// <summary>
+        /// The text is justified when it is flushed left and right. For each line of text, it
+        /// aligns each line of the wrapped text in a cell to the right and left (except the last
+        /// line). Only text in wrapped lines (except last one) is justified. Text with explicit
+        /// line breaks isn't.
+        /// </summary>
         Justify,
         Left,
         Right
@@ -47,11 +70,19 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets or sets the cell's text indentation.
         /// </summary>
+        /// <value>
+        /// The value means a width equal to <c>indent_value * 3 * width_of_space_in_normal_font</c>.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">When the value is outside of [0,255].</exception>
         Int32 Indent { get; set; }
 
         /// <summary>
         /// Gets or sets whether the cell's last line is justified or not.
         /// </summary>
+        /// <value>
+        /// The value changes the behavior of <see cref="XLAlignmentHorizontalValues.Distributed"/>
+        /// alignment. Name of the property doesn't match actual behavior.
+        /// </value>
         Boolean JustifyLastLine { get; set; }
 
         /// <summary>
@@ -62,18 +93,34 @@ namespace ClosedXML.Excel
         /// <summary>
         /// Gets or sets the cell's relative indent.
         /// </summary>
+        /// <remarks>
+        /// This property doesn't seem to work. It only set indent of a cell to 0 when used as part
+        /// of differential format (regardless of relative ident value or actual ident value).
+        /// </remarks>
+        /// <value>
+        /// The value is used only in differential formatting. It determines an additional indent
+        /// to add to cells exiting <see cref="Indent"/>.
+        /// </value>
         Int32 RelativeIndent { get; set; }
 
         /// <summary>
         /// Gets or sets whether the cell's font size should decrease to fit the contents.
         /// </summary>
+        /// <remarks>
+        /// Only applicable when <see cref="WrapText"/> is <c>false</c>, either directly or
+        /// implicitly through some <see cref="XLAlignmentHorizontalValues"/> alignment (e.g.
+        /// <see cref="XLAlignmentHorizontalValues.Distributed"/>).
+        /// </remarks>
         Boolean ShrinkToFit { get; set; }
 
         /// <summary>
-        /// Gets or sets the cell's text rotation in degrees. Allowed values are -90
-        /// (text is rotated clockwise) to 90 (text is rotated counterclockwise) and
-        /// 255 for vertical layout of a text.
+        /// Gets or sets the cell's text rotation in degrees. 
         /// </summary>
+        /// <value>
+        /// Allowed values are -90 (text is rotated clockwise) to 90 (text is rotated
+        /// counterclockwise) and 255 for vertical layout of a text.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">When setting the rotation to a value outside of [-90,90] or 255.</exception>
         Int32 TextRotation { get; set; }
 
         /// <summary>
@@ -82,29 +129,94 @@ namespace ClosedXML.Excel
         Boolean WrapText { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the cell's text should be displayed from to to bottom
-        /// <para>(as opposed to the normal left to right).</para>
+        /// Gets or sets whether the cell's text should be displayed from top to bottom
+        /// (as opposed to the normal left to right).
         /// </summary>
+        /// <remarks>
+        /// The setter has same effect as as <c>alignment.TextRotation = topToBottom ? 255 : 0</c>.
+        /// </remarks>
         Boolean TopToBottom { get; set; }
 
+        /// <summary>
+        /// Sets the cell's horizontal alignment.
+        /// </summary>
+        /// <inheritdoc cref="Horizontal"/>
         IXLStyle SetHorizontal(XLAlignmentHorizontalValues value);
 
+        /// <summary>
+        /// Sets the cell's vertical alignment.
+        /// </summary>
+        /// <inheritdoc cref="Vertical"/>
         IXLStyle SetVertical(XLAlignmentVerticalValues value);
 
+        /// <summary>
+        /// Sets the cell's text indentation.
+        /// </summary>
+        /// <inheritdoc cref="Indent"/>
         IXLStyle SetIndent(Int32 value);
 
-        IXLStyle SetJustifyLastLine(); IXLStyle SetJustifyLastLine(Boolean value);
+        /// <summary>
+        /// Changes mode of <see cref="XLAlignmentHorizontalValues.Distributed"/> alignment.
+        /// </summary>
+        /// <inheritdoc cref="JustifyLastLine"/>
+        IXLStyle SetJustifyLastLine();
 
+        /// <summary>
+        /// Changes mode of <see cref="XLAlignmentHorizontalValues.Distributed"/> alignment.
+        /// </summary>
+        /// <inheritdoc cref="JustifyLastLine"/>
+        IXLStyle SetJustifyLastLine(Boolean value);
+
+        /// <summary>
+        /// Sets the cell's reading order.
+        /// </summary>
+        /// <inheritdoc cref="ReadingOrder"/>
         IXLStyle SetReadingOrder(XLAlignmentReadingOrderValues value);
 
         IXLStyle SetRelativeIndent(Int32 value);
 
-        IXLStyle SetShrinkToFit(); IXLStyle SetShrinkToFit(Boolean value);
+        /// <summary>
+        /// Sets whether the cell's font size should decrease to fit the contents.
+        /// </summary>
+        /// <inheritdoc cref="ShrinkToFit"/>
+        IXLStyle SetShrinkToFit();
 
+        /// <summary>
+        /// Sets whether the cell's font size should decrease to fit the contents.
+        /// </summary>
+        /// <inheritdoc cref="ShrinkToFit"/>
+        IXLStyle SetShrinkToFit(Boolean value);
+
+        /// <summary>
+        /// Sets the cell's text rotation in degrees. 
+        /// </summary>
+        /// <inheritdoc cref="TextRotation"/>
         IXLStyle SetTextRotation(Int32 value);
 
-        IXLStyle SetWrapText(); IXLStyle SetWrapText(Boolean value);
+        /// <summary>
+        /// Sets whether the cell's text should wrap if it doesn't fit.
+        /// </summary>
+        /// <inheritdoc cref="WrapText"/>
+        IXLStyle SetWrapText();
 
-        IXLStyle SetTopToBottom(); IXLStyle SetTopToBottom(Boolean value);
+        /// <summary>
+        /// Sets whether the cell's text should wrap if it doesn't fit.
+        /// </summary>
+        /// <inheritdoc cref="WrapText"/>
+        IXLStyle SetWrapText(Boolean value);
+
+        /// <summary>
+        /// Sets whether the cell's text should be displayed from top to bottom (as opposed to
+        /// the normal left to right).
+        /// </summary>
+        /// <inheritdoc cref="TopToBottom"/>
+        IXLStyle SetTopToBottom();
+
+        /// <summary>
+        /// Sets whether the cell's text should be displayed from top to bottom (as opposed to
+        /// the normal left to right).
+        /// </summary>
+        /// <inheritdoc cref="TopToBottom"/>
+        IXLStyle SetTopToBottom(Boolean value);
     }
 }

--- a/ClosedXML/Excel/Style/XLAlignment.cs
+++ b/ClosedXML/Excel/Style/XLAlignment.cs
@@ -104,6 +104,9 @@ namespace ClosedXML.Excel
             get { return Key.Indent; }
             set
             {
+                if (value is < 0 or > 255)
+                    throw new ArgumentOutOfRangeException();
+
                 if (Indent != value)
                 {
                     if (Horizontal == XLAlignmentHorizontalValues.General)
@@ -155,7 +158,7 @@ namespace ClosedXML.Excel
                 Int32 rotation = value;
 
                 if (rotation != 255 && (rotation < -90 || rotation > 90))
-                    throw new ArgumentException("TextRotation must be between -90 and 90 degrees, or 255.");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "TextRotation must be between -90 and 90 degrees, or 255.");
 
                 Modify(k => k with { TextRotation = rotation });
             }

--- a/docs/migrations/migrate-to-0.106.rst
+++ b/docs/migrations/migrate-to-0.106.rst
@@ -21,6 +21,13 @@ The number format setters (```IXLNumberFormatBase.NumberFormatId```,
 now throw an ```ArgumentOutOfRangeException``` when supplied number format id is
 not a predefined format id from ```XLPredefinedFormat```.
 
+************
+IXLAlignment
+************
+
+The ``IXLAlignment.TextRotation`` now throws ``ArgumentOutOfRangeException`` on invalid rotation
+instead of original ``ArgumentException``.
+
 *************
 IXLWorksheets
 *************


### PR DESCRIPTION
Add a new API object that represents the `IXLAlignment` backed by the XLWorkbookStyle object, instead of current repositories.