### PR TITLE
Data Validations: Re-add enforcement of one-dv-per-cell invariant

### DIFF
--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -293,12 +293,6 @@ namespace ClosedXML.Tests.Excel.DataValidations
         }
 
         [Test]
-        public void CannotCreateDataValidationWithoutRange()
-        {
-            Assert.Throws<ArgumentNullException>(() => new XLDataValidation(null));
-        }
-
-        [Test]
         public void DataValidationHasWorksheetAndRangesWhenCreated()
         {
             using (var wb = new XLWorkbook())
@@ -306,9 +300,9 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var ws = wb.AddWorksheet();
                 var range = ws.Range("A1:A3");
 
-                var dv = new XLDataValidation(range);
+                var dv = range.CreateDataValidation();
 
-                Assert.AreSame(ws, dv.Worksheet);
+                Assert.AreSame(ws, ((XLDataValidation)dv).Worksheet);
                 Assert.AreSame(range, dv.Ranges.Single());
             }
         }
@@ -322,7 +316,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var range1 = ws.Range("A1:A3");
                 var range2 = ws.Range("C1:C3");
                 var ranges3 = ws.Ranges("D1:D3,F1:F3");
-                var dv = new XLDataValidation(range1);
+                var dv = range1.CreateDataValidation();
 
                 dv.AddRange(range2);
                 dv.AddRanges(ranges3);
@@ -343,7 +337,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var ws2 = wb.AddWorksheet();
                 var range1 = ws1.Range("A1:A3");
                 var range2 = ws2.Range("C1:C3");
-                var dv = new XLDataValidation(range1);
+                var dv = range1.CreateDataValidation();
 
                 dv.AddRange(range2);
 
@@ -360,7 +354,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var range1 = ws.Range("A1:A3");
                 var range2 = ws.Range("C1:C3");
                 var ranges3 = ws.Ranges("D1:D3,F1:F3");
-                var dv = new XLDataValidation(range1);
+                var dv = range1.CreateDataValidation();
                 dv.AddRange(range2);
                 dv.AddRanges(ranges3);
 
@@ -379,7 +373,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var range1 = ws.Range("A1:A3");
                 var range2 = ws.Range("C1:C3");
 
-                var dv = new XLDataValidation(range1);
+                var dv = range1.CreateDataValidation();
                 dv.AddRange(range2);
 
                 dv.RemoveRange(range1);
@@ -397,7 +391,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var range1 = ws.Range("A1:A3");
                 var range2 = ws.Range("C1:C3");
 
-                var dv = new XLDataValidation(range1);
+                var dv = range1.CreateDataValidation();
 
                 dv.RemoveRange(range2);
                 dv.RemoveRange(null);

--- a/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -1,18 +1,12 @@
+using System.Collections.Generic;
+using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
-using System;
-using System.Linq;
 
 namespace ClosedXML.Tests.Excel.DataValidations
 {
     public class XLDataValidationsTests
     {
-        [Test]
-        public void CannotCreateWithoutWorksheet()
-        {
-            Assert.Throws<ArgumentNullException>(() => new XLDataValidations(null));
-        }
-
         [Test]
         public void AddedRangesAreTransferredToTargetSheet()
         {
@@ -34,6 +28,83 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 Assert.AreSame(ws1, dv1.Ranges.Single().Worksheet);
                 Assert.AreSame(ws2, dv2.Ranges.Single().Worksheet);
             }
+        }
+
+        [Test]
+        [Description("Ensure one-dv-per-cell invariant")]
+        public void AddRange_replaces_intersecting_areas_of_validation()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv = ws.Range("A1:C3").CreateDataValidation();
+            dv.MinValue = "10";
+
+            dv.AddRange(ws.Range("B1:D4"));
+
+            Assert.AreEqual("A1:A3 B1:D4", ToSpaceList(dv.Ranges));
+            Assert.AreEqual("10", dv.MinValue);
+        }
+
+        [Test]
+        public void AddRange_keeps_validation_settings_even_when_it_completely_covers_original()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv = ws.Range("B2:C3").CreateDataValidation();
+            dv.MinValue = "10";
+
+            dv.AddRange(ws.Range("A1:D4"));
+
+            Assert.AreEqual("A1:D4", ToSpaceList(dv.Ranges));
+            Assert.AreEqual("10", dv.MinValue);
+        }
+
+        [Test]
+        [Description("Ensure one-dv-per-cell invariant")]
+        public void AddRange_replaces_area_of_other_validations()
+        {
+            // Arrange
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            var dv1 = ws.Range("A1:A3").CreateDataValidation();
+            dv1.WholeNumber.Between(1, 5);
+
+            var dv2 = ws.Range("B2:D4").CreateDataValidation();
+            dv1.MaxValue = "10";
+
+            // Act
+            dv1.AddRange(ws.Range("B1:D3"));
+
+            // Assert
+            Assert.AreEqual("A1:A3 B1:D3", ToSpaceList(dv1.Ranges));
+            Assert.AreEqual("B4:D4", ToSpaceList(dv2.Ranges));
+        }
+
+        [Test]
+        public void AddRange_deletes_other_validations_that_are_not_used_by_any_cell()
+        {
+            // Arrange
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            var dv1 = ws.Range("A1:A3").CreateDataValidation();
+            dv1.WholeNumber.Between(1, 5);
+
+            var dv2 = ws.Range("B1:B3").CreateDataValidation();
+            dv1.MaxValue = "10";
+
+            // Act
+            dv1.AddRange(ws.Range("B1:B3"));
+
+            // Assert
+            Assert.AreEqual(1, ws.DataValidations.Count());
+
+            Assert.IsTrue(ws.DataValidations.Contains(dv1));
+            Assert.AreEqual("A1:A3 B1:B3", ToSpaceList(dv1.Ranges));
+
+            Assert.IsFalse(ws.DataValidations.Contains(dv2));
+            Assert.IsEmpty(ToSpaceList(dv2.Ranges));
         }
 
         [TestCase("A1:A1", true)]
@@ -137,7 +208,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 var dv2 = ws.Range("B1:B3").CreateDataValidation();
                 dv2.MinValue = "100";
 
-                (ws.DataValidations as XLDataValidations).Consolidate();
+                ((XLDataValidations)ws.DataValidations).Consolidate();
                 dv1.AddRange(ws.Range("C1:C3"));
                 dv2.AddRange(ws.Range("D1:D3"));
 
@@ -146,6 +217,11 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 Assert.True(ws.Cell("C1").HasDataValidation);
                 Assert.False(ws.Cell("D1").HasDataValidation);
             }
+        }
+
+        private static string ToSpaceList(IEnumerable<IXLRange> ranges)
+        {
+            return string.Join(" ", ranges.Select(x => x.RangeAddress.ToStringRelative()));
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1065,9 +1065,7 @@ namespace ClosedXML.Excel
 
         internal XLDataValidation CreateDataValidation()
         {
-            var validation = new XLDataValidation(AsRange());
-            Worksheet.DataValidations.Add(validation);
-            return validation;
+            return Worksheet.DataValidations.Create(new XLSheetRange(SheetPoint));
         }
 
         public void Select()
@@ -1468,7 +1466,7 @@ namespace ClosedXML.Excel
                 CopyDataValidation(otherCell, otherCell.GetDataValidation());
             else if (HasDataValidation)
             {
-                Worksheet.DataValidations.Delete(new XLBookArea(Worksheet.Name, SheetPoint));
+                Worksheet.DataValidations.Delete(new XLSheetRange(SheetPoint));
             }
         }
 

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -11,24 +11,9 @@ namespace ClosedXML.Excel
     {
         private readonly XLWorksheet _worksheet;
 
-        public XLDataValidation(IXLRange range)
-            : this(range?.Worksheet as XLWorksheet)
-        {
-            if (range == null) throw new ArgumentNullException(nameof(range));
-
-            AddRange(range);
-        }
-
-        public XLDataValidation(XLDataValidation dataValidation, XLWorksheet worksheet)
-            : this(worksheet)
+        internal XLDataValidation(XLWorksheet worksheet)
         {
             _worksheet = worksheet;
-            CopyFrom(dataValidation);
-        }
-
-        private XLDataValidation(XLWorksheet worksheet)
-        {
-            _worksheet = worksheet ?? throw new ArgumentNullException(nameof(worksheet));
             Initialize();
         }
 
@@ -41,7 +26,7 @@ namespace ClosedXML.Excel
             Initialize();
         }
 
-        public void CopyFrom(IXLDataValidation dataValidation)
+        internal void CopyFrom(IXLDataValidation dataValidation)
         {
             if (dataValidation == this) return;
 
@@ -186,12 +171,17 @@ namespace ClosedXML.Excel
         /// <param name="range">A range to add.</param>
         public void AddRange(IXLRange range)
         {
-            if (range == null) throw new ArgumentNullException(nameof(range));
+            if (range == null)
+                throw new ArgumentNullException(nameof(range));
 
-            if (range.Worksheet != Worksheet)
-                range = Worksheet.Range(((XLRangeAddress)range.RangeAddress).WithoutWorksheet());
+            // Do not add area if the DV has been detached (e.g. consolidation).
+            var isDetached = !_worksheet.DataValidations.Contains(this);
+            if (isDetached)
+                return;
 
-            Areas = Areas.With(XLBookArea.From(range).Area);
+            // Ignore sheet of a range
+            var area = XLSheetRange.FromRangeAddress(range.RangeAddress);
+            _worksheet.DataValidations.AddArea(this, area);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/DataValidation/XLDataValidations.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidations.cs
@@ -25,7 +25,24 @@ namespace ClosedXML.Excel
             if (dataValidation == null)
                 throw new ArgumentNullException(nameof(dataValidation));
 
-            return Add((XLDataValidation)dataValidation);
+            var dv = (XLDataValidation)dataValidation;
+            if (dv.Worksheet != _worksheet)
+                return CopyFrom(dv);
+
+            // It's possible that it was detached and while detached, it had added some areas?
+            // I have a very hard time understanding the use case and intended behavior. This
+            // API should be scrapped.
+            if (!_dataValidations.Contains(dv))
+            {
+                // Adding a range can split current one -> clear existing DVs so new one can be
+                // added and "one DV per cell" is kept.
+                foreach (var area in dv.Areas)
+                    AdjustDataValidationAreas(_worksheet, area, static (dataValidationAreas, areaOfNewValidation) => dataValidationAreas.DeleteWithoutShift(areaOfNewValidation));
+
+                _dataValidations.Add(dv);
+            }
+
+            return dv;
         }
 
         public Boolean ContainsSingle(IXLRange range)
@@ -53,16 +70,15 @@ namespace ClosedXML.Excel
         /// </summary>
         public IEnumerable<IXLDataValidation> GetAllInRange(IXLRangeAddress rangeAddress)
         {
-            if (rangeAddress == null || !rangeAddress.IsValid)
+            if (rangeAddress is null || !rangeAddress.IsValid)
+                yield break;
+
+            if (rangeAddress.Worksheet != _worksheet)
                 yield break;
 
             var intersectingArea = XLSheetRange.FromRangeAddress(rangeAddress);
-
             foreach (var dataValidation in _dataValidations)
             {
-                if (rangeAddress.Worksheet != dataValidation.Worksheet)
-                    continue;
-
                 foreach (var area in dataValidation.Areas)
                 {
                     if (intersectingArea.Intersects(area))
@@ -100,19 +116,15 @@ namespace ClosedXML.Excel
         /// <returns>True is the data validation rule was found, false otherwise.</returns>
         public bool TryGet(IXLRangeAddress rangeAddress, [NotNullWhen(true)] out IXLDataValidation? foundDataValidation)
         {
-            if (rangeAddress == null || !rangeAddress.IsValid)
+            if (rangeAddress is null || !rangeAddress.IsValid || rangeAddress.Worksheet != _worksheet)
             {
                 foundDataValidation = null;
                 return false;
             }
 
             var coveredArea = XLSheetRange.FromRangeAddress(rangeAddress);
-
             foreach (var dataValidation in _dataValidations)
             {
-                if (rangeAddress.Worksheet != dataValidation.Worksheet)
-                    continue;
-
                 foreach (var area in dataValidation.Areas)
                 {
                     if (area.Covers(coveredArea))
@@ -129,42 +141,36 @@ namespace ClosedXML.Excel
 
         #endregion IXLDataValidations Members
 
-        internal XLDataValidation Add(XLDataValidation dataValidation)
+        /// <summary>
+        /// Create a new DV with an initial area.
+        /// </summary>
+        internal XLDataValidation Create(XLSheetRange area)
         {
-            return Add(dataValidation, skipIntersectionsCheck: false);
+            var dv = new XLDataValidation(_worksheet);
+            _dataValidations.Add(dv);
+            AddArea(dv, area);
+            return dv;
         }
 
-        internal XLDataValidation Add(XLDataValidation dataValidation, bool skipIntersectionsCheck)
+        /// <summary>
+        /// Create a new DV that is created from another DV from different sheet.
+        /// </summary>
+        internal XLDataValidation CopyFrom(XLDataValidation original)
         {
-            XLDataValidation xlDataValidation;
-            if (dataValidation.Ranges.Any(r => r.Worksheet != _worksheet))
-            {
-                xlDataValidation = new XLDataValidation(dataValidation, _worksheet);
-            }
-            else
-            {
-                xlDataValidation = dataValidation;
-            }
-
-            // Adding a range can split current one
-            foreach (var area in dataValidation.Areas)
-                AdjustDataValidationAreas(_worksheet, area, static (dataValidationAreas, areaOfNewValidation) => dataValidationAreas.DeleteWithoutShift(areaOfNewValidation));
-
-            _dataValidations.Add(xlDataValidation);
-            return xlDataValidation;
+            var dv = new XLDataValidation(_worksheet);
+            _dataValidations.Add(dv);
+            dv.CopyFrom(original);
+            return dv;
         }
 
-        internal void Delete(XLBookArea bookArea)
+        internal void Delete(XLSheetRange areaToDelete)
         {
             for (var i = _dataValidations.Count - 1; i >= 0; --i)
             {
                 var dataValidation = _dataValidations[i];
-                if (!XLHelper.SheetComparer.Equals(dataValidation.Worksheet.Name, bookArea.Name))
-                    continue;
-
-                foreach (var area in dataValidation.Areas)
+                foreach (var dataValidationArea in dataValidation.Areas)
                 {
-                    if (area.Intersects(bookArea.Area))
+                    if (dataValidationArea.Intersects(areaToDelete))
                     {
                         _dataValidations.RemoveAt(i);
                         break;
@@ -200,24 +206,58 @@ namespace ClosedXML.Excel
             };
 
             var rules = _dataValidations.ToList();
-            rules.ForEach(Delete);
+            _dataValidations.Clear();
 
             while (rules.Any())
             {
-                var similarRules = rules.Where(r => areEqual(rules.First(), r)).ToList();
+                var consRule = rules.First();
+                _dataValidations.Add(consRule);
+                var similarRules = rules.Where(r => areEqual(consRule, r)).ToList();
                 similarRules.ForEach(r => rules.Remove(r));
 
-                var consRule = similarRules.First();
-                var ranges = similarRules.SelectMany(dv => dv.Ranges).ToList();
-
                 IXLRanges consolidatedRanges = new XLRanges(_worksheet);
-                ranges.ForEach(r => consolidatedRanges.Add(r));
+                foreach (var similarRuleArea in similarRules.SelectMany(dv => dv.Areas))
+                    consolidatedRanges.Add(_worksheet.Range(XLRangeAddress.FromSheetRange(_worksheet, similarRuleArea)));
+
                 consolidatedRanges = consolidatedRanges.Consolidate();
 
                 consRule.ClearRanges();
                 consRule.AddRanges(consolidatedRanges);
-                Add(consRule);
             }
+        }
+
+        internal void AddArea(XLDataValidation modifiedDataValidation, XLSheetRange addedArea)
+        {
+            // Add an area to modifiedDV. This must be done carefully, because there can be only
+            // one DV per cell. Due to this problem, the correspondence area-DV should be managed
+            // by the DV collection and this method should be private. Change to private would
+            // require change of DV to a nested class + separation of API object, so the method is
+            // internal + exception.
+            if (!_dataValidations.Contains(modifiedDataValidation))
+                throw new ArgumentException("Data validation is not a data validation of this sheet.", nameof(modifiedDataValidation));
+
+            // There can be only one DV per cell. Remove DVs from cells that should now belong
+            // to the area and remove DVs without any cells.
+            for (var i = _dataValidations.Count - 1; i >= 0; --i)
+            {
+                var dataValidation = _dataValidations[i];
+
+                // Area could cover whole modifiedDataValidation and could remove the modifiedDV
+                // before the addedArea could be added to the modifiedDV. To avoid this, it is not
+                // cleared.
+                if (dataValidation == modifiedDataValidation)
+                    continue;
+
+                dataValidation.Areas = dataValidation.Areas.DeleteWithoutShift(addedArea);
+                if (dataValidation.Areas.Count == 0)
+                {
+                    _dataValidations.RemoveAt(i);
+                }
+            }
+
+            // Ensure the modifiedDV area list contains only disjunct areas to ensure
+            // the "one DV per cell" invariant.
+            modifiedDataValidation.Areas = modifiedDataValidation.Areas.DeleteWithoutShift(addedArea).With(addedArea);
         }
 
         void ISheetListener.OnInsertAreaAndShiftDown(XLWorksheet sheet, XLSheetRange area)

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -981,8 +981,7 @@ internal class WorksheetPartReader
             if (String.IsNullOrWhiteSpace(txt)) continue;
             foreach (var rangeAddress in txt.Split(' '))
             {
-                var dvt = new XLDataValidation(ws.Range(rangeAddress));
-                ws.DataValidations.Add(dvt, skipIntersectionsCheck: true);
+                var dvt = ws.DataValidations.Create(XLSheetRange.Parse(rangeAddress));
                 if (dvs.AllowBlank != null) dvt.IgnoreBlanks = dvs.AllowBlank;
                 if (dvs.ShowDropDown != null) dvt.InCellDropdown = !dvs.ShowDropDown.Value;
                 if (dvs.ShowErrorMessage != null) dvt.ShowErrorMessage = dvs.ShowErrorMessage;
@@ -1169,8 +1168,7 @@ internal class WorksheetPartReader
             if (String.IsNullOrWhiteSpace(txt)) continue;
             foreach (var rangeAddress in txt.Split(' '))
             {
-                var dvt = new XLDataValidation(ws.Range(rangeAddress));
-                ws.DataValidations.Add(dvt, skipIntersectionsCheck: true);
+                var dvt = ws.DataValidations.Create(XLSheetRange.Parse(rangeAddress));
                 if (dvs.AllowBlank != null) dvt.IgnoreBlanks = dvs.AllowBlank;
                 if (dvs.ShowDropDown != null) dvt.InCellDropdown = !dvs.ShowDropDown.Value;
                 if (dvs.ShowErrorMessage != null) dvt.ShowErrorMessage = dvs.ShowErrorMessage;

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -83,10 +83,7 @@ namespace ClosedXML.Excel
 
         internal XLDataValidation CreateDataValidation()
         {
-            var newRange = AsRange();
-            var dataValidation = new XLDataValidation(newRange);
-            Worksheet.DataValidations.Add(dataValidation);
-            return dataValidation;
+            return Worksheet.DataValidations.Create(SheetRange);
         }
 
         public IXLDataValidation GetDataValidation()

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -293,13 +293,12 @@ namespace ClosedXML.Excel
         public IXLDataValidation CreateDataValidation()
         {
             var firstRange = Ranges.First();
-            var dataValidation = new XLDataValidation(firstRange);
+             var dataValidation = firstRange.Worksheet.DataValidations.Create(firstRange.SheetRange);
             foreach (var range in Ranges.Skip(1))
             {
                 dataValidation.AddRange(range);
             }
 
-            firstRange.Worksheet.DataValidations.Add(dataValidation);
             return dataValidation;
         }
 

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -641,7 +641,7 @@ namespace ClosedXML.Excel
             Internals.CellsCollection.GetCells().ForEach(c => targetSheet.Cell(c.Address).CopyFrom(c, XLCellCopyOptions.Values | XLCellCopyOptions.Styles));
             foreach (var dataValidation in DataValidations)
             {
-                targetSheet.DataValidations.Add(new XLDataValidation(dataValidation, this));
+                targetSheet.DataValidations.CopyFrom(dataValidation);
             }
 
             targetSheet.Visibility = Visibility;


### PR DESCRIPTION
When the the `XLDataValidation` had `IXLRanges` replaced with `XLAreaList` in #2805, the DVs also stopped enforcing one-dv-per-cell invariant. There were also no failing tests for missing the invariant.

The switch and removal was done to fix data validation shifting, but invariant wasn't implemented in the PR to keep scope reasonable.

This change reimplements enforcement of the invariant. To make sure the invariant is enforced, adding an area to a data validation is done in a single function in `XLDataValidations`. The `XLDataValidations` contains all DVs in a sheet and when an area is added to one `XLDataValidation`, it is removed from other DVs. If a DV no longer has any area, it is removed from the `XLDataValidations`.

The invariant has to be enforced only when area is added to DV, removal of areas can't violate the invariant. Thus `IXDataValidation.ClearRanges` and other area removals can be done directly in `XLDataValidation`.

This is basically emergency repair, in the long run, whole conceptual API model should be replaced with something less concerned with XML data structures and more with behavior. Addition or removal of `XLDataValidations` should be basically transparent to user. Excel also doesn't provide access to individual DVs and thanks to the one-dv-per-cell invariant, the DVs behave more like cell property.

Example:

>  `ws.Range("A1:C3").DataValidations.List("one,two")`
>  `ws.Range("A1:C3").DataValidations.Clear()`