### PR TITLE
Add a representation of ST_Sqref

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests.Excel.Coordinates;
+
+[TestFixture]
+internal class XLAreaListTests
+{
+    [TestCase("A1:C3", "A1", "B1:C3 A2:A4")]
+    [TestCase("A1:C3", "B1", "A1:A3 C1:C3 B2:B4")]
+    [TestCase("A1:C3", "C1", "A1:B3 C2:C4")]
+    [TestCase("A1:C3", "A2", "A1 B1:C3 A3:A4")]
+    [TestCase("A1:C3", "B2", "A1:A3 B1 C1:C3 B3:B4")]
+    [TestCase("A1:C3", "C2", "A1:B3 C1 C3:C4")]
+    [TestCase("A1:C3", "A3", "A1:A2 B1:C3 A4")]
+    [TestCase("A1:C3", "B3", "A1:A3 B1:B2 C1:C3 B4")]
+    [TestCase("A1:C3", "C3", "A1:B3 C1:C2 C4")]
+
+    [TestCase("B1:D3", "A1:A3", "B1:D3")] // Insert to left side - don't move
+    [TestCase("A2:C4", "A1:C1", "A3:C5")] // Insert to top side - shift
+    [TestCase("A2:C4", "A2:C2", "A3:C5")] // Insert to top edge - shift
+    [TestCase("A2:C4", "A1", "B2:C4 A3:A5")] // Insert to top side - shift
+    [TestCase("A1:C3", "D1:D3", "A1:C3")] // Insert to right side - don't move
+    [TestCase("A1:C3", "A4:C5", "A1:C5")] // Insert to bottom edge - extend
+    [TestCase("A1:C3", "A4", "A1:C3 A4")] // Insert to bottom side - extend
+    [TestCase("A1:C3", "B4:E5", "A1:C3 B4:C5")] // Insert to bottom edge (inserted area is out of bounds of the area) - extend
+
+    [TestCase("A1048576", "A1048576", "")] // Push out of sheet
+    [TestCase("A1048575:A1048576", "A1048575", "A1048576")] // Partially push out of sheet
+    [TestCase("A1:A1048576", "A1", "A1:A1048576")] // Columns are not changed
+    public void InsertAndShiftDown(string areaList, string insertedArea, string expected)
+    {
+        var list = new XLAreaList(new List<XLSheetRange> { XLSheetRange.Parse(areaList) });
+        var result = list.InsertAndShiftDown(XLSheetRange.Parse(insertedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1:C3", "A1", "A2:C3 B1:D1")]
+    [TestCase("A1:C3", "B1", "A1:A3 B2:C3 C1:D1")]
+    [TestCase("A1:C3", "C1", "A1:B3 C2:C3 D1")]
+    [TestCase("A1:C3", "A2", "A1:C1 A3:C3 B2:D2")]
+    [TestCase("A1:C3", "B2", "A1:A3 B1:C1 B3:C3 C2:D2")]
+    [TestCase("A1:C3", "C2", "A1:B3 C1 C3 D2")]
+    [TestCase("A1:C3", "A3", "A1:C2 B3:D3")]
+    [TestCase("A1:C3", "B3", "A1:A3 B1:C2 C3:D3")]
+    [TestCase("A1:C3", "C3", "A1:B3 C1:C2 D3")]
+
+    [TestCase("A1:C3", "A1:A3", "B1:D3")] // Insert to left edge - shift, don't extend
+    [TestCase("A2:C4", "A1", "A2:C4")] // Insert to top side - don't move
+    [TestCase("A1:C3", "D1:D3", "A1:D3")] // Insert to right edge - extend
+    [TestCase("A1:C3", "D2:E10", "A1:C3 D2:E3")] // Insert to right edge (inserted area is out of bounds of the area) - extend
+    [TestCase("A1:C3", "E1:E3", "A1:C3")] // Insert to right side  - don't move
+    [TestCase("A1:C3", "A4", "A1:C3")] // Insert to bottom side  - don't move
+
+    [TestCase("XFD1", "XFD1", "")] // Push out of sheet
+    [TestCase("XFC1:XFD1", "XFC1", "XFD1")] // Partially push out of sheet
+    [TestCase("A1:XFD1", "A1", "A1:XFD1")] // Rows are not changed
+    public void InsertAndShiftRight(string areaList, string insertedArea, string expected)
+    {
+        var list = new XLAreaList(new List<XLSheetRange> { XLSheetRange.Parse(areaList) });
+        var result = list.InsertAndShiftRight(XLSheetRange.Parse(insertedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1:C3", "A1", "B1:C3 A1:A2")]
+    [TestCase("A1:C3", "B1", "A1:A3 C1:C3 B1:B2")]
+    [TestCase("A1:C3", "C1", "A1:B3 C1:C2")]
+    [TestCase("A1:C3", "A2", "A1 B1:C3 A2")]
+    [TestCase("A1:C3", "B2", "A1:A3 B1 C1:C3 B2")]
+    [TestCase("A1:C3", "C2", "A1:B3 C1 C2")]
+    [TestCase("A1:C3", "A3", "A1:A2 B1:C3")]
+    [TestCase("A1:C3", "B3", "A1:A3 B1:B2 C1:C3")]
+    [TestCase("A1:C3", "C3", "A1:B3 C1:C2")]
+
+    [TestCase("B1:D3", "A1:A3", "B1:D3")] // Delete on the left side - don't move
+    [TestCase("A2:C4", "A1:C1", "A1:C3")] // Delete on top side - shift
+    [TestCase("A1:C3", "D1:D3", "A1:C3")] // Delete on right side - don't move
+    [TestCase("A1:C3", "A4", "A1:C3")] // Delete on bottom side - don't move
+
+    [TestCase("A1:A3", "A1:D5", "")] // Delete completely
+    [TestCase("A1:A1048576", "A1", "A1:A1048576")] // Columns are not changed
+    public void DeleteAndShiftUp(string areaList, string deletedArea, string expected)
+    {
+        var list = new XLAreaList(new List<XLSheetRange> { XLSheetRange.Parse(areaList) });
+        var result = list.DeleteAndShiftUp(XLSheetRange.Parse(deletedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+
+    [TestCase("A1:C3", "A1", "A2:C3 A1:B1")]
+    [TestCase("A1:C3", "B1", "A1:A3 B2:C3 B1")]
+    [TestCase("A1:C3", "C1", "A1:B3 C2:C3")]
+    [TestCase("A1:C3", "A2", "A1:C1 A3:C3 A2:B2")]
+    [TestCase("A1:C3", "B2", "A1:A3 B1:C1 B3:C3 B2")]
+    [TestCase("A1:C3", "C2", "A1:B3 C1 C3")]
+    [TestCase("A1:C3", "A3", "A1:C2 A3:B3")]
+    [TestCase("A1:C3", "B3", "A1:A3 B1:C2 B3")]
+    [TestCase("A1:C3", "C3", "A1:B3 C1:C2")]
+
+    [TestCase("B1:D3", "A1:A3", "A1:C3")] // Delete on the left side - shift
+    [TestCase("A2:C4", "A1", "A2:C4")] // Delete on top side - don't move
+    [TestCase("A1:C3", "D1:D3", "A1:C3")] // Delete on right side - don't move
+    [TestCase("A1:C3", "A4", "A1:C3")] // Delete on bottom side - don't move
+
+    [TestCase("A1:A3", "A1:D5", "")] // Delete completely
+    [TestCase("A1:XFD1", "A1", "A1:XFD1")] // Rows are not changed
+    public void DeleteAndShiftLeft(string areaList, string deletedArea, string expected)
+    {
+        var list = new XLAreaList(new List<XLSheetRange> { XLSheetRange.Parse(areaList) });
+        var result = list.DeleteAndShiftLeft(XLSheetRange.Parse(deletedArea));
+
+        Assert.AreEqual(expected, result.ToSpaceList());
+    }
+}

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -1,0 +1,210 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClosedXML.Excel;
+
+/// <summary>
+/// An immutable collection of areas. An equivalent of <c>ST_Sqref</c> (sequence of references).
+/// List doesn't allow duplicate areas.
+/// </summary>
+internal class XLAreaList : IEnumerable<XLSheetRange>
+{
+    internal static readonly XLAreaList Empty = new(new List<XLSheetRange>());
+    private readonly List<XLSheetRange> _areas;
+
+    internal XLAreaList(List<XLSheetRange> areas)
+    {
+        _areas = areas;
+    }
+
+    internal int Count => _areas.Count;
+
+    internal XLAreaList With(XLSheetRange area)
+    {
+        if (_areas.Contains(area))
+            return this;
+
+        return new XLAreaList(new List<XLSheetRange>(_areas) { area });
+    }
+
+    internal XLAreaList Without(XLSheetRange area)
+    {
+        var indexToDelete = _areas.IndexOf(area);
+        if (indexToDelete == -1)
+            return this;
+
+        var newList = new List<XLSheetRange>(_areas);
+        newList.RemoveAt(indexToDelete);
+        return new XLAreaList(newList);
+    }
+
+    internal XLAreaList InsertAndShiftDown(XLSheetRange insertedArea)
+    {
+        var groove = insertedArea.ExtendBelow(XLHelper.MaxRowNumber);
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullColumnHeight)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            var insertWontSplitOriginalArea = insertedArea.LeftColumn <= originalArea.LeftColumn && insertedArea.RightColumn >= originalArea.RightColumn;
+            if (insertWontSplitOriginalArea)
+            {
+                var shiftedArea = originalArea.ShiftOrExtendDown(insertedArea.TopRow, insertedArea.Height);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+            else if (insertedArea.TopRow == originalArea.BottomRow + 1)
+            {
+                result.Add(originalArea);
+                var touchingArea = insertedArea.Intersect(new XLSheetRange(XLHelper.MinRowNumber, originalArea.LeftColumn, XLHelper.MaxRowNumber, originalArea.RightColumn));
+                if (touchingArea is not null)
+                    result.Add(touchingArea.Value);
+            }
+            else
+            {
+                var inGrooveArea = originalArea.Exclude(groove, result);
+                if (inGrooveArea is null)
+                    continue;
+
+                // There is something to shift, so shift it downwards
+                var shiftedArea = inGrooveArea.Value.ShiftOrExtendDown(insertedArea.TopRow, insertedArea.Height);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList InsertAndShiftRight(XLSheetRange insertedArea)
+    {
+        // Find an area that will be shifted (if there is any). It must be in a groove
+        // from insertedArea to the right end of a sheet
+        var groove = insertedArea.ExtendRight(XLHelper.MaxColumnNumber);
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullRowWidth)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            var insertWontSplitOriginalArea = insertedArea.TopRow <= originalArea.TopRow && insertedArea.BottomRow >= originalArea.BottomRow;
+            if (insertWontSplitOriginalArea)
+            {
+                var shiftedArea = originalArea.ShiftOrExtendRight(insertedArea.LeftColumn, insertedArea.Width);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+            else if (insertedArea.LeftColumn == originalArea.RightColumn + 1)
+            {
+                result.Add(originalArea);
+                var touchingArea = insertedArea.Intersect(new XLSheetRange(originalArea.TopRow, XLHelper.MinColumnNumber, originalArea.BottomRow, XLHelper.MaxColumnNumber));
+                if (touchingArea is not null)
+                    result.Add(touchingArea.Value);
+            }
+            else
+            {
+                var inGrooveArea = originalArea.Exclude(groove, result);
+                if (inGrooveArea is null)
+                    continue;
+
+                // There is something to shift, so shift it rightwards
+                var shiftedArea = inGrooveArea.Value.ShiftOrExtendRight(insertedArea.LeftColumn, insertedArea.Width);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList DeleteAndShiftUp(XLSheetRange deletedArea)
+    {
+        var groove = deletedArea.ExtendBelow(XLHelper.MaxRowNumber);
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullColumnHeight)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+            var deleteWontSplitOriginalArea = deletedArea.LeftColumn <= originalArea.LeftColumn && deletedArea.RightColumn >= originalArea.RightColumn;
+            if (deleteWontSplitOriginalArea)
+            {
+                var shiftedArea = originalArea.ShiftOrShrinkUp(deletedArea.TopRow, deletedArea.Height);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+            else
+            {
+                var inGrooveArea = originalArea.Exclude(groove, result);
+                if (inGrooveArea is not null)
+                {
+                    // There is something to shift, so shift it upwards
+                    var shiftedArea = inGrooveArea.Value.ShiftOrShrinkUp(deletedArea.TopRow, deletedArea.Height);
+                    if (shiftedArea is not null)
+                        result.Add(shiftedArea.Value);
+                }
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    internal XLAreaList DeleteAndShiftLeft(XLSheetRange deletedArea)
+    {
+        var groove = deletedArea.ExtendRight(XLHelper.MaxColumnNumber);
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+        {
+            if (originalArea.HasFullRowWidth)
+            {
+                result.Add(originalArea);
+                continue;
+            }
+
+            var deleteWontSplitOriginalArea = deletedArea.TopRow <= originalArea.TopRow && deletedArea.BottomRow >= originalArea.BottomRow;
+            if (deleteWontSplitOriginalArea)
+            {
+                var shiftedArea = originalArea.ShiftOrShrinkLeft(deletedArea.LeftColumn, deletedArea.Width);
+                if (shiftedArea is not null)
+                    result.Add(shiftedArea.Value);
+            }
+            else
+            {
+                var inGrooveArea = originalArea.Exclude(groove, result);
+                if (inGrooveArea is not null)
+                {
+                    // There is something to shift, so shift it leftward
+                    var shiftedArea = inGrooveArea.Value.ShiftOrShrinkLeft(deletedArea.LeftColumn, deletedArea.Width);
+                    if (shiftedArea is not null)
+                        result.Add(shiftedArea.Value);
+                }
+            }
+        }
+
+        return new XLAreaList(result);
+    }
+
+    public IEnumerator<XLSheetRange> GetEnumerator()
+    {
+        return _areas.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    internal string ToSpaceList()
+    {
+        return string.Join(" ", _areas);
+    }
+}

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -69,6 +69,16 @@ namespace ClosedXML.Excel
         /// </summary>
         public int BottomRow => LastPoint.Row;
 
+        /// <summary>
+        /// Does area span from first to last column?
+        /// </summary>
+        internal bool HasFullRowWidth => LeftColumn == XLHelper.MinColumnNumber && RightColumn == XLHelper.MaxColumnNumber;
+
+        /// <summary>
+        /// Does area span from first to last row?
+        /// </summary>
+        internal bool HasFullColumnHeight => TopRow == XLHelper.MinRowNumber && BottomRow == XLHelper.MaxRowNumber;
+
         public override bool Equals(object? obj)
         {
             return obj is XLSheetRange range && Equals(range);
@@ -379,6 +389,28 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
+        /// Return a new range that has been shifted in vertical direction by <paramref name="rowShift"/>.
+        /// If the shifted area is out of sheet bounds, clip part that is out.
+        /// </summary>
+        /// <param name="rowShift">How many rows to shift.</param>
+        /// <returns>Shifted clipped area or <c>null</c> if area was shifted completely out of a sheet.</returns>
+        internal XLSheetRange? ShiftRowsAndClip(int rowShift)
+        {
+            var shiftedTop = TopRow + rowShift;
+            if (shiftedTop > XLHelper.MaxRowNumber)
+                return null;
+
+            var shiftedBottom = BottomRow + rowShift;
+            if (shiftedBottom < XLHelper.MinRowNumber)
+                return null;
+
+            var clippedTop = Math.Max(shiftedTop, XLHelper.MinRowNumber);
+            var clippedBottom = Math.Min(shiftedBottom, XLHelper.MaxRowNumber);
+
+            return new XLSheetRange(clippedTop, LeftColumn, clippedBottom, RightColumn);
+        }
+
+        /// <summary>
         /// Return a new range that has been shifted in horizontal direction by <paramref name="columnShift"/>.
         /// </summary>
         /// <param name="columnShift">By how much to shift the range, positive - rightward, negative - leftward.</param>
@@ -388,6 +420,28 @@ namespace ClosedXML.Excel
             var topLeftCorner = FirstPoint.ShiftColumn(columnShift);
             var bottomRightCorner = LastPoint.ShiftColumn(columnShift);
             return new XLSheetRange(topLeftCorner, bottomRightCorner);
+        }
+
+        /// <summary>
+        /// Return a new range that has been shifted in horizontal direction by <paramref name="columnShift"/>.
+        /// If the shifted area is out of sheet bounds, clip part that is out.
+        /// </summary>
+        /// <param name="columnShift">How many columns to shift.</param>
+        /// <returns>Shifted clipped area or <c>null</c> if area was shifted completely out of a sheet.</returns>
+        internal XLSheetRange? ShiftColumnsAndClip(int columnShift)
+        {
+            var shiftedLeft = LeftColumn + columnShift;
+            if (shiftedLeft > XLHelper.MaxColumnNumber)
+                return null;
+
+            var shiftedRight = RightColumn + columnShift;
+            if (shiftedRight < XLHelper.MinColumnNumber)
+                return null;
+
+            var clippedLeft = Math.Max(shiftedLeft, XLHelper.MinColumnNumber);
+            var clippedRight = Math.Min(shiftedRight, XLHelper.MaxColumnNumber);
+
+            return new XLSheetRange(TopRow, clippedLeft, BottomRow, clippedRight);
         }
 
         public IEnumerator<XLSheetPoint> GetEnumerator()
@@ -710,6 +764,158 @@ namespace ClosedXML.Excel
 
             result = repositioned;
             return true;
+        }
+
+        /// <summary>
+        /// Determine a areas that contain all cells of this area without <paramref name="range"/>
+        /// and add them to the <paramref name="nonExcludedAreas"/>.
+        /// </summary>
+        /// <param name="range">Range to exclude from this one.</param>
+        /// <param name="nonExcludedAreas">A list to which add remaining (non-excluded) areas.</param>
+        /// <returns>If an area was excluded, the excluded area.</returns>
+        internal XLSheetRange? Exclude(XLSheetRange range, List<XLSheetRange> nonExcludedAreas)
+        {
+            if (Intersect(range) is not { } intersection)
+            {
+                nonExcludedAreas.Add(this);
+                return null;
+            }
+
+            // left
+            if (LeftColumn < intersection.LeftColumn)
+                nonExcludedAreas.Add(new XLSheetRange(TopRow, LeftColumn, BottomRow, intersection.LeftColumn - 1));
+
+            // top
+            if (TopRow < intersection.TopRow)
+                nonExcludedAreas.Add(new XLSheetRange(TopRow, intersection.LeftColumn, intersection.TopRow - 1, intersection.RightColumn));
+
+            // bottom
+            if (BottomRow > intersection.BottomRow)
+                nonExcludedAreas.Add(new XLSheetRange(intersection.BottomRow + 1, intersection.LeftColumn, BottomRow, intersection.RightColumn));
+
+            // right
+            if (RightColumn > intersection.RightColumn)
+                nonExcludedAreas.Add(new XLSheetRange(TopRow, intersection.RightColumn + 1, BottomRow, RightColumn));
+
+            return intersection;
+        }
+
+        /// <summary>
+        /// Return an area that has dimensions as if columns were inserted at <paramref name="insertedLeftColumn"/>.
+        /// Mimics Excel behavior.
+        /// </summary>
+        /// <param name="insertedLeftColumn">A position where columns are inserted.</param>
+        /// <param name="insertedWidth">How many columns were inserted.</param>
+        internal XLSheetRange? ShiftOrExtendRight(int insertedLeftColumn, int insertedWidth)
+        {
+            Debug.Assert(insertedWidth >= 0);
+
+            // Area inserted at the right edge extends - that is the reason for - 1
+            if (RightColumn < insertedLeftColumn - 1)
+            {
+                // inserted is to the right of area -> no shift
+                return this;
+            }
+
+            if (LeftColumn >= insertedLeftColumn)
+            {
+                // Inserted is to the left of affected area -> shift
+                return ShiftColumnsAndClip(insertedWidth);
+            }
+
+            // inserted is in the middle of affected: affectedLeft < insertedLeft <= affectedRight
+            return ExtendRight(insertedWidth);
+        }
+
+        /// <summary>
+        /// Return an area that has dimensions as if a rows were inserted at <paramref name="insertedTopRow"/>.
+        /// Mimics Excel behavior.
+        /// </summary>
+        /// <param name="insertedTopRow">A position where rows are inserted.</param>
+        /// <param name="insertedHeight">How many rows were inserted.</param>
+        internal XLSheetRange? ShiftOrExtendDown(int insertedTopRow, int insertedHeight)
+        {
+            Debug.Assert(insertedHeight >= 0);
+
+            // Area inserted at the bottom edge extends - that is the reason for - 1
+            if (BottomRow < insertedTopRow - 1)
+            {
+                // inserted is below the area -> no shift
+                return this;
+            }
+
+            if (TopRow >= insertedTopRow)
+            {
+                // Inserted is above the area -> shift
+                return ShiftRowsAndClip(insertedHeight);
+            }
+
+            // inserted is in the middle of affected: affectedTop < insertedTop <= affectedBottom
+            return ExtendBelow(insertedHeight);
+        }
+
+        /// <summary>
+        /// Return an area that has dimensions as if a rows were deleted from <paramref name="deletedTopRow"/>.
+        /// Mimics Excel behavior.
+        /// </summary>
+        /// <param name="deletedTopRow">A position from which where rows are deleted.</param>
+        /// <param name="deletedHeight">How many rows were deleted.</param>
+        internal XLSheetRange? ShiftOrShrinkUp(int deletedTopRow, int deletedHeight)
+        {
+            Debug.Assert(deletedHeight >= 0);
+            if (BottomRow < deletedTopRow || deletedHeight == 0)
+            {
+                // deleted is below the area -> no shift or shrink
+                return this;
+            }
+
+            var deletedBottomRow = deletedTopRow + deletedHeight - 1;
+            if (deletedBottomRow < TopRow)
+            {
+                // Deleted area is completely above the area -> only shift
+                return ShiftRows(-deletedHeight);
+            }
+
+            // Shrink by how much deletedArea and area overlap
+            var shrink = Math.Min(BottomRow, deletedBottomRow) - Math.Max(TopRow, deletedTopRow) + 1;
+            if (shrink == Height)
+                return null;
+
+            var shift = Math.Max(TopRow - deletedTopRow, 0);
+            var shifted = ShiftRows(-shift);
+            return new XLSheetRange(shifted.TopRow, shifted.LeftColumn, shifted.BottomRow - shrink, shifted.RightColumn);
+        }
+
+        /// <summary>
+        /// Return an area that has dimensions as if a column were deleted from <paramref name="deletedLeftColumn"/>.
+        /// Mimics Excel behavior.
+        /// </summary>
+        /// <param name="deletedLeftColumn">A position from which where columns are deleted.</param>
+        /// <param name="deletedWidth">How many columns were deleted.</param>
+        internal XLSheetRange? ShiftOrShrinkLeft(int deletedLeftColumn, int deletedWidth)
+        {
+            Debug.Assert(deletedWidth >= 0);
+            if (RightColumn < deletedLeftColumn || deletedWidth == 0)
+            {
+                // deleted is to the right of area -> no shift or shrink
+                return this;
+            }
+
+            var deletedRightColumn = deletedLeftColumn + deletedWidth - 1;
+            if (deletedRightColumn < LeftColumn)
+            {
+                // Deleted area is completely to left of area -> only shift
+                return ShiftColumns(-deletedWidth);
+            }
+
+            // Shrink by how much deletedArea and area overlap
+            var shrink = Math.Min(RightColumn, deletedRightColumn) - Math.Max(LeftColumn, deletedLeftColumn) + 1;
+            if (shrink == Width)
+                return null;
+
+            var shift = Math.Max(LeftColumn - deletedLeftColumn, 0);
+            var shifted = ShiftColumns(-shift);
+            return new XLSheetRange(shifted.TopRow, shifted.LeftColumn, shifted.BottomRow, shifted.RightColumn - shrink);
         }
     }
 }


### PR DESCRIPTION
Add `XLAreaList` that should be a representation of OOXML `ST_Sqref` type (sequence of references). `ST_Sqref` is used in several places, e.g. data validations, conditional format or protected ranges.

The `XLAreaList` also contains methods that adjust the area list when an area is inserted/deleted and cells are shifted. The insert/delete shift code is rather repetitive, but I have found that it's not worth it to make it reusable. It's possible, but it needs many parameters and the end result is really hard to read, debug and is basically unmaintainable.

This is a necessary requirement for fixing data validation shifts (and others) from issue #2794.