### PR TITLE
Auto-quote literal strings in List(string) data validation

### DIFF
--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using ClosedXML.Excel;
 using NUnit.Framework;
@@ -451,6 +452,38 @@ namespace ClosedXML.Tests.Excel.DataValidations
             dv.List("LocalRange");
 
             Assert.AreEqual("LocalRange", dv.Value);
+        }
+
+        [Test]
+        public void Issue1711_ListWithPreQuotedString_AndAutoFilter()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Set up headers
+            ws.Cell("A1").Value = "User";
+            ws.Cell("B1").Value = "Date";
+            ws.Cell("C1").Value = "Error";
+            ws.Cell("D1").Value = "Is Issue";
+
+            // Add data rows
+            for (var row = 2; row <= 11; row++)
+            {
+                ws.Cell(row, 4).Value = row <= 6 ? "Is Issue" : "No Issue";
+            }
+
+            // Set up AutoFilter on column 4 with "Is Issue" filter
+            ws.RangeUsed().SetAutoFilter().Column(4).AddFilter("Is Issue");
+
+            // User passes a pre-quoted string with comma-separated values
+            var errorList = new List<string> { "New", "Backdated", "Old", "Other" };
+            var errors = $"\"{string.Join(",", errorList)}\"";
+
+            var dv = ws.Range("C2:C11").CreateDataValidation();
+            dv.List(errors, true);
+
+            // Pre-quoted string should be stored verbatim
+            Assert.AreEqual("\"New,Backdated,Old,Other\"", dv.Value);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationTests.cs
@@ -399,5 +399,58 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 Assert.AreSame(range1, dv.Ranges.Single());
             }
         }
+
+        [Test]
+        [TestCase("$F$2:$F$8", "$F$2:$F$8", Description = "Cell reference stored verbatim")]
+        [TestCase("Sheet1!$A$1:$A$10", "Sheet1!$A$1:$A$10", Description = "Sheet-qualified reference stored verbatim")]
+        [TestCase("\"foobar\"", "\"foobar\"", Description = "Already quoted string stored verbatim")]
+        [TestCase("\"foo,bar,baz\"", "\"foo,bar,baz\"", Description = "Already quoted CSV stored verbatim")]
+        [TestCase("=YesNo", "=YesNo", Description = "Formula reference stored verbatim")]
+        [TestCase("=Sheet1!$A$1:$A$10", "=Sheet1!$A$1:$A$10", Description = "Formula with sheet reference stored verbatim")]
+        [TestCase("foobar", "\"foobar\"", Description = "Literal string gets quoted")]
+        [TestCase("foo,bar,baz", "\"foo,bar,baz\"", Description = "Literal CSV list gets quoted")]
+        [TestCase("123abc", "\"123abc\"", Description = "String starting with number gets quoted")]
+        [TestCase("MyNamedRange", "\"MyNamedRange\"", Description = "Non-existent named range gets quoted")]
+        public void List_String_AutoQuotesLiteralStrings(string input, string expectedValue)
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+            var dv = ws.Cell("A1").CreateDataValidation();
+
+            dv.List(input);
+
+            Assert.AreEqual(XLAllowedValues.List, dv.AllowedValues);
+            Assert.AreEqual(expectedValue, dv.Value);
+        }
+
+        [Test]
+        public void List_String_ExistingNamedRangeStoredVerbatim()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Create a workbook-scoped named range
+            wb.DefinedNames.Add("MyNamedRange", ws.Range("E1:E5"));
+
+            var dv = ws.Cell("A1").CreateDataValidation();
+            dv.List("MyNamedRange");
+
+            Assert.AreEqual("MyNamedRange", dv.Value);
+        }
+
+        [Test]
+        public void List_String_WorksheetScopedNamedRangeStoredVerbatim()
+        {
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            // Create a worksheet-scoped named range
+            ws.DefinedNames.Add("LocalRange", ws.Range("E1:E5"));
+
+            var dv = ws.Cell("A1").CreateDataValidation();
+            dv.List("LocalRange");
+
+            Assert.AreEqual("LocalRange", dv.Value);
+        }
     }
 }

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -223,7 +223,45 @@ namespace ClosedXML.Excel
         {
             AllowedValues = XLAllowedValues.List;
             InCellDropdown = inCellDropdown;
-            Value = list;
+            Value = NormalizeListValue(list);
+        }
+
+        private string NormalizeListValue(string list)
+        {
+            if (string.IsNullOrEmpty(list))
+                return list;
+
+            // Already quoted - store verbatim
+            if (list.StartsWith("\"") && list.EndsWith("\""))
+                return list;
+
+            // Formula reference (e.g., =YesNo, =Sheet1!A1:A10) - store verbatim
+            if (list.StartsWith("="))
+                return list;
+
+            // Valid range address (e.g., $F$2:$F$8, Sheet1!A1:A10) - store verbatim
+            if (XLHelper.IsValidRangeAddress(list))
+                return list;
+
+            // Check if it's an existing defined name in worksheet or workbook scope
+            if (IsExistingDefinedName(list))
+                return list;
+
+            // Literal string - wrap in quotes
+            return $"\"{list}\"";
+        }
+
+        private bool IsExistingDefinedName(string name)
+        {
+            // Check worksheet-scoped defined names
+            if (_worksheet.DefinedNames.Contains(name))
+                return true;
+
+            // Check workbook-scoped defined names
+            if (_worksheet.Workbook.DefinedNames.Contains(name))
+                return true;
+
+            return false;
         }
 
         public void List(IXLRange range)


### PR DESCRIPTION
## Summary:
Modify `XLDataValidation.List(string)` to automatically wrap literal strings in double quotes when they are not valid cell references, formula references, or existing named ranges.

##  Changes

  - Add check for formulas,  references and named ranges.
  - Literal strings that don't match any valid reference pattern are now auto-quoted

Resolves #2822 #1711 