### PR TITLE
Hyperlinks: Allow multiple links in same area

### DIFF
--- a/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
+++ b/ClosedXML.Tests/Excel/Hyperlinks/XLHyperlinksTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace ClosedXML.Tests.Excel.Hyperlinks;
 
 [TestFixture]
+[TestOf(typeof(XLHyperlinks))]
 public class XLHyperlinksTests
 {
     [TestCaseSource(nameof(StructuralChangeCases))]
@@ -34,6 +35,182 @@ public class XLHyperlinksTests
                 ("D5", ws => ws.Column("D").InsertColumnsBefore(2), "F5"), // Insert column leftward
                 ("D5", ws => ws.Row(2).InsertRowsAbove(4), "D9"), // Insert row above
             }.Select(x => new object[] { x.Item1, x.Item2, x.Item3 });
+        }
+    }
+
+    [Test]
+    public void Shift_doesnt_collide_hyperlinks()
+    {
+        // In former original data structures, there could be only one hyperlink per area
+        // and when links were shifted, one link could shift to a position of another that
+        // hasn't been yet shifted. New data structure allows multiple links in a same area,
+        // though I hope it's a rare occurence.
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+
+        var linkA1 = ws.Cell("A1").CreateHyperlink();
+        linkA1.ExternalAddress = new Uri("http://example.com");
+
+        var linkA2 = ws.Cell("A2").CreateHyperlink();
+        linkA2.ExternalAddress = new Uri("http://google.com");
+
+        // Original problem was that linkA1 was shifted to A2, but linkA2 wasn't yet shifted to A3.
+        // Thus original dictionary threw "An item with the same key has already been added"
+        Assert.DoesNotThrow(() => ws.Row(1).InsertRowsAbove(1));
+
+        Assert.IsFalse(ws.Cell("A1").HasHyperlink);
+        Assert.AreSame(linkA1, ws.Cell("A2").GetHyperlink());
+        Assert.AreSame(linkA2, ws.Cell("A3").GetHyperlink());
+    }
+
+    [Test]
+    public void Delete_link_removes_link_from_cell()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var link = ws.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+
+        // Act
+        var deleted = ws.Hyperlinks.Delete(link);
+
+        // Assert
+        Assert.IsTrue(deleted);
+        Assert.AreEqual(ws.Style.Font.FontColor, ws.Cell("A1").Style.Font.FontColor);
+        Assert.AreEqual(ws.Style.Font.Underline, ws.Cell("A1").Style.Font.Underline);
+        Assert.IsNull(link.Container);
+        Assert.IsFalse(ws.Hyperlinks.TryGet(ws.Cell("A1").Address, out _));
+    }
+
+    [Test]
+    public void Delete_link_for_address_deletes_the_link()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var link = ws.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+
+        // Act
+        var deleted = ws.Hyperlinks.Delete(ws.Cell("A1").Address);
+
+        // Assert
+        Assert.IsTrue(deleted);
+        Assert.AreEqual(ws.Style.Font.FontColor, ws.Cell("A1").Style.Font.FontColor);
+        Assert.AreEqual(ws.Style.Font.Underline, ws.Cell("A1").Style.Font.Underline);
+        Assert.IsNull(link.Container);
+        Assert.IsFalse(ws.Hyperlinks.TryGet(ws.Cell("A1").Address, out _));
+    }
+
+    [Test]
+    public void Delete_links_for_cell_address_without_link_doesnt_throw()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+
+        // Act
+        var wasDeleted = ws.Hyperlinks.Delete(ws.Cell("A1").Address);
+
+        // Assert
+        Assert.IsFalse(wasDeleted);
+    }
+
+    [Test]
+    public void Delete_link_for_address_of_wrong_sheet_doesnt_delete_the_link()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws1 = wb.AddWorksheet();
+        var link = ws1.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+        var ws2 = wb.AddWorksheet();
+
+        // Act
+        var deleted = ws1.Hyperlinks.Delete(ws2.Cell("A1").Address);
+
+        // Assert
+        Assert.IsFalse(deleted);
+    }
+
+    [Test]
+    public void Get_returns_hyperlink_for_address()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var link = ws.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+
+        // Act
+        var foundLink = ws.Hyperlinks.Get(ws.Cell("A1").Address);
+
+        // Assert
+        Assert.AreSame(link, foundLink);
+    }
+
+    [Test]
+    public void Get_throws_exception_when_address_doesnt_have_link()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var link = ws.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+        var otherSheet = wb.AddWorksheet();
+
+        // Act + Assert
+        foreach (var addressWithoutLink in new[] { ws.Cell("A2").Address, otherSheet.Cell("A1").Address })
+        {
+            Assert.Throws<KeyNotFoundException>(() => ws.Hyperlinks.Get(addressWithoutLink));
+        }
+    }
+
+    [Test]
+    public void Get_only_returns_links_from_correct_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws1 = wb.AddWorksheet();
+        var link = ws1.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+        var ws2 = wb.AddWorksheet();
+        var wrongSheetAddress = ws2.Cell("A1").Address;
+
+        Assert.Throws<KeyNotFoundException>(() => ws1.Hyperlinks.Get(wrongSheetAddress));
+    }
+
+    [Test]
+    public void TryGet_returns_hyperlink_for_address()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var link = ws.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+
+        // Act
+        var wasFound = ws.Hyperlinks.TryGet(ws.Cell("A1").Address, out var foundLink);
+
+        // Assert
+        Assert.IsTrue(wasFound);
+        Assert.AreSame(link, foundLink);
+    }
+
+    [Test]
+    public void TryGet_doesnt_return_link_for_wrong_address()
+    {
+        // Arrange
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var link = ws.Cell("A1").CreateHyperlink();
+        link.ExternalAddress = new Uri("https://example.com");
+        var otherSheet = wb.AddWorksheet();
+
+        // Act + Assert
+        foreach (var addressWithoutLink in new[] { ws.Cell("A2").Address, otherSheet.Cell("A1").Address })
+        {
+            Assert.IsFalse(ws.Hyperlinks.TryGet(addressWithoutLink, out _));
         }
     }
 }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -818,13 +818,9 @@ namespace ClosedXML.Excel
         /// <inheritdoc />
         public void SetHyperlink(XLHyperlink? hyperlink)
         {
-            if (Worksheet.Hyperlinks.TryGet(SheetPoint, out var existingHyperlink))
-                Worksheet.Hyperlinks.Delete(existingHyperlink);
-
+            Worksheet.Hyperlinks.SetCellHyperlink(SheetPoint, hyperlink);
             if (hyperlink is null)
                 return;
-
-            Worksheet.Hyperlinks.Add(SheetPoint, hyperlink);
 
             var cellFont = GetStyleForRead().Font;
             var sheetFont = Worksheet.StyleValue.Font;
@@ -837,15 +833,15 @@ namespace ClosedXML.Excel
 
         internal void SetCellHyperlink(XLHyperlink hyperlink)
         {
-            Worksheet.Hyperlinks.Clear(SheetPoint);
-            Worksheet.Hyperlinks.Add(SheetPoint, hyperlink);
+            Worksheet.Hyperlinks.SetCellHyperlink(SheetPoint, hyperlink);
         }
 #nullable disable
 
         public XLHyperlink CreateHyperlink()
         {
-            SetHyperlink(new XLHyperlink());
-            return GetHyperlink();
+            var link = new XLHyperlink();
+            SetHyperlink(link);
+            return link;
         }
 
         public IXLCells InsertCellsAbove(int numberOfRows)
@@ -1096,7 +1092,7 @@ namespace ClosedXML.Excel
             return this;
         }
 
-        public Boolean HasHyperlink => Worksheet.Hyperlinks.TryGet(SheetPoint, out _);
+        public Boolean HasHyperlink => Worksheet.Hyperlinks.HasHyperlink(SheetPoint);
 
         /// <inheritdoc />
         public Boolean ShowPhonetic

--- a/ClosedXML/Excel/Hyperlinks/IXLHyperlinks.cs
+++ b/ClosedXML/Excel/Hyperlinks/IXLHyperlinks.cs
@@ -1,8 +1,9 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ClosedXML.Excel;
 
-public interface IXLHyperlinks: IEnumerable<XLHyperlink>
+public interface IXLHyperlinks : IEnumerable<XLHyperlink>
 {
     /// <summary>
     /// Remove the hyperlink from a worksheet. Doesn't throw if hyperlinks is
@@ -47,5 +48,5 @@ public interface IXLHyperlinks: IEnumerable<XLHyperlink>
     /// <param name="address">Address of the cell.</param>
     /// <param name="hyperlink">Found hyperlink.</param>
     /// <returns><c>true</c> if there was a hyperlink for <paramref name="address"/>, <c>false</c> otherwise.</returns>
-    bool TryGet(IXLAddress address, out XLHyperlink hyperlink);
+    bool TryGet(IXLAddress address, [NotNullWhen(true)] out XLHyperlink? hyperlink);
 }

--- a/ClosedXML/Excel/Hyperlinks/XLHyperlinks.cs
+++ b/ClosedXML/Excel/Hyperlinks/XLHyperlinks.cs
@@ -1,14 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using ClosedXML.Utils;
 
 namespace ClosedXML.Excel;
 
 internal class XLHyperlinks : IXLHyperlinks, ISheetListener
 {
     private readonly XLWorksheet _worksheet;
-    private readonly Dictionary<XLSheetRange, XLHyperlink> _hyperlinks = new();
+
+    /// <summary>
+    /// XLHyperlink doesn't contain range, it is user created and only then it is associated with an area in a sheet.
+    /// </summary>
+    private readonly List<(XLHyperlink Link, XLSheetRange Area)> _hyperlinks = new();
+    private readonly RTree<XLHyperlink> _areaIndex = new();
+    private readonly Dictionary<XLHyperlink, XLSheetRange> _linkIndex = new();
 
     private delegate (bool Success, XLSheetRange? RepositionedArea) RepositionFunc(XLSheetRange hyperlinkArea);
 
@@ -62,19 +70,19 @@ internal class XLHyperlinks : IXLHyperlinks, ISheetListener
         if (sheet != _worksheet)
             return;
 
-        var hyperlinkAreas = _hyperlinks.Keys.ToArray();
-        foreach (var hyperlinkArea in hyperlinkAreas)
+        // Styles are responsibility of style slice => only shift areas
+        foreach (var (link, linkArea) in _hyperlinks.ToArray())
         {
-            var (success, newHlArea) = reposition(hyperlinkArea);
+            var (success, newLinkArea) = reposition(linkArea);
             if (!success)
                 continue; // Partial cover, don't move.
 
-            if (hyperlinkArea == newHlArea)
+            if (linkArea == newLinkArea)
                 continue; // Nothing changed
 
-            _hyperlinks.Remove(hyperlinkArea, out var hyperlink);
-            if (newHlArea is not null)
-                _hyperlinks.Add(newHlArea.Value, hyperlink);
+            Remove(link);
+            if (newLinkArea is not null)
+                Add(newLinkArea.Value, link);
         }
     }
 
@@ -82,7 +90,8 @@ internal class XLHyperlinks : IXLHyperlinks, ISheetListener
 
     public IEnumerator<XLHyperlink> GetEnumerator()
     {
-        return _hyperlinks.Values.GetEnumerator();
+        // Enumerate in same order it was loaded and will be saved
+        return _hyperlinks.Select(static x => x.Link).GetEnumerator();
     }
 
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
@@ -93,94 +102,143 @@ internal class XLHyperlinks : IXLHyperlinks, ISheetListener
     /// <inheritdoc />
     public bool Delete(XLHyperlink hyperlink)
     {
-        if (!TryGet(hyperlink, out var range))
+        if (!Remove(hyperlink, out var linkArea))
             return false;
 
-        Clear(range.Value);
-        ClearHyperlinkStyle(range.Value);
+        ClearHyperlinkStyle(linkArea);
         return true;
     }
 
     /// <inheritdoc />
     public bool Delete(IXLAddress address)
     {
-        var point = XLSheetPoint.FromAddress(address);
-        if (Clear(point))
-        {
-            ClearHyperlinkStyle(point);
-            return true;
-        }
+        if (address.Worksheet is not null && address.Worksheet != _worksheet)
+            return false;
 
-        return false;
+        var cellPoint = XLSheetPoint.FromAddress(address);
+        if (!TryGet(cellPoint, out var cellLink))
+            return false;
+
+        Remove(cellLink);
+        ClearHyperlinkStyle(cellPoint);
+        return true;
     }
 
     /// <inheritdoc />
     public XLHyperlink Get(IXLAddress address)
     {
-        return _hyperlinks[XLSheetPoint.FromAddress(address)];
+        if (address.Worksheet is not null && address.Worksheet != _worksheet)
+            throw new KeyNotFoundException("Address is for a different sheet.");
+
+        var point = XLSheetPoint.FromAddress(address);
+        if (!TryGet(point, out var link))
+            throw new KeyNotFoundException($"No hyperlink is defined for cell {point}.");
+
+        return link;
     }
 
     /// <inheritdoc />
-    public bool TryGet(IXLAddress address, out XLHyperlink hyperlink)
+    public bool TryGet(IXLAddress address, [NotNullWhen(true)] out XLHyperlink? hyperlink)
     {
-        return _hyperlinks.TryGetValue(XLSheetPoint.FromAddress(address), out hyperlink);
-    }
-
-    /// <summary>
-    /// Add a hyperlink. Doesn't modify style, unlike public API.
-    /// </summary>
-    internal void Add(XLSheetRange range, XLHyperlink hyperlink)
-    {
-        if (hyperlink.Container is not null && hyperlink.Container != this)
+        if (address.Worksheet is not null && address.Worksheet != _worksheet)
         {
-            throw new InvalidOperationException("Hyperlink is attached to a different worksheet. Either remove it from the original worksheet or create a new hyperlink.");
+            hyperlink = null;
+            return false;
         }
 
-        _hyperlinks.Remove(range);
-        _hyperlinks.Add(range, hyperlink);
-        hyperlink.Container = this;
+        var point = XLSheetPoint.FromAddress(address);
+        return TryGet(point, out hyperlink);
     }
 
-    internal bool TryGet(XLSheetRange range, [NotNullWhen(true)] out XLHyperlink? hyperlink)
+    internal bool HasHyperlink(XLSheetPoint point)
     {
-        return _hyperlinks.TryGetValue(range, out hyperlink);
+        var areaNodes = new List<RTree<XLHyperlink>.Node>();
+        return _areaIndex.GetNodes(point, areaNodes).Count > 0;
     }
 
     /// <summary>
-    /// Remove a hyperlink. Doesn't modify style, unlike public API.
+    /// Set a hyperlink of a single cell. Doesn't modify style, ignores hyperlinks with areas that
+    /// cover the cell.
     /// </summary>
-    internal bool Clear(XLSheetRange range)
+    internal void SetCellHyperlink(XLSheetPoint point, XLHyperlink? link)
     {
-        if (_hyperlinks.Remove(range, out var hyperlink))
+        // We only care about links defined for individual cell, not any link that covers the cell
+        var pointNodes = new List<RTree<XLHyperlink>.Node>();
+        _areaIndex.GetNodes(point, pointNodes);
+        foreach (var existingLink in pointNodes)
+            Remove(existingLink.Data);
+        
+        if (link is null)
+            return;
+
+        Add(point, link);
+    }
+
+    internal bool TryGet(XLSheetPoint point, [NotNullWhen(true)] out XLHyperlink? hyperlink)
+    {
+        var cellArea = new XLSheetRange(point);
+        var areaNodes = new List<RTree<XLHyperlink>.Node>();
+        _areaIndex.GetNodes(cellArea, areaNodes);
+
+        if (areaNodes.Count == 0)
         {
-            hyperlink.Container = null;
+            hyperlink = null;
+            return false;
+        }
+
+        if (areaNodes.Count == 1)
+        {
+            hyperlink = areaNodes[0].Data;
             return true;
         }
 
-        return false;
+        // There are multiple areas for the point. When hyperlink areas overlap, Excel opens
+        // the last one. So it is likely the correct one. But take a random one (areaNodes are
+        // not guaranteed to be in correct order), because this API is just beyond any hope and
+        // will be completely scrapped ASAP.
+        hyperlink = areaNodes[^1].Data;
+        return true;
     }
 
     internal XLCell? GetCell(XLHyperlink hyperlink)
     {
-        if (!TryGet(hyperlink, out var range))
+        if (!_linkIndex.TryGetValue(hyperlink, out var area))
             return null;
 
-        return new XLCell(_worksheet, range.Value.FirstPoint);
+        return new XLCell(_worksheet, area.FirstPoint);
     }
 
-    private bool TryGet(XLHyperlink hyperlink, [NotNullWhen(true)] out XLSheetRange? range)
+    private void Add(XLSheetRange linkArea, XLHyperlink link)
     {
-        var ranges = _hyperlinks
-            .Where(x => x.Value == hyperlink)
-            .Select(x => x.Key)
-            .ToList();
-        if (ranges.Count == 0)
-        {
-            range = null;
-            return false;
-        }
+        if (link.Container is not null && link.Container != this)
+            throw new InvalidOperationException("Hyperlink is attached to a different worksheet. Either remove it from the original worksheet or create a new hyperlink.");
 
-        range = ranges.Single();
+        if (_linkIndex.ContainsKey(link))
+            return;
+
+        _linkIndex.Add(link, linkArea);
+        _areaIndex.Insert(new RTree<XLHyperlink>.Node(linkArea, link));
+        _hyperlinks.Add((link, linkArea));
+        link.Container = this;
+        Debug.Assert(_hyperlinks.Count == _linkIndex.Count);
+        Debug.Assert(_hyperlinks.Count == _areaIndex.Count);
+    }
+
+    private void Remove(XLHyperlink link)
+    {
+        Remove(link, out _);
+    }
+
+    private bool Remove(XLHyperlink link, out XLSheetRange area)
+    {
+        if (!_linkIndex.Remove(link, out area))
+            return false;
+
+        _areaIndex.Delete(new RTree<XLHyperlink>.Node(area, link));
+        _hyperlinks.RemoveAll(x => x.Link == link);
+        link.Container = null;
+        Debug.Assert(_hyperlinks.Count == _linkIndex.Count);
+        Debug.Assert(_hyperlinks.Count == _areaIndex.Count);
         return true;
     }
 

--- a/ClosedXML/Utils/RTree.cs
+++ b/ClosedXML/Utils/RTree.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using ClosedXML.Excel;
+using RBush;
+
+namespace ClosedXML.Utils;
+
+/// <summary>
+/// R-Tree for <see cref="XLSheetRange"/> areas and some data associated with the area. The R-Tree
+/// allows multiple occurrences per area.
+/// </summary>
+/// <typeparam name="TData">Data associated with each area.</typeparam>
+internal sealed class RTree<TData>
+{
+    private readonly RBush<AreaData> _rBush = new();
+
+    /// <summary>
+    /// Number of nodes stores in R-Tree.
+    /// </summary>
+    internal int Count => _rBush.Count;
+
+    internal void Insert(Node node)
+    {
+        _rBush.Insert(new AreaData(node.Area, node.Data));
+    }
+
+    /// <remarks>
+    /// It's not enough to specify only an area. The item also has to be specified, because area
+    /// can contain multiple items (e.g. multiple conditional formats can be specified for same
+    /// area).
+    /// </remarks>
+    internal void Delete(Node node)
+    {
+        _rBush.Delete(new AreaData(node.Area, node.Data));
+    }
+
+    internal List<Node> GetNodes(XLSheetRange area, List<Node> buffer)
+    {
+        var envelope = ToEnvelope(area);
+        GetNodes(_rBush.Root, in envelope, buffer);
+        return buffer;
+    }
+
+    /// <summary>
+    /// Info about leaf node of R-Tree.
+    /// </summary>
+    /// <param name="Area">Area of a sheet.</param>
+    /// <param name="Data">Data associated with the <paramref name="Area"/> (e.g. color or hyperlink).</param>
+    internal readonly record struct Node(XLSheetRange Area, TData Data);
+
+    // AreaData must implement Equals for RBush.Delete operation to properly work
+    private sealed class AreaData : ISpatialData, IEquatable<AreaData>
+    {
+        private readonly Envelope _area;
+
+        public AreaData(XLSheetRange area, TData data)
+        {
+            _area = ToEnvelope(area);
+            Data = data;
+        }
+
+        public ref readonly Envelope Envelope => ref _area;
+
+        internal TData Data { get; }
+
+        internal XLSheetRange Area => ToArea(in _area);
+
+        public override int GetHashCode()
+        {
+            // Class is never used in a hash table and equals is fast by itself.
+            return 0;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is AreaData other && Equals(other);
+        }
+
+        public bool Equals(AreaData? other)
+        {
+            if (other is null) 
+                return false;
+
+            if (ReferenceEquals(this, other)) 
+                return true;
+
+            // Use reference equals for data, because it might contain some business equals that
+            // could mis-equal a data, e.g. border has business-like equals.
+            return _area.Equals(other._area) && ReferenceEquals(Data, other.Data);
+        }
+    }
+
+    private static Envelope ToEnvelope(XLSheetRange range)
+    {
+        return new Envelope(range.LeftColumn, range.TopRow, range.RightColumn, range.BottomRow);
+    }
+
+    private static XLSheetRange ToArea(in Envelope envelope)
+    {
+        return new XLSheetRange((int)envelope.MinX, (int)envelope.MinY, (int)envelope.MaxX, (int)envelope.MaxY);
+    }
+
+    private static void GetNodes(RBush<AreaData>.Node node, in Envelope boundingBox, List<Node> coveringNodes)
+    {
+        if (!node.Envelope.Contains(in boundingBox))
+            return;
+
+        if (node.IsLeaf)
+        {
+            for (var index = 0; index < node.Children.Count; index++)
+            {
+                var castedChild = (AreaData)node.Children[index];
+                if (castedChild.Envelope == boundingBox)
+                {
+                    coveringNodes.Add(new Node(castedChild.Area, castedChild.Data));
+                }
+            }
+
+            return;
+        }
+
+        for (var index = 0; index < node.Children.Count; index++)
+        {
+            var childNode = (RBush<AreaData>.Node)node.Children[index];
+            GetNodes(childNode, in boundingBox, coveringNodes);
+        }
+    }
+}


### PR DESCRIPTION
Original data structure required one area to have only one links. That threw an exception during structural changes, when one link was shifted to not-yet shifted link.

Internal structure was modified. It is now held in:
* a simple list (roughly equivalent of elements in a worksheet part)
* index: link -> area (used to find are affected by a link)
* index: area -> links (used to find links for cell/ranges).

Overall, the changes are directed toward a state where hyperlinks can be for areas instead of cells and future API rework.

Resolves #2801