### PR TITLE
Remove unnecessary picture name validations

### DIFF
--- a/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
+++ b/ClosedXML.Tests/Excel/ImageHandling/PictureTests.cs
@@ -480,5 +480,63 @@ namespace ClosedXML.Tests
                 () => new XLWorkbook(stream),
                 @"Other\Pictures\ImageShapeZOrder-Output.xlsx");
         }
+
+        [TestCase("@")]
+        [TestCase(":")]
+        [TestCase("\\")]
+        [TestCase("/")]
+        [TestCase("?")]
+        [TestCase("*")]
+        [TestCase("[]")]
+        [TestCase(" ")] // Whitespace name is allowed, but can't be empty
+        [TestCase("C:\\Images\\pic.jpg")] // Path with multiple forbidden chars
+        [TestCase("http://example.com/image.jpg")] // URL with multiple forbidden chars
+        [TestCase("Picture@01\\QPosted@")] // A name from a problematic workbook
+        public void PictureCanHaveUnusualCharactersInName(string nameWithUnusualCharacter)
+        {
+            // The name of a picture couldn't contain certain characters in some ancient version of Excel. Verify that
+            // it is no longer the case through the whole lifecycle (add picture, change name, save, load).
+            AssertPictureNameAllowed(nameWithUnusualCharacter);
+        }
+
+        [Test]
+        public void PictureNameCanBeLong()
+        {
+            // Picture name was originally limited to 31 characters. Verify that it is no longer the case.
+            var longName = new string('a', 100_000);
+            AssertPictureNameAllowed(longName);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void PictureNameCantBeNullOrEmpty(string invalidName)
+        {
+            // Picture name is a required attribute, though Excel generates a name if it isn't specified instead of failing.
+            using var wb = new XLWorkbook();
+            var ws = wb.AddWorksheet();
+
+            using var imageStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png");
+            var picture = ws.AddPicture(imageStream);
+            Assert.Throws<ArgumentException>(() => picture.Name = invalidName);
+        }
+
+        private static void AssertPictureNameAllowed(string testedName)
+        {
+            TestHelper.CreateSaveLoadAssert(
+                wb =>
+                {
+                    using var imageStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ClosedXML.Tests.Resource.Images.ImageHandling.png");
+                    var ws1 = wb.AddWorksheet("AddPicture");
+                    ws1.AddPicture(imageStream, testedName);
+
+                    var ws2 = wb.AddWorksheet("Setter");
+                    var picture = ws2.AddPicture(imageStream);
+                    picture.Name = testedName;
+                }, wb =>
+                {
+                    Assert.AreEqual(testedName, wb.Worksheet("AddPicture").Pictures.Single().Name);
+                    Assert.AreEqual(testedName, wb.Worksheet("Setter").Pictures.Single().Name);
+                });
+        }
     }
 }

--- a/ClosedXML.Tests/TestHelper.cs
+++ b/ClosedXML.Tests/TestHelper.cs
@@ -279,5 +279,24 @@ namespace ClosedXML.Tests
                 assertLoadedWorkbook(wb, ws);
             }
         }
+
+        /// <summary>
+        /// Test if some aspect of a workbook can survive through save and load cycle.
+        /// </summary>
+        public static void CreateSaveLoadAssert(Action<XLWorkbook> createWorksheet, Action<XLWorkbook> assertLoadedWorkbook, bool validate = true, bool evaluateFormulas = false)
+        {
+            using var ms = new MemoryStream();
+            using (var wb = new XLWorkbook())
+            {
+                createWorksheet(wb);
+                wb.SaveAs(ms, validate, evaluateFormulas);
+            }
+
+            ms.Position = 0;
+            using (var wb = new XLWorkbook(ms))
+            {
+                assertLoadedWorkbook(wb);
+            }
+        }
     }
 }

--- a/ClosedXML/Excel/Drawings/IXLPicture.cs
+++ b/ClosedXML/Excel/Drawings/IXLPicture.cs
@@ -33,6 +33,10 @@ namespace ClosedXML.Excel.Drawings
 
         Int32 Left { get; set; }
 
+        /// <summary>
+        /// Set the name of a picture.
+        /// </summary>
+        /// <exception cref="ArgumentException">Name is already used in the sheet, is null or empty.</exception>
         String Name { get; set; }
 
         /// <summary>

--- a/ClosedXML/Excel/Drawings/XLPicture.cs
+++ b/ClosedXML/Excel/Drawings/XLPicture.cs
@@ -14,7 +14,6 @@ namespace ClosedXML.Excel.Drawings
     [DebuggerDisplay("{Name}")]
     internal class XLPicture : IXLPicture
     {
-        private const String InvalidNameChars = @":\/?*[]";
         private Int32 _height;
         private Int32 _id;
         private String _name = string.Empty;
@@ -338,14 +337,8 @@ namespace ClosedXML.Excel.Drawings
 
         internal void SetName(string value)
         {
-            if (String.IsNullOrWhiteSpace(value))
-                throw new ArgumentException("Picture names cannot be empty");
-
-            if (value.IndexOfAny(InvalidNameChars.ToCharArray()) != -1)
-                throw new ArgumentException($"Picture names cannot contain any of the following characters: {InvalidNameChars}");
-
-            if (value.Length > 31)
-                throw new ArgumentException("Picture names cannot be more than 31 characters");
+            if (String.IsNullOrEmpty(value))
+                throw new ArgumentException("Picture names cannot be null or empty.");
 
             _name = value;
         }


### PR DESCRIPTION
New Excels (at least 2016+) can read long excel picture names and allow unusual characters (?/\[]). The code contained validations that are no longer required by Excel and there are real workbooks that hit these limits.

Remove the limits, both on unusual characters and length. The OOXML only requires `xsd:string` type.

The "null or whitespace validation" was also relaxed to "null or empty" Excel is fine with whitespace names. It doesn't crash on empty string, but generates a dummy name -> empty check was kept.

Supplants #2716, #2715
