### PR TITLE
Data Validations: Fix shifting on area/row/col insert/delete 

### DIFF
--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -3,171 +3,160 @@ using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
 
-namespace ClosedXML.Tests.Excel.DataValidations
+namespace ClosedXML.Tests.Excel.DataValidations;
+
+[TestFixture]
+public class DataValidationShiftTests
 {
-    [TestFixture]
-    public class DataValidationShiftTests
+    [Test]
+    public void DataValidationShiftedOnColumnInsert()
     {
-        [Test]
-        public void DataValidationShiftedOnColumnInsert()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:D7").Value = 1;
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("DataValidationShift");
+        ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Cells("A1:D7").Value = 1;
 
-                ws.Column(2).InsertColumnsAfter(2);
-                var dv = ws.DataValidations.ToArray();
+        ws.Column(2).InsertColumnsAfter(2);
+        var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(5, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A2:D2", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A3:E3", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B4:D6", dv[3].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("E7:F7", dv[4].Ranges.Single().RangeAddress.ToString());
-            }
-        }
+        Assert.AreEqual(5, dv.Length);
+        Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("A2:D2", dv[1].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("A3:E3", dv[2].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("B4:D6", dv[3].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("E7:F7", dv[4].Ranges.Single().RangeAddress.ToString());
+    }
 
-        [Test]
-        public void DataValidationShiftedOnRowInsert()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:G5").Value = 1;
+    [Test]
+    public void DataValidationShiftedOnRowInsert()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("DataValidationShift");
+        ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Cells("A1:G5").Value = 1;
 
-                ws.Row(2).InsertRowsBelow(2);
-                var dv = ws.DataValidations.ToArray();
+        ws.Row(2).InsertRowsBelow(2);
+        var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(5, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B1:B4", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("C1:C5", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("D2:F4", dv[3].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("G6:G7", dv[4].Ranges.Single().RangeAddress.ToString());
-            }
-        }
+        Assert.AreEqual(5, dv.Length);
+        Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("B1:B4", dv[1].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("C1:C5", dv[2].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("D2:F4", dv[3].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("G6:G7", dv[4].Ranges.Single().RangeAddress.ToString());
+    }
 
-        [Test]
-        public void DataValidationShiftedOnColumnDelete()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:D7").Value = 1;
+    [Test]
+    public void DataValidationShiftedOnColumnDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("DataValidationShift");
+        ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("A2:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("A3:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("B4:B6").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("C7:D7").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Cells("A1:D7").Value = 1;
 
-                ws.Column(2).Delete();
-                var dv = ws.DataValidations.ToArray();
+        ws.Column(2).Delete();
+        var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(4, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A2:A2", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("A3:B3", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B7:C7", dv[3].Ranges.Single().RangeAddress.ToString());
-            }
-        }
+        Assert.AreEqual(4, dv.Length);
+        Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("A2:A2", dv[1].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("A3:B3", dv[2].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("B7:C7", dv[3].Ranges.Single().RangeAddress.ToString());
+    }
 
-        [Test]
-        public void DataValidationShiftedOnRowDelete()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
-                ws.Cells("A1:G5").Value = 1;
+    [Test]
+    public void DataValidationShiftedOnRowDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("DataValidationShift");
+        ws.Range("A1:A1").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("B1:B2").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("C1:C3").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("D2:F2").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Range("G4:G5").CreateDataValidation().WholeNumber.Between(0, 1);
+        ws.Cells("A1:G5").Value = 1;
 
-                ws.Row(2).Delete();
-                var dv = ws.DataValidations.ToArray();
+        ws.Row(2).Delete();
+        var dv = ws.DataValidations.ToArray();
 
-                Assert.AreEqual(4, dv.Length);
-                Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("B1:B1", dv[1].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("C1:C2", dv[2].Ranges.Single().RangeAddress.ToString());
-                Assert.AreEqual("G3:G4", dv[3].Ranges.Single().RangeAddress.ToString());
-            }
-        }
+        Assert.AreEqual(4, dv.Length);
+        Assert.AreEqual("A1:A1", dv[0].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("B1:B1", dv[1].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("C1:C2", dv[2].Ranges.Single().RangeAddress.ToString());
+        Assert.AreEqual("G3:G4", dv[3].Ranges.Single().RangeAddress.ToString());
+    }
 
-        [TestCase(new[] { "A10:A11" }, "1-2", new[] { "A8:A9" })]
-        [TestCase(new[] { "A10,A11" }, "1-2", new[] { "A8:A8 A9:A9" })]
-        [TestCase(new[] { "A10", "A11" }, "1-2", new[] { "A8:A8", "A9:A9" })]
-        public void Data_validations_are_shifted_when_rows_above_are_deleted(string[] initialDvs, string rowsToDelete, string[] shiftedDvs)
-        {
-            using var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet();
-            foreach (var initialDv in initialDvs)
-                ws.Ranges(initialDv).CreateDataValidation();
+    [TestCase(new[] { "A10:A11" }, "1-2", new[] { "A8:A9" })]
+    [TestCase(new[] { "A10,A11" }, "1-2", new[] { "A8:A8 A9:A9" })]
+    [TestCase(new[] { "A10", "A11" }, "1-2", new[] { "A8:A8", "A9:A9" })]
+    public void Data_validations_are_shifted_when_rows_above_are_deleted(string[] initialDvs, string rowsToDelete, string[] shiftedDvs)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        foreach (var initialDv in initialDvs)
+            ws.Ranges(initialDv).CreateDataValidation();
 
-            ws.Rows(rowsToDelete).Delete();
+        ws.Rows(rowsToDelete).Delete();
 
-            var resultDvs = ws.DataValidations.Select(dv => ToSpaceList(dv.Ranges));
-            Assert.AreEqual(shiftedDvs, resultDvs);
-        }
+        var resultDvs = ws.DataValidations.Select(dv => ToSpaceList(dv.Ranges));
+        Assert.AreEqual(shiftedDvs, resultDvs);
+    }
 
-        [Test]
-        public void Data_validations_is_removed_when_its_area_is_deleted()
-        {
-            using var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet();
-            ws.Range("A10").CreateDataValidation();
+    [Test]
+    public void Data_validations_is_removed_when_its_area_is_deleted()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("A10").CreateDataValidation();
 
-            ws.Range("A10").Delete(XLShiftDeletedCells.ShiftCellsUp);
+        ws.Range("A10").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-            Assert.IsEmpty(ws.DataValidations);
-        }
+        Assert.IsEmpty(ws.DataValidations);
+    }
 
-        [Test]
-        public void Data_validations_can_split_its_area_when_inserted_or_deleted_area_intersects_its_area()
-        {
-            using var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet();
-            ws.Range("A10:C12").CreateDataValidation();
+    [Test]
+    public void Data_validations_can_split_its_area_when_inserted_or_deleted_area_intersects_its_area()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range("A10:C12").CreateDataValidation();
 
-            ws.Range("B12").Delete(XLShiftDeletedCells.ShiftCellsUp);
+        ws.Range("B12").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-            Assert.AreEqual("A10:A12 B10:B11 C10:C12", ToSpaceList(ws.DataValidations.Single().Ranges));
-        }
+        Assert.AreEqual("A10:A12 B10:B11 C10:C12", ToSpaceList(ws.DataValidations.Single().Ranges));
+    }
 
-        [Test]
-        public void DataValidationShiftedTruncateRange()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("DataValidationShift");
-                ws.AsRange().CreateDataValidation().WholeNumber.Between(0, 1);
-                var dv = ws.DataValidations.Single();
+    [Test]
+    public void DataValidationShiftedTruncateRange()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("DataValidationShift");
+        ws.AsRange().CreateDataValidation().WholeNumber.Between(0, 1);
+        var dv = ws.DataValidations.Single();
 
-                ws.Row(2).InsertRowsAbove(1);
-                Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
+        ws.Row(2).InsertRowsAbove(1);
+        Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
+        Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
 
-                ws.Column(2).InsertColumnsAfter(1);
-                Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
-            }
-        }
+        ws.Column(2).InsertColumnsAfter(1);
+        Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
+        Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
+    }
 
-        private static string ToSpaceList(IEnumerable<IXLRange> ranges)
-        {
-            return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
-        }
+    private static string ToSpaceList(IEnumerable<IXLRange> ranges)
+    {
+        return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -1,6 +1,7 @@
-﻿using ClosedXML.Excel;
-using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
+using ClosedXML.Excel;
+using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.DataValidations
 {
@@ -105,6 +106,46 @@ namespace ClosedXML.Tests.Excel.DataValidations
             }
         }
 
+        [TestCase(new[] { "A10:A11" }, "1-2", new[] { "A8:A9" })]
+        [TestCase(new[] { "A10,A11" }, "1-2", new[] { "A8:A8 A9:A9" })]
+        [TestCase(new[] { "A10", "A11" }, "1-2", new[] { "A8:A8", "A9:A9" })]
+        public void Data_validations_are_shifted_when_rows_above_are_deleted(string[] initialDvs, string rowsToDelete, string[] shiftedDvs)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            foreach (var initialDv in initialDvs)
+                ws.Ranges(initialDv).CreateDataValidation();
+
+            ws.Rows(rowsToDelete).Delete();
+
+            var resultDvs = ws.DataValidations.Select(dv => ToSpaceList(dv.Ranges));
+            Assert.AreEqual(shiftedDvs, resultDvs);
+        }
+
+        [Test]
+        public void Data_validations_is_removed_when_its_area_is_deleted()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Range("A10").CreateDataValidation();
+
+            ws.Range("A10").Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+            Assert.IsEmpty(ws.DataValidations);
+        }
+
+        [Test]
+        public void Data_validations_can_split_its_area_when_inserted_or_deleted_area_intersects_its_area()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            ws.Range("A10:C12").CreateDataValidation();
+
+            ws.Range("B12").Delete(XLShiftDeletedCells.ShiftCellsUp);
+
+            Assert.AreEqual("A10:A12 B10:B11 C10:C12", ToSpaceList(ws.DataValidations.Single().Ranges));
+        }
+
         [Test]
         public void DataValidationShiftedTruncateRange()
         {
@@ -122,6 +163,11 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
                 Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
             }
+        }
+
+        private static string ToSpaceList(IEnumerable<IXLRange> ranges)
+        {
+            return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -1,15 +1,13 @@
+using System;
+using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace ClosedXML.Tests.Excel.DataValidations
 {
     [TestFixture]
     public class DataValidationTests
     {
-
         [Test]
         public void Validation_Reference_List_Values_From_Separate_Sheet()
         {
@@ -213,7 +211,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
         public void DataValidationShiftedOnColumnInsert(string initialAddress, int columnNum, bool setValue, string expectedAddress)
         {
             //Arrange
-            var wb = new XLWorkbook();
+            using var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add("DataValidation");
             var validation = ws.Range(initialAddress).CreateDataValidation();
             validation.WholeNumber.Between(0, 100);
@@ -405,102 +403,6 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 dv.RemoveRange(null);
 
                 Assert.AreSame(range1, dv.Ranges.Single());
-            }
-        }
-
-        [Test]
-        public void AddRangeFiresEvent()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
-
-                IXLRange addedRange = null;
-
-                dv.RangeAdded += (s, e) => addedRange = e.Range;
-
-                dv.AddRange(range2);
-
-                Assert.AreSame(range2, addedRange);
-            }
-        }
-
-        [Test]
-        public void AddRangesFiresMultipleEvents()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var ranges = ws.Ranges("D1:D3,F1:F3");
-                var dv = new XLDataValidation(range1);
-
-                var addedRanges = new List<IXLRange>();
-
-                dv.RangeAdded += (s, e) => addedRanges.Add(e.Range);
-
-                dv.AddRanges(ranges);
-
-                Assert.AreEqual(2, addedRanges.Count);
-            }
-        }
-
-        [Test]
-        public void RemoveRangeFiresEvent()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
-                dv.AddRange(range2);
-                IXLRange removedRange = null;
-                dv.RangeRemoved += (s, e) => removedRange = e.Range;
-
-                dv.RemoveRange(range2);
-
-                Assert.AreSame(range2, removedRange);
-            }
-        }
-
-        [Test]
-        public void RemoveNonExistingRangeDoesNotFireEvent()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
-
-                dv.RangeRemoved += (s, e) => Assert.Fail("Expected not to fire event");
-
-                dv.RemoveRange(range2);
-            }
-        }
-
-        [Test]
-        public void ClearRangesFiresMultipleEvents()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet();
-                var range1 = ws.Range("A1:A3");
-                var range2 = ws.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
-                dv.AddRange(range2);
-
-                var removedRanges = new List<IXLRange>();
-
-                dv.RangeRemoved += (s, e) => removedRanges.Add(e.Range);
-
-                dv.ClearRanges();
-
-                Assert.AreEqual(2, removedRanges.Count);
             }
         }
     }

--- a/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 using System.Linq;
@@ -102,7 +102,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 dv2.MinValue = "100";
 
                 Assert.AreEqual(4, dv1.Ranges.Count());
-                Assert.AreEqual("B2:G3,B4:D6,B7:G7,C11:C13",
+                Assert.AreEqual("B2:D7,E2:G3,E7:G7,C11:C13",
                     string.Join(",", dv1.Ranges.Select(r => r.RangeAddress.ToString())));
             }
         }

--- a/ClosedXML.sln.DotSettings
+++ b/ClosedXML.sln.DotSettings
@@ -103,6 +103,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RANDARRAY/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rowspans/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SORTBY/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sqref/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTAFTER/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTBEFORE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TEXTSPLIT/@EntryIndexedValue">True</s:Boolean>

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1468,7 +1468,7 @@ namespace ClosedXML.Excel
                 CopyDataValidation(otherCell, otherCell.GetDataValidation());
             else if (HasDataValidation)
             {
-                Worksheet.DataValidations.Delete(AsRange());
+                Worksheet.DataValidations.Delete(new XLBookArea(Worksheet.Name, SheetPoint));
             }
         }
 

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -193,6 +193,15 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
         return new XLAreaList(result);
     }
 
+    internal XLAreaList DeleteWithoutShift(XLSheetRange deletedArea)
+    {
+        var result = new List<XLSheetRange>(_areas.Count);
+        foreach (var originalArea in _areas)
+            originalArea.Exclude(deletedArea, result);
+
+        return new XLAreaList(result);
+    }
+
     public IEnumerator<XLSheetRange> GetEnumerator()
     {
         return _areas.GetEnumerator();

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -248,6 +248,14 @@ namespace ClosedXML.Excel
                 point.Column >= FirstPoint.Column && point.Column <= LastPoint.Column;
         }
 
+        internal bool Covers(XLSheetRange otherArea)
+        {
+            return LeftColumn <= otherArea.LeftColumn &&
+                   TopRow <= otherArea.TopRow &&
+                   RightColumn >= otherArea.RightColumn &&
+                   BottomRow >= otherArea.BottomRow;
+        }
+
         /// <summary>
         /// Create a new range from this one by taking a number of rows from the bottom row up.
         /// </summary>

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -7,19 +7,8 @@ using System.Linq;
 
 namespace ClosedXML.Excel
 {
-    internal class RangeEventArgs : EventArgs
-    {
-        public RangeEventArgs(IXLRange range)
-        {
-            Range = range ?? throw new ArgumentNullException(nameof(range));
-        }
-
-        public IXLRange Range { get; }
-    }
-
     internal class XLDataValidation : IXLDataValidation
     {
-        private readonly XLRanges _ranges;
         private readonly XLWorksheet _worksheet;
 
         public XLDataValidation(IXLRange range)
@@ -40,15 +29,12 @@ namespace ClosedXML.Excel
         private XLDataValidation(XLWorksheet worksheet)
         {
             _worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
-            _ranges = new XLRanges(worksheet);
             Initialize();
         }
 
-        internal event EventHandler<RangeEventArgs> RangeAdded;
-
-        internal event EventHandler<RangeEventArgs> RangeRemoved;
-
         internal XLWorksheet Worksheet => _worksheet;
+
+        internal XLAreaList Areas { get; set; } = XLAreaList.Empty;
 
         public void Clear()
         {
@@ -59,7 +45,7 @@ namespace ClosedXML.Excel
         {
             if (dataValidation == this) return;
 
-            if (!_ranges.Any())
+            if (Areas.Count == 0)
                 AddRanges(dataValidation.Ranges);
 
             IgnoreBlanks = dataValidation.IgnoreBlanks;
@@ -85,18 +71,6 @@ namespace ClosedXML.Excel
                    (!String.IsNullOrWhiteSpace(InputTitle) || !String.IsNullOrWhiteSpace(InputMessage)))
                 || (ShowErrorMessage &&
                    (!String.IsNullOrWhiteSpace(ErrorTitle) || !String.IsNullOrWhiteSpace(ErrorMessage)));
-        }
-
-        internal void SplitBy(IXLRangeAddress rangeAddress)
-        {
-            var rangesToSplit = _ranges.GetIntersectedRanges(rangeAddress).ToList();
-
-            foreach (var rangeToSplit in rangesToSplit)
-            {
-                var newRanges = (rangeToSplit as XLRange).Split(rangeAddress, includeIntersection: false);
-                RemoveRange(rangeToSplit);
-                newRanges.ForEach(AddRange);
-            }
         }
 
         private void Initialize()
@@ -151,7 +125,21 @@ namespace ClosedXML.Excel
         public String MaxValue { get => maxValue; set { Validate(value); maxValue = value; } }
         public String MinValue { get => minValue; set { Validate(value); minValue = value; } }
         public XLOperator Operator { get; set; }
-        public IEnumerable<IXLRange> Ranges => _ranges.AsEnumerable();
+
+        public IEnumerable<IXLRange> Ranges
+        {
+            get
+            {
+                var ranges = new XLRanges(Worksheet);
+                foreach (var area in Areas)
+                {
+                    var range = _worksheet.Range(XLRangeAddress.FromSheetRange(_worksheet, area));
+                    ranges.Add(range);
+                }
+
+                return ranges;
+            }
+        }
 
         public Boolean ShowErrorMessage { get; set; }
 
@@ -203,9 +191,7 @@ namespace ClosedXML.Excel
             if (range.Worksheet != Worksheet)
                 range = Worksheet.Range(((XLRangeAddress)range.RangeAddress).WithoutWorksheet());
 
-            _ranges.Add(range);
-
-            RangeAdded?.Invoke(this, new RangeEventArgs(range));
+            Areas = Areas.With(XLBookArea.From(range).Area);
         }
 
         /// <summary>
@@ -229,13 +215,7 @@ namespace ClosedXML.Excel
         /// </summary>
         public void ClearRanges()
         {
-            var allRanges = _ranges.ToList();
-            _ranges.RemoveAll();
-
-            foreach (var range in allRanges)
-            {
-                RangeRemoved?.Invoke(this, new RangeEventArgs(range));
-            }
+            Areas = XLAreaList.Empty;
         }
 
         public void Custom(String customValidation)
@@ -275,14 +255,11 @@ namespace ClosedXML.Excel
             if (range == null)
                 return false;
 
-            var res = _ranges.Remove(range);
-
-            if (res)
-            {
-                RangeRemoved?.Invoke(this, new RangeEventArgs(range));
-            }
-
-            return res;
+            var areaToDelete = XLBookArea.From(range).Area;
+            var originalAreas = Areas;
+            Areas = Areas.Without(areaToDelete);
+            var deleted = originalAreas.Count > Areas.Count;
+            return deleted;
         }
 
         #endregion IXLDataValidation Members

--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -1,33 +1,20 @@
-// Keep this file CodeMaid organised and cleaned
 using System;
-using System.Collections.Generic;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using ClosedXML.Excel.Ranges.Index;
 
 namespace ClosedXML.Excel
 {
-    internal class XLDataValidations : IXLDataValidations, IEnumerable<XLDataValidation>
+    internal class XLDataValidations : IXLDataValidations, IEnumerable<XLDataValidation>, ISheetListener
     {
-        private readonly XLRangeIndex<XLDataValidationIndexEntry> _dataValidationIndex;
-
         private readonly List<XLDataValidation> _dataValidations = new();
         private readonly XLWorksheet _worksheet;
-
-        /// <summary>
-        /// The flag used to avoid unnecessary check for splitting intersected ranges when we already
-        /// are performing the splitting.
-        /// </summary>
-        private bool _skipSplittingExistingRanges = false;
 
         public XLDataValidations(XLWorksheet worksheet)
         {
             _worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
-            _dataValidationIndex = new XLRangeIndex<XLDataValidationIndexEntry>(_worksheet);
         }
-
-        internal XLWorksheet Worksheet => _worksheet;
 
         #region IXLDataValidations Members
 
@@ -67,11 +54,24 @@ namespace ClosedXML.Excel
         public IEnumerable<IXLDataValidation> GetAllInRange(IXLRangeAddress rangeAddress)
         {
             if (rangeAddress == null || !rangeAddress.IsValid)
-                return Enumerable.Empty<IXLDataValidation>();
+                yield break;
 
-            return _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)rangeAddress)
-                .Select(indexEntry => indexEntry.DataValidation)
-                .Distinct();
+            var intersectingArea = XLSheetRange.FromRangeAddress(rangeAddress);
+
+            foreach (var dataValidation in _dataValidations)
+            {
+                if (rangeAddress.Worksheet != dataValidation.Worksheet)
+                    continue;
+
+                foreach (var area in dataValidation.Areas)
+                {
+                    if (intersectingArea.Intersects(area))
+                    {
+                        yield return dataValidation;
+                        break;
+                    }
+                }
+            }
         }
 
         public IEnumerator<XLDataValidation> GetEnumerator()
@@ -93,28 +93,38 @@ namespace ClosedXML.Excel
         /// Get the data validation rule for the range with the specified address if it exists.
         /// </summary>
         /// <param name="rangeAddress">A range address.</param>
-        /// <param name="dataValidation">Data validation rule which ranges collection includes the specified
+        /// <param name="foundDataValidation">Data validation rule which ranges collection includes the specified
         /// address. The specified range should be fully covered with the data validation rule.
         /// For example, if the rule is applied to ranges A1:A3,C1:C3 then this method will
         /// return True for ranges A1:A3, C1:C2, A2:A3, and False for ranges A1:C3, A1:C1, etc.</param>
         /// <returns>True is the data validation rule was found, false otherwise.</returns>
-        public bool TryGet(IXLRangeAddress rangeAddress, [NotNullWhen(true)] out IXLDataValidation? dataValidation)
+        public bool TryGet(IXLRangeAddress rangeAddress, [NotNullWhen(true)] out IXLDataValidation? foundDataValidation)
         {
-            dataValidation = null;
             if (rangeAddress == null || !rangeAddress.IsValid)
+            {
+                foundDataValidation = null;
                 return false;
+            }
 
-            var candidates = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)rangeAddress)
-                .Where(c => c.RangeAddress.Contains(rangeAddress.FirstAddress) &&
-                            c.RangeAddress.Contains(rangeAddress.LastAddress));
+            var coveredArea = XLSheetRange.FromRangeAddress(rangeAddress);
 
-            var candidate = candidates.FirstOrDefault();
-            if (candidate is null)
-                return false;
+            foreach (var dataValidation in _dataValidations)
+            {
+                if (rangeAddress.Worksheet != dataValidation.Worksheet)
+                    continue;
 
-            dataValidation = candidate.DataValidation;
+                foreach (var area in dataValidation.Areas)
+                {
+                    if (area.Covers(coveredArea))
+                    {
+                        foundDataValidation = dataValidation;
+                        return true;
+                    }
+                }
+            }
 
-            return true;
+            foundDataValidation = null;
+            return false;
         }
 
         #endregion IXLDataValidations Members
@@ -127,51 +137,45 @@ namespace ClosedXML.Excel
         internal XLDataValidation Add(XLDataValidation dataValidation, bool skipIntersectionsCheck)
         {
             XLDataValidation xlDataValidation;
-            if (dataValidation.Ranges.Any(r => r.Worksheet != Worksheet))
+            if (dataValidation.Ranges.Any(r => r.Worksheet != _worksheet))
             {
-                xlDataValidation = new XLDataValidation(dataValidation, Worksheet);
+                xlDataValidation = new XLDataValidation(dataValidation, _worksheet);
             }
             else
             {
                 xlDataValidation = dataValidation;
             }
 
-            xlDataValidation.RangeAdded += OnRangeAdded;
-            xlDataValidation.RangeRemoved += OnRangeRemoved;
-
-            foreach (var range in xlDataValidation.Ranges)
-            {
-                ProcessRangeAdded(range, xlDataValidation, skipIntersectionsCheck);
-            }
+            // Adding a range can split current one
+            foreach (var area in dataValidation.Areas)
+                AdjustDataValidationAreas(_worksheet, area, static (dataValidationAreas, areaOfNewValidation) => dataValidationAreas.DeleteWithoutShift(areaOfNewValidation));
 
             _dataValidations.Add(xlDataValidation);
-
             return xlDataValidation;
         }
 
-        internal void Delete(IXLRange range)
+        internal void Delete(XLBookArea bookArea)
         {
-            if (range == null) throw new ArgumentNullException(nameof(range));
+            for (var i = _dataValidations.Count - 1; i >= 0; --i)
+            {
+                var dataValidation = _dataValidations[i];
+                if (!XLHelper.SheetComparer.Equals(dataValidation.Worksheet.Name, bookArea.Name))
+                    continue;
 
-            var dataValidationsToRemove = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)range.RangeAddress)
-                .Select(e => e.DataValidation)
-                .Distinct()
-                .ToList();
-
-            dataValidationsToRemove.ForEach(Delete);
+                foreach (var area in dataValidation.Areas)
+                {
+                    if (area.Intersects(bookArea.Area))
+                    {
+                        _dataValidations.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
         }
 
         internal void Delete(XLDataValidation dataValidation)
         {
-            if (!_dataValidations.Remove(dataValidation))
-                return;
-            dataValidation.RangeAdded -= OnRangeAdded;
-            dataValidation.RangeRemoved -= OnRangeRemoved;
-
-            foreach (var range in dataValidation.Ranges)
-            {
-                ProcessRangeRemoved(range);
-            }
+            _dataValidations.Remove(dataValidation);
         }
 
         internal void Consolidate()
@@ -216,74 +220,44 @@ namespace ClosedXML.Excel
             }
         }
 
-        private void OnRangeAdded(object sender, RangeEventArgs e)
+        void ISheetListener.OnInsertAreaAndShiftDown(XLWorksheet sheet, XLSheetRange area)
         {
-            ProcessRangeAdded(e.Range, (XLDataValidation) sender, skipIntersectionCheck: false);
+            AdjustDataValidationAreas(sheet, area, static (sqref, insertedArea) => sqref.InsertAndShiftDown(insertedArea));
         }
 
-        private void OnRangeRemoved(object sender, RangeEventArgs e)
+        void ISheetListener.OnInsertAreaAndShiftRight(XLWorksheet sheet, XLSheetRange area)
         {
-            ProcessRangeRemoved(e.Range);
+            AdjustDataValidationAreas(sheet, area, static (sqref, insertedArea) => sqref.InsertAndShiftRight(insertedArea));
         }
 
-        private void ProcessRangeAdded(IXLRange range, XLDataValidation dataValidation, bool skipIntersectionCheck)
+        void ISheetListener.OnDeleteAreaAndShiftLeft(XLWorksheet sheet, XLSheetRange deletedRange)
         {
-            if (!skipIntersectionCheck)
+            AdjustDataValidationAreas(sheet, deletedRange, static (sqref, deletedArea) => sqref.DeleteAndShiftLeft(deletedArea));
+        }
+
+        void ISheetListener.OnDeleteAreaAndShiftUp(XLWorksheet sheet, XLSheetRange deletedRange)
+        {
+            AdjustDataValidationAreas(sheet, deletedRange, static (sqref, deletedArea) => sqref.DeleteAndShiftUp(deletedArea));
+        }
+
+        private void AdjustDataValidationAreas(XLWorksheet sheet, XLSheetRange affectedRange, Func<XLAreaList, XLSheetRange, XLAreaList> adjustAreas)
+        {
+            if (sheet != _worksheet)
+                return;
+
+            for (var i = _dataValidations.Count - 1; i >= 0; --i)
             {
-                SplitExistingRanges(range.RangeAddress);
-            }
-
-            var indexEntry = new XLDataValidationIndexEntry(range.RangeAddress, dataValidation);
-            _dataValidationIndex.Add(indexEntry);
-        }
-
-        private void ProcessRangeRemoved(IXLRange range)
-        {
-            var entries = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)range.RangeAddress)
-                .Where(e => Equals(e.RangeAddress, range.RangeAddress));
-            entries.ToArray().ForEach(entry => _dataValidationIndex.Remove(entry.RangeAddress));
-        }
-
-        private void SplitExistingRanges(IXLRangeAddress rangeAddress)
-        {
-            if (_skipSplittingExistingRanges) return;
-
-            try
-            {
-                _skipSplittingExistingRanges = true;
-                var entries = _dataValidationIndex.GetIntersectedRanges((XLRangeAddress)rangeAddress)
-                    .ToList();
-
-                foreach (var entry in entries)
+                var dataValidation = _dataValidations[i];
+                var modifiedAreaList = adjustAreas(dataValidation.Areas, affectedRange);
+                if (modifiedAreaList.Count == 0)
                 {
-                    entry.DataValidation.SplitBy(rangeAddress);
+                    _dataValidations.RemoveAt(i);
+                }
+                else
+                {
+                    dataValidation.Areas = modifiedAreaList;
                 }
             }
-            finally
-            {
-                _skipSplittingExistingRanges = false;
-            }
-
-            //TODO Remove empty data validations
-        }
-
-        /// <summary>
-        /// Class used for indexing data validation rules.
-        /// </summary>
-        private class XLDataValidationIndexEntry : IXLAddressable
-        {
-            public XLDataValidationIndexEntry(IXLRangeAddress rangeAddress, XLDataValidation dataValidation)
-            {
-                RangeAddress = rangeAddress;
-                DataValidation = dataValidation;
-            }
-
-            public XLDataValidation DataValidation { get; }
-
-            /// <summary>
-            ///   Gets an object with the boundaries of this range.
-            /// </summary>
-            public IXLRangeAddress RangeAddress { get; }
         }
     }
 }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1222,7 +1222,6 @@ namespace ClosedXML.Excel
             }
 
             ShiftConditionalFormattingColumns(range, columnsShifted);
-            ShiftDataValidationColumns(range, columnsShifted);
             ShiftPageBreaksColumns(range, columnsShifted);
             RemoveInvalidSparklines();
 
@@ -1231,6 +1230,7 @@ namespace ClosedXML.Excel
                 Workbook.CalcEngine,
                 Hyperlinks,
                 Workbook.DefinedNamesInternal,
+                DataValidations,
             };
 
             foreach (var worksheet in Workbook.WorksheetsInternal)
@@ -1311,54 +1311,6 @@ namespace ClosedXML.Excel
             }
         }
 
-        private void ShiftDataValidationColumns(XLRange range, int columnsShifted)
-        {
-            if (!DataValidations.Any<XLDataValidation>())
-                return;
-
-            Int32 firstCol = range.RangeAddress.FirstAddress.ColumnNumber;
-            if (firstCol == 1) return;
-
-            int colNum = columnsShifted > 0 ? firstCol - 1 : firstCol;
-            var model = Column(colNum).AsRange();
-
-            foreach (var dv in DataValidations.ToList<XLDataValidation>())
-            {
-                var dvRanges = dv.Ranges.ToList();
-                dv.ClearRanges();
-
-                foreach (var dvRange in dvRanges)
-                {
-                    var dvAddress = dvRange.RangeAddress;
-                    IXLRange newRange;
-                    if (dvRange.Intersects(model))
-                    {
-                        newRange = Range(dvAddress.FirstAddress.RowNumber,
-                                         dvAddress.FirstAddress.ColumnNumber,
-                                         dvAddress.LastAddress.RowNumber,
-                                         Math.Min(XLHelper.MaxColumnNumber, dvAddress.LastAddress.ColumnNumber + columnsShifted));
-                    }
-                    else if (dvAddress.FirstAddress.ColumnNumber >= firstCol)
-                    {
-                        newRange = Range(dvAddress.FirstAddress.RowNumber,
-                                         Math.Max(dvAddress.FirstAddress.ColumnNumber + columnsShifted, firstCol),
-                                         dvAddress.LastAddress.RowNumber,
-                                         Math.Min(XLHelper.MaxColumnNumber, dvAddress.LastAddress.ColumnNumber + columnsShifted));
-                    }
-                    else
-                        newRange = dvRange;
-
-                    if (newRange.RangeAddress.IsValid &&
-                        newRange.RangeAddress.FirstAddress.ColumnNumber <=
-                        newRange.RangeAddress.LastAddress.ColumnNumber)
-                        dv.AddRange(newRange);
-                }
-
-                if (!dv.Ranges.Any())
-                    DataValidations.Delete(v => v == dv);
-            }
-        }
-
         internal override void WorksheetRangeShiftedRows(XLRange range, int rowsShifted)
         {
             if (!range.IsEntireRow())
@@ -1378,7 +1330,6 @@ namespace ClosedXML.Excel
             }
 
             ShiftConditionalFormattingRows(range, rowsShifted);
-            ShiftDataValidationRows(range, rowsShifted);
             RemoveInvalidSparklines();
             ShiftPageBreaksRows(range, rowsShifted);
 
@@ -1387,6 +1338,7 @@ namespace ClosedXML.Excel
                 Workbook.CalcEngine,
                 Hyperlinks,
                 Workbook.DefinedNamesInternal,
+                DataValidations
             };
             foreach (var worksheet in Workbook.WorksheetsInternal)
                 sheetListeners.Add(worksheet.DefinedNames);
@@ -1462,53 +1414,6 @@ namespace ClosedXML.Excel
 
                 if (!cf.Ranges.Any())
                     ConditionalFormats.Remove(f => f == cf);
-            }
-        }
-
-        private void ShiftDataValidationRows(XLRange range, int rowsShifted)
-        {
-            if (!DataValidations.Any<XLDataValidation>())
-                return;
-
-            Int32 firstRow = range.RangeAddress.FirstAddress.RowNumber;
-            if (firstRow == 1) return;
-
-            int rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
-            var model = Row(rowNum).AsRange();
-
-            foreach (var dv in DataValidations.ToList<XLDataValidation>())
-            {
-                var dvRanges = dv.Ranges.ToList();
-                dv.ClearRanges();
-
-                foreach (var dvRange in dvRanges)
-                {
-                    var dvAddress = dvRange.RangeAddress;
-                    IXLRange newRange;
-                    if (dvRange.Intersects(model))
-                    {
-                        newRange = Range(dvAddress.FirstAddress.RowNumber,
-                                         dvAddress.FirstAddress.ColumnNumber,
-                                         Math.Min(XLHelper.MaxRowNumber, dvAddress.LastAddress.RowNumber + rowsShifted),
-                                         dvAddress.LastAddress.ColumnNumber);
-                    }
-                    else if (dvAddress.FirstAddress.RowNumber >= firstRow)
-                    {
-                        newRange = Range(Math.Max(dvAddress.FirstAddress.RowNumber + rowsShifted, firstRow),
-                                         dvAddress.FirstAddress.ColumnNumber,
-                                         Math.Min(XLHelper.MaxRowNumber, dvAddress.LastAddress.RowNumber + rowsShifted),
-                                         dvAddress.LastAddress.ColumnNumber);
-                    }
-                    else
-                        newRange = dvRange;
-
-                    if (newRange.RangeAddress.IsValid &&
-                        newRange.RangeAddress.FirstAddress.RowNumber <= newRange.RangeAddress.LastAddress.RowNumber)
-                        dv.AddRange(newRange);
-                }
-
-                if (!dv.Ranges.Any())
-                    DataValidations.Delete(v => v == dv);
             }
         }
 


### PR DESCRIPTION
Replace property that holds info which cells are affected by DV. The original `IXLRanges` was replaced by `XLAreaList`.

This change also adds `ISheetListener` to `XLDataValidations` and thus replaces `IXLRanges` magical shifting with explicit shifting code directly in `XLDataValidations`. This is a part of an ongoing initiative to make various objects more self-contained and modular.

Plus, the `XLAreaList` shifting code can deal with insert/deletion of areas, whereas original one can only deal with inserted/deleted rows/columns.

The `XLRangeIndex<;XLDataValidationIndexEntry>` has also been removed. It was house keeping infrastructure to speed up a check if a cell is using DV (That index was originally introduced for #1071 in #1207). I checked the performance difference ([gist](https://gist.github.com/jahav/053df85458cfbabc9e3ece1b8034149f)). It does start to get slower at 500+DV, but is noticeable at 6400 DV, so I think it's fine for now. 

I want to stop using of `IXLRange` in internal code and use it only for external API and thus `XLRangeIndex` is on it's way out anyway. I will probably add something (Quad-tree or R-tree based on area) back later, but correctness takes precedence over performance and even I I don't make it in current release, the splash zone is limited to workbooks with 1000+DV.

The other DV problem that will be solved in a separate PR is enforcement of "one DV per cell."

Resolves #2794 