### PR TITLE
Data Validations: use internal types

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -505,9 +505,6 @@ namespace ClosedXML.Excel
 
         IXLCell SetActive(Boolean value = true);
 
-        [Obsolete("Use GetDataValidation to access the existing rule, or CreateDataValidation() to create a new one.")]
-        IXLDataValidation SetDataValidation();
-
         IXLCell SetFormulaA1(String formula);
 
         IXLCell SetFormulaR1C1(String formula);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1068,18 +1068,6 @@ namespace ClosedXML.Excel
             return validation;
         }
 
-        [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
-        public IXLDataValidation SetDataValidation()
-        {
-            var validation = GetDataValidation();
-            if (validation == null)
-            {
-                validation = new XLDataValidation(AsRange());
-                Worksheet.DataValidations.Add(validation);
-            }
-            return validation;
-        }
-
         public void Select()
         {
             AsRange().Select();

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1061,7 +1061,9 @@ namespace ClosedXML.Excel
             return dataValidation;
         }
 
-        public IXLDataValidation CreateDataValidation()
+        IXLDataValidation IXLCell.CreateDataValidation() => CreateDataValidation();
+
+        internal XLDataValidation CreateDataValidation()
         {
             var validation = new XLDataValidation(AsRange());
             Worksheet.DataValidations.Add(validation);
@@ -1262,7 +1264,7 @@ namespace ClosedXML.Excel
                     var dvTargetRange = Worksheet.Range(dvTargetAddress);
                     if (newDataValidation == null)
                     {
-                        newDataValidation = dvTargetRange.CreateDataValidation() as XLDataValidation;
+                        newDataValidation = dvTargetRange.CreateDataValidation();
                         newDataValidation.CopyFrom(dataValidation);
                     }
                     else

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -151,7 +151,7 @@ internal class XLCells :
 
         if (_options.HasFlag(XLCellsUsedOptions.DataValidation))
             candidates = candidates.Union(
-                worksheet.DataValidations.SelectMany(dv => dv.Ranges.SelectMany(r => GetAllCellsInRange(r.RangeAddress))));
+                worksheet.DataValidations.SelectMany<XLDataValidation, XLSheetPoint>(dv => dv.Ranges.SelectMany(r => GetAllCellsInRange(r.RangeAddress))));
 
         if (_options.HasFlag(XLCellsUsedOptions.Sparklines))
             candidates = candidates.Union(

--- a/ClosedXML/Excel/DataValidation/IXLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/IXLDataValidations.cs
@@ -1,44 +1,41 @@
-#nullable disable
-
-// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
-namespace ClosedXML.Excel
+namespace ClosedXML.Excel;
+
+public interface IXLDataValidations : IEnumerable<IXLDataValidation>
 {
-    public interface IXLDataValidations : IEnumerable<IXLDataValidation>
-    {
-        IXLWorksheet Worksheet { get; }
+    IXLWorksheet Worksheet { get; }
 
-        /// <summary>
-        /// Add data validation rule to the collection. If the specified rule refers to another
-        /// worksheet than the collection, the copy will be created and its ranges will refer
-        /// to the worksheet of the collection. Otherwise the original instance will be placed
-        /// in the collection.
-        /// </summary>
-        /// <param name="dataValidation">A data validation rule to add.</param>
-        /// <returns>The instance that has actually been added in the collection
-        /// (may be a copy of the specified one).</returns>
-        IXLDataValidation Add(IXLDataValidation dataValidation);
+    /// <summary>
+    /// Add data validation rule to the collection. If the specified rule refers to another
+    /// worksheet than the collection, the copy will be created and its ranges will refer
+    /// to the worksheet of the collection. Otherwise the original instance will be placed
+    /// in the collection.
+    /// </summary>
+    /// <param name="dataValidation">A data validation rule to add.</param>
+    /// <returns>The instance that has actually been added in the collection
+    /// (may be a copy of the specified one).</returns>
+    IXLDataValidation Add(IXLDataValidation dataValidation);
 
-        Boolean ContainsSingle(IXLRange range);
+    Boolean ContainsSingle(IXLRange range);
 
-        void Delete(Predicate<IXLDataValidation> predicate);
+    void Delete(Predicate<IXLDataValidation> predicate);
 
-        /// <summary>
-        /// Get all data validation rules applied to ranges that intersect the specified range.
-        /// </summary>
-        IEnumerable<IXLDataValidation> GetAllInRange(IXLRangeAddress rangeAddress);
+    /// <summary>
+    /// Get all data validation rules applied to ranges that intersect the specified range.
+    /// </summary>
+    IEnumerable<IXLDataValidation> GetAllInRange(IXLRangeAddress rangeAddress);
 
-        /// <summary>
-        /// Get the data validation rule for the range with the specified address if it exists.
-        /// </summary>
-        /// <param name="rangeAddress">A range address.</param>
-        /// <param name="dataValidation">Data validation rule which ranges collection includes the specified
-        /// address. The specified range should be fully covered with the data validation rule.
-        /// For example, if the rule is applied to ranges A1:A3,C1:C3 then this method will
-        /// return True for ranges A1:A3, C1:C2, A2:A3, and False for ranges A1:C3, A1:C1, etc.</param>
-        /// <returns>True is the data validation rule was found, false otherwise.</returns>
-        bool TryGet(IXLRangeAddress rangeAddress, out IXLDataValidation dataValidation);
-    }
+    /// <summary>
+    /// Get the data validation rule for the range with the specified address if it exists.
+    /// </summary>
+    /// <param name="rangeAddress">A range address.</param>
+    /// <param name="dataValidation">Data validation rule which ranges collection includes the specified
+    /// address. The specified range should be fully covered with the data validation rule.
+    /// For example, if the rule is applied to ranges A1:A3,C1:C3 then this method will
+    /// return True for ranges A1:A3, C1:C2, A2:A3, and False for ranges A1:C3, A1:C1, etc.</param>
+    /// <returns>True is the data validation rule was found, false otherwise.</returns>
+    bool TryGet(IXLRangeAddress rangeAddress, [NotNullWhen(true)] out IXLDataValidation? dataValidation);
 }

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -30,7 +30,7 @@ namespace ClosedXML.Excel
             AddRange(range);
         }
 
-        public XLDataValidation(IXLDataValidation dataValidation, XLWorksheet worksheet)
+        public XLDataValidation(XLDataValidation dataValidation, XLWorksheet worksheet)
             : this(worksheet)
         {
             _worksheet = worksheet;

--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -1,18 +1,18 @@
 // Keep this file CodeMaid organised and cleaned
-using ClosedXML.Excel.Ranges.Index;
 using System;
 using System.Collections.Generic;
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using ClosedXML.Excel.Ranges.Index;
 
 namespace ClosedXML.Excel
 {
-    using System.Collections;
-    using System.Linq;
-
-    internal class XLDataValidations : IXLDataValidations
+    internal class XLDataValidations : IXLDataValidations, IEnumerable<XLDataValidation>
     {
         private readonly XLRangeIndex<XLDataValidationIndexEntry> _dataValidationIndex;
 
-        private readonly List<IXLDataValidation> _dataValidations = new List<IXLDataValidation>();
+        private readonly List<XLDataValidation> _dataValidations = new();
         private readonly XLWorksheet _worksheet;
 
         /// <summary>
@@ -33,9 +33,12 @@ namespace ClosedXML.Excel
 
         IXLWorksheet IXLDataValidations.Worksheet => _worksheet;
 
-        public IXLDataValidation Add(IXLDataValidation dataValidation)
+        IXLDataValidation IXLDataValidations.Add(IXLDataValidation dataValidation)
         {
-            return Add(dataValidation, skipIntersectionsCheck: false);
+            if (dataValidation == null)
+                throw new ArgumentNullException(nameof(dataValidation));
+
+            return Add((XLDataValidation)dataValidation);
         }
 
         public Boolean ContainsSingle(IXLRange range)
@@ -58,32 +61,6 @@ namespace ClosedXML.Excel
             dataValidationsToRemove.ForEach(Delete);
         }
 
-        public void Delete(IXLDataValidation dataValidation)
-        {
-            if (!_dataValidations.Remove(dataValidation))
-                return;
-            var xlDataValidation = (XLDataValidation) dataValidation;
-            xlDataValidation.RangeAdded -= OnRangeAdded;
-            xlDataValidation.RangeRemoved -= OnRangeRemoved;
-
-            foreach (var range in dataValidation.Ranges)
-            {
-                ProcessRangeRemoved(range);
-            }
-        }
-
-        public void Delete(IXLRange range)
-        {
-            if (range == null) throw new ArgumentNullException(nameof(range));
-
-            var dataValidationsToRemove = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)range.RangeAddress)
-                .Select(e => e.DataValidation)
-                .Distinct()
-                .ToList();
-
-            dataValidationsToRemove.ForEach(Delete);
-        }
-
         /// <summary>
         /// Get all data validation rules applied to ranges that intersect the specified range.
         /// </summary>
@@ -97,9 +74,14 @@ namespace ClosedXML.Excel
                 .Distinct();
         }
 
-        public IEnumerator<IXLDataValidation> GetEnumerator()
+        public IEnumerator<XLDataValidation> GetEnumerator()
         {
             return _dataValidations.GetEnumerator();
+        }
+
+        IEnumerator<IXLDataValidation> IEnumerable<IXLDataValidation>.GetEnumerator()
+        {
+            return GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -116,7 +98,7 @@ namespace ClosedXML.Excel
         /// For example, if the rule is applied to ranges A1:A3,C1:C3 then this method will
         /// return True for ranges A1:A3, C1:C2, A2:A3, and False for ranges A1:C3, A1:C1, etc.</param>
         /// <returns>True is the data validation rule was found, false otherwise.</returns>
-        public bool TryGet(IXLRangeAddress rangeAddress, out IXLDataValidation? dataValidation)
+        public bool TryGet(IXLRangeAddress rangeAddress, [NotNullWhen(true)] out IXLDataValidation? dataValidation)
         {
             dataValidation = null;
             if (rangeAddress == null || !rangeAddress.IsValid)
@@ -135,19 +117,23 @@ namespace ClosedXML.Excel
             return true;
         }
 
-        internal IXLDataValidation Add(IXLDataValidation dataValidation, bool skipIntersectionsCheck)
-        {
-            if (dataValidation == null) throw new ArgumentNullException(nameof(dataValidation));
+        #endregion IXLDataValidations Members
 
+        internal XLDataValidation Add(XLDataValidation dataValidation)
+        {
+            return Add(dataValidation, skipIntersectionsCheck: false);
+        }
+
+        internal XLDataValidation Add(XLDataValidation dataValidation, bool skipIntersectionsCheck)
+        {
             XLDataValidation xlDataValidation;
-            if (!(dataValidation is XLDataValidation) ||
-                dataValidation.Ranges.Any(r => r.Worksheet != Worksheet))
+            if (dataValidation.Ranges.Any(r => r.Worksheet != Worksheet))
             {
                 xlDataValidation = new XLDataValidation(dataValidation, Worksheet);
             }
             else
             {
-                xlDataValidation = (XLDataValidation)dataValidation;
+                xlDataValidation = dataValidation;
             }
 
             xlDataValidation.RangeAdded += OnRangeAdded;
@@ -163,9 +149,32 @@ namespace ClosedXML.Excel
             return xlDataValidation;
         }
 
-        #endregion IXLDataValidations Members
+        internal void Delete(IXLRange range)
+        {
+            if (range == null) throw new ArgumentNullException(nameof(range));
 
-        public void Consolidate()
+            var dataValidationsToRemove = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)range.RangeAddress)
+                .Select(e => e.DataValidation)
+                .Distinct()
+                .ToList();
+
+            dataValidationsToRemove.ForEach(Delete);
+        }
+
+        internal void Delete(XLDataValidation dataValidation)
+        {
+            if (!_dataValidations.Remove(dataValidation))
+                return;
+            dataValidation.RangeAdded -= OnRangeAdded;
+            dataValidation.RangeRemoved -= OnRangeRemoved;
+
+            foreach (var range in dataValidation.Ranges)
+            {
+                ProcessRangeRemoved(range);
+            }
+        }
+
+        internal void Consolidate()
         {
             Func<IXLDataValidation, IXLDataValidation, bool> areEqual = (dv1, dv2) =>
             {

--- a/ClosedXML/Excel/Ranges/IXLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeBase.cs
@@ -299,9 +299,6 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLDataValidation CreateDataValidation();
 
-        [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
-        IXLDataValidation SetDataValidation();
-
         IXLConditionalFormat AddConditionalFormat();
 
         void Select();

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1764,25 +1764,6 @@ namespace ClosedXML.Excel
             return Worksheet.RangeColumn(new XLRangeAddress(firstCellAddress, lastCellAddress));
         }
 
-        [Obsolete("Use GetDataValidation() to access the existing rule, or CreateDataValidation() to create a new one.")]
-        public IXLDataValidation SetDataValidation()
-        {
-            var existingValidation = GetDataValidation();
-            if (existingValidation != null && existingValidation.Ranges.Any(r => r == this))
-                return existingValidation;
-
-            IXLDataValidation dataValidationToCopy = Worksheet.DataValidations.GetAllInRange(RangeAddress)
-                .FirstOrDefault();
-
-            var newRange = AsRange();
-            var dataValidation = new XLDataValidation(newRange);
-            if (dataValidationToCopy != null)
-                dataValidation.CopyFrom(dataValidationToCopy);
-
-            Worksheet.DataValidations.Add(dataValidation);
-            return dataValidation;
-        }
-
         public IXLConditionalFormat AddConditionalFormat()
         {
             var cf = new XLConditionalFormat(Worksheet, AsRange());

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -76,7 +76,12 @@ namespace ClosedXML.Excel
             }
         }
 
-        public IXLDataValidation CreateDataValidation()
+        IXLDataValidation IXLRangeBase.CreateDataValidation()
+        {
+            return CreateDataValidation();
+        }
+
+        internal XLDataValidation CreateDataValidation()
         {
             var newRange = AsRange();
             var dataValidation = new XLDataValidation(newRange);

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -639,7 +639,11 @@ namespace ClosedXML.Excel
             Internals.ColumnsCollection.ForEach(kp => kp.Value.CopyTo(targetSheet.Column(kp.Key)));
             Internals.RowsCollection.ForEach(kp => kp.Value.CopyTo(targetSheet.Row(kp.Key)));
             Internals.CellsCollection.GetCells().ForEach(c => targetSheet.Cell(c.Address).CopyFrom(c, XLCellCopyOptions.Values | XLCellCopyOptions.Styles));
-            DataValidations.ForEach(dv => targetSheet.DataValidations.Add(new XLDataValidation(dv, this)));
+            foreach (var dataValidation in DataValidations)
+            {
+                targetSheet.DataValidations.Add(new XLDataValidation(dataValidation, this));
+            }
+
             targetSheet.Visibility = Visibility;
             targetSheet.ColumnWidth = ColumnWidth;
             targetSheet.ColumnWidthChanged = ColumnWidthChanged;
@@ -1309,14 +1313,16 @@ namespace ClosedXML.Excel
 
         private void ShiftDataValidationColumns(XLRange range, int columnsShifted)
         {
-            if (!DataValidations.Any()) return;
+            if (!DataValidations.Any<XLDataValidation>())
+                return;
+
             Int32 firstCol = range.RangeAddress.FirstAddress.ColumnNumber;
             if (firstCol == 1) return;
 
             int colNum = columnsShifted > 0 ? firstCol - 1 : firstCol;
             var model = Column(colNum).AsRange();
 
-            foreach (var dv in DataValidations.ToList())
+            foreach (var dv in DataValidations.ToList<XLDataValidation>())
             {
                 var dvRanges = dv.Ranges.ToList();
                 dv.ClearRanges();
@@ -1461,14 +1467,16 @@ namespace ClosedXML.Excel
 
         private void ShiftDataValidationRows(XLRange range, int rowsShifted)
         {
-            if (!DataValidations.Any()) return;
+            if (!DataValidations.Any<XLDataValidation>())
+                return;
+
             Int32 firstRow = range.RangeAddress.FirstAddress.RowNumber;
             if (firstRow == 1) return;
 
             int rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
             var model = Row(rowNum).AsRange();
 
-            foreach (var dv in DataValidations.ToList())
+            foreach (var dv in DataValidations.ToList<XLDataValidation>())
             {
                 var dvRanges = dv.Ranges.ToList();
                 dv.ClearRanges();

--- a/docs/migrations/migrate-to-0.106.rst
+++ b/docs/migrations/migrate-to-0.106.rst
@@ -52,3 +52,10 @@ IXLRangeBase
 
 An obsolete method ``IXLRangeBase.SetDataValidation`` has been removed. Use ``GetDataValidation()``
 to access the existing rule, or ``CreateDataValidation()`` to create a new one.
+
+*******
+IXLCell
+*******
+
+An obsolete method ``IXLRangeBase.SetDataValidation`` has been removed. Use ``GetDataValidation()``
+to access the existing rule, or ``CreateDataValidation()`` to create a new one.

--- a/docs/migrations/migrate-to-0.106.rst
+++ b/docs/migrations/migrate-to-0.106.rst
@@ -45,3 +45,10 @@ Defined names
 
 A property setter ``IXLDefinedName.RefersTo`` now throws an ``ArgumentException``
 when trying to set an empty/whitespace-only value.
+
+************
+IXLRangeBase
+************
+
+An obsolete method ``IXLRangeBase.SetDataValidation`` has been removed. Use ``GetDataValidation()``
+to access the existing rule, or ``CreateDataValidation()`` to create a new one.


### PR DESCRIPTION
Make `XLDataValidations` use internal types, so it's not necessary constantly cast public API to actual internal type. 

It also removes two obsolete methods that were deprecated several years ago.

Related to #2794.