### PR TITLE
Added .NET8.0 as explicit target and Update SixLabors.Fonts

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <LangVersion>11.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <!-- netstandard 2.0 doesn't contain nullable annotations for BCL, so we want to export
          annotations for our consumers, but no warnings for our code. Warnings will be
          emitted by netstandard2.1 target -->
     <Nullable Condition="'$(TargetFramework)' == 'netstandard2.0'">annotations</Nullable>
-    <Nullable Condition="'$(TargetFramework)' == 'netstandard2.1'">enable</Nullable>
+    <Nullable Condition="'$(TargetFramework)' != 'netstandard2.0'">enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -45,7 +45,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="RBush.Signed" Version="4.0.0" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <PackageReference Include="ClosedXML.Parser" Version="2.0.0-preview1" />
   </ItemGroup>
 
@@ -53,6 +52,14 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="SixLabors.Fonts" Version="2.1.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClosedXML/Excel/Caching/XLRepositoryBase.cs
+++ b/ClosedXML/Excel/Caching/XLRepositoryBase.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Excel.Caching
         /// <returns>True if entry exists and alive, false otherwise.</returns>
         public bool ContainsKey(ref Tkey key, out Tvalue? value)
         {
-            if (_storage.TryGetValue(key, out WeakReference cachedReference))
+            if (_storage.TryGetValue(key, out WeakReference? cachedReference))
             {
                 value = cachedReference.Target as Tvalue;
                 return value != null;
@@ -66,7 +66,7 @@ namespace ClosedXML.Excel.Caching
 
             do
             {
-                if (_storage.TryGetValue(key, out WeakReference cachedReference) &&
+                if (_storage.TryGetValue(key, out WeakReference? cachedReference) &&
                     cachedReference.Target is Tvalue storedValue)
                 {
                     return storedValue;
@@ -78,20 +78,20 @@ namespace ClosedXML.Excel.Caching
 
         public Tvalue GetOrCreate(ref Tkey key)
         {
-            if (_storage.TryGetValue(key, out WeakReference cachedReference) &&
+            if (_storage.TryGetValue(key, out WeakReference? cachedReference) &&
                 cachedReference.Target is Tvalue storedValue)
             {
                 return storedValue;
             }
 
-            _storage.TryRemove(key, out WeakReference _);
+            _storage.TryRemove(key, out WeakReference? _);
             var value = _createNew(key);
             return Store(ref key, value)!;
         }
 
         public Tvalue? Replace(ref Tkey oldKey, ref Tkey newKey)
         {
-            if (_storage.TryRemove(oldKey, out WeakReference cachedReference) && cachedReference != null)
+            if (_storage.TryRemove(oldKey, out WeakReference? cachedReference) && cachedReference != null)
             {
                 _storage.TryAdd(newKey, cachedReference);
                 return GetOrCreate(ref newKey);
@@ -102,7 +102,7 @@ namespace ClosedXML.Excel.Caching
 
         public void Remove(ref Tkey key)
         {
-            _storage.TryRemove(key, out WeakReference _);
+            _storage.TryRemove(key, out WeakReference? _);
         }
 
         public override void Clear()
@@ -121,7 +121,7 @@ namespace ClosedXML.Excel.Caching
                     var val = pair.Value.Target as Tvalue;
                     if (val == null)
                     {
-                        _storage.TryRemove(pair.Key, out WeakReference _);
+                        _storage.TryRemove(pair.Key, out WeakReference? _);
                     }
                     return val;
                 })

--- a/ClosedXML/Excel/CalcEngine/ScalarValue.cs
+++ b/ClosedXML/Excel/CalcEngine/ScalarValue.cs
@@ -208,7 +208,7 @@ namespace ClosedXML.Excel.CalcEngine
         {
             if (text is null)
                 return Blank;
-            if (text == String.Empty)
+            if (text.Length == 0)
                 return Blank;
             if (StringComparer.OrdinalIgnoreCase.Equals("TRUE", text))
                 return true;

--- a/ClosedXML/Excel/Cells/SharedStringTable.cs
+++ b/ClosedXML/Excel/Cells/SharedStringTable.cs
@@ -158,7 +158,7 @@ namespace ClosedXML.Excel
             internal readonly object? Value;
 
             /// <summary>
-            /// Must be as flag for inline string, so the default value is false => ShareString is true by default 
+            /// Must be as flag for inline string, so the default value is false => ShareString is true by default
             /// </summary>
             internal readonly bool Inline;
 
@@ -168,7 +168,7 @@ namespace ClosedXML.Excel
                 Inline = inline;
             }
 
-            public override bool Equals(object obj) => obj is Text other && Equals(other);
+            public override bool Equals(object? obj) => obj is Text other && Equals(other);
 
             public bool Equals(Text other) => Equals(Value, other.Value) && Inline == other.Inline;
 

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -86,7 +86,7 @@ namespace ClosedXML.Excel
                 var toDelete = new Dictionary<IXLWorksheet, List<Int32>>();
                 foreach (XLColumn c in Columns)
                 {
-                    if (!toDelete.TryGetValue(c.Worksheet, out List<Int32> list))
+                    if (!toDelete.TryGetValue(c.Worksheet, out List<Int32>? list))
                     {
                         list = new List<Int32>();
                         toDelete.Add(c.Worksheet, list);

--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -207,12 +207,12 @@ namespace ClosedXML.Excel
             }
         }
 
-        private void OnRangeAdded(object sender, RangeEventArgs e)
+        private void OnRangeAdded(object? sender, RangeEventArgs e)
         {
-            ProcessRangeAdded(e.Range, (XLDataValidation) sender, skipIntersectionCheck: false);
+            ProcessRangeAdded(e.Range, (XLDataValidation) sender!, skipIntersectionCheck: false);
         }
 
-        private void OnRangeRemoved(object sender, RangeEventArgs e)
+        private void OnRangeRemoved(object? sender, RangeEventArgs e)
         {
             ProcessRangeRemoved(e.Range);
         }

--- a/ClosedXML/Excel/DefinedNames/XLDefinedNames.cs
+++ b/ClosedXML/Excel/DefinedNames/XLDefinedNames.cs
@@ -42,7 +42,7 @@ namespace ClosedXML.Excel
 
         internal XLDefinedName DefinedName(String name)
         {
-            if (_namedRanges.TryGetValue(name, out XLDefinedName range))
+            if (_namedRanges.TryGetValue(name, out XLDefinedName? range))
                 return range;
 
             throw new KeyNotFoundException($"Name {name} not found.");
@@ -104,11 +104,11 @@ namespace ClosedXML.Excel
                                 "The range address '{0}' for the named range '{1}' is not a valid range.", rangeAddress,
                                 name));
 
-                        if (Scope == XLNamedRangeScope.Workbook || !XLHelper.NamedRangeReferenceRegex.Match(range.ToString()).Success)
+                        if (Scope == XLNamedRangeScope.Workbook || !XLHelper.NamedRangeReferenceRegex.Match(range.ToString()!).Success)
                             throw new ArgumentException(
                                 "For named ranges in the workbook scope, specify the sheet name in the reference.");
 
-                        rangeAddress = range.ToString();
+                        rangeAddress = range.ToString()!;
                     }
                 }
             }

--- a/ClosedXML/Excel/Hyperlinks/XLHyperlinks.cs
+++ b/ClosedXML/Excel/Hyperlinks/XLHyperlinks.cs
@@ -74,7 +74,7 @@ internal class XLHyperlinks : IXLHyperlinks, ISheetListener
 
             _hyperlinks.Remove(hyperlinkArea, out var hyperlink);
             if (newHlArea is not null)
-                _hyperlinks.Add(newHlArea.Value, hyperlink);
+                _hyperlinks.Add(newHlArea.Value, hyperlink!);
         }
     }
 
@@ -123,7 +123,7 @@ internal class XLHyperlinks : IXLHyperlinks, ISheetListener
     /// <inheritdoc />
     public bool TryGet(IXLAddress address, out XLHyperlink hyperlink)
     {
-        return _hyperlinks.TryGetValue(XLSheetPoint.FromAddress(address), out hyperlink);
+        return _hyperlinks.TryGetValue(XLSheetPoint.FromAddress(address), out hyperlink!);
     }
 
     /// <summary>

--- a/ClosedXML/Excel/IO/CustomFilePropertiesPartWriter.cs
+++ b/ClosedXML/Excel/IO/CustomFilePropertiesPartWriter.cs
@@ -41,7 +41,7 @@ namespace ClosedXML.Excel.IO
                 {
                     var vTDouble1 = new VTDouble
                     {
-                        Text = p.GetValue<Double>().ToInvariantString()
+                        Text = p.GetValue<Double>().ToInvariantString()!
                     };
                     customDocumentProperty.AppendChild(vTDouble1);
                 }

--- a/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
+++ b/ClosedXML/Excel/IO/PivotTableDefinitionPartWriter2.cs
@@ -524,7 +524,7 @@ internal class PivotTableDefinitionPartWriter2
         xml.WriteAttributeDefault("cacheIndex", pivotArea.CacheIndex, false);
         xml.WriteAttributeDefault("outline", pivotArea.Outline, true);
         if (pivotArea.Offset is not null)
-            xml.WriteAttribute("offset", pivotArea.Offset.ToString());
+            xml.WriteAttribute("offset", pivotArea.Offset.ToString()!);
 
         xml.WriteAttributeDefault("collapsedLevelsAreSubtotals", pivotArea.CollapsedLevelsAreSubtotals, false);
         if (pivotArea.Axis is not null)

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -222,7 +222,7 @@ namespace ClosedXML.Excel.IO
             pane.VerticalSplit = ySplit;
 
             // When panes are frozen, which part should move.
-            PaneValues split;
+            PaneValues split = PaneValues.BottomLeft;
             if (ySplit == 0 && hSplit == 0)
                 split = PaneValues.TopLeft;
             else if (ySplit == 0 && hSplit != 0)

--- a/ClosedXML/Excel/IO/XmlToEnumMapper.cs
+++ b/ClosedXML/Excel/IO/XmlToEnumMapper.cs
@@ -36,7 +36,7 @@ internal sealed class XmlToEnumMapper : IEnumMapper
         where TEnum : struct, Enum
     {
         var enumMap = GetEnumMap<TEnum>();
-        return enumMap.ValueToKey.TryGetValue(enumValue, out text);
+        return enumMap.ValueToKey.TryGetValue(enumValue, out text!);
     }
 
     private BiDictionary<string, TEnum> GetEnumMap<TEnum>()

--- a/ClosedXML/Excel/PivotTables/XLPivotSourceConnection.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotSourceConnection.cs
@@ -15,7 +15,7 @@ internal sealed class XLPivotSourceConnection : IXLPivotSource
 
     public uint ConnectionId { get; }
 
-    public bool Equals(IXLPivotSource otherSource)
+    public bool Equals(IXLPivotSource? otherSource)
     {
         var other = otherSource as XLPivotSourceConnection;
         if (other is null)

--- a/ClosedXML/Excel/PivotTables/XLPivotSourceConsolidation.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotSourceConsolidation.cs
@@ -37,7 +37,7 @@ internal sealed class XLPivotSourceConsolidation : IXLPivotSource
     /// </summary>
     public IReadOnlyList<XLPivotCacheSourceConsolidationRangeSet> RangeSets { get; init; } = Array.Empty<XLPivotCacheSourceConsolidationRangeSet>();
 
-    public bool Equals(IXLPivotSource otherSource)
+    public bool Equals(IXLPivotSource? otherSource)
     {
         var other = otherSource as XLPivotSourceConsolidation;
         if (other is null)

--- a/ClosedXML/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotSourceExternalWorkbook.cs
@@ -47,7 +47,7 @@ internal sealed class XLPivotSourceExternalWorkbook : IXLPivotSource
         throw new NotImplementedException("External workbook source is not supported.");
     }
 
-    public bool Equals(IXLPivotSource otherSource)
+    public bool Equals(IXLPivotSource? otherSource)
     {
         var other = otherSource as XLPivotSourceExternalWorkbook;
         if (other is null)

--- a/ClosedXML/Excel/PivotTables/XLPivotSourceReference.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotSourceReference.cs
@@ -40,7 +40,7 @@ namespace ClosedXML.Excel
         /// </summary>
         internal string? Name { get; }
 
-        public bool Equals(IXLPivotSource otherSource)
+        public bool Equals(IXLPivotSource? otherSource)
         {
             var other = otherSource as XLPivotSourceReference;
             if (other is null)

--- a/ClosedXML/Excel/PivotTables/XLPivotSourceScenario.cs
+++ b/ClosedXML/Excel/PivotTables/XLPivotSourceScenario.cs
@@ -8,7 +8,7 @@ namespace ClosedXML.Excel;
 /// </summary>
 internal sealed class XLPivotSourceScenario : IXLPivotSource
 {
-    public bool Equals(IXLPivotSource other)
+    public bool Equals(IXLPivotSource? other)
     {
         return other is XLPivotSourceScenario;
     }

--- a/ClosedXML/Excel/Ranges/XLRangeAddress.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeAddress.cs
@@ -377,7 +377,7 @@ namespace ClosedXML.Excel
                 return ToStringRelative(includeSheet);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is XLRangeAddress))
             {
@@ -395,7 +395,7 @@ namespace ClosedXML.Excel
             var hashCode = -778064135;
             hashCode = hashCode * -1521134295 + FirstAddress.GetHashCode();
             hashCode = hashCode * -1521134295 + LastAddress.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<XLWorksheet?>.Default.GetHashCode(Worksheet);
+            hashCode = hashCode * -1521134295 + EqualityComparer<XLWorksheet?>.Default.GetHashCode(Worksheet!);
             return hashCode;
         }
 

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -26,7 +26,7 @@ namespace ClosedXML.Excel
 
         private IXLRangeIndex<XLRange> GetRangeIndex(IXLWorksheet worksheet)
         {
-            if (!_indexes.TryGetValue(worksheet, out IXLRangeIndex<XLRange> rangeIndex))
+            if (!_indexes.TryGetValue(worksheet, out IXLRangeIndex<XLRange>? rangeIndex))
             {
                 rangeIndex = new XLRangeIndex<XLRange>(worksheet);
                 _indexes.Add(worksheet, rangeIndex);
@@ -271,7 +271,7 @@ namespace ClosedXML.Excel
             return retVal;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as XLRanges);
         }

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -84,7 +84,7 @@ namespace ClosedXML.Excel
                 var toDelete = new Dictionary<IXLWorksheet, List<Int32>>();
                 foreach (XLRow r in Rows)
                 {
-                    if (!toDelete.TryGetValue(r.Worksheet, out List<Int32> list))
+                    if (!toDelete.TryGetValue(r.Worksheet, out List<Int32>? list))
                     {
                         list = new List<Int32>();
                         toDelete.Add(r.Worksheet, list);

--- a/ClosedXML/Excel/Sparkline/XLSparkLineGroups.cs
+++ b/ClosedXML/Excel/Sparkline/XLSparkLineGroups.cs
@@ -85,7 +85,7 @@ namespace ClosedXML.Excel
         /// </summary>
         /// <param name="cell">The cell to find the sparkline for</param>
         /// <returns>The sparkline in the cell or null if no sparklines are found</returns>
-        public IXLSparkline GetSparkline(IXLCell cell)
+        public IXLSparkline? GetSparkline(IXLCell cell)
         {
             return _sparklineGroups
                 .Select(g => g.GetSparkline(cell))

--- a/ClosedXML/Excel/Style/Api/XLFillCellFormat.IXLFill.cs
+++ b/ClosedXML/Excel/Style/Api/XLFillCellFormat.IXLFill.cs
@@ -40,7 +40,7 @@ internal sealed partial class XLFillCellFormat : IXLFill
         return _parent;
     }
 
-    bool IEquatable<IXLFill>.Equals(IXLFill other)
+    bool IEquatable<IXLFill>.Equals(IXLFill? other)
     {
         // This is a "business" equality, i.e. will both fills look the same.
         // This is gradient fill, other can only represent pattern, regardless of what it actually is.
@@ -48,10 +48,10 @@ internal sealed partial class XLFillCellFormat : IXLFill
         if (!isPatternFill)
             return false;
 
-        if (!HasFill(this) && !HasFill(other))
+        if (!HasFill(this) && !HasFill(other!))
             return true;
 
-        if (PatternType != other.PatternType)
+        if (PatternType != other!.PatternType)
             return false;
 
         if (BackgroundColor != other.BackgroundColor)

--- a/ClosedXML/Excel/Style/Colors/XLColor_Public.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Public.cs
@@ -95,16 +95,16 @@ namespace ClosedXML.Excel
 
         #region IEquatable<XLColor> Members
 
-        public bool Equals(XLColor other)
+        public bool Equals(XLColor? other)
         {
-            return Key == other.Key;
+            return Key == other!.Key;
         }
 
         #endregion IEquatable<XLColor> Members
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return Equals((XLColor)obj);
+            return Equals((XLColor)obj!);
         }
 
         public override int GetHashCode()

--- a/ClosedXML/Excel/Style/XLAlignment.cs
+++ b/ClosedXML/Excel/Style/XLAlignment.cs
@@ -299,7 +299,7 @@ namespace ClosedXML.Excel
             return sb.ToString();
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as XLAlignment);
         }

--- a/ClosedXML/Excel/Style/XLFill.cs
+++ b/ClosedXML/Excel/Style/XLFill.cs
@@ -168,7 +168,7 @@ namespace ClosedXML.Excel
 
         #region Overridden
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as XLFill);
         }

--- a/ClosedXML/Excel/Style/XLFont.cs
+++ b/ClosedXML/Excel/Style/XLFont.cs
@@ -370,7 +370,7 @@ namespace ClosedXML.Excel
             return sb.ToString();
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as XLFont);
         }

--- a/ClosedXML/Excel/Style/XLFontName.cs
+++ b/ClosedXML/Excel/Style/XLFontName.cs
@@ -24,7 +24,7 @@ internal readonly record struct XLFontName : IEquatable<string>
 
     public string Text { get; }
 
-    public bool Equals(string other)
+    public bool Equals(string? other)
     {
         return string.Equals(Text, other, Comparison);
     }

--- a/ClosedXML/Excel/Style/XLProtection.cs
+++ b/ClosedXML/Excel/Style/XLProtection.cs
@@ -118,12 +118,12 @@ namespace ClosedXML.Excel
 
         #region Overridden
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return Equals((IXLProtection)obj);
+            return Equals((IXLProtection?)obj);
         }
 
-        public bool Equals(IXLProtection other)
+        public bool Equals(IXLProtection? other)
         {
             var otherP = other as XLProtection;
             if (otherP == null)

--- a/ClosedXML/Excel/Style/XLStyleValue.cs
+++ b/ClosedXML/Excel/Style/XLStyleValue.cs
@@ -58,7 +58,7 @@ namespace ClosedXML.Excel
 
         internal XLProtectionValue Protection { get; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(this, obj))
                 return true;

--- a/ClosedXML/Excel/Tables/XLTableTheme.cs
+++ b/ClosedXML/Excel/Tables/XLTableTheme.cs
@@ -88,7 +88,7 @@ namespace ClosedXML.Excel
         {
             return (allThemes ?? (allThemes = typeof(XLTableTheme).GetFields(BindingFlags.Static | BindingFlags.Public)
                 .Where(fi => fi.FieldType.Equals(typeof(XLTableTheme)))
-                .Select(fi => (XLTableTheme)fi.GetValue(null))
+                .Select(fi => (XLTableTheme)fi.GetValue(null)!)
                 .ToArray()));
         }
 

--- a/ClosedXML/Excel/XLCellValue.cs
+++ b/ClosedXML/Excel/XLCellValue.cs
@@ -263,7 +263,7 @@ namespace ClosedXML.Excel
             // should deal with any weird formats.
             if (text is null)
                 return Blank.Value;
-            if (text == String.Empty)
+            if (text.Length == 0)
                 return Blank.Value;
             if (StringComparer.OrdinalIgnoreCase.Equals("TRUE", text))
                 return true;

--- a/ClosedXML/Excel/XLWorksheets.cs
+++ b/ClosedXML/Excel/XLWorksheets.cs
@@ -200,7 +200,7 @@ namespace ClosedXML.Excel
 
         public void Rename(String oldSheetName, String newSheetName)
         {
-            if (String.IsNullOrWhiteSpace(oldSheetName) || !_worksheets.TryGetValue(oldSheetName, out XLWorksheet ws)) return;
+            if (String.IsNullOrWhiteSpace(oldSheetName) || !_worksheets.TryGetValue(oldSheetName, out XLWorksheet? ws)) return;
 
             if (!oldSheetName.Equals(newSheetName, StringComparison.OrdinalIgnoreCase)
                 && _worksheets.ContainsKey(newSheetName))

--- a/ClosedXML/Extensions/ObjectExtensions.cs
+++ b/ClosedXML/Extensions/ObjectExtensions.cs
@@ -11,7 +11,7 @@ namespace ClosedXML.Excel
             return (T)Convert.ChangeType(o, typeof(T));
         }
 
-        public static string ToInvariantString<T>(this T value) where T : struct
+        public static string? ToInvariantString<T>(this T value) where T : struct
         {
             return value switch
             {

--- a/ClosedXML/Utils/BiDictionary.cs
+++ b/ClosedXML/Utils/BiDictionary.cs
@@ -57,7 +57,7 @@ internal class BiDictionary<TKey, TValue> : IReadOnlyBiDictionary<TKey, TValue>
 
     public bool TryGetValue(TKey key, out TValue value)
     {
-        return _keyToValue.TryGetValue(key, out value);
+        return _keyToValue.TryGetValue(key, out value!);
     }
 
     public bool ContainsKey(TKey key)

--- a/ClosedXML/Utils/CryptographicAlgorithms.cs
+++ b/ClosedXML/Utils/CryptographicAlgorithms.cs
@@ -44,7 +44,9 @@ namespace ClosedXML.Utils
 
         public static string GetSalt(int length = 32)
         {
+#pragma warning disable SYSLIB0023
             using (var random = new RNGCryptoServiceProvider())
+#pragma warning restore SYSLIB0023
             {
                 var salt = new byte[length];
                 random.GetNonZeroBytes(salt);
@@ -108,7 +110,9 @@ namespace ClosedXML.Utils
             var bytes = saltBytes.Concat(passwordBytes).ToArray();
 
             byte[] hashedBytes;
+#pragma warning disable SYSLIB0021
             using (var hash = new SHA512Managed())
+#pragma warning restore SYSLIB0021
             {
                 hashedBytes = hash.ComputeHash(bytes);
 

--- a/ClosedXML/Utils/ReferenceEqualityComparer.cs
+++ b/ClosedXML/Utils/ReferenceEqualityComparer.cs
@@ -8,7 +8,7 @@ internal sealed class ReferenceEqualityComparer<T> : IEqualityComparer<T>
 {
     public static readonly ReferenceEqualityComparer<T> Instance = new();
 
-    public bool Equals(T x, T y) => ReferenceEquals(x, y);
+    public bool Equals(T? x, T? y) => ReferenceEquals(x, y);
 
     public int GetHashCode(T obj) => RuntimeHelpers.GetHashCode(obj);
 }


### PR DESCRIPTION
Added .net8 as an explicit target and updated SixLabors.Fonts for .net8

With this we allow Applications on newer TargetFrameworks to consume the latest SixLabors.ImageSharp versions. 
The library still targets .netstandard2.0 and .netstandard2.1 for the rest.

