### PR TITLE
Add cancellation token to LoadOptions

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -12,7 +12,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         public void Init()
         {
             // Make sure tests run on a deterministic culture
-            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
         }
 
         [Test]
@@ -237,6 +237,13 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("NETWORKDAYS(10,100,{20,50})", "DateAndTime.NetWorkDays")]
         [TestCase("WORKDAY(10,100,{20,50})", "DateAndTime.Workday")]
         [TestCase("YEARFRAC(1,10000,1)", "DateAndTime.YearFrac")]
+        [TestCase("AND(TRUE,TRUE)", "Logical.And")]
+        [TestCase("OR(TRUE,TRUE)", "Logical.Or")]
+        [TestCase("COLUMN(D:Z)", "Lookup.Column")]
+        [TestCase("HLOOKUP(2,{0,1,2,3},1)", "Lookup.Hlookup")]
+        [TestCase("MATCH(5,{1,7})", "Lookup.Match")]
+        [TestCase("ROW(2:5)", "Lookup.Row")]
+        [TestCase("VLOOKUP(2,{0;1;2;3},1)", "Lookup.Vlookup")]
         public void Can_cancel_function_execution(string formula, string expectedStackTrace)
         {
             var cts = new CancellationTokenSource();

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -1,6 +1,7 @@
 using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
+using System.Threading;
 
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
@@ -214,6 +215,36 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             ws.Cell("A1").FormulaA1 = "$B$4(5)";
 
             Assert.AreEqual(XLError.CellReference, ws.Cell("A1").Value);
+        }
+
+        [TestCase("BASE(1E15,30)", "MathTrig.Base")]
+        [TestCase("COMBIN(1000,500)", "MathTrig.Combin")]
+        [TestCase("COMBINA(100,500)", "MathTrig.CombinA")]
+        [TestCase("DECIMAL(\"ZZZ\",26)", "MathTrig.Decimal")]
+        [TestCase("GCD(123456,54124)", "MathTrig.Gcd")]
+        [TestCase("LCM(123456,54124)", "MathTrig.Lcm")]
+        [TestCase("MDETERM({1,2;3,4})", "MathTrig.MDeterm")]
+        [TestCase("MINVERSE({1,2;3,4})", "MathTrig.MInverse")]
+        [TestCase("MMULT({1},{2})", "MathTrig.MMult")]
+        [TestCase("MULTINOMIAL(2,3,4)", "MathTrig.Multinomial")]
+        [TestCase("PRODUCT(2,3,{4,5,6})", "MathTrig.Product")]
+        [TestCase("SERIESSUM(2,1,2,{1,2,3})", "MathTrig.SeriesSum")]
+        [TestCase("SUM(2,1,2,{1,2,3})", "MathTrig.Sum")]
+        [TestCase("SUMIF(B1:B4,\"=5\")", "MathTrig.SumIf")]
+        [TestCase("SUMIFS(B1:B4,C1:C4,\">0\")", "MathTrig.SumIfs")]
+        [TestCase("SUMPRODUCT({2,3},{4,5})", "MathTrig.SumProduct")]
+        [TestCase("SUMSQ(5,4)", "MathTrig.SumSq")]
+        public void Can_cancel_function_execution(string formula, string expectedStackTrace)
+        {
+            var cts = new CancellationTokenSource();
+            using var wb = new XLWorkbook(new LoadOptions { CancellationToken = cts.Token });
+            var ws = wb.AddWorksheet();
+            ws.Cell("A1").FormulaA1 = formula;
+
+            cts.Cancel();
+            var ex = Assert.Throws<OperationCanceledException>(() => _ = ws.Cell("A1").Value);
+
+            StringAssert.Contains(expectedStackTrace + "(", ex?.StackTrace);
         }
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -273,6 +273,19 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("VARPA({1,5})", "Statistical.VarPA")]
         [TestCase("VAR.S({1,5})", "Statistical.Var")]
         [TestCase("VAR.P({1,5})", "Statistical.VarP")]
+        [TestCase("ASC(\"A\")", "Text.Asc")]
+        [TestCase("CLEAN(\"A\")", "Text.Clean")]
+        [TestCase("CONCAT(\"A\",\"B\")", "Text.Concat")]
+        [TestCase("CONCATENATE(\"A\",\"B\")", "Text.Concatenate")]
+        [TestCase("LEFT(\"AB\",1)", "Text.Left")]
+        [TestCase("LOWER(\"A\")", "Text.Lower")]
+        [TestCase("NUMBERVALUE(\"1\")", "Text.NumberValue")]
+        [TestCase("PROPER(\"hello\")", "Text.Proper")]
+        [TestCase("REPT(\"A\",10)", "Text.Rept")]
+        [TestCase("RIGHT(\"AB\",1)", "Text.Right")]
+        [TestCase("T({100})", "Text.T")]
+        [TestCase("TEXTJOIN(\"-\",TRUE,\"A\",\"B\")", "Text.TextJoin")]
+        [TestCase("TRIM(\"ABC\")", "Text.Trim")]
         public void Can_cancel_function_execution(string formula, string expectedStackTrace)
         {
             var cts = new CancellationTokenSource();

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -244,11 +244,41 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("MATCH(5,{1,7})", "Lookup.Match")]
         [TestCase("ROW(2:5)", "Lookup.Row")]
         [TestCase("VLOOKUP(2,{0;1;2;3},1)", "Lookup.Vlookup")]
+        [TestCase("AVERAGE({1,2;3,4})", "Statistical.Average")]
+        [TestCase("AVERAGEA({1,2;3,4})", "Statistical.AverageA")]
+        [TestCase("BINOMDIST(6,10,0.5,TRUE)", "Statistical.BinomDist")]
+        [TestCase("BINOM.DIST(6,10,0.5,TRUE)", "Statistical.BinomDist")]
+        [TestCase("COUNT({1,2})", "Statistical.Count")]
+        [TestCase("COUNTA({1,2})", "Statistical.Count")]
+        [TestCase("COUNTBLANK(D1:D7)", "Statistical.CountBlank")]
+        [TestCase("COUNTIF(D1:D7,\">0\")", "Statistical.CountIf")]
+        [TestCase("COUNTIFS(D1:D7,\">0\")", "Statistical.CountIfs")]
+        [TestCase("DEVSQ({1,2})", "Statistical.DevSq")]
+        [TestCase("GEOMEAN({1,2})", "Statistical.GeoMean")]
+        [TestCase("LARGE({10,11,12},2)", "Statistical.Large")]
+        [TestCase("MAX({1,5})", "Statistical.Max")]
+        [TestCase("MAXA({1,5})", "Statistical.MaxA")]
+        [TestCase("MEDIAN({1,5,7})", "Statistical.Median")]
+        [TestCase("MIN({1,5})", "Statistical.Min")]
+        [TestCase("MINA({1,5})", "Statistical.MinA")]
+        [TestCase("STDEV({1,5})", "Statistical.StDev")]
+        [TestCase("STDEVA({1,5})", "Statistical.StDevA")]
+        [TestCase("STDEVP({1,5})", "Statistical.StDevP")]
+        [TestCase("STDEVPA({1,5})", "Statistical.StDevPA")]
+        [TestCase("STDEV.S({1,5})", "Statistical.StDev")]
+        [TestCase("STDEV.P({1,5})", "Statistical.StDevP")]
+        [TestCase("VAR({1,5})", "Statistical.Var")]
+        [TestCase("VARA({1,5})", "Statistical.VarA")]
+        [TestCase("VARP({1,5})", "Statistical.VarP")]
+        [TestCase("VARPA({1,5})", "Statistical.VarPA")]
+        [TestCase("VAR.S({1,5})", "Statistical.Var")]
+        [TestCase("VAR.P({1,5})", "Statistical.VarP")]
         public void Can_cancel_function_execution(string formula, string expectedStackTrace)
         {
             var cts = new CancellationTokenSource();
             using var wb = new XLWorkbook(new LoadOptions { CancellationToken = cts.Token });
             var ws = wb.AddWorksheet();
+            ws.Cell("D1").Value = 4; // Need a non-blank cell for COUNTBLANK check
             ws.Cell("A1").FormulaA1 = formula;
 
             cts.Cancel();

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -6,15 +6,9 @@ using System.Threading;
 namespace ClosedXML.Tests.Excel.CalcEngine
 {
     [TestFixture]
+    [SetCulture("en-US")]
     public class FunctionsTests
     {
-        [SetUp]
-        public void Init()
-        {
-            // Make sure tests run on a deterministic culture
-            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
-        }
-
         [Test]
         public void Asc()
         {

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -3,295 +3,294 @@ using NUnit.Framework;
 using System;
 using System.Threading;
 
-namespace ClosedXML.Tests.Excel.CalcEngine
+namespace ClosedXML.Tests.Excel.CalcEngine;
+
+[TestFixture]
+[SetCulture("en-US")]
+public class FunctionsTests
 {
-    [TestFixture]
-    [SetCulture("en-US")]
-    public class FunctionsTests
+    [Test]
+    public void Asc()
     {
-        [Test]
-        public void Asc()
+        Object actual;
+
+        actual = XLWorkbook.EvaluateExpr(@"Asc(""Text"")");
+        Assert.AreEqual("Text", actual);
+    }
+
+    [Test]
+    public void Clean()
+    {
+        Object actual;
+
+        actual = XLWorkbook.EvaluateExpr(String.Format(@"Clean(""A{0}B"")", Environment.NewLine));
+        Assert.AreEqual("AB", actual);
+    }
+
+    [Test]
+    public void Dollar()
+    {
+        using var wb = new XLWorkbook();
+        object actual = wb.Evaluate("DOLLAR(12345.123)");
+        Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.12", actual);
+
+        actual = wb.Evaluate("DOLLAR(12345.123, 1)");
+        Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.1", actual);
+    }
+
+    [TestCase("A", "A", true)]
+    [TestCase("A", "a", false)]
+    [TestCase("", "", true)]
+    public void Exact(string lhs, string rhs, bool result)
+    {
+        var actual = XLWorkbook.EvaluateExpr($"EXACT(\"{lhs}\", \"{rhs}\")");
+        Assert.AreEqual(result, actual);
+    }
+
+    [Test]
+    public void Exact_converts_values_to_text()
+    {
+        Assert.AreEqual(false, XLWorkbook.EvaluateExpr("EXACT(TRUE, \"true\")"));
+        Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(TRUE, \"TRUE\")"));
+        Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(1, \"1\")"));
+        Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(IF(TRUE,), \"\")"));
+
+        // Check blank cell
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        Assert.AreEqual(true, ws.Evaluate("EXACT(A1, \"\")"));
+    }
+
+    [Test]
+    public void Exact_propagates_errors()
+    {
+        Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("EXACT(#DIV/0!, \"A\")"));
+        Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("EXACT(\"A\", #DIV/0!)"));
+    }
+
+    [Test]
+    public void Fixed()
+    {
+        Object actual;
+
+        actual = XLWorkbook.EvaluateExpr("Fixed(12345.123)");
+        Assert.AreEqual("12,345.12", actual);
+
+        actual = XLWorkbook.EvaluateExpr("Fixed(12345.123, 1)");
+        Assert.AreEqual("12,345.1", actual);
+
+        actual = XLWorkbook.EvaluateExpr("Fixed(12345.123, 1, TRUE)");
+        Assert.AreEqual("12345.1", actual);
+    }
+
+    [Test]
+    public void Formula_from_another_sheet()
+    {
+        var wb = new XLWorkbook();
+        IXLWorksheet ws1 = wb.AddWorksheet("ws1");
+        ws1.FirstCell().SetValue(1).CellRight().SetFormulaA1("A1 + 1");
+        IXLWorksheet ws2 = wb.AddWorksheet("ws2");
+        ws2.FirstCell().SetFormulaA1("ws1!B1 + 1");
+        object v = ws2.FirstCell().Value;
+        Assert.AreEqual(3.0, v);
+    }
+
+    [Test]
+    public void TextConcat()
+    {
+        var wb = new XLWorkbook();
+        IXLWorksheet ws = wb.AddWorksheet("Sheet1");
+        ws.Cell("A1").Value = 1;
+        ws.Cell("A2").Value = 1;
+        ws.Cell("B1").Value = 1;
+        ws.Cell("B2").Value = 1;
+
+        ws.Cell("C1").FormulaA1 = "\"The total value is: \" & SUM(A1:B2)";
+
+        object r = ws.Cell("C1").Value;
+        Assert.AreEqual("The total value is: 4", r);
+    }
+
+    [Test]
+    public void Trim()
+    {
+        Assert.AreEqual("Test", XLWorkbook.EvaluateExpr("Trim(\"Test    \")"));
+
+        //Should not trim non breaking space
+        //See http://office.microsoft.com/en-us/excel-help/trim-function-HP010062581.aspx
+        Assert.AreEqual("Test\u00A0", XLWorkbook.EvaluateExpr("Trim(\"Test\u00A0 \")"));
+    }
+
+    [Test]
+    public void TestEmptyTallyOperations()
+    {
+        //In these test no values have been set
+        XLWorkbook wb = new XLWorkbook();
+        wb.Worksheets.Add("TallyTests");
+        var cell = wb.Worksheet(1).Cell(1, 1).SetFormulaA1("=MAX(D1,D2)");
+        Assert.AreEqual(0, cell.Value);
+        cell = wb.Worksheet(1).Cell(2, 1).SetFormulaA1("=MIN(D1,D2)");
+        Assert.AreEqual(0, cell.Value);
+        cell = wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=SUM(D1,D2)");
+        Assert.AreEqual(0, cell.Value);
+    }
+
+    [Test]
+    public void TestOmittedParameters()
+    {
+        using (var wb = new XLWorkbook())
         {
-            Object actual;
+            object value;
+            value = wb.Evaluate("=IF(TRUE,1)");
+            Assert.AreEqual(1, value);
 
-            actual = XLWorkbook.EvaluateExpr(@"Asc(""Text"")");
-            Assert.AreEqual("Text", actual);
+            value = wb.Evaluate("=IF(TRUE,1,)");
+            Assert.AreEqual(1, value);
+
+            value = wb.Evaluate("=ISBLANK(IF(FALSE,1,))");
+            Assert.AreEqual(true, value);
+
+            value = wb.Evaluate("=IF(FALSE,,2)");
+            Assert.AreEqual(2, value);
         }
+    }
 
-        [Test]
-        public void Clean()
-        {
-            Object actual;
+    [Test]
+    public void TestDefaultExcelFunctionNamespace()
+    {
+        Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("TODAY()"));
+        Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("_xlfn.TODAY()"));
+        Assert.IsTrue((bool)XLWorkbook.EvaluateExpr("_xlfn.TODAY() = TODAY()"));
+    }
 
-            actual = XLWorkbook.EvaluateExpr(String.Format(@"Clean(""A{0}B"")", Environment.NewLine));
-            Assert.AreEqual("AB", actual);
-        }
+    [TestCase("=1234%", 12.34)]
+    [TestCase("=1234%%", 0.1234)]
+    [TestCase("=100+200%", 102.0)]
+    [TestCase("=100%+200", 201.0)]
+    [TestCase("=(100+200)%", 3.0)]
+    [TestCase("=200%^5", 32.0)]
+    [TestCase("=200%^400%", 16.0)]
+    [TestCase("=SUM(100,200,300)%", 6.0)]
+    public void PercentOperator(string formula, double expectedResult)
+    {
+        var res = (double)XLWorkbook.EvaluateExpr(formula);
 
-        [Test]
-        public void Dollar()
-        {
-            using var wb = new XLWorkbook();
-            object actual = wb.Evaluate("DOLLAR(12345.123)");
-            Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.12", actual);
+        Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
+    }
 
-            actual = wb.Evaluate("DOLLAR(12345.123, 1)");
-            Assert.AreEqual(TestHelper.CurrencySymbol + "12,345.1", actual);
-        }
+    [TestCase("=--1", 1)]
+    [TestCase("=++1", 1)]
+    [TestCase("=-+-+-1", -1)]
+    [TestCase("=2^---2", 0.25)]
+    public void MultipleUnaryOperators(string formula, double expectedResult)
+    {
+        var res = (double)XLWorkbook.EvaluateExpr(formula);
 
-        [TestCase("A", "A", true)]
-        [TestCase("A", "a", false)]
-        [TestCase("", "", true)]
-        public void Exact(string lhs, string rhs, bool result)
-        {
-            var actual = XLWorkbook.EvaluateExpr($"EXACT(\"{lhs}\", \"{rhs}\")");
-            Assert.AreEqual(result, actual);
-        }
+        Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
+    }
 
-        [Test]
-        public void Exact_converts_values_to_text()
-        {
-            Assert.AreEqual(false, XLWorkbook.EvaluateExpr("EXACT(TRUE, \"true\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(TRUE, \"TRUE\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(1, \"1\")"));
-            Assert.AreEqual(true, XLWorkbook.EvaluateExpr("EXACT(IF(TRUE,), \"\")"));
+    [TestCase("RIGHT(\"2020\", 2) + 1", 21)]
+    [TestCase("LEFT(\"20.2020\", 6) + 1", 21.202)]
+    [TestCase("2 + (\"3\" & \"4\")", 36)]
+    [TestCase("2 + \"3\" & \"4\"", "54")]
+    [TestCase("\"7\" & \"4\"", "74")]
+    public void TestStringSubExpression(string formula, object expectedResult)
+    {
+        var actual = XLWorkbook.EvaluateExpr(formula);
 
-            // Check blank cell
-            using var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet();
-            Assert.AreEqual(true, ws.Evaluate("EXACT(A1, \"\")"));
-        }
+        Assert.AreEqual(expectedResult, actual);
+    }
 
-        [Test]
-        public void Exact_propagates_errors()
-        {
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("EXACT(#DIV/0!, \"A\")"));
-            Assert.AreEqual(XLError.DivisionByZero, XLWorkbook.EvaluateExpr("EXACT(\"A\", #DIV/0!)"));
-        }
+    [Test]
+    public void Cell_function_is_evaluated_to_reference_error()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").FormulaA1 = "$B$4(5)";
 
-        [Test]
-        public void Fixed()
-        {
-            Object actual;
+        Assert.AreEqual(XLError.CellReference, ws.Cell("A1").Value);
+    }
 
-            actual = XLWorkbook.EvaluateExpr("Fixed(12345.123)");
-            Assert.AreEqual("12,345.12", actual);
+    [TestCase("BASE(1E15,30)", "MathTrig.Base")]
+    [TestCase("COMBIN(1000,500)", "MathTrig.Combin")]
+    [TestCase("COMBINA(100,500)", "MathTrig.CombinA")]
+    [TestCase("DECIMAL(\"ZZZ\",26)", "MathTrig.Decimal")]
+    [TestCase("GCD(123456,54124)", "MathTrig.Gcd")]
+    [TestCase("LCM(123456,54124)", "MathTrig.Lcm")]
+    [TestCase("MDETERM({1,2;3,4})", "MathTrig.MDeterm")]
+    [TestCase("MINVERSE({1,2;3,4})", "MathTrig.MInverse")]
+    [TestCase("MMULT({1},{2})", "MathTrig.MMult")]
+    [TestCase("MULTINOMIAL(2,3,4)", "MathTrig.Multinomial")]
+    [TestCase("PRODUCT(2,3,{4,5,6})", "MathTrig.Product")]
+    [TestCase("SERIESSUM(2,1,2,{1,2,3})", "MathTrig.SeriesSum")]
+    [TestCase("SUM(2,1,2,{1,2,3})", "MathTrig.Sum")]
+    [TestCase("SUMIF(B1:B4,\"=5\")", "MathTrig.SumIf")]
+    [TestCase("SUMIFS(B1:B4,C1:C4,\">0\")", "MathTrig.SumIfs")]
+    [TestCase("SUMPRODUCT({2,3},{4,5})", "MathTrig.SumProduct")]
+    [TestCase("SUMSQ(5,4)", "MathTrig.SumSq")]
+    [TestCase("NETWORKDAYS(10,100,{20,50})", "DateAndTime.NetWorkDays")]
+    [TestCase("WORKDAY(10,100,{20,50})", "DateAndTime.Workday")]
+    [TestCase("YEARFRAC(1,10000,1)", "DateAndTime.YearFrac")]
+    [TestCase("AND(TRUE,TRUE)", "Logical.And")]
+    [TestCase("OR(TRUE,TRUE)", "Logical.Or")]
+    [TestCase("COLUMN(D:Z)", "Lookup.Column")]
+    [TestCase("HLOOKUP(2,{0,1,2,3},1)", "Lookup.Hlookup")]
+    [TestCase("MATCH(5,{1,7})", "Lookup.Match")]
+    [TestCase("ROW(2:5)", "Lookup.Row")]
+    [TestCase("VLOOKUP(2,{0;1;2;3},1)", "Lookup.Vlookup")]
+    [TestCase("AVERAGE({1,2;3,4})", "Statistical.Average")]
+    [TestCase("AVERAGEA({1,2;3,4})", "Statistical.AverageA")]
+    [TestCase("BINOMDIST(6,10,0.5,TRUE)", "Statistical.BinomDist")]
+    [TestCase("BINOM.DIST(6,10,0.5,TRUE)", "Statistical.BinomDist")]
+    [TestCase("COUNT({1,2})", "Statistical.Count")]
+    [TestCase("COUNTA({1,2})", "Statistical.Count")]
+    [TestCase("COUNTBLANK(D1:D7)", "Statistical.CountBlank")]
+    [TestCase("COUNTIF(D1:D7,\">0\")", "Statistical.CountIf")]
+    [TestCase("COUNTIFS(D1:D7,\">0\")", "Statistical.CountIfs")]
+    [TestCase("DEVSQ({1,2})", "Statistical.DevSq")]
+    [TestCase("GEOMEAN({1,2})", "Statistical.GeoMean")]
+    [TestCase("LARGE({10,11,12},2)", "Statistical.Large")]
+    [TestCase("MAX({1,5})", "Statistical.Max")]
+    [TestCase("MAXA({1,5})", "Statistical.MaxA")]
+    [TestCase("MEDIAN({1,5,7})", "Statistical.Median")]
+    [TestCase("MIN({1,5})", "Statistical.Min")]
+    [TestCase("MINA({1,5})", "Statistical.MinA")]
+    [TestCase("STDEV({1,5})", "Statistical.StDev")]
+    [TestCase("STDEVA({1,5})", "Statistical.StDevA")]
+    [TestCase("STDEVP({1,5})", "Statistical.StDevP")]
+    [TestCase("STDEVPA({1,5})", "Statistical.StDevPA")]
+    [TestCase("STDEV.S({1,5})", "Statistical.StDev")]
+    [TestCase("STDEV.P({1,5})", "Statistical.StDevP")]
+    [TestCase("VAR({1,5})", "Statistical.Var")]
+    [TestCase("VARA({1,5})", "Statistical.VarA")]
+    [TestCase("VARP({1,5})", "Statistical.VarP")]
+    [TestCase("VARPA({1,5})", "Statistical.VarPA")]
+    [TestCase("VAR.S({1,5})", "Statistical.Var")]
+    [TestCase("VAR.P({1,5})", "Statistical.VarP")]
+    [TestCase("ASC(\"A\")", "Text.Asc")]
+    [TestCase("CLEAN(\"A\")", "Text.Clean")]
+    [TestCase("CONCAT(\"A\",\"B\")", "Text.Concat")]
+    [TestCase("CONCATENATE(\"A\",\"B\")", "Text.Concatenate")]
+    [TestCase("LEFT(\"AB\",1)", "Text.Left")]
+    [TestCase("LOWER(\"A\")", "Text.Lower")]
+    [TestCase("NUMBERVALUE(\"1\")", "Text.NumberValue")]
+    [TestCase("PROPER(\"hello\")", "Text.Proper")]
+    [TestCase("REPT(\"A\",10)", "Text.Rept")]
+    [TestCase("RIGHT(\"AB\",1)", "Text.Right")]
+    [TestCase("T({100})", "Text.T")]
+    [TestCase("TEXTJOIN(\"-\",TRUE,\"A\",\"B\")", "Text.TextJoin")]
+    [TestCase("TRIM(\"ABC\")", "Text.Trim")]
+    public void Can_cancel_function_execution(string formula, string expectedStackTrace)
+    {
+        var cts = new CancellationTokenSource();
+        using var wb = new XLWorkbook(new LoadOptions { CancellationToken = cts.Token });
+        var ws = wb.AddWorksheet();
+        ws.Cell("D1").Value = 4; // Need a non-blank cell for COUNTBLANK check
+        ws.Cell("A1").FormulaA1 = formula;
 
-            actual = XLWorkbook.EvaluateExpr("Fixed(12345.123, 1)");
-            Assert.AreEqual("12,345.1", actual);
+        cts.Cancel();
+        var ex = Assert.Throws<OperationCanceledException>(() => _ = ws.Cell("A1").Value);
 
-            actual = XLWorkbook.EvaluateExpr("Fixed(12345.123, 1, TRUE)");
-            Assert.AreEqual("12345.1", actual);
-        }
-
-        [Test]
-        public void Formula_from_another_sheet()
-        {
-            var wb = new XLWorkbook();
-            IXLWorksheet ws1 = wb.AddWorksheet("ws1");
-            ws1.FirstCell().SetValue(1).CellRight().SetFormulaA1("A1 + 1");
-            IXLWorksheet ws2 = wb.AddWorksheet("ws2");
-            ws2.FirstCell().SetFormulaA1("ws1!B1 + 1");
-            object v = ws2.FirstCell().Value;
-            Assert.AreEqual(3.0, v);
-        }
-
-        [Test]
-        public void TextConcat()
-        {
-            var wb = new XLWorkbook();
-            IXLWorksheet ws = wb.AddWorksheet("Sheet1");
-            ws.Cell("A1").Value = 1;
-            ws.Cell("A2").Value = 1;
-            ws.Cell("B1").Value = 1;
-            ws.Cell("B2").Value = 1;
-
-            ws.Cell("C1").FormulaA1 = "\"The total value is: \" & SUM(A1:B2)";
-
-            object r = ws.Cell("C1").Value;
-            Assert.AreEqual("The total value is: 4", r);
-        }
-
-        [Test]
-        public void Trim()
-        {
-            Assert.AreEqual("Test", XLWorkbook.EvaluateExpr("Trim(\"Test    \")"));
-
-            //Should not trim non breaking space
-            //See http://office.microsoft.com/en-us/excel-help/trim-function-HP010062581.aspx
-            Assert.AreEqual("Test\u00A0", XLWorkbook.EvaluateExpr("Trim(\"Test\u00A0 \")"));
-        }
-
-        [Test]
-        public void TestEmptyTallyOperations()
-        {
-            //In these test no values have been set
-            XLWorkbook wb = new XLWorkbook();
-            wb.Worksheets.Add("TallyTests");
-            var cell = wb.Worksheet(1).Cell(1, 1).SetFormulaA1("=MAX(D1,D2)");
-            Assert.AreEqual(0, cell.Value);
-            cell = wb.Worksheet(1).Cell(2, 1).SetFormulaA1("=MIN(D1,D2)");
-            Assert.AreEqual(0, cell.Value);
-            cell = wb.Worksheet(1).Cell(3, 1).SetFormulaA1("=SUM(D1,D2)");
-            Assert.AreEqual(0, cell.Value);
-        }
-
-        [Test]
-        public void TestOmittedParameters()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                object value;
-                value = wb.Evaluate("=IF(TRUE,1)");
-                Assert.AreEqual(1, value);
-
-                value = wb.Evaluate("=IF(TRUE,1,)");
-                Assert.AreEqual(1, value);
-
-                value = wb.Evaluate("=ISBLANK(IF(FALSE,1,))");
-                Assert.AreEqual(true, value);
-
-                value = wb.Evaluate("=IF(FALSE,,2)");
-                Assert.AreEqual(2, value);
-            }
-        }
-
-        [Test]
-        public void TestDefaultExcelFunctionNamespace()
-        {
-            Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("TODAY()"));
-            Assert.DoesNotThrow(() => XLWorkbook.EvaluateExpr("_xlfn.TODAY()"));
-            Assert.IsTrue((bool)XLWorkbook.EvaluateExpr("_xlfn.TODAY() = TODAY()"));
-        }
-
-        [TestCase("=1234%", 12.34)]
-        [TestCase("=1234%%", 0.1234)]
-        [TestCase("=100+200%", 102.0)]
-        [TestCase("=100%+200", 201.0)]
-        [TestCase("=(100+200)%", 3.0)]
-        [TestCase("=200%^5", 32.0)]
-        [TestCase("=200%^400%", 16.0)]
-        [TestCase("=SUM(100,200,300)%", 6.0)]
-        public void PercentOperator(string formula, double expectedResult)
-        {
-            var res = (double)XLWorkbook.EvaluateExpr(formula);
-
-            Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
-        }
-
-        [TestCase("=--1", 1)]
-        [TestCase("=++1", 1)]
-        [TestCase("=-+-+-1", -1)]
-        [TestCase("=2^---2", 0.25)]
-        public void MultipleUnaryOperators(string formula, double expectedResult)
-        {
-            var res = (double)XLWorkbook.EvaluateExpr(formula);
-
-            Assert.AreEqual(expectedResult, res, XLHelper.Epsilon);
-        }
-
-        [TestCase("RIGHT(\"2020\", 2) + 1", 21)]
-        [TestCase("LEFT(\"20.2020\", 6) + 1", 21.202)]
-        [TestCase("2 + (\"3\" & \"4\")", 36)]
-        [TestCase("2 + \"3\" & \"4\"", "54")]
-        [TestCase("\"7\" & \"4\"", "74")]
-        public void TestStringSubExpression(string formula, object expectedResult)
-        {
-            var actual = XLWorkbook.EvaluateExpr(formula);
-
-            Assert.AreEqual(expectedResult, actual);
-        }
-
-        [Test]
-        public void Cell_function_is_evaluated_to_reference_error()
-        {
-            using var wb = new XLWorkbook();
-            var ws = wb.AddWorksheet();
-            ws.Cell("A1").FormulaA1 = "$B$4(5)";
-
-            Assert.AreEqual(XLError.CellReference, ws.Cell("A1").Value);
-        }
-
-        [TestCase("BASE(1E15,30)", "MathTrig.Base")]
-        [TestCase("COMBIN(1000,500)", "MathTrig.Combin")]
-        [TestCase("COMBINA(100,500)", "MathTrig.CombinA")]
-        [TestCase("DECIMAL(\"ZZZ\",26)", "MathTrig.Decimal")]
-        [TestCase("GCD(123456,54124)", "MathTrig.Gcd")]
-        [TestCase("LCM(123456,54124)", "MathTrig.Lcm")]
-        [TestCase("MDETERM({1,2;3,4})", "MathTrig.MDeterm")]
-        [TestCase("MINVERSE({1,2;3,4})", "MathTrig.MInverse")]
-        [TestCase("MMULT({1},{2})", "MathTrig.MMult")]
-        [TestCase("MULTINOMIAL(2,3,4)", "MathTrig.Multinomial")]
-        [TestCase("PRODUCT(2,3,{4,5,6})", "MathTrig.Product")]
-        [TestCase("SERIESSUM(2,1,2,{1,2,3})", "MathTrig.SeriesSum")]
-        [TestCase("SUM(2,1,2,{1,2,3})", "MathTrig.Sum")]
-        [TestCase("SUMIF(B1:B4,\"=5\")", "MathTrig.SumIf")]
-        [TestCase("SUMIFS(B1:B4,C1:C4,\">0\")", "MathTrig.SumIfs")]
-        [TestCase("SUMPRODUCT({2,3},{4,5})", "MathTrig.SumProduct")]
-        [TestCase("SUMSQ(5,4)", "MathTrig.SumSq")]
-        [TestCase("NETWORKDAYS(10,100,{20,50})", "DateAndTime.NetWorkDays")]
-        [TestCase("WORKDAY(10,100,{20,50})", "DateAndTime.Workday")]
-        [TestCase("YEARFRAC(1,10000,1)", "DateAndTime.YearFrac")]
-        [TestCase("AND(TRUE,TRUE)", "Logical.And")]
-        [TestCase("OR(TRUE,TRUE)", "Logical.Or")]
-        [TestCase("COLUMN(D:Z)", "Lookup.Column")]
-        [TestCase("HLOOKUP(2,{0,1,2,3},1)", "Lookup.Hlookup")]
-        [TestCase("MATCH(5,{1,7})", "Lookup.Match")]
-        [TestCase("ROW(2:5)", "Lookup.Row")]
-        [TestCase("VLOOKUP(2,{0;1;2;3},1)", "Lookup.Vlookup")]
-        [TestCase("AVERAGE({1,2;3,4})", "Statistical.Average")]
-        [TestCase("AVERAGEA({1,2;3,4})", "Statistical.AverageA")]
-        [TestCase("BINOMDIST(6,10,0.5,TRUE)", "Statistical.BinomDist")]
-        [TestCase("BINOM.DIST(6,10,0.5,TRUE)", "Statistical.BinomDist")]
-        [TestCase("COUNT({1,2})", "Statistical.Count")]
-        [TestCase("COUNTA({1,2})", "Statistical.Count")]
-        [TestCase("COUNTBLANK(D1:D7)", "Statistical.CountBlank")]
-        [TestCase("COUNTIF(D1:D7,\">0\")", "Statistical.CountIf")]
-        [TestCase("COUNTIFS(D1:D7,\">0\")", "Statistical.CountIfs")]
-        [TestCase("DEVSQ({1,2})", "Statistical.DevSq")]
-        [TestCase("GEOMEAN({1,2})", "Statistical.GeoMean")]
-        [TestCase("LARGE({10,11,12},2)", "Statistical.Large")]
-        [TestCase("MAX({1,5})", "Statistical.Max")]
-        [TestCase("MAXA({1,5})", "Statistical.MaxA")]
-        [TestCase("MEDIAN({1,5,7})", "Statistical.Median")]
-        [TestCase("MIN({1,5})", "Statistical.Min")]
-        [TestCase("MINA({1,5})", "Statistical.MinA")]
-        [TestCase("STDEV({1,5})", "Statistical.StDev")]
-        [TestCase("STDEVA({1,5})", "Statistical.StDevA")]
-        [TestCase("STDEVP({1,5})", "Statistical.StDevP")]
-        [TestCase("STDEVPA({1,5})", "Statistical.StDevPA")]
-        [TestCase("STDEV.S({1,5})", "Statistical.StDev")]
-        [TestCase("STDEV.P({1,5})", "Statistical.StDevP")]
-        [TestCase("VAR({1,5})", "Statistical.Var")]
-        [TestCase("VARA({1,5})", "Statistical.VarA")]
-        [TestCase("VARP({1,5})", "Statistical.VarP")]
-        [TestCase("VARPA({1,5})", "Statistical.VarPA")]
-        [TestCase("VAR.S({1,5})", "Statistical.Var")]
-        [TestCase("VAR.P({1,5})", "Statistical.VarP")]
-        [TestCase("ASC(\"A\")", "Text.Asc")]
-        [TestCase("CLEAN(\"A\")", "Text.Clean")]
-        [TestCase("CONCAT(\"A\",\"B\")", "Text.Concat")]
-        [TestCase("CONCATENATE(\"A\",\"B\")", "Text.Concatenate")]
-        [TestCase("LEFT(\"AB\",1)", "Text.Left")]
-        [TestCase("LOWER(\"A\")", "Text.Lower")]
-        [TestCase("NUMBERVALUE(\"1\")", "Text.NumberValue")]
-        [TestCase("PROPER(\"hello\")", "Text.Proper")]
-        [TestCase("REPT(\"A\",10)", "Text.Rept")]
-        [TestCase("RIGHT(\"AB\",1)", "Text.Right")]
-        [TestCase("T({100})", "Text.T")]
-        [TestCase("TEXTJOIN(\"-\",TRUE,\"A\",\"B\")", "Text.TextJoin")]
-        [TestCase("TRIM(\"ABC\")", "Text.Trim")]
-        public void Can_cancel_function_execution(string formula, string expectedStackTrace)
-        {
-            var cts = new CancellationTokenSource();
-            using var wb = new XLWorkbook(new LoadOptions { CancellationToken = cts.Token });
-            var ws = wb.AddWorksheet();
-            ws.Cell("D1").Value = 4; // Need a non-blank cell for COUNTBLANK check
-            ws.Cell("A1").FormulaA1 = formula;
-
-            cts.Cancel();
-            var ex = Assert.Throws<OperationCanceledException>(() => _ = ws.Cell("A1").Value);
-
-            StringAssert.Contains(expectedStackTrace + "(", ex?.StackTrace);
-        }
+        StringAssert.Contains(expectedStackTrace + "(", ex?.StackTrace);
     }
 }

--- a/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FunctionsTests.cs
@@ -234,6 +234,9 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("SUMIFS(B1:B4,C1:C4,\">0\")", "MathTrig.SumIfs")]
         [TestCase("SUMPRODUCT({2,3},{4,5})", "MathTrig.SumProduct")]
         [TestCase("SUMSQ(5,4)", "MathTrig.SumSq")]
+        [TestCase("NETWORKDAYS(10,100,{20,50})", "DateAndTime.NetWorkDays")]
+        [TestCase("WORKDAY(10,100,{20,50})", "DateAndTime.Workday")]
+        [TestCase("YEARFRAC(1,10000,1)", "DateAndTime.YearFrac")]
         public void Can_cancel_function_execution(string formula, string expectedStackTrace)
         {
             var cts = new CancellationTokenSource();

--- a/ClosedXML/Excel/CalcEngine/CalcContext.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcContext.cs
@@ -31,6 +31,7 @@ namespace ClosedXML.Excel.CalcEngine
             _formulaAddress = formulaAddress;
             _recursive = recursive;
             Culture = culture;
+            CancellationToken = workbook?.CancellationToken ?? CancellationToken.None;
         }
 
         // LEGACY: Remove once legacy functions are migrated
@@ -85,7 +86,7 @@ namespace ClosedXML.Excel.CalcEngine
         /// </summary>
         internal double DateSystemUpperLimit => Use1904DateSystem ? XLHelper.Calendar1904UpperLimit : XLHelper.Calendar1900UpperLimit;
 
-        internal CancellationToken CancellationToken { get; init; } = CancellationToken.None;
+        internal CancellationToken CancellationToken { get; }
 
         /// <summary>
         /// A helper method to check is user cancelled the calculation in function loops.

--- a/ClosedXML/Excel/CalcEngine/CalcContext.cs
+++ b/ClosedXML/Excel/CalcEngine/CalcContext.cs
@@ -10,7 +10,7 @@ using ClosedXML.Excel.CalcEngine.Functions;
 
 namespace ClosedXML.Excel.CalcEngine
 {
-    internal class CalcContext
+    internal sealed class CalcContext
     {
         private readonly XLCalcEngine _calcEngine;
         private readonly XLWorkbook? _workbook;

--- a/ClosedXML/Excel/CalcEngine/Functions/ArgumentsExtensions.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/ArgumentsExtensions.cs
@@ -58,6 +58,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             {
                 if (arg.TryPickScalar(out var scalar, out var collection))
                 {
+                    ctx.ThrowIfCancelled();
                     var conversionResult = convert(scalar, ctx);
                     if (!conversionResult.TryPickT0(out var elementValue, out var elementError))
                         return elementError;
@@ -72,6 +73,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                         : reference!.GetCellsValues(ctx);
                     foreach (var value in valuesIterator)
                     {
+                        ctx.ThrowIfCancelled();
                         if (collectionFilter is not null && !collectionFilter(value))
                             continue;
 

--- a/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/DateAndTime.cs
@@ -41,10 +41,10 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             ce.RegisterFunction("YEARFRAC", 2, 3, AdaptLastOptional(YearFrac, 0), FunctionFlags.Scalar); // Returns the year fraction representing the number of whole days between start_date and end_date
         }
 
-        private static int BusinessDaysUntil(int firstDay, int lastDay, ICollection<int> distinctHolidays)
+        private static int BusinessDaysUntil(CalcContext ctx, int firstDay, int lastDay, ICollection<int> distinctHolidays)
         {
             if (firstDay > lastDay)
-                return -BusinessDaysUntil(lastDay, firstDay, distinctHolidays);
+                return -BusinessDaysUntil(ctx, lastDay, firstDay, distinctHolidays);
 
             var workDays = lastDay - firstDay + 1;
             var fullWeekCount = Math.DivRem(workDays, 7, out var remainingDays);
@@ -62,6 +62,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             // subtract the number of bank holidays during the time interval
             foreach (var holidayDate in distinctHolidays)
             {
+                ctx.ThrowIfCancelled();
                 if (firstDay <= holidayDate && holidayDate <= lastDay)
                 {
                     if (!IsWeekend(holidayDate))
@@ -365,13 +366,14 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var allHolidays = new HashSet<int>();
             foreach (var holidayValue in ctx.GetNonBlankValues(holidays))
             {
+                ctx.ThrowIfCancelled();
                 if (!TryGetDate(ctx, holidayValue, out var holidayDate, out var error))
                     return error;
 
                 allHolidays.Add(holidayDate);
             }
 
-            return BusinessDaysUntil(startSerialDate, endSerialDate, allHolidays);
+            return BusinessDaysUntil(ctx, startSerialDate, endSerialDate, allHolidays);
         }
 
         private static ScalarValue Now()
@@ -568,6 +570,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var startIsHoliday = orderedHolidays.Count > 0 && orderedHolidays[0] == startDate;
             for (var i = startIsHoliday ? 1 : 0; i < orderedHolidays.Count; ++i)
             {
+                ctx.ThrowIfCancelled();
                 var holidayDate = orderedHolidays[i];
 
                 // Because workdays up to and including lastDateSoFar has already been counted, we add + 1.
@@ -578,7 +581,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 // if two holidays were next to each other, the `holidayDate-1` might be *before* `lastDateSoFar+1`.
                 // When days are same, BusinessDaysUntil returns 1 regardless of direction, so add a condition.
                 var segmentWorkdays = lastDateSoFar + oneDay != holidayDate
-                    ? BusinessDaysUntil(lastDateSoFar + oneDay, holidayDate, System.Array.Empty<int>())
+                    ? BusinessDaysUntil(ctx, lastDateSoFar + oneDay, holidayDate, System.Array.Empty<int>())
                     : oneDay;
 
                 if (cmp.Compare(workdaysSoFar + segmentWorkdays, dayOffset) > 0)
@@ -624,6 +627,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 var distinctHolidays = new HashSet<int>();
                 foreach (var holidayValue in ctx.GetNonBlankValues(holidays))
                 {
+                    ctx.ThrowIfCancelled();
                     if (!TryGetDate(ctx, holidayValue, out var holidayDate, out var error))
                         return error;
 
@@ -681,6 +685,8 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 var totalDays = 0;
                 for (var year = startYear; year <= endYear; year++)
                 {
+                    ctx.ThrowIfCancelled();
+
                     // For purposes of average year, 1900 is not counted as a leap year
                     totalDays += DateTime.IsLeapYear(year) ? 366 : 365;
                 }

--- a/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Logical.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using ClosedXML.Excel.CalcEngine.Functions;
 using static ClosedXML.Excel.CalcEngine.Functions.SignatureAdapter;
@@ -10,12 +8,12 @@ namespace ClosedXML.Excel.CalcEngine
     {
         public static void Register(FunctionRegistry ce)
         {
-            ce.RegisterFunction("AND", 1, int.MaxValue, And, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("AND", 1, 255, And, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("FALSE", 0, 0, Adapt(False), FunctionFlags.Scalar);
             ce.RegisterFunction("IF", 2, 3, AdaptLastOptional(If, false), FunctionFlags.Range, AllowRange.Only, 1, 2);
             ce.RegisterFunction("IFERROR", 2, 2, Adapt(IfError), FunctionFlags.Scalar);
             ce.RegisterFunction("NOT", 1, 1, AdaptCoerced(Not), FunctionFlags.Scalar);
-            ce.RegisterFunction("OR", 1, int.MaxValue, Or, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("OR", 1, 255, Or, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("TRUE", 0, 0, Adapt(True), FunctionFlags.Scalar);
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Lookup.cs
@@ -50,7 +50,10 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var span = lastColumn - firstColumn + 1;
             var array = new ScalarValue[1, span];
             for (var col = firstColumn; col <= lastColumn; col++)
+            {
+                ctx.ThrowIfCancelled();
                 array[0, col - firstColumn] = col;
+            }
 
             return new ConstArray(array);
         }
@@ -92,7 +95,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             {
                 // Bisection in Excel and here differs, so we return different values for unsorted ranges, but same values for sorted ranges.
                 var transposedArray = new TransposedArray(array);
-                var foundColumn = Bisection(transposedArray, lookupValue);
+                var foundColumn = Bisection(ctx, transposedArray, lookupValue);
                 if (foundColumn == -1)
                     return XLError.NoValueAvailable;
 
@@ -103,6 +106,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 // TODO: Implement wildcard search
                 for (var columnIndex = 0; columnIndex < array.Width; columnIndex++)
                 {
+                    ctx.ThrowIfCancelled();
                     var currentValue = array[0, columnIndex];
 
                     // Because lookup value can't be an error, it doesn't matter that sort treats all errors as equal.
@@ -250,9 +254,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
             var index = matchType switch
             {
-                < 0 => MatchDescending(target, array, ScalarValueComparer.SortIgnoreCase),
-                0 => MatchUnsorted(target, array, ctx),
-                > 0 => MatchAscending(target, array, ScalarValueComparer.SortIgnoreCase),
+                < 0 => MatchDescending(ctx, target, array, ScalarValueComparer.SortIgnoreCase),
+                0 => MatchUnsorted(ctx, target, array),
+                > 0 => MatchAscending(ctx, target, array, ScalarValueComparer.SortIgnoreCase),
             };
 
             if (index < 0)
@@ -260,9 +264,9 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
             return index + 1;
 
-            static int MatchAscending(ScalarValue target, Array data, IComparer<ScalarValue> comparer)
+            static int MatchAscending(CalcContext ctx, ScalarValue target, Array data, IComparer<ScalarValue> comparer)
             {
-                var index = Bisection(target, data, comparer);
+                var index = Bisection(ctx, target, data, comparer);
                 if (index == -1)
                     return index;
 
@@ -273,11 +277,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 return index;
             }
 
-            static int MatchUnsorted(ScalarValue target, Array data, CalcContext ctx)
+            static int MatchUnsorted(CalcContext ctx, ScalarValue target, Array data)
             {
                 var criteria = Criteria.Create(target, ctx.Culture);
                 for (var i = 0; i < data.Height; ++i)
                 {
+                    ctx.ThrowIfCancelled();
                     var value = data[i, 0];
                     if (target.HaveSameType(value) && criteria.Match(value))
                         return i;
@@ -286,12 +291,14 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 return -1;
             }
 
-            static int MatchDescending(ScalarValue target, Array data, IComparer<ScalarValue> comparer)
+            static int MatchDescending(CalcContext ctx, ScalarValue target, Array data, IComparer<ScalarValue> comparer)
             {
                 // Data should be in ascending order, but Excel doesn't use bisection.
                 var found = -1;
                 for (var i = 0; i < data.Height; ++i)
                 {
+                    ctx.ThrowIfCancelled();
+
                     // Skip elements with different type
                     var value = data[i, 0];
                     while (!value.HaveSameType(target))
@@ -320,19 +327,21 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         /// <summary>
         /// Find index of the greatest element smaller or equal to the <paramref name="target"/>.
         /// </summary>
+        /// <param name="ctx">Context to cancel bisection.</param>
         /// <param name="target">Value to look for.</param>
         /// <param name="data">Data in ascending order.</param>
         /// <param name="comparer">A comparator for comparing two values.</param>
         /// <returns>Index of found element. If the <paramref name="data"/> contains
         ///   a sequence of <paramref name="target"/> values, it can be index of any of them.
         /// </returns>
-        private static int Bisection(ScalarValue target, Array data, IComparer<ScalarValue> comparer)
+        private static int Bisection(CalcContext ctx, ScalarValue target, Array data, IComparer<ScalarValue> comparer)
         {
             // This should match Excel logic perfectly. Make sure to do some fuzzy testing when changing the code.
             var low = 0;
             var high = data.Height - 1;
             while (low < high)
             {
+                ctx.ThrowIfCancelled();
                 var (middle, compare) = FindMiddleAbove(low, high, target, data, comparer);
 
                 if (compare == 0)
@@ -392,7 +401,10 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var span = lastRow - firstRow + 1;
             var array = new ScalarValue[span, 1];
             for (var row = firstRow; row <= lastRow; row++)
+            {
+                ctx.ThrowIfCancelled();
                 array[row - firstRow, 0] = row;
+            }
 
             return new ConstArray(array);
         }
@@ -441,7 +453,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (approximateSearchFlag)
             {
                 // Bisection in Excel and here differs, so we return different values for unsorted ranges, but same values for sorted ranges.
-                var foundRow = Bisection(array, lookupValue);
+                var foundRow = Bisection(ctx, array, lookupValue);
                 if (foundRow == -1)
                     return XLError.NoValueAvailable;
 
@@ -452,6 +464,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 // TODO: Implement wildcard search
                 for (var rowIndex = 0; rowIndex < array.Height; rowIndex++)
                 {
+                    ctx.ThrowIfCancelled();
                     var currentValue = array[rowIndex, 0];
 
                     // Because lookup value can't be an error, it doesn't matter that sort treats all errors as equal.
@@ -464,7 +477,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             }
         }
 
-        private static int Bisection(Array range, ScalarValue lookupValue)
+        private static int Bisection(CalcContext ctx, Array range, ScalarValue lookupValue)
         {
             // Bisection is predicated on a fact that values of the same type are sorted.
             // If they are not, results are unpredictable.
@@ -505,6 +518,8 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             // Now we have two borders with actual values and we know the lookup value is less than high and greater/equal to lower
             while (true)
             {
+                ctx.ThrowIfCancelled();
+
                 // The FindMiddle method returns only values [lowRow, highRow)
                 // so in each loop it decreases the interval. The lowRow value is
                 // the last one checked during search of a middle.

--- a/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/MathTrig.cs
@@ -104,10 +104,10 @@ namespace ClosedXML.Excel.CalcEngine
             ce.RegisterFunction("SQRT", 1, 1, Adapt(Sqrt), FunctionFlags.Scalar);
             ce.RegisterFunction("SQRTPI", 1, 1, Adapt(SqrtPi), FunctionFlags.Scalar);
             ce.RegisterFunction("SUBTOTAL", 2, 255, Adapt(Subtotal), FunctionFlags.Range, AllowRange.Except, 0);
-            ce.RegisterFunction("SUM", 1, int.MaxValue, Sum, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("SUM", 1, 255, Sum, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("SUMIF", 2, 3, AdaptLastOptional(SumIf), FunctionFlags.Range, AllowRange.Only, 0, 2);
             ce.RegisterFunction("SUMIFS", 3, 255, AdaptIfs(SumIfs), FunctionFlags.Range, AllowRange.Only, new[] { 0 }.Concat(Enumerable.Range(0, 128).Select(x => x * 2 + 1)).ToArray());
-            ce.RegisterFunction("SUMPRODUCT", 1, 30, Adapt(SumProduct), FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("SUMPRODUCT", 1, 255, Adapt(SumProduct), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("SUMSQ", 1, 255, SumSq, FunctionFlags.Range, AllowRange.All);
             //ce.RegisterFunction("SUMX2MY2", SumX2MY2, 1);
             //ce.RegisterFunction("SUMX2PY2", SumX2PY2, 1);
@@ -274,7 +274,7 @@ namespace ClosedXML.Excel.CalcEngine
             return XLMath.ATanh(number);
         }
 
-        private static ScalarValue Base(double number, double radix, double minLength)
+        private static ScalarValue Base(CalcContext ctx, double number, double radix, double minLength)
         {
             number = Math.Truncate(number);
             radix = Math.Truncate(radix);
@@ -285,6 +285,7 @@ namespace ClosedXML.Excel.CalcEngine
             var sb = new StringBuilder();
             while (number > 0)
             {
+                ctx.ThrowIfCancelled();
                 var digit = (int)(number % radix);
                 number = Math.Floor(number / radix);
 
@@ -329,7 +330,7 @@ namespace ClosedXML.Excel.CalcEngine
 
         private static ScalarValue Combin(CalcContext ctx, double number, double numberChosen)
         {
-            var combinationsResult = XLMath.CombinChecked(number, numberChosen);
+            var combinationsResult = XLMath.CombinChecked(ctx, number, numberChosen);
             if (!combinationsResult.TryPickT0(out var combinations, out var error))
                 return error;
 
@@ -354,7 +355,7 @@ namespace ClosedXML.Excel.CalcEngine
             var k = number - 1;
             return chosen == 0 || k == 0
                 ? 1
-                : XLMath.Combin(n, k);
+                : XLMath.Combin(ctx, n, k);
         }
 
         private static ScalarValue Cos(double number)
@@ -404,7 +405,7 @@ namespace ClosedXML.Excel.CalcEngine
             return 1 / Math.Sinh(angle);
         }
 
-        private static ScalarValue Decimal(string text, double radix)
+        private static ScalarValue Decimal(CalcContext ctx, string text, double radix)
         {
             radix = Math.Truncate(radix);
             if (radix is < 2 or > 36)
@@ -416,6 +417,7 @@ namespace ClosedXML.Excel.CalcEngine
             var result = 0d;
             foreach (var digit in text.AsSpan().TrimStart())
             {
+                ctx.ThrowIfCancelled();
                 var digitNumber = digit switch
                 {
                     >= '0' and <= '9' => digit - '0',
@@ -650,7 +652,7 @@ namespace ClosedXML.Excel.CalcEngine
             if (!isSquare)
                 return XLError.IncompatibleValue;
 
-            var matrix = new XLMatrix(array);
+            var matrix = new XLMatrix(array, ctx);
             return matrix.Determinant();
         }
 
@@ -663,7 +665,7 @@ namespace ClosedXML.Excel.CalcEngine
             if (!isSquare)
                 return XLError.IncompatibleValue;
 
-            var matrix = new XLMatrix(array);
+            var matrix = new XLMatrix(array, ctx);
             var inverse = matrix.Invert();
             if (inverse.IsSingular())
                 return XLError.NumberInvalid;
@@ -689,6 +691,7 @@ namespace ClosedXML.Excel.CalcEngine
                 {
                     for (var k = 0; k < matrixA.GetLength(1); k++)
                     {
+                        ctx.ThrowIfCancelled();
                         matrixC[i, j] += matrixA[i, k] * matrixB[k, j];
                     }
                 }
@@ -1044,7 +1047,7 @@ namespace ClosedXML.Excel.CalcEngine
             return Sum(ctx, new[] { sumRange }, tally);
         }
 
-        private static AnyValue SumProduct(CalcContext _, Array[] areas)
+        private static AnyValue SumProduct(CalcContext ctx, Array[] areas)
         {
             if (areas.Length < 1)
                 return XLError.IncompatibleValue;
@@ -1082,6 +1085,7 @@ namespace ClosedXML.Excel.CalcEngine
                     var product = 1.0;
                     foreach (var area in areas)
                     {
+                        ctx.ThrowIfCancelled();
                         var scalar = area[rowIdx, colIdx];
 
                         if (scalar.TryPickError(out var error))

--- a/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/SignatureAdapter.cs
@@ -124,7 +124,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction Adapt(Func<double, double, double, bool, AnyValue> f)
+        public static CalcEngineFunction Adapt(Func<CalcContext, double, double, double, bool, AnyValue> f)
         {
             return (ctx, args) =>
             {
@@ -144,7 +144,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg3Converted.TryPickT0(out var arg3, out var err3))
                     return err3;
 
-                return f(arg0, arg1, arg2, arg3);
+                return f(ctx, arg0, arg1, arg2, arg3);
             };
         }
 
@@ -176,7 +176,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             };
         }
 
-        public static CalcEngineFunction Adapt(Func<string, double, ScalarValue> f)
+        public static CalcEngineFunction Adapt(Func<CalcContext, string, double, ScalarValue> f)
         {
             return (ctx, args) =>
             {
@@ -188,7 +188,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 if (!arg1Converted.TryPickT0(out var arg1, out var err1))
                     return err1;
 
-                return f(arg0, arg1).ToAnyValue();
+                return f(ctx, arg0, arg1).ToAnyValue();
             };
         }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -123,7 +123,7 @@ namespace ClosedXML.Excel.CalcEngine
             return Average(ctx, args, TallyAll.WithArrayText);
         }
 
-        private static AnyValue BinomDist(double numberSuccesses, double numberTrials, double successProbability, bool cumulativeFlag)
+        private static AnyValue BinomDist(CalcContext ctx, double numberSuccesses, double numberTrials, double successProbability, bool cumulativeFlag)
         {
             if (successProbability is < 0 or > 1)
                 return XLError.NumberInvalid;
@@ -133,7 +133,7 @@ namespace ClosedXML.Excel.CalcEngine
                 var cdf = 0d;
                 for (var y = 0; y <= numberSuccesses; ++y)
                 {
-                    var result = BinomDist(y, numberTrials, successProbability);
+                    var result = BinomDist(ctx, y, numberTrials, successProbability);
                     if (!result.TryPickT0(out var pf, out var error))
                         return error;
 
@@ -147,7 +147,7 @@ namespace ClosedXML.Excel.CalcEngine
             }
             else
             {
-                var result = BinomDist(numberSuccesses, numberTrials, successProbability);
+                var result = BinomDist(ctx, numberSuccesses, numberTrials, successProbability);
                 if (!result.TryPickT0(out var binomDist, out var error))
                     return error;
 
@@ -155,9 +155,9 @@ namespace ClosedXML.Excel.CalcEngine
             }
         }
 
-        private static OneOf<double, XLError> BinomDist(double x, double n, double p)
+        private static OneOf<double, XLError> BinomDist(CalcContext ctx, double x, double n, double p)
         {
-            if (!XLMath.CombinChecked(n, x).TryPickT0(out var combinations, out var error))
+            if (!XLMath.CombinChecked(ctx, n, x).TryPickT0(out var combinations, out var error))
                 return error;
 
             x = Math.Floor(x);

--- a/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Statistical.cs
@@ -11,8 +11,8 @@ namespace ClosedXML.Excel.CalcEngine
         public static void Register(FunctionRegistry ce)
         {
             //ce.RegisterFunction("AVEDEV", AveDev, 1, int.MaxValue);
-            ce.RegisterFunction("AVERAGE", 1, int.MaxValue, Average, FunctionFlags.Range, AllowRange.All); // Returns the average (arithmetic mean) of the arguments
-            ce.RegisterFunction("AVERAGEA", 1, int.MaxValue, AverageA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("AVERAGE", 1, 255, Average, FunctionFlags.Range, AllowRange.All); // Returns the average (arithmetic mean) of the arguments
+            ce.RegisterFunction("AVERAGEA", 1, 255, AverageA, FunctionFlags.Range, AllowRange.All);
             //BETADIST	Returns the beta cumulative distribution function
             //BETAINV   Returns the inverse of the cumulative distribution function for a specified beta distribution
             ce.RegisterFunction("BINOMDIST", 4, 4, Adapt(BinomDist), FunctionFlags.Scalar); //BINOMDIST	Returns the individual term binomial distribution probability
@@ -22,7 +22,7 @@ namespace ClosedXML.Excel.CalcEngine
             //CHITEST	Returns the test for independence
             //CONFIDENCE	Returns the confidence interval for a population mean
             //CORREL	Returns the correlation coefficient between two data sets
-            ce.RegisterFunction("COUNT", 1, int.MaxValue, Count, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("COUNT", 1, 255, Count, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("COUNTA", 1, 255, CountA, FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("COUNTBLANK", 1, 1, Adapt(CountBlank), FunctionFlags.Range, AllowRange.All);
             ce.RegisterFunction("COUNTIF", 2, 2, Adapt((Func<CalcContext, AnyValue, ScalarValue, AnyValue>)CountIf), FunctionFlags.Range, AllowRange.Only, 0);
@@ -54,10 +54,10 @@ namespace ClosedXML.Excel.CalcEngine
             //LOGINV	Returns the inverse of the lognormal distribution
             //LOGNORMDIST	Returns the cumulative lognormal distribution
             ce.RegisterFunction("MAX", 1, 255, Max, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("MAXA", 1, int.MaxValue, MaxA, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("MEDIAN", 1, int.MaxValue, Median, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("MIN", 1, int.MaxValue, Min, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("MINA", 1, int.MaxValue, MinA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("MAXA", 1, 255, MaxA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("MEDIAN", 1, 255, Median, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("MIN", 1, 255, Min, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("MINA", 1, 255, MinA, FunctionFlags.Range, AllowRange.All);
             //MODE	Returns the most common value in a data set
             //NEGBINOMDIST	Returns the negative binomial distribution
             //NORMDIST	Returns the normal cumulative distribution
@@ -77,24 +77,24 @@ namespace ClosedXML.Excel.CalcEngine
             //SLOPE	Returns the slope of the linear regression line
             //SMALL	Returns the k-th smallest value in a data set
             //STANDARDIZE	Returns a normalized value
-            ce.RegisterFunction("STDEV", 1, int.MaxValue, StDev, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("STDEVA", 1, int.MaxValue, StDevA, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("STDEVP", 1, int.MaxValue, StDevP, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("STDEVPA", 1, int.MaxValue, StDevPA, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("STDEV.S", 1, int.MaxValue, StDev, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("STDEV.P", 1, int.MaxValue, StDevP, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("STDEV", 1, 255, StDev, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("STDEVA", 1, 255, StDevA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("STDEVP", 1, 255, StDevP, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("STDEVPA", 1, 255, StDevPA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("STDEV.S", 1, 255, StDev, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("STDEV.P", 1, 255, StDevP, FunctionFlags.Range, AllowRange.All);
             //STEYX	Returns the standard error of the predicted y-value for each x in the regression
             //TDIST	Returns the Student's t-distribution
             //TINV	Returns the inverse of the Student's t-distribution
             //TREND	Returns values along a linear trend
             //TRIMMEAN	Returns the mean of the interior of a data set
             //TTEST	Returns the probability associated with a Student's t-test
-            ce.RegisterFunction("VAR", 1, int.MaxValue, Var, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VARA", 1, int.MaxValue, VarA, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VARP", 1, int.MaxValue, VarP, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VARPA", 1, int.MaxValue, VarPA, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VAR.S", 1, int.MaxValue, Var, FunctionFlags.Range, AllowRange.All);
-            ce.RegisterFunction("VAR.P", 1, int.MaxValue, VarP, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("VAR", 1, 255, Var, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("VARA", 1, 255, VarA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("VARP", 1, 255, VarP, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("VARPA", 1, 255, VarPA, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("VAR.S", 1, 255, Var, FunctionFlags.Range, AllowRange.All);
+            ce.RegisterFunction("VAR.P", 1, 255, VarP, FunctionFlags.Range, AllowRange.All);
             //WEIBULL	Returns the Weibull distribution
             //ZTEST	Returns the one-tailed probability-value of a z-test
         }
@@ -198,9 +198,13 @@ namespace ClosedXML.Excel.CalcEngine
 
             // To be efficient for cases like whole sheet with only few values, calculate
             // the blank count as number of total area size without non-blank cells.
-            var nonBlankCount = ctx.GetNonBlankValues(new Reference(area))
-                .Where(static value => !value.IsBlank && !(value.IsText && value.GetText().Length == 0))
-                .LongCount();
+            var nonBlankCount = 0L;
+            foreach (var value in ctx.GetNonBlankValues(new Reference(area)))
+            {
+                ctx.ThrowIfCancelled();
+                if (!value.IsBlank && !(value.IsText && value.GetText().Length == 0))
+                    nonBlankCount++;
+            }
 
             return area.Size - nonBlankCount;
         }
@@ -476,6 +480,7 @@ namespace ClosedXML.Excel.CalcEngine
             var total = new List<double>(size);
             foreach (var value in values)
             {
+                ctx.ThrowIfCancelled();
                 if (value.IsError)
                     return value.GetError();
 

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyAll.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyAll.cs
@@ -68,6 +68,8 @@ internal class TallyAll : ITally
         {
             if (arg.TryPickScalar(out var scalar, out var collection))
             {
+                ctx.ThrowIfCancelled();
+
                 // Scalars are converted to number.
                 if (!scalar.ToNumber(ctx.Culture).TryPickT0(out var number, out var error))
                 {
@@ -96,6 +98,8 @@ internal class TallyAll : ITally
                 }
                 foreach (var value in valuesIterator)
                 {
+                    ctx.ThrowIfCancelled();
+
                     // Blank lines are ignored. Logical are counted in reference, but not in array.
                     if (!isArray && value.TryPickLogical(out var logical))
                     {

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyCriteria.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyCriteria.cs
@@ -48,6 +48,7 @@ internal class TallyCriteria : ITally
         var talliedAreas = new List<XLRangeAddress>(args.Length);
         foreach (var arg in args)
         {
+            ctx.ThrowIfCancelled();
             if (!arg.TryPickArea(out var tallyArea, out var error))
                 return error;
 
@@ -72,6 +73,7 @@ internal class TallyCriteria : ITally
         {
             foreach (var area in talliedAreas)
             {
+                ctx.ThrowIfCancelled();
                 var origin = area.FirstAddress;
                 var shifted = new XLSheetPoint(origin.RowNumber + rowOfs, origin.ColumnNumber + colOfs);
                 var cellValue = ctx.GetCellValue(area.Worksheet, shifted.Row, shifted.Column);

--- a/ClosedXML/Excel/CalcEngine/Functions/TallyNumbers.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/TallyNumbers.cs
@@ -53,6 +53,7 @@ internal class TallyNumbers : ITally
         {
             if (arg.TryPickScalar(out var scalar, out var collection))
             {
+                ctx.ThrowIfCancelled();
                 if (_ignoreScalarBlank && scalar.IsBlank)
                     continue;
 
@@ -74,6 +75,7 @@ internal class TallyNumbers : ITally
                     : array;
                 foreach (var value in valuesIterator)
                 {
+                    ctx.ThrowIfCancelled();
                     if (value.TryPickError(out var error))
                     {
                         if (_ignoreErrors)

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -78,7 +78,10 @@ namespace ClosedXML.Excel.CalcEngine
             // Because fullwidth code points are in base multilingual plane, I just skip over surrogates.
             var sb = new StringBuilder(text.Length);
             foreach (int c in text)
+            {
+                ctx.ThrowIfCancelled();
                 sb.Append((char)ToHalfForm(c));
+            }
 
             return sb.ToString();
 
@@ -149,6 +152,7 @@ namespace ClosedXML.Excel.CalcEngine
             var result = new StringBuilder(text.Length);
             foreach (char c in text)
             {
+                ctx.ThrowIfCancelled();
                 int codePoint = c;
                 if (codePoint is >= 0 and <= 0x1F)
                     continue;
@@ -200,6 +204,7 @@ namespace ClosedXML.Excel.CalcEngine
             var sb = new StringBuilder(totalLength);
             foreach (var text in texts)
             {
+                ctx.ThrowIfCancelled();
                 sb.Append(text);
                 if (sb.Length > 32767)
                     return XLError.IncompatibleValue;
@@ -261,6 +266,8 @@ namespace ClosedXML.Excel.CalcEngine
             var i = 0;
             while (numChars > 0 && i < text.Length)
             {
+                ctx.ThrowIfCancelled();
+
                 // Most C# text API will happily ignore invalid surrogate pairs, so do we
                 i += char.IsSurrogatePair(text, i) ? 2 : 1;
                 numChars--;
@@ -284,6 +291,7 @@ namespace ClosedXML.Excel.CalcEngine
             var sb = new StringBuilder(text.Length);
             for (var i = 0; i < text.Length; ++i)
             {
+                ctx.ThrowIfCancelled();
                 var c = text[i];
                 char lowercase;
                 if (i == text.Length - 1 && c == 'Σ')
@@ -331,6 +339,7 @@ namespace ClosedXML.Excel.CalcEngine
             var prevWasLetter = false;
             foreach (var c in text)
             {
+                ctx.ThrowIfCancelled();
                 var casedChar = prevWasLetter
                     ? char.ToLower(c, culture)
                     : char.ToUpper(c, culture);
@@ -383,7 +392,10 @@ namespace ClosedXML.Excel.CalcEngine
 
             var sb = new StringBuilder(resultLength);
             for (var i = 0; i < count; ++i)
+            {
+                ctx.ThrowIfCancelled();
                 sb.Append(text);
+            }
 
             return sb.ToString();
         }
@@ -401,6 +413,7 @@ namespace ClosedXML.Excel.CalcEngine
             var i = text.Length;
             while (numChars > 0 && i > 0)
             {
+                ctx.ThrowIfCancelled();
                 i -= i > 1 && char.IsSurrogatePair(text[i - 2], text[i - 1]) ? 2 : 1;
                 numChars--;
             }
@@ -577,11 +590,15 @@ namespace ClosedXML.Excel.CalcEngine
             var sb = new StringBuilder(span.Length);
             for (var i = 0; i < span.Length; ++i)
             {
+                ctx.ThrowIfCancelled();
                 sb.Append(span[i]);
                 if (span[i] == space)
                 {
                     while (i < span.Length - 1 && span[i + 1] == space)
+                    {
+                        ctx.ThrowIfCancelled();
                         i++;
+                    }
                 }
             }
 
@@ -663,6 +680,7 @@ namespace ClosedXML.Excel.CalcEngine
             var decimalSeen = false;
             foreach (var c in text)
             {
+                ctx.ThrowIfCancelled();
                 if (c == decimalSep)
                 {
                     // Only first decimal separator should be replaced by '.'

--- a/ClosedXML/Excel/CalcEngine/Functions/Text.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/Text.cs
@@ -367,7 +367,7 @@ namespace ClosedXML.Excel.CalcEngine
             return sb.ToString();
         }
 
-        private static ScalarValue Rept(string text, double replicationCount)
+        private static ScalarValue Rept(CalcContext ctx, string text, double replicationCount)
         {
             if (replicationCount is < 0 or >= int.MaxValue + 1d)
                 return XLError.IncompatibleValue;

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMath.cs
@@ -24,7 +24,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return (1.0 / Math.Sinh(x));
         }
 
-        internal static OneOf<double, XLError> CombinChecked(double number, double numberChosen)
+        internal static OneOf<double, XLError> CombinChecked(CalcContext ctx, double number, double numberChosen)
         {
             if (number < 0 || numberChosen < 0)
                 return XLError.NumberInvalid;
@@ -39,14 +39,14 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (n < k)
                 return XLError.NumberInvalid;
 
-            var combinations = Combin(n, k);
+            var combinations = Combin(ctx, n, k);
             if (double.IsInfinity(combinations) || double.IsNaN(combinations))
                 return XLError.NumberInvalid;
 
             return combinations;
         }
 
-        internal static double Combin(double n, double k)
+        internal static double Combin(CalcContext ctx, double n, double k)
         {
             if (k == 0) return 1;
 
@@ -55,6 +55,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             double result = 1;
             for (var i = 1; i <= k; i++, n--)
             {
+                ctx.ThrowIfCancelled();
                 result *= n;
                 result /= i;
             }

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -9,20 +9,22 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         public XLMatrix L;
         public XLMatrix U;
         public int cols;
+        private readonly CalcContext _ctx;
         private double detOfP = 1;
         public double[,] mat;
         private int[] pi;
         public int rows;
 
-        public XLMatrix(int iRows, int iCols) // XLMatrix Class constructor
+        private XLMatrix(int iRows, int iCols, CalcContext ctx) // XLMatrix Class constructor
         {
             rows = iRows;
             cols = iCols;
+            _ctx = ctx;
             mat = new double[rows, cols];
         }
 
-        public XLMatrix(Double[,] arr)
-            : this(arr.GetLength(0), arr.GetLength(1))
+        public XLMatrix(Double[,] arr, CalcContext ctx)
+            : this(arr.GetLength(0), arr.GetLength(1), ctx)
         {
             var roCount = arr.GetLength(0);
             var coCount = arr.GetLength(1);
@@ -47,6 +49,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             {
                 for (var col = 0; col < cols; col++)
                 {
+                    _ctx.ThrowIfCancelled();
                     var element = mat[row, col];
                     if (double.IsNaN(element) || double.IsInfinity(element))
                         return true;
@@ -73,7 +76,11 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             U = Duplicate();
 
             pi = new int[rows];
-            for (var i = 0; i < rows; i++) pi[i] = i;
+            for (var i = 0; i < rows; i++)
+            {
+                _ctx.ThrowIfCancelled();
+                pi[i] = i;
+            }
 
             var k0 = 0;
 
@@ -82,6 +89,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 double p = 0;
                 for (var i = k; i < rows; i++) // find the row with the biggest pivot
                 {
+                    _ctx.ThrowIfCancelled();
                     if (Math.Abs(U[i, k]) > p)
                     {
                         p = Math.Abs(U[i, k]);
@@ -98,6 +106,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 double pom2;
                 for (var i = 0; i < k; i++)
                 {
+                    _ctx.ThrowIfCancelled();
                     pom2 = L[k, i];
                     L[k, i] = L[k0, i];
                     L[k0, i] = pom2;
@@ -107,6 +116,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
                 for (var i = 0; i < cols; i++) // Switch rows in U
                 {
+                    _ctx.ThrowIfCancelled();
                     pom2 = U[k, i];
                     U[k, i] = U[k0, i];
                     U[k0, i] = pom2;
@@ -116,7 +126,10 @@ namespace ClosedXML.Excel.CalcEngine.Functions
                 {
                     L[i, k] = U[i, k] / U[k, k];
                     for (var j = k; j < cols; j++)
+                    {
+                        _ctx.ThrowIfCancelled();
                         U[i, j] = U[i, j] - L[i, k] * U[k, j];
+                    }
                 }
             }
         }
@@ -127,8 +140,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             if (rows != v.rows) throw new ArgumentException("Wrong number of results in solution vector!");
             if (L == null) MakeLU();
 
-            var b = new XLMatrix(rows, 1);
-            for (var i = 0; i < rows; i++) b[i, 0] = v[pi[i], 0]; // switch two items in "v" due to permutation matrix
+            var b = new XLMatrix(rows, 1, _ctx);
+            for (var i = 0; i < rows; i++)
+            {
+                _ctx.ThrowIfCancelled();
+                b[i, 0] = v[pi[i], 0]; // switch two items in "v" due to permutation matrix
+            }
 
             var z = SubsForth(L, b);
             var x = SubsBack(U, z);
@@ -140,7 +157,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         {
             if (L == null) MakeLU();
 
-            var inv = new XLMatrix(rows, cols);
+            var inv = new XLMatrix(rows, cols, _ctx);
 
             for (var i = 0; i < rows; i++)
             {
@@ -162,38 +179,52 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         public XLMatrix Duplicate() // Function returns the copy of this matrix
         {
-            var matrix = new XLMatrix(rows, cols);
+            var matrix = new XLMatrix(rows, cols, _ctx);
             for (var i = 0; i < rows; i++)
+            {
                 for (var j = 0; j < cols; j++)
+                {
+                    _ctx.ThrowIfCancelled();
                     matrix[i, j] = mat[i, j];
+                }
+            }
+
             return matrix;
         }
 
-        public static XLMatrix SubsForth(XLMatrix A, XLMatrix b) // Function solves Ax = b for A as a lower triangular matrix
+        public XLMatrix SubsForth(XLMatrix A, XLMatrix b) // Function solves Ax = b for A as a lower triangular matrix
         {
             if (A.L == null) A.MakeLU();
             var n = A.rows;
-            var x = new XLMatrix(n, 1);
+            var x = new XLMatrix(n, 1, _ctx);
 
             for (var i = 0; i < n; i++)
             {
                 x[i, 0] = b[i, 0];
-                for (var j = 0; j < i; j++) x[i, 0] -= A[i, j] * x[j, 0];
+                for (var j = 0; j < i; j++)
+                {
+                    _ctx.ThrowIfCancelled();
+                    x[i, 0] -= A[i, j] * x[j, 0];
+                }
                 x[i, 0] = x[i, 0] / A[i, i];
             }
             return x;
         }
 
-        public static XLMatrix SubsBack(XLMatrix A, XLMatrix b) // Function solves Ax = b for A as an upper triangular matrix
+        public XLMatrix SubsBack(XLMatrix A, XLMatrix b) // Function solves Ax = b for A as an upper triangular matrix
         {
             if (A.L == null) A.MakeLU();
             var n = A.rows;
-            var x = new XLMatrix(n, 1);
+            var x = new XLMatrix(n, 1, _ctx);
 
             for (var i = n - 1; i > -1; i--)
             {
                 x[i, 0] = b[i, 0];
-                for (var j = n - 1; j > i; j--) x[i, 0] -= A[i, j] * x[j, 0];
+                for (var j = n - 1; j > i; j--)
+                {
+                    _ctx.ThrowIfCancelled();
+                    x[i, 0] -= A[i, j] * x[j, 0];
+                }
                 x[i, 0] = x[i, 0] / A[i, i];
             }
             return x;
@@ -201,11 +232,12 @@ namespace ClosedXML.Excel.CalcEngine.Functions
 
         public XLMatrix ZeroMatrix(int iRows, int iCols) // Function generates the zero matrix
         {
-            var matrix = new XLMatrix(iRows, iCols);
+            var matrix = new XLMatrix(iRows, iCols, _ctx);
             for (var i = 0; i < iRows; i++)
             {
                 for (var j = 0; j < iCols; j++)
                 {
+                    _ctx.ThrowIfCancelled();
                     matrix[i, j] = 0;
                 }
             }
@@ -218,6 +250,7 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var matrix = ZeroMatrix(iRows, iCols);
             for (var i = 0; i < Math.Min(iRows, iCols); i++)
             {
+                _ctx.ThrowIfCancelled();
                 matrix[i, i] = 1;
             }
 

--- a/ClosedXML/Excel/CalcEngine/Functions/XLMatrix.cs
+++ b/ClosedXML/Excel/CalcEngine/Functions/XLMatrix.cs
@@ -1,7 +1,6 @@
 #nullable disable
 
 using System;
-using System.Text.RegularExpressions;
 
 namespace ClosedXML.Excel.CalcEngine.Functions
 {
@@ -60,13 +59,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
         public Boolean IsSquare()
         {
             return (rows == cols);
-        }
-
-        public XLMatrix GetCol(int k)
-        {
-            var m = new XLMatrix(rows, 1);
-            for (var i = 0; i < rows; i++) m[i, 0] = mat[i, k];
-            return m;
         }
 
         public void SetCol(XLMatrix v, int k)
@@ -129,7 +121,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             }
         }
 
-
         public XLMatrix SolveWith(XLMatrix v) // Function solves Ax = v in conformity with solution vector "v"
         {
             if (rows != cols) throw new InvalidOperationException("The matrix is not square!");
@@ -167,15 +158,6 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             var det = detOfP;
             for (var i = 0; i < rows; i++) det *= U[i, i];
             return det;
-        }
-
-        public XLMatrix GetP() // Function returns permutation matrix "P" due to permutation vector "pi"
-        {
-            if (L == null) MakeLU();
-
-            var matrix = ZeroMatrix(rows, cols);
-            for (var i = 0; i < rows; i++) matrix[pi[i], i] = 1;
-            return matrix;
         }
 
         public XLMatrix Duplicate() // Function returns the copy of this matrix
@@ -217,393 +199,29 @@ namespace ClosedXML.Excel.CalcEngine.Functions
             return x;
         }
 
-        public static XLMatrix ZeroMatrix(int iRows, int iCols) // Function generates the zero matrix
+        public XLMatrix ZeroMatrix(int iRows, int iCols) // Function generates the zero matrix
         {
             var matrix = new XLMatrix(iRows, iCols);
             for (var i = 0; i < iRows; i++)
+            {
                 for (var j = 0; j < iCols; j++)
+                {
                     matrix[i, j] = 0;
+                }
+            }
+
             return matrix;
         }
 
-        public static XLMatrix IdentityMatrix(int iRows, int iCols) // Function generates the identity matrix
+        public XLMatrix IdentityMatrix(int iRows, int iCols) // Function generates the identity matrix
         {
             var matrix = ZeroMatrix(iRows, iCols);
             for (var i = 0; i < Math.Min(iRows, iCols); i++)
+            {
                 matrix[i, i] = 1;
+            }
+
             return matrix;
-        }
-
-        public static XLMatrix RandomMatrix(int iRows, int iCols, int dispersion) // Function generates the zero matrix
-        {
-            var random = new Random();
-            var matrix = new XLMatrix(iRows, iCols);
-            for (var i = 0; i < iRows; i++)
-                for (var j = 0; j < iCols; j++)
-                    matrix[i, j] = random.Next(-dispersion, dispersion);
-            return matrix;
-        }
-
-        public static XLMatrix Parse(string ps) // Function parses the matrix from string
-        {
-            var s = NormalizeMatrixString(ps);
-            var rows = Regex.Split(s, "\r\n");
-            var nums = rows[0].Split(' ');
-            var matrix = new XLMatrix(rows.Length, nums.Length);
-            try
-            {
-                for (var i = 0; i < rows.Length; i++)
-                {
-                    nums = rows[i].Split(' ');
-                    for (var j = 0; j < nums.Length; j++) matrix[i, j] = double.Parse(nums[j]);
-                }
-            }
-            catch (FormatException fe)
-            {
-                throw new FormatException("Wrong input format!", fe);
-            }
-            return matrix;
-        }
-
-        public override string ToString() // Function returns matrix as a string
-        {
-            var s = "";
-            for (var i = 0; i < rows; i++)
-            {
-                for (var j = 0; j < cols; j++) s += String.Format("{0,5:0.00}", mat[i, j]) + " ";
-                s += "\r\n";
-            }
-            return s;
-        }
-
-        public static XLMatrix Transpose(XLMatrix m) // XLMatrix transpose, for any rectangular matrix
-        {
-            var t = new XLMatrix(m.cols, m.rows);
-            for (var i = 0; i < m.rows; i++)
-                for (var j = 0; j < m.cols; j++)
-                    t[j, i] = m[i, j];
-            return t;
-        }
-
-        public static XLMatrix Power(XLMatrix m, int pow) // Power matrix to exponent
-        {
-            if (pow == 0) return IdentityMatrix(m.rows, m.cols);
-            if (pow == 1) return m.Duplicate();
-            if (pow == -1) return m.Invert();
-
-            XLMatrix x;
-            if (pow < 0)
-            {
-                x = m.Invert();
-                pow *= -1;
-            }
-            else x = m.Duplicate();
-
-            var ret = IdentityMatrix(m.rows, m.cols);
-            while (pow != 0)
-            {
-                if ((pow & 1) == 1) ret *= x;
-                x *= x;
-                pow >>= 1;
-            }
-            return ret;
-        }
-
-        private static void SafeAplusBintoC(XLMatrix A, int xa, int ya, XLMatrix B, int xb, int yb, XLMatrix C, int size)
-        {
-            for (var i = 0; i < size; i++) // rows
-                for (var j = 0; j < size; j++) // cols
-                {
-                    C[i, j] = 0;
-                    if (xa + j < A.cols && ya + i < A.rows) C[i, j] += A[ya + i, xa + j];
-                    if (xb + j < B.cols && yb + i < B.rows) C[i, j] += B[yb + i, xb + j];
-                }
-        }
-
-        private static void SafeAminusBintoC(XLMatrix A, int xa, int ya, XLMatrix B, int xb, int yb, XLMatrix C, int size)
-        {
-            for (var i = 0; i < size; i++) // rows
-                for (var j = 0; j < size; j++) // cols
-                {
-                    C[i, j] = 0;
-                    if (xa + j < A.cols && ya + i < A.rows) C[i, j] += A[ya + i, xa + j];
-                    if (xb + j < B.cols && yb + i < B.rows) C[i, j] -= B[yb + i, xb + j];
-                }
-        }
-
-        private static void SafeACopytoC(XLMatrix A, int xa, int ya, XLMatrix C, int size)
-        {
-            for (var i = 0; i < size; i++) // rows
-                for (var j = 0; j < size; j++) // cols
-                {
-                    C[i, j] = 0;
-                    if (xa + j < A.cols && ya + i < A.rows) C[i, j] += A[ya + i, xa + j];
-                }
-        }
-
-        private static void AplusBintoC(XLMatrix A, int xa, int ya, XLMatrix B, int xb, int yb, XLMatrix C, int size)
-        {
-            for (var i = 0; i < size; i++) // rows
-                for (var j = 0; j < size; j++) C[i, j] = A[ya + i, xa + j] + B[yb + i, xb + j];
-        }
-
-        private static void AminusBintoC(XLMatrix A, int xa, int ya, XLMatrix B, int xb, int yb, XLMatrix C, int size)
-        {
-            for (var i = 0; i < size; i++) // rows
-                for (var j = 0; j < size; j++) C[i, j] = A[ya + i, xa + j] - B[yb + i, xb + j];
-        }
-
-        private static void ACopytoC(XLMatrix A, int xa, int ya, XLMatrix C, int size)
-        {
-            for (var i = 0; i < size; i++) // rows
-                for (var j = 0; j < size; j++) C[i, j] = A[ya + i, xa + j];
-        }
-
-        private static XLMatrix StrassenMultiply(XLMatrix A, XLMatrix B) // Smart matrix multiplication
-        {
-            if (A.cols != B.rows) throw new ArgumentException("Wrong dimension of matrix!");
-
-            XLMatrix R;
-
-            var msize = Math.Max(Math.Max(A.rows, A.cols), Math.Max(B.rows, B.cols));
-
-            if (msize < 32)
-            {
-                R = ZeroMatrix(A.rows, B.cols);
-                for (var i = 0; i < R.rows; i++)
-                    for (var j = 0; j < R.cols; j++)
-                        for (var k = 0; k < A.cols; k++)
-                            R[i, j] += A[i, k] * B[k, j];
-                return R;
-            }
-
-            var size = 1;
-            var n = 0;
-            while (msize > size)
-            {
-                size *= 2;
-                n++;
-            }
-
-            var h = size / 2;
-
-            var mField = new XLMatrix[n, 9];
-
-            /*
-             *  8x8, 8x8, 8x8, ...
-             *  4x4, 4x4, 4x4, ...
-             *  2x2, 2x2, 2x2, ...
-             *  . . .
-             */
-
-            for (var i = 0; i < n - 4; i++) // rows
-            {
-                var z = (int)Math.Pow(2, n - i - 1);
-                for (var j = 0; j < 9; j++) mField[i, j] = new XLMatrix(z, z);
-            }
-
-            SafeAplusBintoC(A, 0, 0, A, h, h, mField[0, 0], h);
-            SafeAplusBintoC(B, 0, 0, B, h, h, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 1], 1, mField); // (A11 + A22) * (B11 + B22);
-
-            SafeAplusBintoC(A, 0, h, A, h, h, mField[0, 0], h);
-            SafeACopytoC(B, 0, 0, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 2], 1, mField); // (A21 + A22) * B11;
-
-            SafeACopytoC(A, 0, 0, mField[0, 0], h);
-            SafeAminusBintoC(B, h, 0, B, h, h, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 3], 1, mField); //A11 * (B12 - B22);
-
-            SafeACopytoC(A, h, h, mField[0, 0], h);
-            SafeAminusBintoC(B, 0, h, B, 0, 0, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 4], 1, mField); //A22 * (B21 - B11);
-
-            SafeAplusBintoC(A, 0, 0, A, h, 0, mField[0, 0], h);
-            SafeACopytoC(B, h, h, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 5], 1, mField); //(A11 + A12) * B22;
-
-            SafeAminusBintoC(A, 0, h, A, 0, 0, mField[0, 0], h);
-            SafeAplusBintoC(B, 0, 0, B, h, 0, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 6], 1, mField); //(A21 - A11) * (B11 + B12);
-
-            SafeAminusBintoC(A, h, 0, A, h, h, mField[0, 0], h);
-            SafeAplusBintoC(B, 0, h, B, h, h, mField[0, 1], h);
-            StrassenMultiplyRun(mField[0, 0], mField[0, 1], mField[0, 1 + 7], 1, mField); // (A12 - A22) * (B21 + B22);
-
-            R = new XLMatrix(A.rows, B.cols); // result
-
-            // C11
-            for (var i = 0; i < Math.Min(h, R.rows); i++) // rows
-                for (var j = 0; j < Math.Min(h, R.cols); j++) // cols
-                    R[i, j] = mField[0, 1 + 1][i, j] + mField[0, 1 + 4][i, j] - mField[0, 1 + 5][i, j] +
-                              mField[0, 1 + 7][i, j];
-
-            // C12
-            for (var i = 0; i < Math.Min(h, R.rows); i++) // rows
-                for (var j = h; j < Math.Min(2 * h, R.cols); j++) // cols
-                    R[i, j] = mField[0, 1 + 3][i, j - h] + mField[0, 1 + 5][i, j - h];
-
-            // C21
-            for (var i = h; i < Math.Min(2 * h, R.rows); i++) // rows
-                for (var j = 0; j < Math.Min(h, R.cols); j++) // cols
-                    R[i, j] = mField[0, 1 + 2][i - h, j] + mField[0, 1 + 4][i - h, j];
-
-            // C22
-            for (var i = h; i < Math.Min(2 * h, R.rows); i++) // rows
-                for (var j = h; j < Math.Min(2 * h, R.cols); j++) // cols
-                    R[i, j] = mField[0, 1 + 1][i - h, j - h] - mField[0, 1 + 2][i - h, j - h] +
-                              mField[0, 1 + 3][i - h, j - h] + mField[0, 1 + 6][i - h, j - h];
-
-            return R;
-        }
-
-        // function for square matrix 2^N x 2^N
-
-        private static void StrassenMultiplyRun(XLMatrix A, XLMatrix B, XLMatrix C, int l, XLMatrix[,] f)
-        // A * B into C, level of recursion, matrix field
-        {
-            var size = A.rows;
-            var h = size / 2;
-
-            if (size < 32)
-            {
-                for (var i = 0; i < C.rows; i++)
-                    for (var j = 0; j < C.cols; j++)
-                    {
-                        C[i, j] = 0;
-                        for (var k = 0; k < A.cols; k++) C[i, j] += A[i, k] * B[k, j];
-                    }
-                return;
-            }
-
-            AplusBintoC(A, 0, 0, A, h, h, f[l, 0], h);
-            AplusBintoC(B, 0, 0, B, h, h, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 1], l + 1, f); // (A11 + A22) * (B11 + B22);
-
-            AplusBintoC(A, 0, h, A, h, h, f[l, 0], h);
-            ACopytoC(B, 0, 0, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 2], l + 1, f); // (A21 + A22) * B11;
-
-            ACopytoC(A, 0, 0, f[l, 0], h);
-            AminusBintoC(B, h, 0, B, h, h, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 3], l + 1, f); //A11 * (B12 - B22);
-
-            ACopytoC(A, h, h, f[l, 0], h);
-            AminusBintoC(B, 0, h, B, 0, 0, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 4], l + 1, f); //A22 * (B21 - B11);
-
-            AplusBintoC(A, 0, 0, A, h, 0, f[l, 0], h);
-            ACopytoC(B, h, h, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 5], l + 1, f); //(A11 + A12) * B22;
-
-            AminusBintoC(A, 0, h, A, 0, 0, f[l, 0], h);
-            AplusBintoC(B, 0, 0, B, h, 0, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 6], l + 1, f); //(A21 - A11) * (B11 + B12);
-
-            AminusBintoC(A, h, 0, A, h, h, f[l, 0], h);
-            AplusBintoC(B, 0, h, B, h, h, f[l, 1], h);
-            StrassenMultiplyRun(f[l, 0], f[l, 1], f[l, 1 + 7], l + 1, f); // (A12 - A22) * (B21 + B22);
-
-            // C11
-            for (var i = 0; i < h; i++) // rows
-                for (var j = 0; j < h; j++) // cols
-                    C[i, j] = f[l, 1 + 1][i, j] + f[l, 1 + 4][i, j] - f[l, 1 + 5][i, j] + f[l, 1 + 7][i, j];
-
-            // C12
-            for (var i = 0; i < h; i++) // rows
-                for (var j = h; j < size; j++) // cols
-                    C[i, j] = f[l, 1 + 3][i, j - h] + f[l, 1 + 5][i, j - h];
-
-            // C21
-            for (var i = h; i < size; i++) // rows
-                for (var j = 0; j < h; j++) // cols
-                    C[i, j] = f[l, 1 + 2][i - h, j] + f[l, 1 + 4][i - h, j];
-
-            // C22
-            for (var i = h; i < size; i++) // rows
-                for (var j = h; j < size; j++) // cols
-                    C[i, j] = f[l, 1 + 1][i - h, j - h] - f[l, 1 + 2][i - h, j - h] + f[l, 1 + 3][i - h, j - h] +
-                              f[l, 1 + 6][i - h, j - h];
-        }
-
-        public static XLMatrix StupidMultiply(XLMatrix m1, XLMatrix m2) // Stupid matrix multiplication
-        {
-            if (m1.cols != m2.rows) throw new ArgumentException("Wrong dimensions of matrix!");
-
-            var result = ZeroMatrix(m1.rows, m2.cols);
-            for (var i = 0; i < result.rows; i++)
-                for (var j = 0; j < result.cols; j++)
-                    for (var k = 0; k < m1.cols; k++)
-                        result[i, j] += m1[i, k] * m2[k, j];
-            return result;
-        }
-
-        private static XLMatrix Multiply(double n, XLMatrix m) // Multiplication by constant n
-        {
-            var r = new XLMatrix(m.rows, m.cols);
-            for (var i = 0; i < m.rows; i++)
-                for (var j = 0; j < m.cols; j++)
-                    r[i, j] = m[i, j] * n;
-            return r;
-        }
-
-        private static XLMatrix Add(XLMatrix m1, XLMatrix m2)
-        {
-            if (m1.rows != m2.rows || m1.cols != m2.cols)
-                throw new ArgumentException("Matrices must have the same dimensions!");
-            var r = new XLMatrix(m1.rows, m1.cols);
-            for (var i = 0; i < r.rows; i++)
-                for (var j = 0; j < r.cols; j++)
-                    r[i, j] = m1[i, j] + m2[i, j];
-            return r;
-        }
-
-        public static string NormalizeMatrixString(string matStr) // From Andy - thank you! :)
-        {
-            // Remove any multiple spaces
-            while (matStr.IndexOf("  ") != -1)
-                matStr = matStr.Replace("  ", " ");
-
-            // Remove any spaces before or after newlines
-            matStr = matStr.Replace(" \r\n", "\r\n");
-            matStr = matStr.Replace("\r\n ", "\r\n");
-
-            // If the data ends in a newline, remove the trailing newline.
-            // Make it easier by first replacing \r\n’s with |’s then
-            // restore the |’s with \r\n’s
-            matStr = matStr.Replace("\r\n", "|");
-            while (matStr.LastIndexOf("|") == (matStr.Length - 1))
-                matStr = matStr.Substring(0, matStr.Length - 1);
-
-            matStr = matStr.Replace("|", "\r\n");
-            return matStr;
-        }
-
-        //   O P E R A T O R S
-
-        public static XLMatrix operator -(XLMatrix m)
-        {
-            return Multiply(-1, m);
-        }
-
-        public static XLMatrix operator +(XLMatrix m1, XLMatrix m2)
-        {
-            return Add(m1, m2);
-        }
-
-        public static XLMatrix operator -(XLMatrix m1, XLMatrix m2)
-        {
-            return Add(m1, -m2);
-        }
-
-        public static XLMatrix operator *(XLMatrix m1, XLMatrix m2)
-        {
-            return StrassenMultiply(m1, m2);
-        }
-
-        public static XLMatrix operator *(double n, XLMatrix m)
-        {
-            return Multiply(n, m);
         }
     }
 }

--- a/ClosedXML/Excel/LoadOptions.cs
+++ b/ClosedXML/Excel/LoadOptions.cs
@@ -1,6 +1,7 @@
 // Keep this file CodeMaid organized and cleaned
 using System;
 using System.Drawing;
+using System.Threading;
 using ClosedXML.Graphics;
 
 namespace ClosedXML.Excel
@@ -67,5 +68,12 @@ namespace ClosedXML.Excel
         /// OpenXML SDK are not affected. Also, fix an OOXML producer that does this stuff.
         /// </remarks>
         public bool StrictAttributeParsing { get; set; } = true;
+
+        /// <summary>
+        /// A cancellation token to cancel recalculation. Recalculation may be triggered during
+        /// various calls, e.g. <c>IXLCell.Value</c> can start recalculation of a workbook, but
+        /// doesn't have a way to pass token.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
     }
 }

--- a/ClosedXML/Excel/XLWorkbook.cs
+++ b/ClosedXML/Excel/XLWorkbook.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using static ClosedXML.Excel.XLProtectionAlgorithm;
 
 namespace ClosedXML.Excel
@@ -128,6 +129,8 @@ namespace ClosedXML.Excel
 
         /// <inheritdoc cref="LoadOptions.StrictAttributeParsing"/>
         internal bool StrictAttributeParsing { get; }
+
+        internal CancellationToken CancellationToken { get; }
 
         internal XLPivotCaches PivotCachesInternal { get; }
 
@@ -796,6 +799,7 @@ namespace ClosedXML.Excel
             DpiY = loadOptions.Dpi.Y;
             StrictAttributeParsing = loadOptions.StrictAttributeParsing;
             GraphicEngine = loadOptions.GraphicEngine ?? LoadOptions.DefaultGraphicEngine ?? DefaultGraphicEngine.Instance.Value;
+            CancellationToken = loadOptions.CancellationToken;
             Protection = new XLWorkbookProtection(DefaultProtectionAlgorithm);
             DefaultRowHeight = 15;
             DefaultColumnWidth = 8.43;


### PR DESCRIPTION
Add cancellation token to `LoadOptions`. The use case for now is a cancellation of recalculation. The recalculation checks the token and throws if it was cancelled. Recalculation can be called in the background during various calls, e.g. `IXLCell.Value` where it isn't possible to pass token. In the long run, it should also be usable for loading and saving (OpenXML SDK doesn't support that right now https://github.com/dotnet/Open-XML-SDK/issues/1490).

Related to #1407