### PR TITLE
Refactor conditional formats consolidate

### DIFF
--- a/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
+++ b/ClosedXML.Tests/Excel/Ranges/RangeIndexTest.cs
@@ -238,7 +238,7 @@ namespace ClosedXML.Tests.Excel.Ranges
                 ranges.Add(range3);
                 Assert.AreEqual(2, ranges.Count);
 
-                Assert.AreEqual(ranges.Count, ranges.Count());
+                Assert.AreEqual(ranges.Count, ranges.Count<IXLRange>());
 
                 // Add many entries to activate QuadTree
                 for (int i = 1; i <= TEST_COUNT; i++)

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -404,7 +404,7 @@ namespace ClosedXML.Tests
             var ranges = new XLRanges(wb);
             ranges.Add(ws.Range("A1:A2"));
             ranges.Add(ws.Range("B1:B2"));
-            var rangesCopy = ranges.ToList();
+            var rangesCopy = ranges.ToList<IXLRange>();
 
             ranges.RemoveAll(null, false);
             ws.FirstColumn().InsertColumnsBefore(1);
@@ -429,7 +429,7 @@ namespace ClosedXML.Tests
             ranges.RemoveAll(r => r.Intersects(otherRange));
 
             Assert.AreEqual(1, ranges.Count);
-            Assert.AreEqual("A1:A2", ranges.Single().RangeAddress.ToString());
+            Assert.AreEqual("A1:A2", ranges.Single<IXLRange>().RangeAddress.ToString());
         }
 
         [Test]
@@ -462,7 +462,7 @@ namespace ClosedXML.Tests
                 ws2.Range("A13:B14"),
             };
 
-            var actualRanges = ranges.ToList();
+            var actualRanges = ranges.ToList<IXLRange>();
 
             Assert.AreEqual(expectedRanges.Count, actualRanges.Count);
             for (int i = 0; i < actualRanges.Count; i++)

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1198,7 +1198,7 @@ namespace ClosedXML.Excel
             }
 
             var rangesToMerge = asRange.Worksheet.Internals.MergedRanges
-                .Where(mr => asRange.Contains(mr))
+                .Where<XLRange>(mr => asRange.Contains(mr))
                 .Select(mr =>
                 {
                     var firstRow = _rowNumber + (mr.RangeAddress.FirstAddress.RowNumber - asRange.RangeAddress.FirstAddress.RowNumber);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1292,7 +1292,7 @@ namespace ClosedXML.Excel
                     .Select(r => r.RangeAddress.Intersection(fromRange.RangeAddress).Relative(fromRange.RangeAddress, toRange.RangeAddress).AsRange() as XLRange)
                     .ToList();
 
-                var c = new XLConditionalFormat(Worksheet, fmtRanges, true);
+                var c = new XLConditionalFormat(Worksheet, fmtRanges);
                 c.CopyFrom(cf);
                 c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), fmtRanges.First().FirstCell());
 

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -143,7 +143,7 @@ internal class XLCells :
 
         if (_options.HasFlag(XLCellsUsedOptions.MergedRanges))
             candidates = candidates.Union(
-                worksheet.Internals.MergedRanges.SelectMany(r => GetAllCellsInRange(r.RangeAddress)));
+                worksheet.Internals.MergedRanges.SelectMany<XLRange, XLSheetPoint>(r => GetAllCellsInRange(r.RangeAddress)));
 
         if (_options.HasFlag(XLCellsUsedOptions.ConditionalFormats))
             candidates = candidates.Union(

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -38,7 +38,6 @@ namespace ClosedXML.Excel
                 var xStyle = xx.FormatValue;
                 var yStyle = yy.FormatValue;
                 return Equals(xStyle, yStyle)
-                    && xx.CopyDefaultModify == yy.CopyDefaultModify
                     && xx.ConditionalFormatType == yy.ConditionalFormatType
                     && xx.TimePeriod == yy.TimePeriod
                     && xx.IconSetStyle == yy.IconSetStyle
@@ -69,7 +68,6 @@ namespace ClosedXML.Excel
                 unchecked
                 {
                     var hashCode = xStyle.GetHashCode();
-                    hashCode = (hashCode * 397) ^ xx.CopyDefaultModify.GetHashCode();
                     hashCode = (hashCode * 397) ^ xValues.GetHashCode();
                     hashCode = (hashCode * 397) ^ (xx.Colors != null ? xx.Colors.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (xx.ContentTypes != null ? xx.ContentTypes.GetHashCode() : 0);
@@ -126,19 +124,17 @@ namespace ClosedXML.Excel
             IconSetOperators = new XLDictionary<XLCFIconSetOperator>();
         }
 
-        public XLConditionalFormat(XLWorksheet worksheet, XLRange range, Boolean copyDefaultModify = false)
+        public XLConditionalFormat(XLWorksheet worksheet, XLRange range)
             : this(worksheet)
         {
             if (range != null)
                 Ranges.Add(range);
-            CopyDefaultModify = copyDefaultModify;
         }
 
-        public XLConditionalFormat(XLWorksheet worksheet, IEnumerable<XLRange> ranges, Boolean copyDefaultModify = false)
+        public XLConditionalFormat(XLWorksheet worksheet, IEnumerable<XLRange> ranges)
             : this(worksheet)
         {
             ranges?.ForEach(range => Ranges.Add(range));
-            CopyDefaultModify = copyDefaultModify;
         }
 
         public XLConditionalFormat(XLConditionalFormat conditionalFormat, IEnumerable<IXLRange> targetRanges)
@@ -157,8 +153,6 @@ namespace ClosedXML.Excel
         /// Minimum value is 1. It is basically used for ordering of CF during saving.
         /// </summary>
         internal Int32 Priority { get; set; }
-
-        public Boolean CopyDefaultModify { get; set; }
 
         public XLDxfValue? FormatValue { get; set; }
 

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -11,18 +11,12 @@ namespace ClosedXML.Excel
     {
         private readonly XLWorksheet _worksheet;
 
-        private sealed class FullEqualityComparer : IEqualityComparer<XLConditionalFormat>
+        private sealed class NoRangeCfComparer : IEqualityComparer<XLConditionalFormat>
         {
-            private readonly bool _compareRange;
             private readonly DictionaryComparer<int, XLColor> _colorsComparer = new DictionaryComparer<int, XLColor>();
             private readonly EnumerableComparer<string> _listComparer = new EnumerableComparer<string>();
             private readonly DictionaryComparer<int, XLCFContentType> _contentsTypeComparer = new DictionaryComparer<int, XLCFContentType>();
             private readonly DictionaryComparer<int, XLCFIconSetOperator> _iconSetTypeComparer = new DictionaryComparer<int, XLCFIconSetOperator>();
-
-            public FullEqualityComparer(bool compareRange)
-            {
-                _compareRange = compareRange;
-            }
 
             public bool Equals(XLConditionalFormat xx, XLConditionalFormat yy)
             {
@@ -52,8 +46,7 @@ namespace ClosedXML.Excel
                     && _listComparer.Equals(xxFormulas, yyFormulas)
                     && _colorsComparer.Equals(xx.Colors, yy.Colors)
                     && _contentsTypeComparer.Equals(xx.ContentTypes, yy.ContentTypes)
-                    && _iconSetTypeComparer.Equals(xx.IconSetOperators, yy.IconSetOperators)
-                    && (!_compareRange || XLRanges.Equals(xx.Ranges, yy.Ranges));
+                    && _iconSetTypeComparer.Equals(xx.IconSetOperators, yy.IconSetOperators);
             }
 
             public int GetHashCode(XLConditionalFormat obj)
@@ -72,7 +65,6 @@ namespace ClosedXML.Excel
                     hashCode = (hashCode * 397) ^ (xx.Colors != null ? xx.Colors.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (xx.ContentTypes != null ? xx.ContentTypes.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (xx.IconSetOperators != null ? xx.IconSetOperators.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ (_compareRange && xx.Ranges != null ? xx.Ranges.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (int)xx.ConditionalFormatType;
                     hashCode = (hashCode * 397) ^ (int)xx.TimePeriod;
                     hashCode = (hashCode * 397) ^ (int)xx.IconSetStyle;
@@ -101,12 +93,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        private static readonly IEqualityComparer<XLConditionalFormat> NoRangeComparerInstance = new FullEqualityComparer(false);
-
-        public static IEqualityComparer<XLConditionalFormat> NoRangeComparer
-        {
-            get { return NoRangeComparerInstance; }
-        }
+        internal static IEqualityComparer<XLConditionalFormat> NoRangeComparer { get; } = new NoRangeCfComparer();
 
         #region Constructors
 

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -10,6 +10,7 @@ namespace ClosedXML.Excel
     internal class XLConditionalFormat : IXLDxfContainer, IXLConditionalFormat
     {
         private readonly XLWorksheet _worksheet;
+        private readonly XLRanges _ranges;
 
         private sealed class NoRangeCfComparer : IEqualityComparer<XLConditionalFormat>
         {
@@ -104,7 +105,7 @@ namespace ClosedXML.Excel
         {
             _worksheet = worksheet;
             Id = Guid.NewGuid();
-            Ranges = new XLRanges(worksheet);
+            _ranges = new XLRanges(worksheet);
             Values = new XLDictionary<XLFormula>();
             Colors = new XLDictionary<XLColor>();
             ContentTypes = new XLDictionary<XLCFContentType>();
@@ -128,6 +129,13 @@ namespace ClosedXML.Excel
             : this(conditionalFormat._worksheet)
         {
             targetRanges?.ForEach(range => Ranges.Add(range));
+            CopyFrom(conditionalFormat);
+        }
+
+        internal XLConditionalFormat(XLConditionalFormat conditionalFormat, XLAreaList areaList)
+            : this(conditionalFormat._worksheet)
+        {
+            areaList.ForEach(range => Ranges.Add(_worksheet.Range(range)));
             CopyFrom(conditionalFormat);
         }
 
@@ -169,7 +177,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        public IXLRanges Ranges { get; private set; }
+        public IXLRanges Ranges => _ranges;
 
         public XLConditionalFormatType ConditionalFormatType { get; set; }
 
@@ -190,6 +198,14 @@ namespace ClosedXML.Excel
         public Boolean ShowBarOnly { get; set; }
 
         public Boolean StopIfTrue { get; set; }
+
+        internal XLAreaList Areas
+        {
+            get
+            {
+                return new XLAreaList(_ranges.Select<XLRange, XLSheetRange>(range => range.SheetRange).ToList());
+            }
+        }
 
         public IXLConditionalFormat SetStopIfTrue()
         {

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -88,7 +88,7 @@ namespace ClosedXML.Excel
                 var format = formats[0];
                 if (!CFTypesExcludedFromConsolidation.Contains(format.ConditionalFormatType))
                 {
-                    var originalAnchor = format.Areas.First().FirstPoint;
+                    var originalAnchor = format.Areas[0].FirstPoint;
 
                     var (rulesToConsolidate, areasWithSameFormat) = GetConsolidateableRules(formats);
                     var consolidatedAreas = areasWithSameFormat.GetConsolidated();
@@ -99,7 +99,7 @@ namespace ClosedXML.Excel
                     foreach (var consolidatedRuleIndex in rulesToConsolidate)
                         formats.RemoveAt(consolidatedRuleIndex);
 
-                    var consolidatedAnchor = consolidatedAreas.First().FirstPoint;
+                    var consolidatedAnchor = consolidatedAreas[0].FirstPoint;
                     consolidatedCf.AdjustFormulas(_worksheet.Cell(originalAnchor), _worksheet.Cell(consolidatedAnchor));
                     format = consolidatedCf;
                 }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -101,7 +101,7 @@ namespace ClosedXML.Excel
                             var nextFormat = formats[i];
 
                             var intersectsSkipped =
-                                skippedRanges.Any(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any());
+                                skippedRanges.Any<XLRange>(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any());
 
                             var isSameFormat = IsSameFormat(nextFormat);
 
@@ -110,7 +110,7 @@ namespace ClosedXML.Excel
                                 similarFormats.Add(nextFormat);
                                 nextFormat.Ranges.ForEach(r => rangesToJoin.Add(r));
                             }
-                            else if (rangesToJoin.Any(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any()) ||
+                            else if (rangesToJoin.Any<XLRange>(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any()) ||
                                      intersectsSkipped)
                             {
                                 // if we reached the rule intersecting any of captured ranges stop for not breaking the priorities

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -58,87 +58,6 @@ namespace ClosedXML.Excel
             _conditionalFormats.RemoveAll(predicate);
         }
 
-        /// <summary>
-        /// The method consolidate the same conditional formats, which are located in adjacent ranges.
-        /// </summary>
-        internal void Consolidate()
-        {
-            var formats = _conditionalFormats
-                .Where(cf => cf.Ranges.Any())
-                .ToList();
-            _conditionalFormats.Clear();
-
-            while (formats.Count > 0)
-            {
-                var item = formats.First();
-
-                if (!CFTypesExcludedFromConsolidation.Contains(item.ConditionalFormatType))
-                {
-                    var rangesToJoin = new XLRanges(_worksheet);
-                    item.Ranges.ForEach(r => rangesToJoin.Add(r));
-                    var firstRange = item.Ranges.First();
-                    var skippedRanges = new XLRanges(_worksheet);
-                    Func<XLConditionalFormat, bool> IsSameFormat = f =>
-                        f != item && f.Ranges.First().Worksheet.Position == firstRange.Worksheet.Position &&
-                        XLConditionalFormat.NoRangeComparer.Equals(f, item);
-
-                    //Get the top left corner of the rectangle covering all the ranges
-                    var baseAddress = new XLAddress(
-                        item.Ranges.Select(r => r.RangeAddress.FirstAddress.RowNumber).Min(),
-                        item.Ranges.Select(r => r.RangeAddress.FirstAddress.ColumnNumber).Min(),
-                        false, false);
-                    var baseCell = (XLCell)firstRange.Worksheet.Cell(baseAddress);
-
-                    int i = 1;
-                    bool stop = false;
-                    var similarFormats = new List<XLConditionalFormat>();
-                    do
-                    {
-                        stop = (i >= formats.Count);
-
-                        if (!stop)
-                        {
-                            var nextFormat = formats[i];
-
-                            var intersectsSkipped =
-                                skippedRanges.Any<XLRange>(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any());
-
-                            var isSameFormat = IsSameFormat(nextFormat);
-
-                            if (isSameFormat && !intersectsSkipped)
-                            {
-                                similarFormats.Add(nextFormat);
-                                nextFormat.Ranges.ForEach(r => rangesToJoin.Add(r));
-                            }
-                            else if (rangesToJoin.Any<XLRange>(left => nextFormat.Ranges.GetIntersectedRanges(left.RangeAddress).Any()) ||
-                                     intersectsSkipped)
-                            {
-                                // if we reached the rule intersecting any of captured ranges stop for not breaking the priorities
-                                stop = true;
-                            }
-
-                            if (!isSameFormat)
-                                nextFormat.Ranges.ForEach(r => skippedRanges.Add(r));
-                        }
-
-                        i++;
-                    } while (!stop);
-
-                    var consRanges = rangesToJoin.Consolidate();
-                    item.Ranges.RemoveAll();
-                    consRanges.ForEach(r => item.Ranges.Add(r));
-
-                    var targetCell = (XLCell)item.Ranges.First().FirstCell();
-                    item.AdjustFormulas(baseCell, targetCell);
-
-                    similarFormats.ForEach(cf => formats.Remove(cf));
-                }
-
-                _conditionalFormats.Add(item);
-                formats.Remove(item);
-            }
-        }
-
         public void RemoveAll()
         {
             _conditionalFormats.Clear();
@@ -152,6 +71,89 @@ namespace ClosedXML.Excel
             var reorderedFormats = _conditionalFormats.OrderBy(cf => cf.Priority).ToList();
             _conditionalFormats.Clear();
             _conditionalFormats.AddRange(reorderedFormats);
+        }
+
+        /// <summary>
+        /// The method consolidate the same conditional formats, which are located in adjacent ranges.
+        /// </summary>
+        internal void Consolidate()
+        {
+            var formats = _conditionalFormats
+                .Where(cf => cf.Ranges.Any())
+                .ToList();
+            _conditionalFormats.Clear();
+
+            while (formats.Count > 0)
+            {
+                var format = formats[0];
+                if (!CFTypesExcludedFromConsolidation.Contains(format.ConditionalFormatType))
+                {
+                    var originalAnchor = format.Areas.First().FirstPoint;
+
+                    var (rulesToConsolidate, areasWithSameFormat) = GetConsolidateableRules(formats);
+                    var consolidatedAreas = areasWithSameFormat.GetConsolidated();
+                    var consolidatedCf = new XLConditionalFormat(format, consolidatedAreas);
+
+                    // Remove consolidated formats
+                    rulesToConsolidate.Reverse();
+                    foreach (var consolidatedRuleIndex in rulesToConsolidate)
+                        formats.RemoveAt(consolidatedRuleIndex);
+
+                    var consolidatedAnchor = consolidatedAreas.First().FirstPoint;
+                    consolidatedCf.AdjustFormulas(_worksheet.Cell(originalAnchor), _worksheet.Cell(consolidatedAnchor));
+                    format = consolidatedCf;
+                }
+
+                _conditionalFormats.Add(format);
+                formats.RemoveAt(0);
+            }
+        }
+
+        private static (List<int> RulesToConsolidate, XLAreaList AreaList) GetConsolidateableRules(List<XLConditionalFormat> conditionalFormats)
+        {
+            var rule = conditionalFormats[0];
+            var sameFormatAreas = rule.Areas.ToList();
+            var differentFormatAreas = new List<XLSheetRange>();
+
+            // The ids to the list must be in the ascending order
+            var rulesToConsolidate = new List<int>();
+            for (int i = 1; i < conditionalFormats.Count; ++i)
+            {
+                var candidateRule = conditionalFormats[i];
+
+                var intersectsDifferentFormatAreas = differentFormatAreas.Any(differentFormatArea => candidateRule.Areas.Any(v => v.Intersects(differentFormatArea)));
+                if (intersectsDifferentFormatAreas)
+                {
+                    // We reached a rule intersecting any of captured ranges. Stop for not breaking the priorities.
+                    break;
+                }
+
+                var isSameFormat = XLConditionalFormat.NoRangeComparer.Equals(candidateRule, rule);
+                if (isSameFormat)
+                {
+                    // We reached a rule that has same format as the condolidated rule and doesn't interect different
+                    // format areas. We can consolidate the candidate rule with the rule without potentially breaking
+                    // any rule with a priority between rule and candidate rule.
+                    sameFormatAreas.AddRange(candidateRule.Areas);
+                    rulesToConsolidate.Add(i);
+                    continue;
+                }
+
+                var intersectsSameFormatAreas = sameFormatAreas.Any(sameFormatArea => candidateRule.Areas.Any(v => v.Intersects(sameFormatArea)));
+                if (intersectsSameFormatAreas)
+                {
+                    // We reached a rule that has differnet format and intersects area to be consolidated. That means
+                    // it's not possible to consolidate any subsequent rule, because it could break this one, and
+                    // consolidation must stop here.
+                    break;
+                }
+
+                // The most common case: The candidate rule has a different format and doesn't intersect the sameFormatAreas
+                // The format thus must be added to the differentFormatAreas, because it can interrupt subsequent rules.
+                differentFormatAreas.AddRange(candidateRule.Areas);
+            }
+
+            return (rulesToConsolidate, new XLAreaList(sameFormatAreas));
         }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -19,6 +19,8 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
 
     internal int Count => _areas.Count;
 
+    internal XLSheetRange this[int idx] => _areas[idx];
+
     internal XLAreaList With(XLSheetRange area)
     {
         if (_areas.Contains(area))

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -202,6 +202,11 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
         return new XLAreaList(result);
     }
 
+    internal XLAreaList GetConsolidated()
+    {
+        return XLRangeConsolidationEngine.Consolidate(this);
+    }
+
     public IEnumerator<XLSheetRange> GetEnumerator()
     {
         return _areas.GetEnumerator();

--- a/ClosedXML/Excel/DefinedNames/XLDefinedName.cs
+++ b/ClosedXML/Excel/DefinedNames/XLDefinedName.cs
@@ -157,7 +157,7 @@ internal class XLDefinedName : IXLDefinedName, IWorkbookListener
         var rangeToAdd = _container.Workbook.WorksheetsInternal.Worksheet(wsName).Range(rng);
 
         var ranges = new XLRanges(_container.Workbook) { rangeToAdd };
-        RefersTo = _formula + "," + string.Join(",", ranges.Select(RangeToFixed));
+        RefersTo = _formula + "," + string.Join(",", ranges.Select<XLRange, string>(RangeToFixed));
     }
 
     void IWorkbookListener.OnSheetRenamed(string oldSheetName, string newSheetName)

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -591,7 +591,7 @@ namespace ClosedXML.Excel.IO
 
             #region MergeCells
 
-            if ((xlWorksheet).Internals.MergedRanges.Any())
+            if (xlWorksheet.Internals.MergedRanges.Count > 0)
             {
                 if (!worksheet.Elements<MergeCells>().Any())
                 {
@@ -603,7 +603,7 @@ namespace ClosedXML.Excel.IO
                 cm.SetElement(XLWorksheetContents.MergeCells, mergeCells);
                 mergeCells.RemoveAllChildren<MergeCell>();
 
-                foreach (var mergeCell in (xlWorksheet).Internals.MergedRanges.Select(
+                foreach (var mergeCell in xlWorksheet.Internals.MergedRanges.Select<XLRange, string>(
                     m => m.RangeAddress.FirstAddress.ToString() + ":" + m.RangeAddress.LastAddress.ToString()).Select(
                         merged => new MergeCell { Reference = merged }))
                     mergeCells.AppendChild(mergeCell);

--- a/ClosedXML/Excel/Ranges/XLRange.cs
+++ b/ClosedXML/Excel/Ranges/XLRange.cs
@@ -761,7 +761,7 @@ namespace ClosedXML.Excel
                 RangeAddress.FirstAddress.RowNumber + squareSide - 1,
                 RangeAddress.FirstAddress.ColumnNumber + squareSide - 1);
 
-            foreach (var merge in Worksheet.Internals.MergedRanges.Where(Contains).Cast<XLRange>())
+            foreach (var merge in Worksheet.Internals.MergedRanges.Where<XLRange>(Contains))
             {
                 merge.RangeAddress = new XLRangeAddress(
                     merge.RangeAddress.FirstAddress,

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -389,7 +389,7 @@ namespace ClosedXML.Excel
         {
             string tAddress = RangeAddress.ToString();
             var asRange = AsRange();
-            if (Worksheet.Internals.MergedRanges.Select(m => m.RangeAddress.ToString()).Any(mAddress => mAddress == tAddress))
+            if (Worksheet.Internals.MergedRanges.Select<XLRange, string>(m => m.RangeAddress.ToString()).Any(mAddress => mAddress == tAddress))
                 Worksheet.Internals.MergedRanges.Remove(asRange);
 
             return asRange;
@@ -1435,7 +1435,7 @@ namespace ClosedXML.Excel
                     break;
             }
 
-            var mergesToRemove = Worksheet.Internals.MergedRanges.Where(Contains).ToList();
+            var mergesToRemove = Worksheet.Internals.MergedRanges.Where<XLRange>(Contains).ToList();
             mergesToRemove.ForEach(r => Worksheet.Internals.MergedRanges.Remove(r));
 
             var shiftedRange = AsRange();

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -887,7 +887,12 @@ namespace ClosedXML.Excel
             return Range(rangeAddress);
         }
 
-        public XLRange Range(Int32 firstCellRow, Int32 firstCellColumn, Int32 lastCellRow, Int32 lastCellColumn)
+        internal XLRange Range(XLSheetRange area)
+        {
+            return Range(area.TopRow, area.LeftColumn, area.BottomRow, area.RightColumn);
+        }
+
+        internal XLRange Range(Int32 firstCellRow, Int32 firstCellColumn, Int32 lastCellRow, Int32 lastCellColumn)
         {
             var rangeAddress = new XLRangeAddress
             (

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -21,17 +21,17 @@ namespace ClosedXML.Excel
             _allRanges = ranges ?? throw new ArgumentNullException(nameof(ranges));
         }
 
-        public IXLRanges Consolidate()
+        public XLRanges Consolidate()
         {
-            if (!_allRanges.Any())
+            if (_allRanges.Count == 0)
                 return _allRanges;
 
-            var worksheets = _allRanges.Select(r => r.Worksheet).Distinct().OrderBy(ws => ws.Position);
+            var worksheets = _allRanges.Select<XLRange, XLWorksheet>(r => r.Worksheet).Distinct().OrderBy(ws => ws.Position);
 
-            IXLRanges retVal = new XLRanges(_workbook);
+            var retVal = new XLRanges(_workbook);
             foreach (var ws in worksheets)
             {
-                var matrix = new XLRangeConsolidationMatrix(ws, _allRanges.Where(r => r.Worksheet == ws).ToList());
+                var matrix = new XLRangeConsolidationMatrix(ws, _allRanges.Where<XLRange>(r => r.Worksheet == ws).ToList());
                 var consRanges = matrix.GetConsolidatedRanges();
                 foreach (var consRange in consRanges)
                 {

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -48,9 +46,8 @@ namespace ClosedXML.Excel
         /// </summary>
         private class XLRangeConsolidationMatrix
         {
-            private Dictionary<int, BitArray> _bitMatrix;
-            private int _maxColumn = 0;
-            private int _minColumn = XLHelper.MaxColumnNumber + 1;
+            private readonly Dictionary<int, BitArray> _bitMatrix;
+            private readonly int _minColumn;
 
             /// <summary>
             /// Constructor.
@@ -58,7 +55,7 @@ namespace ClosedXML.Excel
             /// <param name="areas">Areas to be consolidated.</param>
             internal XLRangeConsolidationMatrix(IReadOnlyCollection<XLSheetRange> areas)
             {
-                PrepareBitMatrix(areas);
+                (_bitMatrix, _minColumn) = PrepareBitMatrix(areas);
                 FillBitMatrix(areas);
             }
 
@@ -142,30 +139,35 @@ namespace ClosedXML.Excel
                 }
             }
 
-            private void PrepareBitMatrix(IEnumerable<XLSheetRange> areas)
+            private static (Dictionary<int, BitArray> BitMatrix, int MinColumn) PrepareBitMatrix(IReadOnlyCollection<XLSheetRange> areas)
             {
-                _bitMatrix = new Dictionary<int, BitArray>();
+                var minColumn = XLHelper.MaxColumnNumber + 1;
+                var maxColumn = 0;
                 foreach (var area in areas)
                 {
-                    _minColumn = (_minColumn <= area.LeftColumn)
-                        ? _minColumn
+                    minColumn = (minColumn <= area.LeftColumn)
+                        ? minColumn
                         : area.LeftColumn;
-                    _maxColumn = (_maxColumn >= area.RightColumn)
-                        ? _maxColumn
+                    maxColumn = (maxColumn >= area.RightColumn)
+                        ? maxColumn
                         : area.RightColumn;
-
-                    if (!_bitMatrix.ContainsKey(area.TopRow))
-                        _bitMatrix.Add(area.TopRow, null);
-                    if (!_bitMatrix.ContainsKey(area.BottomRow))
-                        _bitMatrix.Add(area.BottomRow, null);
-                    if (!_bitMatrix.ContainsKey(area.BottomRow + 1))
-                        _bitMatrix.Add(area.BottomRow + 1, null);
                 }
 
-                var keys = _bitMatrix.Keys.ToList();
-                foreach (var rowNum in keys)
+                var bitMaskSize = maxColumn - minColumn + 3;
+                var bitMatrix = new Dictionary<int, BitArray>();
+                foreach (var area in areas)
                 {
-                    _bitMatrix[rowNum] = new BitArray(_maxColumn - _minColumn + 3, false);
+                    AddRowBitmask(bitMatrix, area.TopRow, bitMaskSize);
+                    AddRowBitmask(bitMatrix, area.BottomRow, bitMaskSize);
+                    AddRowBitmask(bitMatrix, area.BottomRow + 1, bitMaskSize);
+                }
+
+                return (bitMatrix, minColumn);
+
+                static void AddRowBitmask(Dictionary<int, BitArray> bitMatrix, int rowNum, int bitMaskSize)
+                {
+                    if (!bitMatrix.ContainsKey(rowNum))
+                        bitMatrix.Add(rowNum, new BitArray(bitMaskSize, false));
                 }
             }
 

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -42,31 +42,23 @@ namespace ClosedXML.Excel
             return retVal;
         }
 
-        #region Private Classes
-
         /// <summary>
         /// Class representing the area covering ranges to be consolidated as a set of bit matrices. Does all the dirty job
         /// of ranges consolidation.
         /// </summary>
         private class XLRangeConsolidationMatrix
         {
-            #region Public Constructors
-
             /// <summary>
             /// Constructor.
             /// </summary>
             /// <param name="worksheet">Current worksheet.</param>
             /// <param name="ranges">Ranges to be consolidated. They are expected to belong to the current worksheet, no check is performed.</param>
-            public XLRangeConsolidationMatrix(IXLWorksheet worksheet, IReadOnlyCollection<IXLRange> ranges)
+            internal XLRangeConsolidationMatrix(IXLWorksheet worksheet, IReadOnlyCollection<IXLRange> ranges)
             {
                 _worksheet = worksheet;
                 PrepareBitMatrix(ranges);
                 FillBitMatrix(ranges);
             }
-
-            #endregion Public Constructors
-
-            #region Public Methods
 
             /// <summary>
             /// Get consolidated ranges equivalent to the input ones.
@@ -99,18 +91,10 @@ namespace ClosedXML.Excel
                 }
             }
 
-            #endregion Public Methods
-
-            #region Private Fields
-
             private readonly IXLWorksheet _worksheet;
             private Dictionary<int, BitArray> _bitMatrix;
             private int _maxColumn = 0;
             private int _minColumn = XLHelper.MaxColumnNumber + 1;
-
-            #endregion Private Fields
-
-            #region Private Methods
 
             private void AddToBitMatrix(IXLRangeAddress rangeAddress)
             {
@@ -188,6 +172,7 @@ namespace ClosedXML.Excel
                     _bitMatrix[rowNum] = new BitArray(_maxColumn - _minColumn + 3, false);
                 }
             }
+
             private bool RowIncludesRange(BitArray rowArray, Tuple<int, int> rangeBoundaries)
             {
                 for (int i = rangeBoundaries.Item1; i <= rangeBoundaries.Item2; i++)
@@ -198,10 +183,6 @@ namespace ClosedXML.Excel
 
                 return true;
             }
-
-            #endregion Private Methods
         }
-
-        #endregion Private Classes
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -96,11 +96,11 @@ namespace ClosedXML.Excel
             private void AddToBitMatrix(XLSheetRange area)
             {
                 var rows = _bitMatrix.Keys
-                    .Where(k => k >= area.FirstPoint.Row &&
-                                k <= area.LastPoint.Row);
+                    .Where(k => k >= area.TopRow &&
+                                k <= area.BottomRow);
 
-                var minIndex = area.FirstPoint.Column - _minColumn + 1;
-                var maxIndex = area.LastPoint.Column - _minColumn + 1;
+                var minIndex = area.LeftColumn - _minColumn + 1;
+                var maxIndex = area.RightColumn - _minColumn + 1;
 
                 foreach (var rowNum in rows)
                 {
@@ -147,19 +147,19 @@ namespace ClosedXML.Excel
                 _bitMatrix = new Dictionary<int, BitArray>();
                 foreach (var area in areas)
                 {
-                    _minColumn = (_minColumn <= area.FirstPoint.Column)
+                    _minColumn = (_minColumn <= area.LeftColumn)
                         ? _minColumn
-                        : area.FirstPoint.Column;
-                    _maxColumn = (_maxColumn >= area.LastPoint.Column)
+                        : area.LeftColumn;
+                    _maxColumn = (_maxColumn >= area.RightColumn)
                         ? _maxColumn
-                        : area.LastPoint.Column;
+                        : area.RightColumn;
 
-                    if (!_bitMatrix.ContainsKey(area.FirstPoint.Row))
-                        _bitMatrix.Add(area.FirstPoint.Row, null);
-                    if (!_bitMatrix.ContainsKey(area.LastPoint.Row))
-                        _bitMatrix.Add(area.LastPoint.Row, null);
-                    if (!_bitMatrix.ContainsKey(area.LastPoint.Row + 1))
-                        _bitMatrix.Add(area.LastPoint.Row + 1, null);
+                    if (!_bitMatrix.ContainsKey(area.TopRow))
+                        _bitMatrix.Add(area.TopRow, null);
+                    if (!_bitMatrix.ContainsKey(area.BottomRow))
+                        _bitMatrix.Add(area.BottomRow, null);
+                    if (!_bitMatrix.ContainsKey(area.BottomRow + 1))
+                        _bitMatrix.Add(area.BottomRow + 1, null);
                 }
 
                 var keys = _bitMatrix.Keys.ToList();

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -31,11 +31,11 @@ namespace ClosedXML.Excel
             var retVal = new XLRanges(_workbook);
             foreach (var ws in worksheets)
             {
-                var matrix = new XLRangeConsolidationMatrix(ws, _allRanges.Where<XLRange>(r => r.Worksheet == ws).ToList());
+                var matrix = new XLRangeConsolidationMatrix(_allRanges.Where<XLRange>(r => r.Worksheet == ws).Select(r => r.SheetRange).ToList());
                 var consRanges = matrix.GetConsolidatedRanges();
-                foreach (var consRange in consRanges)
+                foreach (var consArea in consRanges)
                 {
-                    retVal.Add(consRange);
+                    retVal.Add(ws.Range(consArea));
                 }
             }
 
@@ -51,19 +51,17 @@ namespace ClosedXML.Excel
             /// <summary>
             /// Constructor.
             /// </summary>
-            /// <param name="worksheet">Current worksheet.</param>
-            /// <param name="ranges">Ranges to be consolidated. They are expected to belong to the current worksheet, no check is performed.</param>
-            internal XLRangeConsolidationMatrix(IXLWorksheet worksheet, IReadOnlyCollection<IXLRange> ranges)
+            /// <param name="areas">Areas to be consolidated.</param>
+            internal XLRangeConsolidationMatrix(IReadOnlyCollection<XLSheetRange> areas)
             {
-                _worksheet = worksheet;
-                PrepareBitMatrix(ranges);
-                FillBitMatrix(ranges);
+                PrepareBitMatrix(areas);
+                FillBitMatrix(areas);
             }
 
             /// <summary>
             /// Get consolidated ranges equivalent to the input ones.
             /// </summary>
-            public IEnumerable<IXLRange> GetConsolidatedRanges()
+            public IEnumerable<XLSheetRange> GetConsolidatedRanges()
             {
                 var rowNumbers = _bitMatrix.Keys.OrderBy(k => k).ToArray();
                 for (int i = 0; i < rowNumbers.Length; i++)
@@ -80,7 +78,7 @@ namespace ClosedXML.Excel
                         var startColumn = starting.Item1 + _minColumn - 1;
                         var endColumn = starting.Item2 + _minColumn - 1;
 
-                        yield return _worksheet.Range(startRow, startColumn, endRow, endColumn);
+                        yield return new XLSheetRange(startRow, startColumn, endRow, endColumn);
 
                         while (j > i)
                         {
@@ -91,19 +89,18 @@ namespace ClosedXML.Excel
                 }
             }
 
-            private readonly IXLWorksheet _worksheet;
             private Dictionary<int, BitArray> _bitMatrix;
             private int _maxColumn = 0;
             private int _minColumn = XLHelper.MaxColumnNumber + 1;
 
-            private void AddToBitMatrix(IXLRangeAddress rangeAddress)
+            private void AddToBitMatrix(XLSheetRange area)
             {
                 var rows = _bitMatrix.Keys
-                    .Where(k => k >= rangeAddress.FirstAddress.RowNumber &&
-                                k <= rangeAddress.LastAddress.RowNumber);
+                    .Where(k => k >= area.FirstPoint.Row &&
+                                k <= area.LastPoint.Row);
 
-                var minIndex = rangeAddress.FirstAddress.ColumnNumber - _minColumn + 1;
-                var maxIndex = rangeAddress.LastAddress.ColumnNumber - _minColumn + 1;
+                var minIndex = area.FirstPoint.Column - _minColumn + 1;
+                var maxIndex = area.LastPoint.Column - _minColumn + 1;
 
                 foreach (var rowNum in rows)
                 {
@@ -122,11 +119,11 @@ namespace ClosedXML.Excel
                 }
             }
 
-            private void FillBitMatrix(IEnumerable<IXLRange> ranges)
+            private void FillBitMatrix(IEnumerable<XLSheetRange> areas)
             {
-                foreach (var range in ranges)
+                foreach (var area in areas)
                 {
-                    AddToBitMatrix(range.RangeAddress);
+                    AddToBitMatrix(area);
                 }
 
                 System.Diagnostics.Debug.Assert(
@@ -145,25 +142,24 @@ namespace ClosedXML.Excel
                 }
             }
 
-            private void PrepareBitMatrix(IEnumerable<IXLRange> ranges)
+            private void PrepareBitMatrix(IEnumerable<XLSheetRange> areas)
             {
                 _bitMatrix = new Dictionary<int, BitArray>();
-                foreach (var range in ranges)
+                foreach (var area in areas)
                 {
-                    var address = range.RangeAddress;
-                    _minColumn = (_minColumn <= address.FirstAddress.ColumnNumber)
+                    _minColumn = (_minColumn <= area.FirstPoint.Column)
                         ? _minColumn
-                        : address.FirstAddress.ColumnNumber;
-                    _maxColumn = (_maxColumn >= address.LastAddress.ColumnNumber)
+                        : area.FirstPoint.Column;
+                    _maxColumn = (_maxColumn >= area.LastPoint.Column)
                         ? _maxColumn
-                        : address.LastAddress.ColumnNumber;
+                        : area.LastPoint.Column;
 
-                    if (!_bitMatrix.ContainsKey(address.FirstAddress.RowNumber))
-                        _bitMatrix.Add(address.FirstAddress.RowNumber, null);
-                    if (!_bitMatrix.ContainsKey(address.LastAddress.RowNumber))
-                        _bitMatrix.Add(address.LastAddress.RowNumber, null);
-                    if (!_bitMatrix.ContainsKey(address.LastAddress.RowNumber + 1))
-                        _bitMatrix.Add(address.LastAddress.RowNumber + 1, null);
+                    if (!_bitMatrix.ContainsKey(area.FirstPoint.Row))
+                        _bitMatrix.Add(area.FirstPoint.Row, null);
+                    if (!_bitMatrix.ContainsKey(area.LastPoint.Row))
+                        _bitMatrix.Add(area.LastPoint.Row, null);
+                    if (!_bitMatrix.ContainsKey(area.LastPoint.Row + 1))
+                        _bitMatrix.Add(area.LastPoint.Row + 1, null);
                 }
 
                 var keys = _bitMatrix.Keys.ToList();

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -48,6 +48,10 @@ namespace ClosedXML.Excel
         /// </summary>
         private class XLRangeConsolidationMatrix
         {
+            private Dictionary<int, BitArray> _bitMatrix;
+            private int _maxColumn = 0;
+            private int _minColumn = XLHelper.MaxColumnNumber + 1;
+
             /// <summary>
             /// Constructor.
             /// </summary>
@@ -88,10 +92,6 @@ namespace ClosedXML.Excel
                     }
                 }
             }
-
-            private Dictionary<int, BitArray> _bitMatrix;
-            private int _maxColumn = 0;
-            private int _minColumn = XLHelper.MaxColumnNumber + 1;
 
             private void AddToBitMatrix(XLSheetRange area)
             {

--- a/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeConsolidationEngine.cs
@@ -29,7 +29,8 @@ namespace ClosedXML.Excel
             var retVal = new XLRanges(_workbook);
             foreach (var ws in worksheets)
             {
-                var matrix = new XLRangeConsolidationMatrix(_allRanges.Where<XLRange>(r => r.Worksheet == ws).Select(r => r.SheetRange).ToList());
+                var areaList = new XLAreaList(_allRanges.Where<XLRange>(r => r.Worksheet == ws).Select(r => r.SheetRange).ToList());
+                var matrix = new XLRangeConsolidationMatrix(areaList);
                 var consRanges = matrix.GetConsolidatedRanges();
                 foreach (var consArea in consRanges)
                 {
@@ -38,6 +39,16 @@ namespace ClosedXML.Excel
             }
 
             return retVal;
+        }
+
+        internal static XLAreaList Consolidate(XLAreaList areas)
+        {
+            if (areas.Count == 0)
+                return areas;
+
+            var matrix = new XLRangeConsolidationMatrix(areas);
+            var consRanges = matrix.GetConsolidatedRanges().ToList();
+            return new XLAreaList(consRanges);
         }
 
         /// <summary>
@@ -53,7 +64,7 @@ namespace ClosedXML.Excel
             /// Constructor.
             /// </summary>
             /// <param name="areas">Areas to be consolidated.</param>
-            internal XLRangeConsolidationMatrix(IReadOnlyCollection<XLSheetRange> areas)
+            internal XLRangeConsolidationMatrix(XLAreaList areas)
             {
                 (_bitMatrix, _minColumn) = PrepareBitMatrix(areas);
                 FillBitMatrix(areas);
@@ -139,7 +150,7 @@ namespace ClosedXML.Excel
                 }
             }
 
-            private static (Dictionary<int, BitArray> BitMatrix, int MinColumn) PrepareBitMatrix(IReadOnlyCollection<XLSheetRange> areas)
+            private static (Dictionary<int, BitArray> BitMatrix, int MinColumn) PrepareBitMatrix(XLAreaList areas)
             {
                 var minColumn = XLHelper.MaxColumnNumber + 1;
                 var maxColumn = 0;

--- a/ClosedXML/Excel/Ranges/XLRanges.cs
+++ b/ClosedXML/Excel/Ranges/XLRanges.cs
@@ -10,7 +10,7 @@ namespace ClosedXML.Excel
 #if !STYLES_REWORK
         XLStylizedBase,
 #endif
-        IXLRanges
+        IXLRanges, IEnumerable<XLRange>
     {
         private readonly XLWorkbook _workbook;
 
@@ -133,14 +133,18 @@ namespace ClosedXML.Excel
 
         public int Count { get; private set; }
 
-        public IEnumerator<IXLRange> GetEnumerator()
+        public IEnumerator<XLRange> GetEnumerator()
         {
             return Ranges
                 .OrderBy(r => r.Worksheet.Position)
                 .ThenBy(r => r.RangeAddress.FirstAddress.RowNumber)
                 .ThenBy(r => r.RangeAddress.FirstAddress.ColumnNumber)
-                .Cast<IXLRange>()
                 .GetEnumerator();
+        }
+
+        IEnumerator<IXLRange> IEnumerable<IXLRange>.GetEnumerator()
+        {
+            return GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
Refactor XLConditionalFormat consolidate method away from `IXLRange` based API to internal structures based on concrete sheet areas (`ST_Sqref`/`ST_Ref` types in XML).

This is in preparation for refactoring of shifting code of conditional formats from `XLWorksheet` to the CF internal structures (through `ISheetListener`) to be more modular. This shifting refactoring is a long term project and only merged ranges, conditional formats and page break still have custom code in `XLWorkbook` (though some others, e.g. tables still rely on magic shifting).

Fortunately, consolidation method is well covered by existing tests.