### PR TITLE
Fix InsertTable writes emtpy string instead of blank cell for DBNull.Value

### DIFF
--- a/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/XLCellTests.cs
@@ -166,8 +166,8 @@ namespace ClosedXML.Tests
             ws.FirstCell().InsertData(table);
 
             Assert.AreEqual(25, ws.Cell("A1").Value);
-            Assert.AreEqual("", ws.Cell("C4").Value);
-            Assert.AreEqual("", ws.Cell("D5").Value);
+            Assert.IsTrue(ws.Cell("C4").Value.IsBlank);
+            Assert.IsTrue(ws.Cell("D5").Value.IsBlank);
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Tables/TablesTests.cs
+++ b/ClosedXML.Tests/Excel/Tables/TablesTests.cs
@@ -1234,6 +1234,31 @@ namespace ClosedXML.Tests.Excel
             }
         }
 
+        [TestCase(typeof(string))]
+        [TestCase(typeof(object))]
+        public void InsertData_WhenValuesAreDbNull_WritesBlanks(Type columnType)
+        {
+            //arrange
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet("Sheet1");
+
+            var data = new DataTable();
+            data.Columns.Add("Name", columnType);
+            data.Rows.Add("Mario");
+            data.Rows.Add(DBNull.Value); // This should be written as blank
+            data.Rows.Add("Carlo");
+
+            //act
+            var cell = ws.FirstCell();
+            var table = cell.InsertTable(data);
+
+            //assert
+            Assert.AreEqual("Name", table.Cell(1,1).Value);
+            Assert.AreEqual("Mario", table.Cell(2,1).Value);
+            Assert.IsTrue(table.Cell(3, 1).Value.IsBlank);
+            Assert.AreEqual("Carlo", table.Cell(4,1).Value);
+        }
+
         [Test]
         public void TableNotFound()
         {

--- a/ClosedXML/Excel/InsertData/DataTableReader.cs
+++ b/ClosedXML/Excel/InsertData/DataTableReader.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel.InsertData
 
         public IEnumerable<IEnumerable<XLCellValue>> GetRecords()
         {
-            return _dataRows.Select(r => r.ItemArray.Select(XLCellValue.FromInsertedObject));
+            return _dataRows.Select(GetRow);
         }
 
         public int GetPropertiesCount()
@@ -50,6 +50,15 @@ namespace ClosedXML.Excel.InsertData
                 throw new ArgumentOutOfRangeException($"{propertyIndex} exceeds the number of the table columns");
 
             return _dataTable.Columns[propertyIndex].Caption;
+        }
+
+        private IEnumerable<XLCellValue> GetRow(DataRow row)
+        {
+            for(var i=0; i < row.ItemArray.Length; i++)
+            {
+                var value = row.IsNull(i) ? Blank.Value : row.ItemArray[i];
+                yield return XLCellValue.FromInsertedObject(value);
+            }
         }
     }
 }

--- a/ClosedXML/Excel/XLCellValue.cs
+++ b/ClosedXML/Excel/XLCellValue.cs
@@ -226,6 +226,7 @@ namespace ClosedXML.Excel
             XLCellValue convertedValue = value switch
             {
                 null => Blank.Value,
+                DBNull => Blank.Value,
                 Blank blankValue => blankValue,
                 Boolean logical => logical,
                 SByte number => number,


### PR DESCRIPTION
I encountered this issue when writing a DataTable to and Excel spreadsheet using the InsertTable.
DataTable can contain DBNull values for a value. Currently ClosedXml writes a cell with an empty string.
This is not the behavior I would expect and instead I would expect ClosedXml to write a blank cell.