### PR TITLE
Update NUnit

### DIFF
--- a/ClosedXML.Tests/ClosedXML.Tests.csproj
+++ b/ClosedXML.Tests/ClosedXML.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
@@ -31,6 +31,11 @@
   <ItemGroup>
     <ProjectReference Include="..\ClosedXML\ClosedXML.csproj" />
     <ProjectReference Include="..\ClosedXML.Examples\ClosedXML.Examples.csproj" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <!-- Custom global usings added in the csproj file -->
+    <Using Include="NUnit.Framework.Legacy" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/ArithmeticOperatorsTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 
@@ -125,7 +125,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1^4", 0.0)]
         public void Exponentiation_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue).Within(XLHelper.Epsilon));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion
@@ -148,7 +148,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("A1*10", 0.0)]
         public void Multiplication_CanWorkWithScalars(string formula, object expectedValue)
         {
-            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue).Within(XLHelper.Epsilon));
+            Assert.That(Evaluate(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/FormulaParserTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using ClosedXML.Excel.CalcEngine;
 using NUnit.Framework;
 using System;
@@ -184,7 +184,7 @@ namespace ClosedXML.Tests.Excel.CalcEngine
         [TestCase("=PMT(0,1,1000,,1)", -1000)]
         public void Empty_arguments_are_passed_to_function(string formula, object expectedValue)
         {
-            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue).Within(XLHelper.Epsilon));
+            Assert.That(XLWorkbook.EvaluateExpr(formula), Is.EqualTo(expectedValue));
         }
 
         #endregion

--- a/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
@@ -59,7 +59,7 @@ namespace ClosedXML.Tests.Excel.InsertData
         }
 
         [TestCaseSource(nameof(ArraySources))]
-        public void CanCreateArrayReader<T>(IEnumerable<T> data)
+        public void CanCreateArrayReader(IEnumerable data)
         {
             var reader = InsertDataReaderFactory.Instance.CreateReader(data);
 

--- a/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
+++ b/ClosedXML.Tests/Excel/InsertData/InsertDataReaderFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel.InsertData;
+using ClosedXML.Excel.InsertData;
 using NUnit.Framework;
 using System;
 using System.Collections;

--- a/ClosedXML.Tests/Excel/Sparklines/SparklinesTests.cs
+++ b/ClosedXML.Tests/Excel/Sparklines/SparklinesTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Examples.Sparklines;
+using ClosedXML.Examples.Sparklines;
 using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
@@ -727,8 +727,8 @@ namespace ClosedXML.Tests.Excel.Sparklines
                 Assert.IsTrue(group.HorizontalAxis.RightToLeft);
                 Assert.IsTrue(group.HorizontalAxis.DateAxis);
 
-                Assert.AreEqual(6.6, group.VerticalAxis.ManualMax, XLHelper.Epsilon);
-                Assert.AreEqual(1.2, group.VerticalAxis.ManualMin, XLHelper.Epsilon);
+                Assert.AreEqual(6.6, group.VerticalAxis.ManualMax.Value, XLHelper.Epsilon);
+                Assert.AreEqual(1.2, group.VerticalAxis.ManualMin.Value, XLHelper.Epsilon);
                 Assert.AreEqual(XLSparklineAxisMinMax.Custom, group.VerticalAxis.MaxAxisType);
                 Assert.AreEqual(XLSparklineAxisMinMax.Custom, group.VerticalAxis.MinAxisType);
             }
@@ -893,7 +893,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             axis.ManualMin = 100;
 
-            Assert.AreEqual(100, axis.ManualMin, XLHelper.Epsilon);
+            Assert.AreEqual(100, axis.ManualMin.Value, XLHelper.Epsilon);
             Assert.AreEqual(XLSparklineAxisMinMax.Custom, axis.MinAxisType);
         }
 
@@ -907,7 +907,7 @@ namespace ClosedXML.Tests.Excel.Sparklines
 
             axis.ManualMax = 100;
 
-            Assert.AreEqual(100, axis.ManualMax, XLHelper.Epsilon);
+            Assert.AreEqual(100, axis.ManualMax.Value, XLHelper.Epsilon);
             Assert.AreEqual(XLSparklineAxisMinMax.Custom, axis.MaxAxisType);
         }
 

--- a/ClosedXML.Tests/Excel/Styles/BorderTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/BorderTests.cs
@@ -110,7 +110,11 @@ namespace ClosedXML.Tests.Excel.Styles
         }
 
         [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
+#if NETFRAMEWORK
         [Timeout(100)]
+#else
+        [MaxTime(100)]
+#endif
         public void OutsideBorder_for_column()
         {
             using var wb = new XLWorkbook();
@@ -140,7 +144,11 @@ namespace ClosedXML.Tests.Excel.Styles
         }
 
         [Test, Ignore("Performance reasons")] // TODO Styles: Enable after switch
+#if NETFRAMEWORK
         [Timeout(100)]
+#else
+        [MaxTime(100)]
+#endif
         public void InsideBorder_for_one_column()
         {
             using var wb = new XLWorkbook();


### PR DESCRIPTION
Resolves #2834

During update, there was a small issue with a generic test `InsertDataReaderFactoryTests.CanCreateArrayReader<T>(IEnumerable<T>)` (tracked https://github.com/nunit/nunit/issues/5178). Because it tests a non-generic method `CreateReader(IEnumerable)`, it was just changed to `InsertDataReaderFactoryTests.CanCreateArrayReader(IEnumerable)`

This PR fails for now, because AppVeyor doesn't have VS2026 (NET10 C#14) image yet (https://github.com/appveyor/ci/issues/3985). Probably time to migrate to GitHub Action anyway, even with GitHub's one-nine reliability (https://mrshu.github.io/github-statuses/). CI pipeline should have to NET10 out of box.