### PR TITLE
Style rework: IXLProtection and IXLStyle.Equals

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/FormatTestCase.cs
+++ b/ClosedXML.Tests/Excel/Styles/FormatTestCase.cs
@@ -38,6 +38,11 @@ public class FormatTestCase<TApi>
         return new FormatTestCase<IXLAlignment>(align => getter(align), (align, value) => setter(align, (T)value), testValues.Cast<object>().ToArray());
     }
 
+    internal static FormatTestCase<IXLProtection> ForProtection<T>(Func<IXLProtection, T> getter, Action<IXLProtection, T> setter, params T[] testValues)
+    {
+        return new FormatTestCase<IXLProtection>(protection => getter(protection), (protection, value) => setter(protection, (T)value), testValues.Cast<object>().ToArray());
+    }
+
     internal IEnumerable<object> Values => _testValues;
 
     internal object GetPropertyValue(TApi font)

--- a/ClosedXML.Tests/Excel/Styles/ProtectionTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/ProtectionTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Styles;
+
+public class ProtectionTests
+{
+    [Test]
+    [TestCaseSource(nameof(ProtectionApiSetters))]
+    public void Protection_property_can_be_individually_set(FormatTestCase<IXLProtection> testCase)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+
+        var cellFormat = ws.Cell("B2").Style;
+        foreach (var testValue in testCase.Values)
+        {
+            testCase.SetPropertyValue(cellFormat.Protection, testValue);
+            var setValue = testCase.GetPropertyValue(cellFormat.Protection);
+            Assert.AreEqual(testValue, setValue);
+        }
+    }
+
+    [Test]
+    public void Protection_can_be_copied()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var targetProtection = ws.Cell("A2").Style.Protection;
+        Assert.IsTrue(targetProtection.Locked);
+        Assert.IsFalse(targetProtection.Hidden);
+        var source = ws.Cell("A1").Style
+            .Protection.SetLocked(false)
+            .Protection.SetHidden(true);
+
+        targetProtection = source.Protection;
+
+        Assert.IsFalse(targetProtection.Locked);
+        Assert.IsTrue(targetProtection.Hidden);
+    }
+
+    [Test]
+    public void Protection_has_equality_comparison()
+    {
+        Action<IXLProtection>[] changePropertyToNonDefault =
+        {
+            x => x.SetLocked(false),
+            x => x.SetHidden(true)
+        };
+
+        using var wb = new XLWorkbook();
+        foreach (var changeProperty in changePropertyToNonDefault)
+        {
+            var ws = wb.AddWorksheet();
+            var lhs = ws.Cell("A1").Style.Protection;
+            var rhs = ws.Cell("A2").Style.Protection;
+
+            Assert.AreEqual(lhs, rhs);
+            changeProperty(lhs);
+            Assert.AreNotEqual(lhs, rhs);
+        }
+    }
+
+    private static IEnumerable<object> ProtectionApiSetters()
+    {
+        var boolValues = new[] { false, true };
+        yield return FormatTestCase<IXLProtection>.ForProtection(protection => protection.Hidden, (protection, value) => protection.Hidden = value, boolValues);
+        yield return FormatTestCase<IXLProtection>.ForProtection(protection => protection.Hidden, (protection, value) => protection.SetHidden(value), boolValues);
+        yield return FormatTestCase<IXLProtection>.ForProtection(protection => protection.Hidden, (protection, _) => protection.SetHidden(), true);
+
+        yield return FormatTestCase<IXLProtection>.ForProtection(protection => protection.Locked, (protection, value) => protection.Locked = value, boolValues);
+        yield return FormatTestCase<IXLProtection>.ForProtection(protection => protection.Locked, (protection, value) => protection.SetLocked(value), boolValues);
+        yield return FormatTestCase<IXLProtection>.ForProtection(protection => protection.Locked, (protection, _) => protection.SetLocked(), true);
+    }
+}

--- a/ClosedXML.Tests/Excel/Styles/StyleTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/StyleTests.cs
@@ -235,29 +235,29 @@ namespace ClosedXML.Tests.Excel
             get
             {
                 var t = nameof(WorksheetStyleAffectsAllNestedEntities);
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Style)).SetName(t + ": Worksheet");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Style)).SetName(t + ": Worksheet");
 
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Columns().Style)).SetName(t + ": Columns()");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Columns(1, 3).Style)).SetName(t + ": Columns(1, 3)");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Columns("B:F").Style)).SetName(t + ": Columns(\"B:F\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Columns("B", "F").Style)).SetName(t + ": Columns(\"B\", \"F\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Column(5).Style)).SetName(t + ": Column(5)");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Column("D").Style)).SetName(t + ": Column(\"D\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Columns().Style)).SetName(t + ": Columns()");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Columns(1, 3).Style)).SetName(t + ": Columns(1, 3)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Columns("B:F").Style)).SetName(t + ": Columns(\"B:F\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Columns("B", "F").Style)).SetName(t + ": Columns(\"B\", \"F\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Column(5).Style)).SetName(t + ": Column(5)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Column("D").Style)).SetName(t + ": Column(\"D\")");
 
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Rows().Style)).SetName(t + ": Rows()");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Rows(1, 3).Style)).SetName(t + ": Rows(1, 3)");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Rows("1:3").Style)).SetName(t + ": Rows(\"1:3\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Row(5).Style)).SetName(t + ": Row(5)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Rows().Style)).SetName(t + ": Rows()");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Rows(1, 3).Style)).SetName(t + ": Rows(1, 3)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Rows("1:3").Style)).SetName(t + ": Rows(\"1:3\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Row(5).Style)).SetName(t + ": Row(5)");
 
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Cells().Style)).SetName(t + ": Cells()");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Cells("B2,D4").Style)).SetName(t + ": Cells(\"B2, D4\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Cell("F6").Style)).SetName(t + ": Cell(\"F6\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Cell(2, 3).Style)).SetName(t + ": Cell(2, 3)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Cells().Style)).SetName(t + ": Cells()");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Cells("B2,D4").Style)).SetName(t + ": Cells(\"B2, D4\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Cell("F6").Style)).SetName(t + ": Cell(\"F6\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Cell(2, 3).Style)).SetName(t + ": Cell(2, 3)");
 
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Ranges("F6:H9,I8:K10").Style)).SetName(t + ": Ranges(\"F6:H9,I8:K10\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Range("G8:H10").Style)).SetName(t + ": Range(\"G8:H10\")");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Range("G8:H10").Column(1).Style)).SetName(t + ": Range(\"G8:H10\").Column(1)");
-                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>((ws) => ws.Range("G8:H10").Row(2).Style)).SetName(t + ": Range(\"G8:H10\").Row(2)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Ranges("F6:H9,I8:K10").Style)).SetName(t + ": Ranges(\"F6:H9,I8:K10\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Range("G8:H10").Style)).SetName(t + ": Range(\"G8:H10\")");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Range("G8:H10").Column(1).Style)).SetName(t + ": Range(\"G8:H10\").Column(1)");
+                yield return new TestCaseData(new Func<IXLWorksheet, IXLStyle>(ws => ws.Range("G8:H10").Row(2).Style)).SetName(t + ": Range(\"G8:H10\").Row(2)");
             }
         }
     }

--- a/ClosedXML.Tests/Excel/Styles/StyleTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/StyleTests.cs
@@ -1,9 +1,9 @@
-﻿using ClosedXML.Excel;
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ClosedXML.Excel;
+using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel
 {
@@ -169,6 +169,33 @@ namespace ClosedXML.Tests.Excel
 
             var colCellStyle = ws.Cell(5, 2).Style;
             Assert.AreEqual(colStyle, colCellStyle);
+        }
+
+        [Test]
+        public void Style_has_equality_comparison()
+        {
+            Action<IXLStyle>[] changePropertyToNonDefault =
+            {
+                x => x.NumberFormat.SetFormat("0.00"),
+                x => x.Font.SetFontSize(15),
+                x => x.SetIncludeQuotePrefix(),
+                x => x.Fill.SetPatternType(XLFillPatternValues.DarkGrid),
+                x => x.Border.SetBottomBorder(XLBorderStyleValues.Thick),
+                x => x.Alignment.SetHorizontal(XLAlignmentHorizontalValues.Right),
+                x => x.Protection.SetHidden(),
+            };
+
+            using var wb = new XLWorkbook();
+            foreach (var changeProperty in changePropertyToNonDefault)
+            {
+                var ws = wb.AddWorksheet();
+                var lhs = ws.Cell("A1").Style;
+                var rhs = ws.Cell("A2").Style;
+
+                Assert.AreEqual(lhs, rhs);
+                changeProperty(lhs);
+                Assert.AreNotEqual(lhs, rhs);
+            }
         }
 
         private static IEnumerable<TestCaseData> StylizedEntities

--- a/ClosedXML.Tests/Excel/Styles/StyleTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/StyleTests.cs
@@ -198,6 +198,38 @@ namespace ClosedXML.Tests.Excel
             }
         }
 
+        [Test]
+        public void Style_can_be_copied()
+        {
+            Action<IXLStyle>[] changePropertyToNonDefault =
+            {
+                x => x.NumberFormat.SetFormat("0.00"),
+                x => x.Font.SetFontSize(15),
+                x => x.SetIncludeQuotePrefix(),
+                x => x.Fill.SetPatternType(XLFillPatternValues.DarkGrid),
+                x => x.Border.SetBottomBorder(XLBorderStyleValues.Thick),
+                x => x.Alignment.SetHorizontal(XLAlignmentHorizontalValues.Right),
+                x => x.Protection.SetHidden(),
+            };
+
+            using var wb = new XLWorkbook();
+            foreach (var changeProperty in changePropertyToNonDefault)
+            {
+                var ws = wb.AddWorksheet();
+                var source = ws.Cell("A1").Style;
+                var target = ws.Cell("A2").Style;
+
+                Assert.AreEqual(source, target);
+                changeProperty(source);
+                Assert.AreNotEqual(source, target);
+
+                // Copy style
+                target = source;
+
+                Assert.AreEqual(source, target);
+            }
+        }
+
         private static IEnumerable<TestCaseData> StylizedEntities
         {
             get

--- a/ClosedXML/Excel/Style/Api/XLAlignmentCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLAlignmentCellFormat.cs
@@ -12,6 +12,16 @@ internal partial class XLAlignmentCellFormat
         _parent = parent;
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLAlignment other && (this as IEquatable<IXLAlignment>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+
     internal void SetValue(IXLAlignment value)
     {
         Modify(static (alignment, other) => alignment with

--- a/ClosedXML/Excel/Style/Api/XLBorderCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLBorderCellFormat.cs
@@ -1,3 +1,4 @@
+using System;
 using ClosedXML.Excel.Formatting;
 
 namespace ClosedXML.Excel;
@@ -81,6 +82,16 @@ internal sealed partial class XLBorderCellFormat
     {
         get => _parent.Resolve(static x => x.Border.Diagonal.Color);
         set => _parent.ModifyBorder(static (border, diagonalColor) => border with { Diagonal = border.Diagonal with { Color = diagonalColor } }, value);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLBorder other && (this as IEquatable<IXLBorder>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
     }
 
     internal void SetValue(IXLBorder value)

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -21,7 +21,7 @@ internal partial class XLCellFormat : IXLStyle
         set => Border.SetValue(value);
     }
 
-    IXLNumberFormat IXLStyle.DateFormat => throw new NotImplementedException();
+    IXLNumberFormat IXLStyle.DateFormat => NumberFormat;
 
     IXLFill IXLStyle.Fill
     {
@@ -37,8 +37,8 @@ internal partial class XLCellFormat : IXLStyle
 
     bool IXLStyle.IncludeQuotePrefix
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => IncludeQuotePrefix;
+        set => IncludeQuotePrefix = value;
     }
 
     IXLNumberFormat IXLStyle.NumberFormat
@@ -55,7 +55,8 @@ internal partial class XLCellFormat : IXLStyle
 
     IXLStyle IXLStyle.SetIncludeQuotePrefix(bool includeQuotePrefix)
     {
-        throw new NotImplementedException();
+        IncludeQuotePrefix = includeQuotePrefix;
+        return this;
     }
 
     bool IEquatable<IXLStyle>.Equals(IXLStyle? other)

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -49,8 +49,8 @@ internal partial class XLCellFormat : IXLStyle
 
     IXLProtection IXLStyle.Protection
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => Protection;
+        set => Protection.SetValue(value);
     }
 
     IXLStyle IXLStyle.SetIncludeQuotePrefix(bool includeQuotePrefix)

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -8,7 +8,6 @@ namespace ClosedXML.Excel;
 /// </summary>
 internal partial class XLCellFormat : IXLStyle
 {
-    // TODO Styles: Implement remaining format properties by using IXLStyle contract
     IXLAlignment IXLStyle.Alignment
     {
         get => Alignment;
@@ -95,6 +94,12 @@ internal partial class XLCellFormat : IXLStyle
     /// </summary>
     internal void SetStyle(IXLStyle value)
     {
-        throw new NotImplementedException();
+        NumberFormat.SetNumberFormat(value.NumberFormat.Format);
+        Font.SetFont(value.Font);
+        IncludeQuotePrefix = value.IncludeQuotePrefix;
+        Fill.SetValue(value.Fill);
+        Border.SetValue(value.Border);
+        Alignment.SetValue(value.Alignment);
+        Protection.SetValue(value.Protection);
     }
 }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.IXLStyle.cs
@@ -61,7 +61,32 @@ internal partial class XLCellFormat : IXLStyle
 
     bool IEquatable<IXLStyle>.Equals(IXLStyle? other)
     {
-        throw new NotImplementedException();
+        if (other is null)
+            return false;
+
+        // The API object for each component implement IEquitable<IXL..>
+        if (!NumberFormat.Equals(other.NumberFormat))
+            return false;
+
+        if (!Font.Equals(other.Font))
+            return false;
+
+        if (!IncludeQuotePrefix.Equals(other.IncludeQuotePrefix))
+            return false;
+
+        if (!Fill.Equals(other.Fill))
+            return false;
+
+        if (!Border.Equals(other.Border))
+            return false;
+
+        if (!Alignment.Equals(other.Alignment))
+            return false;
+
+        if (!Protection.Equals(other.Protection))
+            return false;
+
+        return true;
     }
 
     /// <summary>

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -31,6 +31,8 @@ internal partial class XLCellFormat
 
     internal XLAlignmentCellFormat Alignment => new(this);
 
+    internal XLProtectionCellFormat Protection => new(this);
+
     /// <summary>
     /// Cell areas in a workbook that should be updated when format is changed, e.g. when we have
     /// a format API object for a row container, the area are all cells of the row. It must be
@@ -244,6 +246,17 @@ internal partial class XLCellFormat
         {
             var modifiedAlignment = modifyAlignment(format.Alignment, value);
             var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Alignment = modifiedAlignment });
+            return modifiedFormat;
+        });
+    }
+
+    internal void ModifyProtection<TProperty>(Func<XLProtectionFormatValue, TProperty, XLProtectionFormatValue> modifyProtection, TProperty value)
+    {
+        var styles = _workbook.Styles;
+        Modify(format =>
+        {
+            var modifiedProtection = modifyProtection(format.Protection, value);
+            var modifiedFormat = styles.GetRegisteredCellFormat(format, cellFormat => cellFormat with { Protection = modifiedProtection });
             return modifiedFormat;
         });
     }

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -83,6 +83,16 @@ internal partial class XLCellFormat
     /// </summary>
     private bool IsCells { get; init; }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLStyle other && (this as IEquatable<IXLStyle>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+
     internal static XLCellFormat ForCell(XLCell cell)
     {
         var workbook = cell.Worksheet.Workbook;

--- a/ClosedXML/Excel/Style/Api/XLCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLCellFormat.cs
@@ -33,6 +33,12 @@ internal partial class XLCellFormat
 
     internal XLProtectionCellFormat Protection => new(this);
 
+    internal bool IncludeQuotePrefix
+    {
+        get => Resolve(static format => format.IncludeQuotePrefix);
+        set => Modify(format => format with { IncludeQuotePrefix = value });
+    }
+
     /// <summary>
     /// Cell areas in a workbook that should be updated when format is changed, e.g. when we have
     /// a format API object for a row container, the area are all cells of the row. It must be

--- a/ClosedXML/Excel/Style/Api/XLFillCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFillCellFormat.cs
@@ -1,3 +1,4 @@
+using System;
 using ClosedXML.Excel.Formatting;
 
 namespace ClosedXML.Excel;
@@ -86,6 +87,16 @@ internal sealed partial class XLFillCellFormat
 
             return new XLFillFormatValue(pattern with { PatternType = patternType });
         }, value);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLFill other && (this as IEquatable<IXLFill>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
     }
 
     internal void SetValue(IXLFill value)

--- a/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLFontCellFormat.cs
@@ -93,6 +93,16 @@ internal sealed partial class XLFontCellFormat
         set => Modify(static (font, scheme) => font with { Scheme = scheme }, value);
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLFont other && (this as IEquatable<IXLFont>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+
     private T Resolve<T>(Func<XLCellFormatValue, T> selector)
     {
         return _parent.Resolve(selector);

--- a/ClosedXML/Excel/Style/Api/XLNumberCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLNumberCellFormat.cs
@@ -34,6 +34,16 @@ internal sealed partial class XLNumberCellFormat
         set => _parent.ModifyNumberFormat(value);
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLNumberFormatBase other && (this as IEquatable<IXLNumberFormatBase>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
+
     internal void SetNumberFormat(string numberFormat)
     {
         Format = numberFormat;

--- a/ClosedXML/Excel/Style/Api/XLProtectionCellFormat.IXLProtection.cs
+++ b/ClosedXML/Excel/Style/Api/XLProtectionCellFormat.IXLProtection.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace ClosedXML.Excel;
+
+internal partial class XLProtectionCellFormat : IXLProtection
+{
+    bool IXLProtection.Locked
+    {
+        get => Resolve(static style => style.Protection.Locked);
+        set => Modify(static (protection, locked) => protection with { Locked = locked }, value);
+    }
+
+    bool IXLProtection.Hidden
+    {
+        get => Resolve(static style => style.Protection.Hidden);
+        set => Modify(static (protection, hidden) => protection with { Hidden = hidden }, value);
+    }
+
+    IXLStyle IXLProtection.SetLocked()
+    {
+        return (this as IXLProtection).SetLocked(true);
+    }
+
+    IXLStyle IXLProtection.SetLocked(bool value)
+    {
+        (this as IXLProtection).Locked = value;
+        return _parent;
+    }
+
+    IXLStyle IXLProtection.SetHidden()
+    {
+        return (this as IXLProtection).SetHidden(true);
+    }
+
+    IXLStyle IXLProtection.SetHidden(bool value)
+    {
+        (this as IXLProtection).Hidden = value;
+        return _parent;
+    }
+
+    bool IEquatable<IXLProtection>.Equals(IXLProtection? other)
+    {
+        if (other is null)
+            return false;
+
+        var protection = Resolve(static style => style.Protection);
+        return protection.Locked == other.Locked && protection.Hidden == other.Hidden;
+    }
+}

--- a/ClosedXML/Excel/Style/Api/XLProtectionCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLProtectionCellFormat.cs
@@ -12,6 +12,15 @@ internal sealed partial class XLProtectionCellFormat
         _parent = parent;
     }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is IXLProtection other && (this as IEquatable<IXLProtection>).Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return 0;
+    }
 
     internal void SetValue(IXLProtection value)
     {

--- a/ClosedXML/Excel/Style/Api/XLProtectionCellFormat.cs
+++ b/ClosedXML/Excel/Style/Api/XLProtectionCellFormat.cs
@@ -1,0 +1,34 @@
+using System;
+using ClosedXML.Excel.Formatting;
+
+namespace ClosedXML.Excel;
+
+internal sealed partial class XLProtectionCellFormat
+{
+    private readonly XLCellFormat _parent;
+
+    internal XLProtectionCellFormat(XLCellFormat parent)
+    {
+        _parent = parent;
+    }
+
+
+    internal void SetValue(IXLProtection value)
+    {
+        Modify(static (_, other) => new XLProtectionFormatValue
+        {
+            Hidden = other.Hidden,
+            Locked = other.Locked
+        }, value);
+    }
+
+    private T Resolve<T>(Func<XLCellFormatValue, T> selector)
+    {
+        return _parent.Resolve(selector);
+    }
+
+    private void Modify<TProperty>(Func<XLProtectionFormatValue, TProperty, XLProtectionFormatValue> modifyProtection, TProperty value)
+    {
+        _parent.ModifyProtection(modifyProtection, value);
+    }
+}

--- a/ClosedXML/Excel/Style/Formatting/XLProtectionFormatValue.cs
+++ b/ClosedXML/Excel/Style/Formatting/XLProtectionFormatValue.cs
@@ -1,6 +1,6 @@
 namespace ClosedXML.Excel.Formatting;
 
-internal class XLProtectionFormatValue
+internal record XLProtectionFormatValue
 {
     public required bool Locked { get; init; }
 

--- a/ClosedXML/Excel/Style/IXLProtection.cs
+++ b/ClosedXML/Excel/Style/IXLProtection.cs
@@ -1,17 +1,50 @@
-#nullable disable
-
 using System;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+public interface IXLProtection : IEquatable<IXLProtection>
 {
-    public interface IXLProtection : IEquatable<IXLProtection>
-    {
-        Boolean Locked { get; set; }
+    /// <summary>
+    /// Get or set whether a cell is locked.
+    /// </summary>
+    /// <remarks>
+    /// When a cell is locked and its sheet is protected (<c>IXLWorksheet.Protection</c>), then
+    /// the protected operations (<see cref="XLSheetProtectionElements"/>) are prohibited on
+    /// the cell.
+    /// </remarks>
+    Boolean Locked { get; set; }
 
-        Boolean Hidden { get; set; }
+    /// <summary>
+    /// Get or set whether cell is a hidden.
+    /// </summary>
+    /// <value>
+    /// When a cell is hidden and its sheet is protected (<c>IXLWorksheet.Protection</c>), then
+    /// application will display content of a cell in a grid, but it will hide formulas bar
+    /// content (i.e. formulas or even plain text).
+    /// </value>
+    Boolean Hidden { get; set; }
 
-        IXLStyle SetLocked(); IXLStyle SetLocked(Boolean value);
+    /// <summary>
+    /// Set cell as locked.
+    /// </summary>
+    /// <inheritdoc cref="Locked"/>
+    IXLStyle SetLocked();
 
-        IXLStyle SetHidden(); IXLStyle SetHidden(Boolean value);
-    }
+    /// <summary>
+    /// Set whether a cell is locked.
+    /// </summary>
+    /// <inheritdoc cref="Locked"/>
+    IXLStyle SetLocked(Boolean value);
+
+    /// <summary>
+    /// Set cell as hidden.
+    /// </summary>
+    /// <inheritdoc cref="Hidden"/>
+    IXLStyle SetHidden();
+
+    /// <summary>
+    /// Set whether a cell is hidden.
+    /// </summary>
+    /// <inheritdoc cref="Hidden"/>
+    IXLStyle SetHidden(Boolean value);
 }


### PR DESCRIPTION
Add last missing functionality for replacement of `XLStyle` (cell format) in reworked style infrastructure. Yay. Now, to do the same thing for the differential formatting  😣😩