### PR TITLE
Fix conditional format clear that split the conditional format area

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -114,4 +114,34 @@ internal class XLAreaListTests
 
         Assert.AreEqual(expected, result.ToSpaceList());
     }
+
+    [TestCase("A1", "A1", ExpectedResult = true)]
+    [TestCase("A1:C3", "B2", ExpectedResult = true)]
+    [TestCase("B2:C3", "A2", ExpectedResult = false)]
+    [TestCase("A1:C2 B3:C3", "A3", ExpectedResult = false)]
+    public bool IntersectsWith_determines_intersection_with_any_area(string areaListText, string areaText)
+    {
+        var areaList = Parse(areaListText);
+        var area = XLSheetRange.Parse(areaText);
+        return areaList.IntersectsWith(area);
+    }
+
+    [TestCase("A1", "B1", ExpectedResult = "A1")]
+    [TestCase("A1:E5", "C3:C4", ExpectedResult = "A1:B5 C1:C2 C5 D1:E5")]
+    [TestCase("B2:C5 B9 C4:D7", "C4:C5", ExpectedResult = "B2:B5 C2:C3 B9 C6:C7 D4:D7")]
+    public string Excluding_returns_area_list_without_excluded(string areaListText, string excludedAreaText)
+    {
+        var areaList = Parse(areaListText);
+        var excludedArea = XLSheetRange.Parse(excludedAreaText);
+        return areaList.Excluding(excludedArea).ToSpaceList();
+    }
+
+    private static XLAreaList Parse(string spaceList)
+    {
+        var list = new List<XLSheetRange>();
+        foreach (var reference in spaceList.Split(' '))
+            list.Add(XLSheetRange.Parse(reference));
+
+        return new XLAreaList(list);
+    }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -10,12 +10,12 @@ internal class XLAreaListTests
     [TestCase("A1:C3", "A1", "B1:C3 A2:A4")]
     [TestCase("A1:C3", "B1", "A1:A3 C1:C3 B2:B4")]
     [TestCase("A1:C3", "C1", "A1:B3 C2:C4")]
-    [TestCase("A1:C3", "A2", "A1 B1:C3 A3:A4")]
-    [TestCase("A1:C3", "B2", "A1:A3 B1 C1:C3 B3:B4")]
-    [TestCase("A1:C3", "C2", "A1:B3 C1 C3:C4")]
-    [TestCase("A1:C3", "A3", "A1:A2 B1:C3 A4")]
-    [TestCase("A1:C3", "B3", "A1:A3 B1:B2 C1:C3 B4")]
-    [TestCase("A1:C3", "C3", "A1:B3 C1:C2 C4")]
+    [TestCase("A1:C3", "A2", "A1:C1 B2:C3 A3:A4")]
+    [TestCase("A1:C3", "B2", "A1:C1 A2:A3 C2:C3 B3:B4")]
+    [TestCase("A1:C3", "C2", "A1:C1 A2:B3 C3:C4")]
+    [TestCase("A1:C3", "A3", "A1:C2 B3:C3 A4")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 C3 B4")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3 C4")]
 
     [TestCase("B1:D3", "A1:A3", "B1:D3")] // Insert to left side - don't move
     [TestCase("A2:C4", "A1:C1", "A3:C5")] // Insert to top side - shift
@@ -38,14 +38,14 @@ internal class XLAreaListTests
     }
 
     [TestCase("A1:C3", "A1", "A2:C3 B1:D1")]
-    [TestCase("A1:C3", "B1", "A1:A3 B2:C3 C1:D1")]
-    [TestCase("A1:C3", "C1", "A1:B3 C2:C3 D1")]
+    [TestCase("A1:C3", "B1", "A2:C3 A1 C1:D1")]
+    [TestCase("A1:C3", "C1", "A2:C3 A1:B1 D1")]
     [TestCase("A1:C3", "A2", "A1:C1 A3:C3 B2:D2")]
-    [TestCase("A1:C3", "B2", "A1:A3 B1:C1 B3:C3 C2:D2")]
-    [TestCase("A1:C3", "C2", "A1:B3 C1 C3 D2")]
+    [TestCase("A1:C3", "B2", "A1:C1 A3:C3 A2 C2:D2")]
+    [TestCase("A1:C3", "C2", "A1:C1 A3:C3 A2:B2 D2")]
     [TestCase("A1:C3", "A3", "A1:C2 B3:D3")]
-    [TestCase("A1:C3", "B3", "A1:A3 B1:C2 C3:D3")]
-    [TestCase("A1:C3", "C3", "A1:B3 C1:C2 D3")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 C3:D3")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3 D3")]
 
     [TestCase("A1:C3", "A1:A3", "B1:D3")] // Insert to left edge - shift, don't extend
     [TestCase("A2:C4", "A1", "A2:C4")] // Insert to top side - don't move
@@ -68,12 +68,12 @@ internal class XLAreaListTests
     [TestCase("A1:C3", "A1", "B1:C3 A1:A2")]
     [TestCase("A1:C3", "B1", "A1:A3 C1:C3 B1:B2")]
     [TestCase("A1:C3", "C1", "A1:B3 C1:C2")]
-    [TestCase("A1:C3", "A2", "A1 B1:C3 A2")]
-    [TestCase("A1:C3", "B2", "A1:A3 B1 C1:C3 B2")]
-    [TestCase("A1:C3", "C2", "A1:B3 C1 C2")]
-    [TestCase("A1:C3", "A3", "A1:A2 B1:C3")]
-    [TestCase("A1:C3", "B3", "A1:A3 B1:B2 C1:C3")]
-    [TestCase("A1:C3", "C3", "A1:B3 C1:C2")]
+    [TestCase("A1:C3", "A2", "A1:C1 B2:C3 A2")]
+    [TestCase("A1:C3", "B2", "A1:C1 A2:A3 C2:C3 B2")]
+    [TestCase("A1:C3", "C2", "A1:C1 A2:B3 C2")]
+    [TestCase("A1:C3", "A3", "A1:C2 B3:C3")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 C3")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3")]
 
     [TestCase("B1:D3", "A1:A3", "B1:D3")] // Delete on the left side - don't move
     [TestCase("A2:C4", "A1:C1", "A1:C3")] // Delete on top side - shift
@@ -91,14 +91,14 @@ internal class XLAreaListTests
     }
 
     [TestCase("A1:C3", "A1", "A2:C3 A1:B1")]
-    [TestCase("A1:C3", "B1", "A1:A3 B2:C3 B1")]
-    [TestCase("A1:C3", "C1", "A1:B3 C2:C3")]
+    [TestCase("A1:C3", "B1", "A2:C3 A1 B1")]
+    [TestCase("A1:C3", "C1", "A2:C3 A1:B1")]
     [TestCase("A1:C3", "A2", "A1:C1 A3:C3 A2:B2")]
-    [TestCase("A1:C3", "B2", "A1:A3 B1:C1 B3:C3 B2")]
-    [TestCase("A1:C3", "C2", "A1:B3 C1 C3")]
+    [TestCase("A1:C3", "B2", "A1:C1 A3:C3 A2 B2")]
+    [TestCase("A1:C3", "C2", "A1:C1 A3:C3 A2:B2")]
     [TestCase("A1:C3", "A3", "A1:C2 A3:B3")]
-    [TestCase("A1:C3", "B3", "A1:A3 B1:C2 B3")]
-    [TestCase("A1:C3", "C3", "A1:B3 C1:C2")]
+    [TestCase("A1:C3", "B3", "A1:C2 A3 B3")]
+    [TestCase("A1:C3", "C3", "A1:C2 A3:B3")]
 
     [TestCase("B1:D3", "A1:A3", "A1:C3")] // Delete on the left side - shift
     [TestCase("A2:C4", "A1", "A2:C4")] // Delete on top side - don't move
@@ -127,8 +127,8 @@ internal class XLAreaListTests
     }
 
     [TestCase("A1", "B1", ExpectedResult = "A1")]
-    [TestCase("A1:E5", "C3:C4", ExpectedResult = "A1:B5 C1:C2 C5 D1:E5")]
-    [TestCase("B2:C5 B9 C4:D7", "C4:C5", ExpectedResult = "B2:B5 C2:C3 B9 C6:C7 D4:D7")]
+    [TestCase("A1:E5", "C3:C4", ExpectedResult = "A1:E2 A5:E5 A3:B4 D3:E4")]
+    [TestCase("B2:C5 B9 C4:D7", "C4:C5", ExpectedResult = "B2:C3 B4:B5 B9 C6:D7 D4:D5")]
     public string Excluding_returns_area_list_without_excluded(string areaListText, string excludedAreaText)
     {
         var areaList = Parse(areaListText);

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using ClosedXML.Excel;
 using NUnit.Framework;
 
@@ -246,6 +247,49 @@ namespace ClosedXML.Tests.Excel.Coordinates
 
             Assert.False(success);
             Assert.Null(result);
+        }
+
+        [TestCase("B2:D4", "B2", "B2", ExpectedResult = "B3:D4 C2:D2")]
+        [TestCase("B2:D4", "A1:B2", "B2", ExpectedResult = "B3:D4 C2:D2")]
+        [TestCase("B2:D4", "C2", "C2", ExpectedResult = "B3:D4 B2 D2")]
+        [TestCase("B2:D4", "C1:C2", "C2", ExpectedResult = "B3:D4 B2 D2")]
+        [TestCase("B2:D4", "D2", "D2", ExpectedResult = "B3:D4 B2:C2")]
+        [TestCase("B2:D4", "D1:E2", "D2", ExpectedResult = "B3:D4 B2:C2")]
+        [TestCase("B2:D4", "B3", "B3", ExpectedResult = "B2:D2 B4:D4 C3:D3")]
+        [TestCase("B2:D4", "A3:B3", "B3", ExpectedResult = "B2:D2 B4:D4 C3:D3")]
+        [TestCase("B2:D4", "C3", "C3", ExpectedResult = "B2:D2 B4:D4 B3 D3")]
+        [TestCase("B2:D4", "D3", "D3", ExpectedResult = "B2:D2 B4:D4 B3:C3")]
+        [TestCase("B2:D4", "D3:E3", "D3", ExpectedResult = "B2:D2 B4:D4 B3:C3")]
+        [TestCase("B2:D4", "B4", "B4", ExpectedResult = "B2:D3 C4:D4")]
+        [TestCase("B2:D4", "A4:B5", "B4", ExpectedResult = "B2:D3 C4:D4")]
+        [TestCase("B2:D4", "C4", "C4", ExpectedResult = "B2:D3 B4 D4")]
+        [TestCase("B2:D4", "C4:C5", "C4", ExpectedResult = "B2:D3 B4 D4")]
+        [TestCase("B2:D4", "D4", "D4", ExpectedResult = "B2:D3 B4:C4")]
+        [TestCase("B2:D4", "D4:E5", "D4", ExpectedResult = "B2:D3 B4:C4")]
+        [TestCase("B2:D4", "B3:D3", "B3:D3", ExpectedResult = "B2:D2 B4:D4")]
+        [TestCase("B2:D4", "A3:E3", "B3:D3", ExpectedResult = "B2:D2 B4:D4")]
+        [TestCase("B2:D4", "C2:C4", "C2:C4", ExpectedResult = "B2:B4 D2:D4")]
+        [TestCase("B2:D4", "C1:C5", "C2:C4", ExpectedResult = "B2:B4 D2:D4")]
+        public string Exclude_splits_original_area_when_excluded_area_intersects(string originalAreaText, string excludingAreaText, string excludedAreaText)
+        {
+            var originalArea = XLSheetRange.Parse(originalAreaText);
+            var excludedArea = XLSheetRange.Parse(excludedAreaText);
+            var excludingArea = XLSheetRange.Parse(excludingAreaText);
+            var list = new List<XLSheetRange>();
+            Assert.AreEqual(excludedArea, originalArea.Exclude(excludingArea, list));
+            return list.ToSpaceList();
+        }
+
+        [TestCase("B2:C3", "A1")]
+        [TestCase("B2:C3", "D1:G20")]
+        [TestCase("A1", "A2:C5")]
+        public void Exclude_keeps_original_area_when_excluded_area_doesnt_intersects(string originalAreaText, string excludedAreaText)
+        {
+            var originalArea = XLSheetRange.Parse(originalAreaText);
+            var excludedArea = XLSheetRange.Parse(excludedAreaText);
+            var list = new List<XLSheetRange>();
+            Assert.IsNull(originalArea.Exclude(excludedArea, list));
+            Assert.AreEqual(originalAreaText, list.ToSpaceList());
         }
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -135,7 +135,7 @@ public class DataValidationShiftTests
 
         ws.Range("B12").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-        Assert.AreEqual("A10:A12 B10:B11 C10:C12", ws.DataValidations.Single().Ranges.ToSpaceList());
+        Assert.AreEqual("A10:C11 A12:A12 C12:C12", ws.DataValidations.Single().Ranges.ToSpaceList());
     }
 
     [Test]

--- a/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/DataValidationShiftTests.cs
@@ -110,7 +110,7 @@ public class DataValidationShiftTests
 
         ws.Rows(rowsToDelete).Delete();
 
-        var resultDvs = ws.DataValidations.Select(dv => ToSpaceList(dv.Ranges));
+        var resultDvs = ws.DataValidations.Select(dv => dv.Ranges.ToSpaceList());
         Assert.AreEqual(shiftedDvs, resultDvs);
     }
 
@@ -135,7 +135,7 @@ public class DataValidationShiftTests
 
         ws.Range("B12").Delete(XLShiftDeletedCells.ShiftCellsUp);
 
-        Assert.AreEqual("A10:A12 B10:B11 C10:C12", ToSpaceList(ws.DataValidations.Single().Ranges));
+        Assert.AreEqual("A10:A12 B10:B11 C10:C12", ws.DataValidations.Single().Ranges.ToSpaceList());
     }
 
     [Test]
@@ -153,10 +153,5 @@ public class DataValidationShiftTests
         ws.Column(2).InsertColumnsAfter(1);
         Assert.IsTrue(dv.Ranges.Single().RangeAddress.IsValid);
         Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", dv.Ranges.Single().RangeAddress.ToString());
-    }
-
-    private static string ToSpaceList(IEnumerable<IXLRange> ranges)
-    {
-        return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
     }
 }

--- a/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
+++ b/ClosedXML.Tests/Excel/DataValidations/XLDataValidationsTests.cs
@@ -173,8 +173,7 @@ namespace ClosedXML.Tests.Excel.DataValidations
                 dv2.MinValue = "100";
 
                 Assert.AreEqual(4, dv1.Ranges.Count());
-                Assert.AreEqual("B2:D7,E2:G3,E7:G7,C11:C13",
-                    string.Join(",", dv1.Ranges.Select(r => r.RangeAddress.ToString())));
+                Assert.AreEqual("B2:G3 B4:D6 B7:G7 C11:C13", dv1.Ranges.ToSpaceList());
             }
         }
 

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -385,15 +385,14 @@ namespace ClosedXML.Tests
         }
 
         [Test]
-        public void NoClearConditionalFormattingsWhenRangePartiallySuperimposed()
+        public void ClearConditionalFormattingsWhenRangePartiallySuperimposed()
         {
             var ws = new XLWorkbook().Worksheets.Add("Sheet1");
             ws.Range("C3:G4").AddConditionalFormat();
             ws.Range("C2:D3").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws.ConditionalFormats.Single().Ranges.Count);
-            Assert.AreEqual("C3:G4", ws.ConditionalFormats.Single().Ranges.Single().RangeAddress.ToStringRelative());
+            Assert.AreEqual("E3:G4 C4:D4", ws.ConditionalFormats.Single().Ranges.ToSpaceList());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeBaseTests.cs
@@ -392,7 +392,7 @@ namespace ClosedXML.Tests
             ws.Range("C2:D3").Clear(XLClearOptions.ConditionalFormats);
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual("E3:G4 C4:D4", ws.ConditionalFormats.Single().Ranges.ToSpaceList());
+            Assert.AreEqual("E3:G3 C4:G4", ws.ConditionalFormats.Single().Ranges.ToSpaceList());
         }
 
         [Test]

--- a/ClosedXML.Tests/Utils/EnumerableExtensions.cs
+++ b/ClosedXML.Tests/Utils/EnumerableExtensions.cs
@@ -4,10 +4,15 @@ using System.Linq;
 
 namespace ClosedXML.Tests;
 
-internal static class RangeExtensions
+internal static class EnumerableExtensions
 {
     public static string ToSpaceList(this IEnumerable<IXLRange> ranges)
     {
         return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
+    }
+
+    public static string ToSpaceList(this IEnumerable<XLSheetRange> areas)
+    {
+        return string.Join(" ", areas);
     }
 }

--- a/ClosedXML.Tests/Utils/RangeExtensions.cs
+++ b/ClosedXML.Tests/Utils/RangeExtensions.cs
@@ -1,0 +1,13 @@
+using ClosedXML.Excel;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClosedXML.Tests;
+
+internal static class RangeExtensions
+{
+    public static string ToSpaceList(this IEnumerable<IXLRange> ranges)
+    {
+        return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
+    }
+}

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -710,7 +710,7 @@ namespace ClosedXML.Excel
 
                 if (clearOptions.HasFlag(XLClearOptions.ConditionalFormats))
                 {
-                    AsRange().ClearConditionalFormatting();
+                    Worksheet.ConditionalFormats.Clear(SheetPoint);
                 }
 
                 if (clearOptions.HasFlag(XLClearOptions.Comments))

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -710,7 +710,7 @@ namespace ClosedXML.Excel
 
                 if (clearOptions.HasFlag(XLClearOptions.ConditionalFormats))
                 {
-                    AsRange().RemoveConditionalFormatting();
+                    AsRange().ClearConditionalFormatting();
                 }
 
                 if (clearOptions.HasFlag(XLClearOptions.Comments))

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -967,7 +967,7 @@ namespace ClosedXML.Excel
                 return false;
 
             if (options.HasFlag(XLCellsUsedOptions.ConditionalFormats)
-                && Worksheet.ConditionalFormats.SelectMany(cf => cf.Ranges).Any(range => range.Contains(this)))
+                && Worksheet.ConditionalFormats.SelectMany<XLConditionalFormat, IXLRange>(cf => cf.Ranges).Any(range => range.Contains(this)))
                 return false;
 
             if (options.HasFlag(XLCellsUsedOptions.Sparklines) && HasSparkline)
@@ -1245,7 +1245,7 @@ namespace ClosedXML.Excel
             var conditionalFormats = otherCell
                 .Worksheet
                 .ConditionalFormats
-                .Where(c => c.Ranges.GetIntersectedRanges(otherCell).Any())
+                .Where<XLConditionalFormat>(c => c.Ranges.GetIntersectedRanges(otherCell).Any())
                 .ToList();
 
             foreach (var cf in conditionalFormats)
@@ -1269,9 +1269,9 @@ namespace ClosedXML.Excel
             var srcSheet = fromRange.Worksheet;
             int minRo = fromRange.RangeAddress.FirstAddress.RowNumber;
             int minCo = fromRange.RangeAddress.FirstAddress.ColumnNumber;
-            if (srcSheet.ConditionalFormats.Any(r => r.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any()))
+            if (srcSheet.ConditionalFormats.Any<XLConditionalFormat>(r => r.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any()))
             {
-                var fs = srcSheet.ConditionalFormats.SelectMany(cf => cf.Ranges.GetIntersectedRanges(fromRange.RangeAddress)).ToArray();
+                var fs = srcSheet.ConditionalFormats.SelectMany<XLConditionalFormat, IXLRange>(cf => cf.Ranges.GetIntersectedRanges(fromRange.RangeAddress)).ToArray();
                 if (fs.Any())
                 {
                     minRo = fs.Max(r => r.RangeAddress.LastAddress.RowNumber);
@@ -1283,7 +1283,7 @@ namespace ClosedXML.Excel
             rCnt = Math.Min(rCnt, fromRange.RowCount());
             cCnt = Math.Min(cCnt, fromRange.ColumnCount());
             var toRange = Worksheet.Range(this, Worksheet.Cell(_rowNumber + rCnt - 1, _columnNumber + cCnt - 1));
-            var formats = srcSheet.ConditionalFormats.Where(f => f.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any());
+            var formats = srcSheet.ConditionalFormats.Where<XLConditionalFormat>(f => f.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any());
 
             foreach (var cf in formats.ToList())
             {

--- a/ClosedXML/Excel/Cells/XLCells.cs
+++ b/ClosedXML/Excel/Cells/XLCells.cs
@@ -147,7 +147,7 @@ internal class XLCells :
 
         if (_options.HasFlag(XLCellsUsedOptions.ConditionalFormats))
             candidates = candidates.Union(
-                worksheet.ConditionalFormats.SelectMany(cf => cf.Ranges.SelectMany(r => GetAllCellsInRange(r.RangeAddress))));
+                worksheet.ConditionalFormats.SelectMany<XLConditionalFormat, XLSheetPoint>(cf => cf.Ranges.SelectMany(r => GetAllCellsInRange(r.RangeAddress))));
 
         if (_options.HasFlag(XLCellsUsedOptions.DataValidation))
             candidates = candidates.Union(

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -15,7 +15,6 @@ namespace ClosedXML.Excel
         private sealed class NoRangeCfComparer : IEqualityComparer<XLConditionalFormat>
         {
             private readonly DictionaryComparer<int, XLColor> _colorsComparer = new DictionaryComparer<int, XLColor>();
-            private readonly EnumerableComparer<string> _listComparer = new EnumerableComparer<string>();
             private readonly DictionaryComparer<int, XLCFContentType> _contentsTypeComparer = new DictionaryComparer<int, XLCFContentType>();
             private readonly DictionaryComparer<int, XLCFIconSetOperator> _iconSetTypeComparer = new DictionaryComparer<int, XLCFIconSetOperator>();
 
@@ -43,8 +42,8 @@ namespace ClosedXML.Excel
                     && xx.StopIfTrue == yy.StopIfTrue
                     && xx.ShowIconOnly == yy.ShowIconOnly
                     && xx.ShowBarOnly == yy.ShowBarOnly
-                    && _listComparer.Equals(xxValues, yyValues)
-                    && _listComparer.Equals(xxFormulas, yyFormulas)
+                    && SetEquals(xxValues, yyValues)
+                    && SetEquals(xxFormulas, yyFormulas)
                     && _colorsComparer.Equals(xx.Colors, yy.Colors)
                     && _contentsTypeComparer.Equals(xx.ContentTypes, yy.ContentTypes)
                     && _iconSetTypeComparer.Equals(xx.IconSetOperators, yy.IconSetOperators);
@@ -78,6 +77,12 @@ namespace ClosedXML.Excel
                     hashCode = (hashCode * 397) ^ xx.StopIfTrue.GetHashCode();
                     return hashCode;
                 }
+            }
+
+            private static bool SetEquals<T>(IEnumerable<T> first, IEnumerable<T> second)
+            {
+                return new HashSet<T>(second, EqualityComparer<T>.Default)
+                    .SetEquals(first);
             }
         }
 
@@ -559,33 +564,6 @@ namespace ClosedXML.Excel
         public int GetHashCode(Dictionary<TKey, TValue> obj)
         {
             throw new NotImplementedException();
-        }
-    }
-
-    internal class EnumerableComparer<T> : IEqualityComparer<IEnumerable<T>>
-    {
-        private readonly IEqualityComparer<T> _valueComparer;
-
-        public EnumerableComparer(IEqualityComparer<T> valueComparer = null)
-        {
-            this._valueComparer = valueComparer ?? EqualityComparer<T>.Default;
-        }
-
-        public bool Equals(IEnumerable<T> x, IEnumerable<T> y)
-        {
-            return SetEquals(x, y, _valueComparer);
-        }
-
-        public int GetHashCode(IEnumerable<T> obj)
-        {
-            throw new NotImplementedException();
-        }
-
-        public static bool SetEquals(IEnumerable<T> first, IEnumerable<T> second,
-            IEqualityComparer<T> comparer)
-        {
-            return new HashSet<T>(second, comparer ?? EqualityComparer<T>.Default)
-                .SetEquals(first);
         }
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -215,6 +215,12 @@ namespace ClosedXML.Excel
             {
                 return new XLAreaList(_ranges.Select<XLRange, XLSheetRange>(range => range.SheetRange).ToList());
             }
+            set
+            {
+                Ranges.RemoveAll();
+                foreach (var area in value)
+                    Ranges.Add(_worksheet.Range(area));
+            }
         }
 
         public IXLConditionalFormat SetStopIfTrue()

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -142,15 +142,8 @@ namespace ClosedXML.Excel
             ranges?.ForEach(range => Ranges.Add(range));
         }
 
-        public XLConditionalFormat(XLConditionalFormat conditionalFormat, IEnumerable<IXLRange> targetRanges)
-            : this(conditionalFormat._worksheet)
-        {
-            targetRanges?.ForEach(range => Ranges.Add(range));
-            CopyFrom(conditionalFormat);
-        }
-
-        internal XLConditionalFormat(XLConditionalFormat conditionalFormat, XLAreaList areaList)
-            : this(conditionalFormat._worksheet)
+        internal XLConditionalFormat(XLWorksheet worksheet, XLConditionalFormat conditionalFormat, XLAreaList areaList)
+            : this(worksheet)
         {
             areaList.ForEach(range => Ranges.Add(_worksheet.Range(range)));
             CopyFrom(conditionalFormat);
@@ -239,8 +232,7 @@ namespace ClosedXML.Excel
         {
             if (targetSheet == Range?.Worksheet)
                 throw new InvalidOperationException("Cannot copy conditional format to the worksheet it already belongs to.");
-            var targetRanges = Ranges.Select(r => targetSheet.Range(((XLRangeAddress)r.RangeAddress).WithoutWorksheet()));
-            var newCf = new XLConditionalFormat(this, targetRanges);
+            var newCf = new XLConditionalFormat((XLWorksheet)targetSheet, this, Areas);
             targetSheet.ConditionalFormats.Add(newCf);
             return newCf;
         }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -14,10 +14,6 @@ namespace ClosedXML.Excel
 
         private sealed class NoRangeCfComparer : IEqualityComparer<XLConditionalFormat>
         {
-            private readonly DictionaryComparer<int, XLColor> _colorsComparer = new DictionaryComparer<int, XLColor>();
-            private readonly DictionaryComparer<int, XLCFContentType> _contentsTypeComparer = new DictionaryComparer<int, XLCFContentType>();
-            private readonly DictionaryComparer<int, XLCFIconSetOperator> _iconSetTypeComparer = new DictionaryComparer<int, XLCFIconSetOperator>();
-
             public bool Equals(XLConditionalFormat xx, XLConditionalFormat yy)
             {
                 if (ReferenceEquals(xx, yy)) return true;
@@ -44,9 +40,9 @@ namespace ClosedXML.Excel
                     && xx.ShowBarOnly == yy.ShowBarOnly
                     && SetEquals(xxValues, yyValues)
                     && SetEquals(xxFormulas, yyFormulas)
-                    && _colorsComparer.Equals(xx.Colors, yy.Colors)
-                    && _contentsTypeComparer.Equals(xx.ContentTypes, yy.ContentTypes)
-                    && _iconSetTypeComparer.Equals(xx.IconSetOperators, yy.IconSetOperators);
+                    && Equals(xx.Colors, yy.Colors)
+                    && Equals(xx.ContentTypes, yy.ContentTypes)
+                    && Equals(xx.IconSetOperators, yy.IconSetOperators);
             }
 
             public int GetHashCode(XLConditionalFormat obj)
@@ -83,6 +79,22 @@ namespace ClosedXML.Excel
             {
                 return new HashSet<T>(second, EqualityComparer<T>.Default)
                     .SetEquals(first);
+            }
+
+            private static bool Equals<TValue>(Dictionary<int, TValue> x, Dictionary<int, TValue> y)
+            {
+                if (x.Count != y.Count)
+                    return false;
+                if (x.Keys.Except(y.Keys).Any())
+                    return false;
+                if (y.Keys.Except(x.Keys).Any())
+                    return false;
+                var valueComparer = EqualityComparer<TValue>.Default;
+                foreach (var pair in x)
+                    if (!valueComparer.Equals(pair.Value, y[pair.Key]))
+                        return false;
+
+                return true;
             }
         }
 
@@ -534,36 +546,6 @@ namespace ClosedXML.Excel
             ReverseIconOrder = reverseIconOrder;
             ShowIconOnly = showIconOnly;
             return new XLCFIconSet(this);
-        }
-    }
-
-    internal class DictionaryComparer<TKey, TValue> :
-        IEqualityComparer<Dictionary<TKey, TValue>>
-    {
-        private readonly IEqualityComparer<TValue> _valueComparer;
-
-        public DictionaryComparer(IEqualityComparer<TValue> valueComparer = null)
-        {
-            this._valueComparer = valueComparer ?? EqualityComparer<TValue>.Default;
-        }
-
-        public bool Equals(Dictionary<TKey, TValue> x, Dictionary<TKey, TValue> y)
-        {
-            if (x.Count != y.Count)
-                return false;
-            if (x.Keys.Except(y.Keys).Any())
-                return false;
-            if (y.Keys.Except(x.Keys).Any())
-                return false;
-            foreach (var pair in x)
-                if (!_valueComparer.Equals(pair.Value, y[pair.Key]))
-                    return false;
-            return true;
-        }
-
-        public int GetHashCode(Dictionary<TKey, TValue> obj)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -92,7 +92,7 @@ namespace ClosedXML.Excel
 
                     var (rulesToConsolidate, areasWithSameFormat) = GetConsolidateableRules(formats);
                     var consolidatedAreas = areasWithSameFormat.GetConsolidated();
-                    var consolidatedCf = new XLConditionalFormat(format, consolidatedAreas);
+                    var consolidatedCf = new XLConditionalFormat(_worksheet, format, consolidatedAreas);
 
                     // Remove consolidated formats
                     rulesToConsolidate.Reverse();

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -74,6 +74,30 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
+        /// Clear conditional formats in the <paramref name="area"/>. Split if necessary, remove if
+        /// conditional format has no area left.
+        /// </summary>
+        internal void Clear(XLSheetRange area)
+        {
+            for (var i = _conditionalFormats.Count - 1; i >= 0; --i)
+            {
+                var conditionalFormat = _conditionalFormats[i];
+                if (!conditionalFormat.Areas.IntersectsWith(area))
+                    continue;
+
+                var remainingAreas = conditionalFormat.Areas.Excluding(area);
+                if (remainingAreas.Count > 0)
+                {
+                    conditionalFormat.Areas = remainingAreas;
+                }
+                else
+                {
+                    _conditionalFormats.RemoveAt(i);
+                }
+            }
+        }
+
+        /// <summary>
         /// The method consolidate the same conditional formats, which are located in adjacent ranges.
         /// </summary>
         internal void Consolidate()

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -9,7 +9,7 @@ namespace ClosedXML.Excel
     /// a collection of <see cref="XLConditionalFormat"/>. Doesn't contain pivot table formats,
     /// they are in pivot table <see cref="XLPivotTable.ConditionalFormats"/>,
     /// </summary>
-    internal class XLConditionalFormats : IXLConditionalFormats
+    internal class XLConditionalFormats : IXLConditionalFormats, IEnumerable<XLConditionalFormat>
     {
         private readonly XLWorksheet _worksheet;
         private readonly List<XLConditionalFormat> _conditionalFormats = new();

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -209,6 +209,29 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
         return XLRangeConsolidationEngine.Consolidate(this);
     }
 
+    internal bool IntersectsWith(XLSheetRange otherArea)
+    {
+        foreach (var area in _areas)
+        {
+            if (area.Intersects(otherArea))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal XLAreaList Excluding(XLSheetRange excludedArea)
+    {
+        if (!IntersectsWith(excludedArea))
+            return this;
+
+        var list = new List<XLSheetRange>();
+        foreach (var area in _areas)
+            area.Exclude(excludedArea, list);
+
+        return new XLAreaList(list);
+    }
+
     public IEnumerator<XLSheetRange> GetEnumerator()
     {
         return _areas.GetEnumerator();

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -789,21 +789,21 @@ namespace ClosedXML.Excel
                 return null;
             }
 
-            // left
-            if (LeftColumn < intersection.LeftColumn)
-                nonExcludedAreas.Add(new XLSheetRange(TopRow, LeftColumn, BottomRow, intersection.LeftColumn - 1));
-
             // top
             if (TopRow < intersection.TopRow)
-                nonExcludedAreas.Add(new XLSheetRange(TopRow, intersection.LeftColumn, intersection.TopRow - 1, intersection.RightColumn));
+                nonExcludedAreas.Add(new XLSheetRange(TopRow, LeftColumn, intersection.TopRow - 1, RightColumn));
 
             // bottom
             if (BottomRow > intersection.BottomRow)
-                nonExcludedAreas.Add(new XLSheetRange(intersection.BottomRow + 1, intersection.LeftColumn, BottomRow, intersection.RightColumn));
+                nonExcludedAreas.Add(new XLSheetRange(intersection.BottomRow + 1, LeftColumn, BottomRow, RightColumn));
+
+            // left
+            if (LeftColumn < intersection.LeftColumn)
+                nonExcludedAreas.Add(new XLSheetRange(intersection.TopRow, LeftColumn, intersection.BottomRow, intersection.LeftColumn - 1));
 
             // right
             if (RightColumn > intersection.RightColumn)
-                nonExcludedAreas.Add(new XLSheetRange(TopRow, intersection.RightColumn + 1, BottomRow, RightColumn));
+                nonExcludedAreas.Add(new XLSheetRange(intersection.TopRow, intersection.RightColumn + 1, intersection.BottomRow, RightColumn));
 
             return intersection;
         }

--- a/ClosedXML/Excel/DataValidation/XLDataValidation.cs
+++ b/ClosedXML/Excel/DataValidation/XLDataValidation.cs
@@ -1,8 +1,6 @@
-#nullable disable
-
-// Keep this file CodeMaid organised and cleaned
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace ClosedXML.Excel
@@ -58,6 +56,7 @@ namespace ClosedXML.Excel
                    (!String.IsNullOrWhiteSpace(ErrorTitle) || !String.IsNullOrWhiteSpace(ErrorMessage)));
         }
 
+        [MemberNotNull(nameof(minValue), nameof(maxValue), nameof(InputTitle), nameof(InputMessage), nameof(ErrorTitle), nameof(ErrorMessage))]
         private void Initialize()
         {
             AllowedValues = XLAllowedValues.AnyValue;
@@ -72,8 +71,8 @@ namespace ClosedXML.Excel
             ErrorStyle = XLErrorStyle.Stop;
             Operator = XLOperator.Between;
             Value = String.Empty;
-            MinValue = String.Empty;
-            MaxValue = String.Empty;
+            minValue = String.Empty;
+            maxValue = String.Empty;
         }
 
         #region IXLDataValidation Members

--- a/ClosedXML/Excel/IO/WorksheetPartWriter.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartWriter.cs
@@ -673,7 +673,7 @@ namespace ClosedXML.Excel.IO
                 }
             }
 
-            var exlst = xlWorksheet.ConditionalFormats.Where(c => c.ConditionalFormatType == XLConditionalFormatType.DataBar).ToArray();
+            var exlst = xlWorksheet.ConditionalFormats.Where<XLConditionalFormat>(c => c.ConditionalFormatType == XLConditionalFormatType.DataBar).ToArray();
             if (exlst.Any())
             {
                 if (!worksheet.Elements<WorksheetExtensionList>().Any())

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -411,7 +411,7 @@ namespace ClosedXML.Excel
             }
 
             if (clearOptions.HasFlag(XLClearOptions.ConditionalFormats))
-                ClearConditionalFormatting();
+                Worksheet.ConditionalFormats.Clear(SheetRange);
 
             if (clearOptions.HasFlag(XLClearOptions.DataValidation))
             {
@@ -439,36 +439,6 @@ namespace ClosedXML.Excel
             var xlRangeAddress = this.RangeAddress.Relative(in xlSourceBaseRangeAddress, in xlTargetBaseRangeAddress);
 
             return ((XLRangeBase)targetBaseRange).Range(in xlRangeAddress);
-        }
-
-        internal void ClearConditionalFormatting()
-        {
-            // Removal should be rare, so only allocate if necessary
-            List<XLConditionalFormat> toRemoveCfs = null;
-            var area = SheetRange;
-            foreach (var format in Worksheet.ConditionalFormats)
-            {
-                var formatAreas = format.Areas;
-                if (!formatAreas.IntersectsWith(area))
-                    continue;
-
-                var remainingAreas = formatAreas.Excluding(area);
-                if (remainingAreas.Count > 0)
-                {
-                    format.Areas = remainingAreas;
-                }
-                else
-                {
-                    toRemoveCfs ??= new List<XLConditionalFormat>();
-                    toRemoveCfs.Add(format);
-                }
-            }
-
-            if (toRemoveCfs is null)
-                return;
-
-            foreach (var toRemovedCf in toRemoveCfs)
-                Worksheet.ConditionalFormats.Remove(x => x == toRemovedCf);
         }
 
         internal void RemoveSparklines()

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -445,7 +445,7 @@ namespace ClosedXML.Excel
         {
             var mf = RangeAddress.FirstAddress;
             var ml = RangeAddress.LastAddress;
-            foreach (var format in Worksheet.ConditionalFormats.Where(x => x.Ranges.GetIntersectedRanges(RangeAddress).Any()).ToList())
+            foreach (var format in Worksheet.ConditionalFormats.Where<XLConditionalFormat>(x => x.Ranges.GetIntersectedRanges(RangeAddress).Any()).ToList())
             {
                 var cfRanges = format.Ranges.ToList();
                 format.Ranges.RemoveAll();
@@ -1940,7 +1940,7 @@ namespace ClosedXML.Excel
             {
                 cellsUsed = cellsUsed.Union(
                     Worksheet.ConditionalFormats
-                        .SelectMany(cf => cf.Ranges.GetIntersectedRanges(RangeAddress))
+                        .SelectMany<XLConditionalFormat, IXLRange>(cf => cf.Ranges.GetIntersectedRanges(RangeAddress))
                         .Select(selector)
                         .Where(predicate)
                 );

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -411,7 +411,7 @@ namespace ClosedXML.Excel
             }
 
             if (clearOptions.HasFlag(XLClearOptions.ConditionalFormats))
-                RemoveConditionalFormatting();
+                ClearConditionalFormatting();
 
             if (clearOptions.HasFlag(XLClearOptions.DataValidation))
             {
@@ -441,67 +441,34 @@ namespace ClosedXML.Excel
             return ((XLRangeBase)targetBaseRange).Range(in xlRangeAddress);
         }
 
-        internal void RemoveConditionalFormatting()
+        internal void ClearConditionalFormatting()
         {
-            var mf = RangeAddress.FirstAddress;
-            var ml = RangeAddress.LastAddress;
-            foreach (var format in Worksheet.ConditionalFormats.Where<XLConditionalFormat>(x => x.Ranges.GetIntersectedRanges(RangeAddress).Any()).ToList())
+            // Removal should be rare, so only allocate if necessary
+            List<XLConditionalFormat> toRemoveCfs = null;
+            var area = SheetRange;
+            foreach (var format in Worksheet.ConditionalFormats)
             {
-                var cfRanges = format.Ranges.ToList();
-                format.Ranges.RemoveAll();
+                var formatAreas = format.Areas;
+                if (!formatAreas.IntersectsWith(area))
+                    continue;
 
-                foreach (var cfRange in cfRanges)
+                var remainingAreas = formatAreas.Excluding(area);
+                if (remainingAreas.Count > 0)
                 {
-                    if (!cfRange.Intersects(this))
-                    {
-                        format.Ranges.Add(cfRange);
-                        continue;
-                    }
-
-                    var f = cfRange.RangeAddress.FirstAddress;
-                    var l = cfRange.RangeAddress.LastAddress;
-                    bool byWidth = false, byHeight = false;
-                    XLRange rng1 = null, rng2 = null;
-                    if (mf.ColumnNumber <= f.ColumnNumber && ml.ColumnNumber >= l.ColumnNumber)
-                    {
-                        if (mf.RowNumber.Between(f.RowNumber, l.RowNumber) || ml.RowNumber.Between(f.RowNumber, l.RowNumber))
-                        {
-                            if (mf.RowNumber > f.RowNumber)
-                                rng1 = Worksheet.Range(f.RowNumber, f.ColumnNumber, mf.RowNumber - 1, l.ColumnNumber);
-                            if (ml.RowNumber < l.RowNumber)
-                                rng2 = Worksheet.Range(ml.RowNumber + 1, f.ColumnNumber, l.RowNumber, l.ColumnNumber);
-                        }
-                        byWidth = true;
-                    }
-
-                    if (mf.RowNumber <= f.RowNumber && ml.RowNumber >= l.RowNumber)
-                    {
-                        if (mf.ColumnNumber.Between(f.ColumnNumber, l.ColumnNumber) || ml.ColumnNumber.Between(f.ColumnNumber, l.ColumnNumber))
-                        {
-                            if (mf.ColumnNumber > f.ColumnNumber)
-                                rng1 = Worksheet.Range(f.RowNumber, f.ColumnNumber, l.RowNumber, mf.ColumnNumber - 1);
-                            if (ml.ColumnNumber < l.ColumnNumber)
-                                rng2 = Worksheet.Range(f.RowNumber, ml.ColumnNumber + 1, l.RowNumber, l.ColumnNumber);
-                        }
-                        byHeight = true;
-                    }
-
-                    if (rng1 != null)
-                    {
-                        format.Ranges.Add(rng1);
-                    }
-                    if (rng2 != null)
-                    {
-                        //TODO: reflect the formula for a new range
-                        format.Ranges.Add(rng2);
-                    }
-
-                    if (!byWidth && !byHeight)
-                        format.Ranges.Add(cfRange); // Not split, preserve original
+                    format.Areas = remainingAreas;
                 }
-                if (!format.Ranges.Any())
-                    Worksheet.ConditionalFormats.Remove(x => x == format);
+                else
+                {
+                    toRemoveCfs ??= new List<XLConditionalFormat>();
+                    toRemoveCfs.Add(format);
+                }
             }
+
+            if (toRemoveCfs is null)
+                return;
+
+            foreach (var toRemovedCf in toRemoveCfs)
+                Worksheet.ConditionalFormats.Remove(x => x == toRemovedCf);
         }
 
         internal void RemoveSparklines()

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -668,7 +668,8 @@ namespace ClosedXML.Excel
             Tables.ForEach<XLTable>(t => t.CopyTo(targetSheet, false));
             DefinedNames.ForEach<XLDefinedName>(nr => nr.CopyTo(targetSheet)); // Names must modify table references, so keep the order.
             PivotTables.ForEach<XLPivotTable>(pt => pt.CopyTo(targetSheet.Cell(pt.TargetCell.Address.CastTo<XLAddress>().WithoutWorksheet())));
-            ConditionalFormats.ForEach(cf => cf.CopyTo(targetSheet));
+            foreach (var cf in ConditionalFormats)
+                cf.CopyTo(targetSheet);
 
             // Sparklines were already copied during copy of columns, rows and cells, but piecemeal (e.g. multi-cell
             // sparkline group could be split into group-per-cell). Since this is a copy of whole sheet, just remove
@@ -1269,14 +1270,14 @@ namespace ClosedXML.Excel
 
         private void ShiftConditionalFormattingColumns(XLRange range, int columnsShifted)
         {
-            if (!ConditionalFormats.Any()) return;
+            if (!ConditionalFormats.Any<XLConditionalFormat>()) return;
             Int32 firstCol = range.RangeAddress.FirstAddress.ColumnNumber;
             if (firstCol == 1) return;
 
             int colNum = columnsShifted > 0 ? firstCol - 1 : firstCol;
             var model = Column(colNum).AsRange();
 
-            foreach (var cf in ConditionalFormats.ToList())
+            foreach (var cf in ConditionalFormats.ToList<XLConditionalFormat>())
             {
                 var cfRanges = cf.Ranges.ToList();
                 cf.Ranges.RemoveAll();
@@ -1384,14 +1385,14 @@ namespace ClosedXML.Excel
 
         private void ShiftConditionalFormattingRows(XLRange range, int rowsShifted)
         {
-            if (!ConditionalFormats.Any()) return;
+            if (!ConditionalFormats.Any<XLConditionalFormat>()) return;
             Int32 firstRow = range.RangeAddress.FirstAddress.RowNumber;
             if (firstRow == 1) return;
 
             int rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
             var model = Row(rowNum).AsRange();
 
-            foreach (var cf in ConditionalFormats.ToList())
+            foreach (var cf in ConditionalFormats.ToList<XLConditionalFormat>())
             {
                 var cfRanges = cf.Ranges.ToList();
                 cf.Ranges.RemoveAll();

--- a/docs/migrations/migrate-to-0.106.rst
+++ b/docs/migrations/migrate-to-0.106.rst
@@ -98,3 +98,17 @@ to the default format of a workbook (e.g. ``ws.Cell("A1").Style = wb.Style``).
 
 Default color of fill and border colors ``IXLStyle`` elements is now ``XLColor.Automatic``.
 Previously, it was (``XLColor.FromIndex(64)``).
+
+****************************
+Clearing conditional formats
+****************************
+
+Partial clearing of conditional format (e.g. clearing `B2` of conditional format for area ``A1:C3``)
+now correctly splits the format of into individual remaining areas (e.g. into ``A1:A3 B1 C1:C3 B3``).
+
+Originally, the partial clearing only worked for some situations. Concretely, it only worked when
+the area was fully horizontally/vertically split, but not for corners (``A1:B2`` without a corner) or
+center (``A1:C3`` without ``B2``).
+
+Reminder: the clearing of a conditional format is done through the Clear method with appropritate
+option, e.g. ``ws.Range("A2:C5").Clear(XLClearOptions.ConditionalFormats)``.


### PR DESCRIPTION
When conditional formats were cleaned from a range, the `IXLRange.Clear(XLClearOptions)` method didn't work for most cases that caused splits of an area of conditional format. This PR fixes that and the `IXLRange.Clear(XLClearOptions)` method now correctly splits CF area.

There is no bug, but this is basically a prerequisite for refactoring of CF shifting code into `ISheetListener`.

Old version only supported horizontal or vertical splits as demonstrated in the screenshot. The  **0.105** can only split area into two, but not create an "eye", "groove" or cut off "corner". The **develop** branch can split conditional format any any way:
<img width="875" height="347" alt="image" src="https://github.com/user-attachments/assets/a0852621-a6bc-4535-91d7-c4a4e3b90d63" />

Demo code:
```csharp
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();
ws.Range("A1:D6").AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Blue);

ws.Range("A2:G2").Clear(XLClearOptions.ConditionalFormats);
ws.Cell("B4").Clear(XLClearOptions.ConditionalFormats);
ws.Range("B6:B10").Clear(XLClearOptions.ConditionalFormats);
ws.Range("D5:E6").Clear(XLClearOptions.ConditionalFormats);

wb.SaveAs("cf-clean.xlsx");
```
