### PR TITLE
Shift conditional formats formulas on structural change

### DIFF
--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
 using System.Linq;
@@ -35,9 +35,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Cell("A1").CopyTo("B2");
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual(2, ws.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("A1:A1", ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
-            Assert.AreEqual("B2:B2", ws.ConditionalFormats.First().Ranges.Last().RangeAddress.ToString());
+            Assert.AreEqual("A1:A1 B2:B2", ws.ConditionalFormats.First().Ranges.ToSpaceList());
         }
 
         [Test]
@@ -52,8 +50,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws.Cell("A1").CopyTo("B2");
 
             Assert.AreEqual(1, ws.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("A1:C3", ws.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+            Assert.AreEqual("A1:C3", ws.ConditionalFormats.First().Ranges.ToSpaceList());
         }
 
         [Test]
@@ -75,8 +72,8 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             Assert.AreEqual(1, ws2.ConditionalFormats.First().Ranges.Count);
             Assert.AreEqual("Sheet1", ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name);
             Assert.AreEqual("Sheet2", ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("A1:A1", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
-            Assert.AreEqual("B2:B2", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+            Assert.AreEqual("A1:A1", ws1.ConditionalFormats.First().Ranges.ToSpaceList());
+            Assert.AreEqual("B2:B2", ws2.ConditionalFormats.First().Ranges.ToSpaceList());
         }
 
         [Test]

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatCopyTests.cs
@@ -67,13 +67,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             ws1.Cell("A1").CopyTo(otherCell);
 
             Assert.AreEqual(1, ws1.ConditionalFormats.Count());
+            Assert.AreEqual("Sheet1!A1:A1", ws1.ConditionalFormats.First().Ranges.ToSpaceList(true));
+
             Assert.AreEqual(1, ws2.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws1.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual(1, ws2.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("Sheet1", ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("Sheet2", ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("A1:A1", ws1.ConditionalFormats.First().Ranges.ToSpaceList());
-            Assert.AreEqual("B2:B2", ws2.ConditionalFormats.First().Ranges.ToSpaceList());
+            Assert.AreEqual("Sheet2!B2:B2", ws2.ConditionalFormats.First().Ranges.ToSpaceList(true));
         }
 
         [Test]
@@ -103,11 +100,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             format.CopyTo(ws2);
 
             Assert.AreEqual(1, ws1.ConditionalFormats.Count());
+            Assert.AreEqual("Sheet1!A1:C3", ws1.ConditionalFormats.First().Ranges.ToSpaceList(true));
+
             Assert.AreEqual(1, ws2.ConditionalFormats.Count());
-            Assert.AreEqual(1, ws1.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual(1, ws2.ConditionalFormats.First().Ranges.Count);
-            Assert.AreEqual("Sheet1!A1:C3", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
-            Assert.AreEqual("Sheet2!A1:C3", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString(XLReferenceStyle.A1, true));
+            Assert.AreEqual("Sheet2!A1:C3", ws2.ConditionalFormats.First().Ranges.ToSpaceList(true));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
@@ -24,11 +24,11 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
                 var cf = ws.ConditionalFormats.ToArray();
 
                 Assert.AreEqual(5, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("A2:D2", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("A3:E3", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("B4:D6", cf[3].Range.RangeAddress.ToString());
-                Assert.AreEqual("E7:F7", cf[4].Range.RangeAddress.ToString());
+                Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+                Assert.AreEqual("A2:D2", cf[1].Ranges.ToSpaceList());
+                Assert.AreEqual("A3:E3", cf[2].Ranges.ToSpaceList());
+                Assert.AreEqual("B4:D6", cf[3].Ranges.ToSpaceList());
+                Assert.AreEqual("E7:F7", cf[4].Ranges.ToSpaceList());
             }
         }
 
@@ -74,10 +74,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
                 var cf = ws.ConditionalFormats.ToArray();
 
                 Assert.AreEqual(4, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("A2:A2", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("A3:B3", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("B7:C7", cf[3].Range.RangeAddress.ToString());
+                Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+                Assert.AreEqual("A2:A2", cf[1].Ranges.ToSpaceList());
+                Assert.AreEqual("A3:B3", cf[2].Ranges.ToSpaceList());
+                Assert.AreEqual("B7:C7", cf[3].Ranges.ToSpaceList());
             }
         }
 
@@ -98,10 +98,10 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
                 var cf = ws.ConditionalFormats.ToArray();
 
                 Assert.AreEqual(4, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("B1:B1", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("C1:C2", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("G3:G4", cf[3].Range.RangeAddress.ToString());
+                Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+                Assert.AreEqual("B1:B1", cf[1].Ranges.ToSpaceList());
+                Assert.AreEqual("C1:C2", cf[2].Ranges.ToSpaceList());
+                Assert.AreEqual("G3:G4", cf[3].Ranges.ToSpaceList());
             }
         }
 
@@ -116,11 +116,11 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
                 ws.Row(2).InsertRowsAbove(1);
                 Assert.IsTrue(cf.Range.RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Range.RangeAddress.ToString());
+                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
 
                 ws.Column(2).InsertColumnsAfter(1);
                 Assert.IsTrue(cf.Range.RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Range.RangeAddress.ToString());
+                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
             }
         }
     }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
@@ -1,127 +1,116 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System.Linq;
 
-namespace ClosedXML.Tests.Excel.ConditionalFormats
+namespace ClosedXML.Tests.Excel.ConditionalFormats;
+
+[TestFixture]
+public class ConditionalFormatShiftTests
 {
-    [TestFixture]
-    public class ConditionalFormatShiftTests
+    [Test]
+    public void CFShiftedOnColumnInsert()
     {
-        [Test]
-        public void CFShiftedOnColumnInsert()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:D7").Value = 1;
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("CFShift");
+        ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+        ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+        ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+        ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+        ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+        ws.Cells("A1:D7").Value = 1;
 
-                ws.Column(2).InsertColumnsAfter(2);
-                var cf = ws.ConditionalFormats.ToArray();
+        ws.Column(2).InsertColumnsAfter(2);
+        var cf = ws.ConditionalFormats.ToArray();
 
-                Assert.AreEqual(5, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
-                Assert.AreEqual("A2:D2", cf[1].Ranges.ToSpaceList());
-                Assert.AreEqual("A3:E3", cf[2].Ranges.ToSpaceList());
-                Assert.AreEqual("B4:D6", cf[3].Ranges.ToSpaceList());
-                Assert.AreEqual("E7:F7", cf[4].Ranges.ToSpaceList());
-            }
-        }
+        Assert.AreEqual(5, cf.Length);
+        Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+        Assert.AreEqual("A2:D2", cf[1].Ranges.ToSpaceList());
+        Assert.AreEqual("A3:E3", cf[2].Ranges.ToSpaceList());
+        Assert.AreEqual("B4:D6", cf[3].Ranges.ToSpaceList());
+        Assert.AreEqual("E7:F7", cf[4].Ranges.ToSpaceList());
+    }
 
-        [Test]
-        public void CFShiftedOnRowInsert()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:G5").Value = 1;
+    [Test]
+    public void CFShiftedOnRowInsert()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("CFShift");
+        ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+        ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+        ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+        ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+        ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+        ws.Cells("A1:G5").Value = 1;
 
-                ws.Row(2).InsertRowsBelow(2);
-                var cf = ws.ConditionalFormats.ToArray();
+        ws.Row(2).InsertRowsBelow(2);
+        var cf = ws.ConditionalFormats.ToArray();
 
-                Assert.AreEqual(5, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Range.RangeAddress.ToString());
-                Assert.AreEqual("B1:B4", cf[1].Range.RangeAddress.ToString());
-                Assert.AreEqual("C1:C5", cf[2].Range.RangeAddress.ToString());
-                Assert.AreEqual("D2:F4", cf[3].Range.RangeAddress.ToString());
-                Assert.AreEqual("G6:G7", cf[4].Range.RangeAddress.ToString());
-            }
-        }
+        Assert.AreEqual(5, cf.Length);
+        Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+        Assert.AreEqual("B1:B4", cf[1].Ranges.ToSpaceList());
+        Assert.AreEqual("C1:C5", cf[2].Ranges.ToSpaceList());
+        Assert.AreEqual("D2:F4", cf[3].Ranges.ToSpaceList());
+        Assert.AreEqual("G6:G7", cf[4].Ranges.ToSpaceList());
+    }
 
-        [Test]
-        public void CFShiftedOnColumnDelete()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:D7").Value = 1;
+    [Test]
+    public void CFShiftedOnColumnDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("CFShift");
+        ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+        ws.Range("A2:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+        ws.Range("A3:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+        ws.Range("B4:B6").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+        ws.Range("C7:D7").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+        ws.Cells("A1:D7").Value = 1;
 
-                ws.Column(2).Delete();
-                var cf = ws.ConditionalFormats.ToArray();
+        ws.Column(2).Delete();
+        var cf = ws.ConditionalFormats.ToArray();
 
-                Assert.AreEqual(4, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
-                Assert.AreEqual("A2:A2", cf[1].Ranges.ToSpaceList());
-                Assert.AreEqual("A3:B3", cf[2].Ranges.ToSpaceList());
-                Assert.AreEqual("B7:C7", cf[3].Ranges.ToSpaceList());
-            }
-        }
+        Assert.AreEqual(4, cf.Length);
+        Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+        Assert.AreEqual("A2:A2", cf[1].Ranges.ToSpaceList());
+        Assert.AreEqual("A3:B3", cf[2].Ranges.ToSpaceList());
+        Assert.AreEqual("B7:C7", cf[3].Ranges.ToSpaceList());
+    }
 
-        [Test]
-        public void CFShiftedOnRowDelete()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
-                ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
-                ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
-                ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
-                ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
-                ws.Cells("A1:G5").Value = 1;
+    [Test]
+    public void CFShiftedOnRowDelete()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("CFShift");
+        ws.Range("A1:A1").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AirForceBlue);
+        ws.Range("B1:B2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.AliceBlue);
+        ws.Range("C1:C3").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Alizarin);
+        ws.Range("D2:F2").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Almond);
+        ws.Range("G4:G5").AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Amaranth);
+        ws.Cells("A1:G5").Value = 1;
 
-                ws.Row(2).Delete();
-                var cf = ws.ConditionalFormats.ToArray();
+        ws.Row(2).Delete();
+        var cf = ws.ConditionalFormats.ToArray();
 
-                Assert.AreEqual(4, cf.Length);
-                Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
-                Assert.AreEqual("B1:B1", cf[1].Ranges.ToSpaceList());
-                Assert.AreEqual("C1:C2", cf[2].Ranges.ToSpaceList());
-                Assert.AreEqual("G3:G4", cf[3].Ranges.ToSpaceList());
-            }
-        }
+        Assert.AreEqual(4, cf.Length);
+        Assert.AreEqual("A1:A1", cf[0].Ranges.ToSpaceList());
+        Assert.AreEqual("B1:B1", cf[1].Ranges.ToSpaceList());
+        Assert.AreEqual("C1:C2", cf[2].Ranges.ToSpaceList());
+        Assert.AreEqual("G3:G4", cf[3].Ranges.ToSpaceList());
+    }
 
-        [Test]
-        public void CFShiftedTruncateRange()
-        {
-            using (var wb = new XLWorkbook())
-            {
-                var ws = wb.AddWorksheet("CFShift");
-                ws.AsRange().AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Red);
-                var cf = ws.ConditionalFormats.Single();
+    [Test]
+    public void CFShiftedTruncateRange()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("CFShift");
+        ws.AsRange().AddConditionalFormat().WhenGreaterThan(0).Fill.SetBackgroundColor(XLColor.Red);
+        var cf = ws.ConditionalFormats.Single();
 
-                ws.Row(2).InsertRowsAbove(1);
-                Assert.IsTrue(cf.Range.RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
+        ws.Row(2).InsertRowsAbove(1);
+        Assert.IsTrue(cf.Range.RangeAddress.IsValid);
+        Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
 
-                ws.Column(2).InsertColumnsAfter(1);
-                Assert.IsTrue(cf.Range.RangeAddress.IsValid);
-                Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
-            }
-        }
+        ws.Column(2).InsertColumnsAfter(1);
+        Assert.IsTrue(cf.Range.RangeAddress.IsValid);
+        Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
     }
 }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatShiftTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using ClosedXML.Excel;
 using NUnit.Framework;
 using System.Linq;
@@ -112,5 +114,117 @@ public class ConditionalFormatShiftTests
         ws.Column(2).InsertColumnsAfter(1);
         Assert.IsTrue(cf.Range.RangeAddress.IsValid);
         Assert.AreEqual($"1:{XLHelper.MaxRowNumber}", cf.Ranges.ToSpaceList());
+    }
+
+    [TestCaseSource(nameof(GetSplitTestCases))]
+    public void Conditional_formats_can_split_when_inserted_or_deleted_doesnt_shift_whole_cf_area(string initialCfArea, Action<IXLWorksheet> shiftAction, string shiftedCfArea)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Range(initialCfArea).AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Red);
+
+        shiftAction(ws);
+
+        Assert.AreEqual(shiftedCfArea, ws.ConditionalFormats.Single().Ranges.ToSpaceList());
+    }
+
+    [TestCaseSource(nameof(GetFormulaShiftTestCases))]
+    public void Conditional_format_shifts_formulas(string cfArea, string formula, Action<IXLWorksheet> shiftAction, string shiftedFormula)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet");
+        ws.Range(cfArea).AddConditionalFormat().WhenEquals(formula).Fill.SetBackgroundColor(XLColor.Red);
+
+        shiftAction(ws);
+
+        Assert.AreEqual(shiftedFormula, ws.ConditionalFormats.Single().Values.Single().Value.Value);
+    }
+
+    [Test]
+    public void Conditional_format_shifts_formula_only_if_formula_cells_are_affected_by_shift()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = 1;
+        ws.Cell("B1").AddConditionalFormat().WhenEquals("=A1").Fill.SetBackgroundColor(XLColor.Red);
+
+        // Shift only range with CF, not the referenced cells. Formula retains same A1 address
+        ws.Range("B1").InsertRowsAbove(1);
+
+        Assert.AreEqual("A1", ws.ConditionalFormats.Single().Values.Single().Value.Value);
+        Assert.AreEqual("B2:B2", ws.ConditionalFormats.Single().Ranges.ToSpaceList());
+    }
+
+    [TestCase("A1")]
+    [TestCase("Sheet!A1")]
+    public void Conditional_format_does_not_shift_values_that_look_like_formulas(string formulaLookAlike)
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Sheet");
+        ws.Cell("B1").AddConditionalFormat().WhenEquals(formulaLookAlike).Fill.SetBackgroundColor(XLColor.Red);
+
+        ws.Row(1).InsertRowsAbove(1);
+
+        Assert.AreEqual(formulaLookAlike, ws.ConditionalFormats.Single().Values.Single().Value.Value);
+    }
+
+    [Test]
+    public void Conditional_format_formula_referencing_another_sheet_is_updated_when_another_sheet_is_modified()
+    {
+        using var wb = new XLWorkbook();
+        var sheet = wb.AddWorksheet("Sheet");
+        var another = wb.AddWorksheet("Another");
+        sheet.Cell("A1").AddConditionalFormat().WhenEquals("=Another!B2").Fill.SetBackgroundColor(XLColor.Red);
+
+        another.Row(1).InsertRowsAbove(2);
+
+        Assert.AreEqual("Another!B4", sheet.ConditionalFormats.Single().Values.Single().Value.Value);
+    }
+
+    private static IEnumerable<TestCaseData<string, Action<IXLWorksheet>, string>> GetSplitTestCases()
+    {
+        yield return new TestCaseData<string, Action<IXLWorksheet>, string>("A1:C3", ws => ws.Range("A1").InsertRowsAbove(2), "B1:C3 A3:A5");
+        yield return new TestCaseData<string, Action<IXLWorksheet>, string>("A1:C3", ws => ws.Range("A2").InsertColumnsBefore(2), "A1:C1 C2:E2 A3:C3");
+        yield return new TestCaseData<string, Action<IXLWorksheet>, string>("A10:C12", ws => ws.Range("B10").Delete(XLShiftDeletedCells.ShiftCellsUp), "A10:A12 B10:B11 C10:C12");
+        yield return new TestCaseData<string, Action<IXLWorksheet>, string>("D1:G3", ws => ws.Range("A1:C2").Delete(XLShiftDeletedCells.ShiftCellsLeft), "A1:D2 D3:G3");
+    }
+
+    private static IEnumerable<TestCaseData<string, string, Action<IXLWorksheet>, string>> GetFormulaShiftTestCases()
+    {
+        // Smoke test
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("A1", "=B1", ws => ws.Row(1).InsertRowsAbove(1), "B2");
+
+        // Insert or delete whole row or column
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Row(1).InsertRowsAbove(1), "IF(C4>A2,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Row(2).InsertRowsAbove(1), "IF(C4>A1,TRUE,FALSE)");
+
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Column(2).InsertColumnsBefore(2), "IF(E3>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Column(1).InsertColumnsBefore(1), "IF(D3>B1,TRUE,FALSE)");
+
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Row(2).Delete(), "IF(C2>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Row(1).Delete(), "IF(C2>#REF!,TRUE,FALSE)");
+
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Column(2).Delete(), "IF(B3>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Column(1).Delete(), "IF(B3>#REF!,TRUE,FALSE)");
+
+        // Insert or delete area that shifts only portion of formula
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("B2:C2").InsertRowsAbove(2), "IF(C5>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("A1").InsertRowsAbove(2), "IF(C3>A3,TRUE,FALSE)");
+
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("B2:B3").InsertColumnsBefore(2), "IF(E3>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("A1").InsertColumnsBefore(2), "IF(C3>C1,TRUE,FALSE)");
+
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("B2:C2").Delete(XLShiftDeletedCells.ShiftCellsUp), "IF(C2>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("A1").Delete(XLShiftDeletedCells.ShiftCellsUp), "IF(C3>#REF!,TRUE,FALSE)");
+
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("B1:B3").Delete(XLShiftDeletedCells.ShiftCellsLeft), "IF(B3>A1,TRUE,FALSE)");
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("C3:E5", "=IF(C3>A1,TRUE,FALSE)", ws => ws.Range("A1:A2").Delete(XLShiftDeletedCells.ShiftCellsLeft), "IF(C3>#REF!,TRUE,FALSE)");
+
+        // Do not shift formulas form other sheets
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("A2", "=Other!A2", ws => ws.Row(1).InsertRowsAbove(10), "Other!A2");
+
+        // Shift formulas with sheet name of the sheet with CF
+        yield return new TestCaseData<string, string, Action<IXLWorksheet>, string>("A2", "=Sheet!B2", ws => ws.Row(1).InsertRowsAbove(1), "Sheet!B3");
+
     }
 }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ClosedXML.Excel;
 using NUnit.Framework;
 using System.Globalization;
@@ -16,7 +17,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             // The input file contains duplicates of same dxf and thus the output also contains some duplicate dxf.
             TestHelper.LoadSaveAndCompare(
                 @"Other\StyleReferenceFiles\ConditionalFormattingOrder\inputfile.xlsx",
-                @"Other\StyleReferenceFiles\ConditionalFormattingOrder\ConditionalFormattingOrder.xlsx");            
+                @"Other\StyleReferenceFiles\ConditionalFormattingOrder\ConditionalFormattingOrder.xlsx");
         }
 
         [TestCase(true, 7)]
@@ -152,6 +153,44 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
                 Assert.AreEqual(1, cf.Values.Count);
                 CollectionAssert.AreEqual(expectedFormula, cf.Values[1].Value);
             }
+        }
+
+        [Test]
+        public void Range_setter_throws_on_range_from_different_worksheet()
+        {
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            var cf = ws1.Range("A1").AddConditionalFormat();
+            var ws2 = wb.AddWorksheet();
+            var differentSheetRange = ws2.Range("B5");
+
+            Assert.Throws<ArgumentException>(() => cf.Range = differentSheetRange);
+        }
+
+        [Test]
+        public void Ranges_setter_throws_on_range_from_different_worksheet()
+        {
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            var cf = ws1.Range("A1").AddConditionalFormat();
+
+            var ranges = ws1.Ranges("B1");
+            var differentSheetRange = wb.AddWorksheet().Range("C1");
+            ranges.Add(differentSheetRange);
+
+            Assert.That(() => cf.Ranges = ranges, Throws.TypeOf<ArgumentException>().With.Message.Contains("must be from worksheet"));
+        }
+
+        [Test]
+        public void Ranges_setter_throws_on_empty_ranges()
+        {
+            using var wb = new XLWorkbook();
+            var ws1 = wb.AddWorksheet();
+            var cf = ws1.Range("A1").AddConditionalFormat();
+
+            var emptyRanges = ws1.Ranges("");
+
+            Assert.That(() => cf.Ranges = emptyRanges, Throws.TypeOf<ArgumentException>().With.Message.Contains("empty"));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatsConsolidateTests.cs
@@ -153,7 +153,7 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             var cf3 = ws.ConditionalFormats.ElementAt(2);
             Assert.That(cf1, Is.EqualTo(cf3).Using(new CfFormatComaparer()));
             Assert.That(cf1, Is.Not.EqualTo(cf2).Using(new CfFormatComaparer()));
-            Assert.IsTrue(ws.ConditionalFormats.All(cf => cf.Ranges.Count == 1), "Number of ranges in consolidated conditional formats is expected to be 1");
+            Assert.IsTrue(ws.ConditionalFormats.All(cf => cf.Ranges.Count() == 1), "Number of ranges in consolidated conditional formats is expected to be 1");
             Assert.AreEqual("A1:A1", cf1.Ranges.Single().RangeAddress.ToString());
             Assert.AreEqual("A2:A3", cf2.Ranges.Single().RangeAddress.ToString());
             Assert.AreEqual("A2:A8", cf3.Ranges.Single().RangeAddress.ToString());
@@ -165,8 +165,9 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             using var wb = new XLWorkbook();
             var ws = wb.Worksheets.Add();
 
-            var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>();
-            var cf = new XLConditionalFormat((XLWorksheet)ws, ranges);
+            var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8");
+            var cf = ranges.First().AddConditionalFormat();
+            cf.Ranges = ranges;
             cf.Values.Add(new XLFormula("=A3=$D3"));
             cf.Style.Fill.SetBackgroundColor(XLColor.Red);
             ws.ConditionalFormats.Add(cf);
@@ -188,17 +189,20 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
             {
                 var ws = wb.Worksheets.Add("Sheet");
 
-                var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8").Cast<XLRange>().ToList();
-                var cf1 = new XLConditionalFormat((XLWorksheet)ws, ranges);
+                var ranges = ws.Ranges("B3:B8,C3:C4,A3:A4,C5:C8,A5:A8");
+                var cf1 = ranges.First().AddConditionalFormat();
+                cf1.Ranges = ranges;
                 cf1.ColorScale()
                     .LowestValue(XLColor.Red)
                     .HighestValue(XLColor.Green);
 
-                var cf2 = new XLConditionalFormat((XLWorksheet)ws, ranges);
+                var cf2 = ranges.First().AddConditionalFormat();
+                cf2.Ranges = ranges;
                 cf2.ColorScale()
                     .LowestValue(XLColor.Red)
                     .HighestValue(XLColor.Green);
-                Assert.True(XLConditionalFormat.NoRangeComparer.Equals(cf1, cf2));
+                Assert.AreNotSame(cf1, cf2);
+                Assert.True(XLConditionalFormat.NoRangeComparer.Equals((XLConditionalFormat)cf1, (XLConditionalFormat)cf2));
             }
         }
 

--- a/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -126,6 +126,19 @@ internal class XLAreaListTests
         return areaList.IntersectsWith(area);
     }
 
+    [TestCase("A1", "A1", ExpectedResult = "A1")]
+    [TestCase("A1:C3", "B2", ExpectedResult = "A1:C3")]
+    [TestCase("A1:C3", "B2:D4", ExpectedResult = "A1:C3")]
+    [TestCase("A1 C1", "A1:C1", ExpectedResult = "A1 C1")]
+    [TestCase("A1 C1", "B1", ExpectedResult = "")]
+    [TestCase("A1 C1", "B1:D2", ExpectedResult = "C1")]
+    public string IntersectingWith_returns_areas_intersecting_with_the_other_area(string areaListText, string areaText)
+    {
+        var areaList = Parse(areaListText);
+        var area = XLSheetRange.Parse(areaText);
+        return areaList.IntersectingWith(area).ToSpaceList();
+    }
+
     [TestCase("A1", "B1", ExpectedResult = "A1")]
     [TestCase("A1:E5", "C3:C4", ExpectedResult = "A1:E2 A5:E5 A3:B4 D3:E4")]
     [TestCase("B2:C5 B9 C4:D7", "C4:C5", ExpectedResult = "B2:C3 B4:B5 B9 C6:D7 D4:D5")]

--- a/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLAreaListTests.cs
@@ -149,6 +149,19 @@ internal class XLAreaListTests
         return areaList.Excluding(excludedArea).ToSpaceList();
     }
 
+    [TestCase("A1", "A1", "A1", ExpectedResult = "A1")] // Copy from same point to the same point
+    [TestCase("A1", "B5", "A1", ExpectedResult = "B5")] // Copy to different point
+    [TestCase("B2", "D2", "A1:C3", ExpectedResult = "E3")] // The intersected area is not in corner and shifted doesn't start at the target point
+    [TestCase("D3:G6", "A1", "E4:F5", ExpectedResult = "A1:B2")]
+    [TestCase("B2", XLHelper.LastSheetAddress, "A1:C3", ExpectedResult = null)] // Copied area is out of sheet. Rare, but can happen.
+    public string TryCopyAreaTo_return_list_of_intersecting_areas_shifted_to_target(string areaListText, string targetPointText, string areaToCopyText)
+    {
+        var areaList = Parse(areaListText);
+        var targetPoint = XLSheetPoint.Parse(targetPointText);
+        var areaToCopy = XLSheetRange.Parse(areaToCopyText);
+        return areaList.TryCopyAreaTo(targetPoint, areaToCopy, out var result) ? result.ToSpaceList() : null;
+    }
+
     private static XLAreaList Parse(string spaceList)
     {
         var list = new List<XLSheetRange>();

--- a/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/XLSheetRangeTests.cs
@@ -291,5 +291,21 @@ namespace ClosedXML.Tests.Excel.Coordinates
             Assert.IsNull(originalArea.Exclude(excludedArea, list));
             Assert.AreEqual(originalAreaText, list.ToSpaceList());
         }
+
+        [TestCase("A1", 0, 2, ExpectedResult = "C1")]
+        [TestCase("A1", 1, 0, ExpectedResult = "A2")]
+        [TestCase("A1", 0, -1, ExpectedResult = null)]
+        [TestCase("A1", -1, 0, ExpectedResult = null)]
+        [TestCase(XLHelper.LastSheetAddress, 0, 1, ExpectedResult = null)]
+        [TestCase(XLHelper.LastSheetAddress, 1, 0, ExpectedResult = null)]
+        [TestCase("B2:D3", 2, 3, ExpectedResult = "E4:G5")]
+        [TestCase("B2:D3", -2, -3, ExpectedResult = "A1")]
+        [TestCase("XFA1048574:XFC1048575", 2, 3, ExpectedResult = "XFD1048576")]
+        public string ShiftAndClip_shifts_and_clips_area(string areaText, int rowShift, int columnShift)
+        {
+            var area = XLSheetRange.Parse(areaText);
+            var shifted = area.ShiftAndClip(rowShift, columnShift);
+            return shifted is not null ? shifted.ToString() : null;
+        }
     }
 }

--- a/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/CopyingRangesTests.cs
@@ -132,8 +132,8 @@ namespace ClosedXML.Tests
 
             Assert.AreEqual("Sheet1", ws1.ConditionalFormats.First().Ranges.First().Worksheet.Name);
             Assert.AreEqual("Sheet2", ws2.ConditionalFormats.First().Ranges.First().Worksheet.Name);
-            Assert.AreEqual("A1:J2", ws1.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
-            Assert.AreEqual("A1:A2", ws2.ConditionalFormats.First().Ranges.First().RangeAddress.ToString());
+            Assert.AreEqual("A1:J2", ws1.ConditionalFormats.First().Ranges.ToSpaceList());
+            Assert.AreEqual("A1:A2", ws2.ConditionalFormats.First().Ranges.ToSpaceList());
         }
 
         private static void FillRow(IXLRow row1)

--- a/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
+++ b/ClosedXML.Tests/Excel/Worksheets/XLWorksheetTests.cs
@@ -602,7 +602,7 @@ namespace ClosedXML.Tests
                 ws1.Range("A:A").AddConditionalFormat()
                     .WhenContains("0").Fill.SetBackgroundColor(XLColor.Red);
                 var cf = ws1.Range("B1:C2").AddConditionalFormat();
-                cf.Ranges.Add(ws1.Range("D4:D5"));
+                cf.Ranges = ws1.Ranges("B1:C2,D4:D5");
                 cf.WhenEqualOrGreaterThan(100).Font.SetBold();
 
                 var ws2 = ws1.CopyTo(wb2, "Copy");
@@ -612,13 +612,7 @@ namespace ClosedXML.Tests
                 {
                     var original = ws1.ConditionalFormats.ElementAt(i);
                     var copy = ws2.ConditionalFormats.ElementAt(i);
-                    Assert.AreEqual(original.Ranges.Count, copy.Ranges.Count);
-                    for (int j = 0; j < original.Ranges.Count; j++)
-                    {
-                        Assert.AreEqual(original.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false),
-                            copy.Ranges.ElementAt(j).RangeAddress.ToString(XLReferenceStyle.A1, false));
-                    }
-
+                    Assert.AreEqual(original.Ranges.ToSpaceList(), copy.Ranges.ToSpaceList());
                     Assert.AreEqual(((XLConditionalFormat)original).FormatValue, ((XLConditionalFormat)copy).FormatValue);
                     Assert.AreEqual(original.Values.Single().Value.Value, copy.Values.Single().Value.Value);
                 }

--- a/ClosedXML.Tests/Utils/EnumerableExtensions.cs
+++ b/ClosedXML.Tests/Utils/EnumerableExtensions.cs
@@ -6,9 +6,9 @@ namespace ClosedXML.Tests;
 
 internal static class EnumerableExtensions
 {
-    public static string ToSpaceList(this IEnumerable<IXLRange> ranges)
+    public static string ToSpaceList(this IEnumerable<IXLRange> ranges, bool includeSheet = false)
     {
-        return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, false)));
+        return string.Join(" ", ranges.Select(r => r.RangeAddress.ToString(XLReferenceStyle.A1, includeSheet)));
     }
 
     public static string ToSpaceList(this IEnumerable<XLSheetRange> areas)

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1236,53 +1236,8 @@ namespace ClosedXML.Excel
                 }
             }
 
-            CopyConditionalFormatsFrom(asRange);
+            Worksheet.ConditionalFormats.CopyFrom(asRange.Worksheet, asRange.SheetRange, SheetPoint);
             return this;
-        }
-
-        private void CopyConditionalFormatsFrom(XLCell otherCell)
-        {
-            var conditionalFormats = otherCell
-                .Worksheet
-                .ConditionalFormats
-                .Where<XLConditionalFormat>(c => c.Ranges.GetIntersectedRanges(otherCell).Any())
-                .ToList();
-
-            foreach (var cf in conditionalFormats)
-            {
-                if (otherCell.Worksheet == Worksheet)
-                {
-                    if (!cf.Ranges.GetIntersectedRanges(this).Any())
-                    {
-                        cf.Ranges.Add(this);
-                    }
-                }
-                else
-                {
-                    CopyConditionalFormatsFrom(otherCell.AsRange());
-                }
-            }
-        }
-
-        private void CopyConditionalFormatsFrom(XLRangeBase fromRange)
-        {
-            var srcSheet = fromRange.Worksheet;
-            var toRangeAddress = new XLRangeAddress(Address, Address);
-            var formats = srcSheet.ConditionalFormats.Where<XLConditionalFormat>(f => f.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any());
-
-            foreach (var cf in formats.ToList())
-            {
-                var fmtRanges = cf.Ranges
-                    .GetIntersectedRanges(fromRange.RangeAddress)
-                    .Select(r => r.RangeAddress.Intersection(fromRange.RangeAddress).Relative(fromRange.RangeAddress, toRangeAddress).AsRange() as XLRange)
-                    .ToList();
-
-                var c = new XLConditionalFormat(Worksheet, fmtRanges);
-                c.CopyFrom(cf);
-                c.AdjustFormulas((XLCell)cf.Ranges.First().FirstCell(), fmtRanges.First().FirstCell());
-
-                Worksheet.ConditionalFormats.Add(c);
-            }
         }
 
         private void ClearMerged()
@@ -1345,7 +1300,7 @@ namespace ClosedXML.Excel
                 CopySparklineFrom(otherCell);
 
             if (options.HasFlag(XLCellCopyOptions.ConditionalFormats))
-                CopyConditionalFormatsFrom(otherCell);
+                Worksheet.ConditionalFormats.CopyFrom(otherCell.Worksheet, otherCell.SheetPoint, SheetPoint, true);
 
             if (options.HasFlag(XLCellCopyOptions.DataValidations))
                 CopyDataValidationFrom(otherCell);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1267,29 +1267,14 @@ namespace ClosedXML.Excel
         private void CopyConditionalFormatsFrom(XLRangeBase fromRange)
         {
             var srcSheet = fromRange.Worksheet;
-            int minRo = fromRange.RangeAddress.FirstAddress.RowNumber;
-            int minCo = fromRange.RangeAddress.FirstAddress.ColumnNumber;
-            if (srcSheet.ConditionalFormats.Any<XLConditionalFormat>(r => r.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any()))
-            {
-                var fs = srcSheet.ConditionalFormats.SelectMany<XLConditionalFormat, IXLRange>(cf => cf.Ranges.GetIntersectedRanges(fromRange.RangeAddress)).ToArray();
-                if (fs.Any())
-                {
-                    minRo = fs.Max(r => r.RangeAddress.LastAddress.RowNumber);
-                    minCo = fs.Max(r => r.RangeAddress.LastAddress.ColumnNumber);
-                }
-            }
-            int rCnt = minRo - fromRange.RangeAddress.FirstAddress.RowNumber + 1;
-            int cCnt = minCo - fromRange.RangeAddress.FirstAddress.ColumnNumber + 1;
-            rCnt = Math.Min(rCnt, fromRange.RowCount());
-            cCnt = Math.Min(cCnt, fromRange.ColumnCount());
-            var toRange = Worksheet.Range(this, Worksheet.Cell(_rowNumber + rCnt - 1, _columnNumber + cCnt - 1));
+            var toRangeAddress = new XLRangeAddress(Address, Address);
             var formats = srcSheet.ConditionalFormats.Where<XLConditionalFormat>(f => f.Ranges.GetIntersectedRanges(fromRange.RangeAddress).Any());
 
             foreach (var cf in formats.ToList())
             {
                 var fmtRanges = cf.Ranges
                     .GetIntersectedRanges(fromRange.RangeAddress)
-                    .Select(r => r.RangeAddress.Intersection(fromRange.RangeAddress).Relative(fromRange.RangeAddress, toRange.RangeAddress).AsRange() as XLRange)
+                    .Select(r => r.RangeAddress.Intersection(fromRange.RangeAddress).Relative(fromRange.RangeAddress, toRangeAddress).AsRange() as XLRange)
                     .ToList();
 
                 var c = new XLConditionalFormat(Worksheet, fmtRanges);

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -1300,23 +1300,6 @@ namespace ClosedXML.Excel
             }
         }
 
-        private bool SetDataTable(object o)
-        {
-            if (o is DataTable dataTable)
-                return InsertData(dataTable) != null;
-            else
-                return false;
-        }
-
-        private bool SetEnumerable(object collectionObject)
-        {
-            // IXLRichText implements IEnumerable, but we don't want to handle this here.
-            if (collectionObject is IXLRichText) return false;
-
-            var asEnumerable = collectionObject as IEnumerable;
-            return InsertData(asEnumerable) != null;
-        }
-
         private void ClearMerged()
         {
             List<IXLRange> mergeToDelete = Worksheet.Internals.MergedRanges.GetIntersectedRanges(Address).ToList();
@@ -1981,11 +1964,6 @@ namespace ClosedXML.Excel
         internal bool IsInferiorMergedCell()
         {
             return this.IsMerged() && !this.Address.Equals(this.MergedRange().RangeAddress.FirstAddress);
-        }
-
-        internal bool IsSuperiorMergedCell()
-        {
-            return this.IsMerged() && this.Address.Equals(this.MergedRange().RangeAddress.FirstAddress);
         }
 
         /// <summary>

--- a/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormat.cs
@@ -1,6 +1,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 
 namespace ClosedXML.Excel
 {
@@ -154,7 +155,11 @@ namespace ClosedXML.Excel
         /// </summary>
         IXLRange Range { get; set; }
 
-        IXLRanges Ranges { get; }
+        /// <summary>
+        /// Get or set all ranges the conditional format applies to.
+        /// </summary>
+        /// <exception cref="ArgumentException">If sequence contains no elements or the range is from different worksheet.</exception>
+        IEnumerable<IXLRange> Ranges { get; set; }
 
         XLDictionary<XLFormula> Values { get; }
 

--- a/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/IXLConditionalFormats.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -98,7 +98,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        internal void AdjustFormulas(XLCell baseCell, XLCell targetCell)
+        private void AdjustFormulas(XLCell baseCell, XLCell targetCell)
         {
             var keys = Values.Keys.ToList();
             foreach (var key in keys)
@@ -147,6 +147,10 @@ namespace ClosedXML.Excel
         {
             areaList.ForEach(range => Ranges.Add(_worksheet.Range(range)));
             CopyFrom(conditionalFormat);
+
+            var sourceAnchor = _worksheet.Cell(conditionalFormat.Areas[0].FirstPoint);
+            var targetAnchor = _worksheet.Cell(areaList[0].FirstPoint);
+            AdjustFormulas(sourceAnchor, targetAnchor);
         }
 
         #endregion Constructors

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -10,11 +10,9 @@ namespace ClosedXML.Excel
     internal class XLConditionalFormat : IXLDxfContainer, IXLConditionalFormat
     {
         private readonly XLWorksheet _worksheet;
-        private readonly XLRanges _ranges;
-
         private sealed class NoRangeCfComparer : IEqualityComparer<XLConditionalFormat>
         {
-            public bool Equals(XLConditionalFormat xx, XLConditionalFormat yy)
+            public bool Equals(XLConditionalFormat? xx, XLConditionalFormat? yy)
             {
                 if (ReferenceEquals(xx, yy)) return true;
                 if (ReferenceEquals(xx, null)) return false;
@@ -23,8 +21,8 @@ namespace ClosedXML.Excel
 
                 var xxValues = xx.Values.Values.Where(v => v == null || !v.IsFormula).Select(v => v?.Value);
                 var yyValues = yy.Values.Values.Where(v => v == null || !v.IsFormula).Select(v => v?.Value);
-                var xxFormulas = xx.Ranges.Count > 0 ? xx.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)xx.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
-                var yyFormulas = yy.Ranges.Count > 0 ? yy.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)yy.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)) : null;
+                var xxFormulas = xx.Areas.Count > 0 ? xx.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)xx.Range.FirstCell()).GetFormulaR1C1(f.Value)) : null;
+                var yyFormulas = yy.Areas.Count > 0 ? yy.Values.Values.Where(v => v != null && v.IsFormula).Select(f => ((XLCell)yy.Range.FirstCell()).GetFormulaR1C1(f.Value)) : null;
                 var xStyle = xx.FormatValue;
                 var yStyle = yy.FormatValue;
                 return Equals(xStyle, yStyle)
@@ -50,9 +48,9 @@ namespace ClosedXML.Excel
                 var xx = obj;
                 var xStyle = obj.FormatValue;
                 var xValues = xx.Values.Values.Where(v => !v.IsFormula).Select(v => v.Value);
-                if (obj.Ranges.Count > 0)
+                if (obj.Areas.Count > 0)
                     xValues = xValues
-                    .Union(xx.Values.Values.Where(v => v.IsFormula).Select(f => ((XLCell)obj.Ranges.First().FirstCell()).GetFormulaR1C1(f.Value)));
+                    .Union(xx.Values.Values.Where(v => v.IsFormula).Select(f => ((XLCell)obj.Range.FirstCell()).GetFormulaR1C1(f.Value)));
 
                 unchecked
                 {
@@ -115,37 +113,23 @@ namespace ClosedXML.Excel
 
         #region Constructors
 
-        private XLConditionalFormat(XLWorksheet worksheet)
+        internal XLConditionalFormat(XLWorksheet worksheet, XLAreaList areaList)
 #if !STYLES_REWORK
             : base(XLStyle.Default.Value)
 #endif
         {
             _worksheet = worksheet;
             Id = Guid.NewGuid();
-            _ranges = new XLRanges(worksheet);
+            Areas = areaList;
             Values = new XLDictionary<XLFormula>();
             Colors = new XLDictionary<XLColor>();
             ContentTypes = new XLDictionary<XLCFContentType>();
             IconSetOperators = new XLDictionary<XLCFIconSetOperator>();
         }
 
-        public XLConditionalFormat(XLWorksheet worksheet, XLRange range)
-            : this(worksheet)
-        {
-            if (range != null)
-                Ranges.Add(range);
-        }
-
-        public XLConditionalFormat(XLWorksheet worksheet, IEnumerable<XLRange> ranges)
-            : this(worksheet)
-        {
-            ranges?.ForEach(range => Ranges.Add(range));
-        }
-
         internal XLConditionalFormat(XLWorksheet worksheet, XLConditionalFormat conditionalFormat, XLAreaList areaList)
-            : this(worksheet)
+            : this(worksheet, areaList)
         {
-            areaList.ForEach(range => Ranges.Add(_worksheet.Range(range)));
             CopyFrom(conditionalFormat);
 
             var sourceAnchor = _worksheet.Cell(conditionalFormat.Areas[0].FirstPoint);
@@ -183,15 +167,22 @@ namespace ClosedXML.Excel
 
         public IXLRange Range
         {
-            get { return Ranges.FirstOrDefault(); }
-            set
-            {
-                Ranges.RemoveAll();
-                Ranges.Add(value);
-            }
+            get => _worksheet.Range(Areas[0]);
+            set => Areas = XLAreaList.FromRange(_worksheet, value);
         }
 
-        public IXLRanges Ranges => _ranges;
+        public IEnumerable<IXLRange> Ranges
+        {
+            get
+            {
+                var ranges = new XLRanges(_worksheet);
+                foreach (var area in Areas)
+                    ranges.Add(_worksheet.Range(area));
+
+                return ranges;
+            }
+            set => Areas = XLAreaList.FromRanges(_worksheet, value);
+        }
 
         public XLConditionalFormatType ConditionalFormatType { get; set; }
 
@@ -213,19 +204,7 @@ namespace ClosedXML.Excel
 
         public Boolean StopIfTrue { get; set; }
 
-        internal XLAreaList Areas
-        {
-            get
-            {
-                return new XLAreaList(_ranges.Select<XLRange, XLSheetRange>(range => range.SheetRange).ToList());
-            }
-            set
-            {
-                Ranges.RemoveAll();
-                foreach (var area in value)
-                    Ranges.Add(_worksheet.Range(area));
-            }
-        }
+        internal XLAreaList Areas { get; set; }
 
         public IXLConditionalFormat SetStopIfTrue()
         {

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using ClosedXML.Excel.CalcEngine.Visitors;
+using ClosedXML.Parser;
 
 namespace ClosedXML.Excel
 {
@@ -9,7 +11,7 @@ namespace ClosedXML.Excel
     /// a collection of <see cref="XLConditionalFormat"/>. Doesn't contain pivot table formats,
     /// they are in pivot table <see cref="XLPivotTable.ConditionalFormats"/>,
     /// </summary>
-    internal class XLConditionalFormats : IXLConditionalFormats, IEnumerable<XLConditionalFormat>
+    internal class XLConditionalFormats : IXLConditionalFormats, IEnumerable<XLConditionalFormat>, ISheetListener
     {
         private readonly XLWorksheet _worksheet;
         private readonly List<XLConditionalFormat> _conditionalFormats = new();
@@ -143,7 +145,7 @@ namespace ClosedXML.Excel
                 var format = formats[0];
                 if (!CFTypesExcludedFromConsolidation.Contains(format.ConditionalFormatType))
                 {
-                    var (rulesToConsolidate, areasWithSameFormat) = GetConsolidateableRules(formats);
+                    var (rulesToConsolidate, areasWithSameFormat) = GetConsolidatableRules(formats);
                     var consolidatedAreas = areasWithSameFormat.GetConsolidated();
                     var consolidatedCf = new XLConditionalFormat(_worksheet, format, consolidatedAreas);
 
@@ -160,7 +162,7 @@ namespace ClosedXML.Excel
             }
         }
 
-        private static (List<int> RulesToConsolidate, XLAreaList AreaList) GetConsolidateableRules(List<XLConditionalFormat> conditionalFormats)
+        private static (List<int> RulesToConsolidate, XLAreaList AreaList) GetConsolidatableRules(List<XLConditionalFormat> conditionalFormats)
         {
             var rule = conditionalFormats[0];
             var sameFormatAreas = rule.Areas.ToList();
@@ -206,5 +208,80 @@ namespace ClosedXML.Excel
 
             return (rulesToConsolidate, new XLAreaList(sameFormatAreas));
         }
+
+        #region ISheetListener
+
+        void ISheetListener.OnInsertAreaAndShiftDown(XLWorksheet sheet, XLSheetRange insertedArea)
+        {
+            var inserted = new XLBookArea(sheet.Name, insertedArea);
+            var refMod = new ReferenceShiftOnInsertRefModVisitor(inserted, true);
+            AdjustFormulas(refMod);
+
+            AdjustConditionalFormatAreas(sheet, inserted.Area, static (sqref, insertedArea) => sqref.InsertAndShiftDown(insertedArea));
+        }
+
+        void ISheetListener.OnInsertAreaAndShiftRight(XLWorksheet sheet, XLSheetRange insertedArea)
+        {
+            var inserted = new XLBookArea(sheet.Name, insertedArea);
+            var refMod = new ReferenceShiftOnInsertRefModVisitor(inserted, false);
+            AdjustFormulas(refMod);
+
+            AdjustConditionalFormatAreas(sheet, inserted.Area, static (sqref, insertedArea) => sqref.InsertAndShiftRight(insertedArea));
+        }
+
+        void ISheetListener.OnDeleteAreaAndShiftLeft(XLWorksheet sheet, XLSheetRange deletedArea)
+        {
+            var deleted = new XLBookArea(sheet.Name, deletedArea);
+            var refMod = new ReferenceShiftOnDeleteRefModVisitor(deleted, XLShiftDeletedCells.ShiftCellsLeft);
+            AdjustFormulas(refMod);
+
+            AdjustConditionalFormatAreas(sheet, deleted.Area, static (sqref, deletedArea) => sqref.DeleteAndShiftLeft(deletedArea));
+        }
+
+        void ISheetListener.OnDeleteAreaAndShiftUp(XLWorksheet sheet, XLSheetRange deletedArea)
+        {
+            var deleted = new XLBookArea(sheet.Name, deletedArea);
+            var refMod = new ReferenceShiftOnDeleteRefModVisitor(deleted, XLShiftDeletedCells.ShiftCellsUp);
+            AdjustFormulas(refMod);
+
+            AdjustConditionalFormatAreas(sheet, deleted.Area, static (sqref, deletedArea) => sqref.DeleteAndShiftUp(deletedArea));
+        }
+
+        private void AdjustFormulas(CopyVisitor refMod)
+        {
+            foreach (var conditionalFormat in _conditionalFormats)
+            {
+                var anchor = conditionalFormat.Areas[0].FirstPoint;
+                var formulaIndexes = conditionalFormat.Values.Where(x => x.Value.IsFormula).Select(x => x.Key).ToArray();
+                foreach (var index in formulaIndexes)
+                {
+                    var originalFormula = conditionalFormat.Values[index];
+                    var shiftedFormula = FormulaConverter.ModifyA1(originalFormula.Value, _worksheet.Name, anchor.Row, anchor.Column, refMod);
+                    conditionalFormat.Values[index] = new XLFormula(shiftedFormula) { IsFormula = true };
+                }
+            }
+        }
+
+        private void AdjustConditionalFormatAreas(XLWorksheet sheet, XLSheetRange affectedRange, Func<XLAreaList, XLSheetRange, XLAreaList> adjustAreas)
+        {
+            if (sheet != _worksheet)
+                return;
+
+            for (var i = _conditionalFormats.Count - 1; i >= 0; --i)
+            {
+                var conditionalFormat = _conditionalFormats[i];
+                var modifiedAreaList = adjustAreas(conditionalFormat.Areas, affectedRange);
+                if (modifiedAreaList.Count == 0)
+                {
+                    _conditionalFormats.RemoveAt(i);
+                }
+                else
+                {
+                    conditionalFormat.Areas = modifiedAreaList;
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormats.cs
@@ -97,6 +97,37 @@ namespace ClosedXML.Excel
             }
         }
 
+        internal void CopyFrom(XLWorksheet sourceSheet, XLSheetRange sourceArea, XLSheetPoint targetPoint, bool mergeUncoveredInSameSheet = false)
+        {
+            // If source and target sheets are same, do not go over the end
+            var sourceCfCount = sourceSheet.ConditionalFormats._conditionalFormats.Count;
+            for (var i = 0; i < sourceCfCount; ++i)
+            {
+                var sourceCf = sourceSheet.ConditionalFormats._conditionalFormats[i];
+                if (!sourceCf.Areas.TryCopyAreaTo(targetPoint, sourceArea, out var targetAreas))
+                    continue;
+
+                // Legacy behavior where a copied single point was merged into CF when not covered.
+                // But only for cell copy API, nor range copy API (even if range is only 1x1).
+                if (mergeUncoveredInSameSheet && _worksheet == sourceSheet)
+                {
+                    foreach (var targetArea in targetAreas)
+                    {
+                        var isCovered = sourceCf.Areas.Any(sourceCfArea => sourceCfArea.Covers(targetArea));
+                        if (!isCovered)
+                        {
+                            sourceCf.Areas = sourceCf.Areas.With(targetArea);
+                        }
+                    }
+                }
+                else
+                {
+                    var targetCfCopy = new XLConditionalFormat(_worksheet, sourceCf, targetAreas);
+                    Add(targetCfCopy);
+                }
+            }
+        }
+
         /// <summary>
         /// The method consolidate the same conditional formats, which are located in adjacent ranges.
         /// </summary>
@@ -112,8 +143,6 @@ namespace ClosedXML.Excel
                 var format = formats[0];
                 if (!CFTypesExcludedFromConsolidation.Contains(format.ConditionalFormatType))
                 {
-                    var originalAnchor = format.Areas[0].FirstPoint;
-
                     var (rulesToConsolidate, areasWithSameFormat) = GetConsolidateableRules(formats);
                     var consolidatedAreas = areasWithSameFormat.GetConsolidated();
                     var consolidatedCf = new XLConditionalFormat(_worksheet, format, consolidatedAreas);
@@ -123,8 +152,6 @@ namespace ClosedXML.Excel
                     foreach (var consolidatedRuleIndex in rulesToConsolidate)
                         formats.RemoveAt(consolidatedRuleIndex);
 
-                    var consolidatedAnchor = consolidatedAreas[0].FirstPoint;
-                    consolidatedCf.AdjustFormulas(_worksheet.Cell(originalAnchor), _worksheet.Cell(consolidatedAnchor));
                     format = consolidatedCf;
                 }
 
@@ -155,7 +182,7 @@ namespace ClosedXML.Excel
                 var isSameFormat = XLConditionalFormat.NoRangeComparer.Equals(candidateRule, rule);
                 if (isSameFormat)
                 {
-                    // We reached a rule that has same format as the condolidated rule and doesn't interect different
+                    // We reached a rule that has same format as the consolidated rule and doesn't intersect different
                     // format areas. We can consolidate the candidate rule with the rule without potentially breaking
                     // any rule with a priority between rule and candidate rule.
                     sameFormatAreas.AddRange(candidateRule.Areas);
@@ -166,7 +193,7 @@ namespace ClosedXML.Excel
                 var intersectsSameFormatAreas = sameFormatAreas.Any(sameFormatArea => candidateRule.Areas.Any(v => v.Intersects(sameFormatArea)));
                 if (intersectsSameFormatAreas)
                 {
-                    // We reached a rule that has differnet format and intersects area to be consolidated. That means
+                    // We reached a rule that has different format and intersects area to be consolidated. That means
                     // it's not possible to consolidate any subsequent rule, because it could break this one, and
                     // consolidation must stop here.
                     break;

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ClosedXML.Excel;
 
@@ -230,6 +231,39 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
             if (area.Intersects(otherArea))
                 yield return area;
         }
+    }
+
+    /// <summary>
+    /// A helper function used mostly in copy&amp;paste functionality. It takes the areas,
+    /// intersects them with the <paramref name="areaToCopy"/> and shifts it to the <paramref name="target"/>.
+    /// If there are areas, return it in the <paramref name="result"/>.
+    /// </summary>
+    internal bool TryCopyAreaTo(XLSheetPoint target, XLSheetRange areaToCopy, [NotNullWhen(true)] out XLAreaList? result)
+    {
+        var rowShift = target.Row - areaToCopy.FirstPoint.Row;
+        var columnShift = target.Column - areaToCopy.FirstPoint.Column;
+        List<XLSheetRange>? copyList = null;
+        foreach (var area in _areas)
+        {
+            if (area.Intersect(areaToCopy) is not { } intersection)
+                continue;
+
+            // End can but cut off, but the area will always have at least 1x1 so it is valid
+            if (intersection.ShiftAndClip(rowShift, columnShift) is not { } shiftedArea)
+                continue;
+
+            copyList ??= new List<XLSheetRange>();
+            copyList.Add(shiftedArea);
+        }
+
+        if (copyList is not null)
+        {
+            result = new XLAreaList(copyList);
+            return true;
+        }
+
+        result = null;
+        return false;
     }
 
     internal XLAreaList Excluding(XLSheetRange excludedArea)

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -13,6 +14,11 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
     internal static readonly XLAreaList Empty = new(new List<XLSheetRange>());
     private readonly List<XLSheetRange> _areas;
 
+    internal XLAreaList(XLSheetRange area)
+    {
+        _areas = new List<XLSheetRange>(1) { area };
+    }
+
     internal XLAreaList(List<XLSheetRange> areas)
     {
         _areas = areas;
@@ -21,6 +27,28 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
     internal int Count => _areas.Count;
 
     internal XLSheetRange this[int idx] => _areas[idx];
+
+    internal static XLAreaList FromRange(XLWorksheet worksheet, IXLRange range)
+    {
+        ThrowOnDifferentSheet(worksheet, range);
+        return new XLAreaList(XLSheetRange.FromRangeAddress(range.RangeAddress));
+    }
+
+    /// <exception cref="ArgumentException">Sequence is empty or a range is from a different sheet.</exception>
+    internal static XLAreaList FromRanges(XLWorksheet worksheet, IEnumerable<IXLRange> value)
+    {
+        var areas = new List<XLSheetRange>();
+        foreach (var range in value)
+        {
+            ThrowOnDifferentSheet(worksheet, range);
+            areas.Add(XLSheetRange.FromRangeAddress(range.RangeAddress));
+        }
+
+        if (areas.Count == 0)
+            throw new ArgumentException("Sequence is empty. At least one range is required.");
+
+        return new XLAreaList(areas);
+    }
 
     internal XLAreaList With(XLSheetRange area)
     {
@@ -291,5 +319,11 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
     internal string ToSpaceList()
     {
         return string.Join(" ", _areas);
+    }
+
+    private static void ThrowOnDifferentSheet(XLWorksheet worksheet, IXLRange range)
+    {
+        if (range.Worksheet is not null && range.Worksheet != worksheet)
+            throw new ArgumentException($"Range {range} belongs to worksheet {range.Worksheet.Name}, but must be from worksheet {worksheet.Name}.");
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLAreaList.cs
+++ b/ClosedXML/Excel/Coordinates/XLAreaList.cs
@@ -220,6 +220,18 @@ internal class XLAreaList : IEnumerable<XLSheetRange>
         return false;
     }
 
+    /// <summary>
+    /// Return areas in the list (with the original size) intersecting with the <paramref name="otherArea"/>.
+    /// </summary>
+    internal IEnumerable<XLSheetRange> IntersectingWith(XLSheetRange otherArea)
+    {
+        foreach (var area in _areas)
+        {
+            if (area.Intersects(otherArea))
+                yield return area;
+        }
+    }
+
     internal XLAreaList Excluding(XLSheetRange excludedArea)
     {
         if (!IntersectsWith(excludedArea))

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -942,5 +942,10 @@ namespace ClosedXML.Excel
             var shifted = ShiftColumns(-shift);
             return new XLSheetRange(shifted.TopRow, shifted.LeftColumn, shifted.BottomRow, shifted.RightColumn - shrink);
         }
+
+        internal XLAreaList ToAreaList()
+        {
+            return new XLAreaList(this);
+        }
     }
 }

--- a/ClosedXML/Excel/Coordinates/XLSheetRange.cs
+++ b/ClosedXML/Excel/Coordinates/XLSheetRange.cs
@@ -385,6 +385,23 @@ namespace ClosedXML.Excel
         }
 
         /// <summary>
+        /// Return a new range that has been shifted in vertical direction by <paramref name="rowShift"/> and in horizontal direction by <paramref name="columnShift"/>.
+        /// </summary>
+        /// <param name="rowShift">By how much to shift the range.</param>
+        /// <param name="columnShift">By how many columns to shift the range.</param>
+        /// <returns>Newly created area.</returns>
+        internal XLSheetRange? ShiftAndClip(int rowShift, int columnShift)
+        {
+            if (ShiftRowsAndClip(rowShift) is not { } rowShifted)
+                return null;
+
+            if (rowShifted.ShiftColumnsAndClip(columnShift) is not { } rowAndColumnShifted)
+                return null;
+
+            return rowAndColumnShifted;
+        }
+
+        /// <summary>
         /// Return a new range that has been shifted in vertical direction by <paramref name="rowShift"/>.
         /// </summary>
         /// <param name="rowShift">By how much to shift the range, positive - downwards, negative - upwards.</param>

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -808,7 +808,7 @@ internal class WorksheetPartReader
         {
             var ranges = conditionalFormatting.SequenceOfReferences.Items
                 .Select(sor => ws.Range(sor.Value));
-            var conditionalFormat = new XLConditionalFormat(ws, ranges);
+            var conditionalFormat = new XLConditionalFormat(ws, XLAreaList.FromRanges(ws, ranges));
 
             conditionalFormat.StopIfTrue = OpenXmlHelper.GetBooleanValueAsBool(fr.StopIfTrue, false);
 

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -229,6 +229,7 @@ namespace ClosedXML.Excel
         {
             return FirstCellUsed(XLCellsUsedOptions.AllContents);
         }
+
         IXLCell IXLRangeBase.FirstCellUsed(XLCellsUsedOptions options)
         {
             return FirstCellUsed(options, null);
@@ -248,6 +249,7 @@ namespace ClosedXML.Excel
         {
             return LastCellUsed(XLCellsUsedOptions.AllContents);
         }
+
         IXLCell IXLRangeBase.LastCellUsed(XLCellsUsedOptions options)
         {
             return LastCellUsed(options, null);
@@ -1861,7 +1863,7 @@ namespace ClosedXML.Excel
         {
             predicate ??= (t => true);
 
-            //To avoid unnecessary initialization of thousands cells
+            // To avoid unnecessary initialization of thousands cells to not hang on very large CFs, DVs or merged ranges.
             var opt = options
                       & ~XLCellsUsedOptions.ConditionalFormats
                       & ~XLCellsUsedOptions.DataValidation
@@ -1875,9 +1877,11 @@ namespace ClosedXML.Excel
 
             if (options.HasFlag(XLCellsUsedOptions.ConditionalFormats))
             {
+                var area = SheetRange;
                 cellsUsed = cellsUsed.Union(
                     Worksheet.ConditionalFormats
-                        .SelectMany<XLConditionalFormat, IXLRange>(cf => cf.Ranges.GetIntersectedRanges(RangeAddress))
+                        .SelectMany<XLConditionalFormat, XLSheetRange>(cf => cf.Areas.IntersectingWith(area))
+                        .Select(cfArea => Worksheet.Range(cfArea))
                         .Select(selector)
                         .Where(predicate)
                 );

--- a/ClosedXML/Excel/Ranges/XLRangeBase.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeBase.cs
@@ -1738,7 +1738,7 @@ namespace ClosedXML.Excel
 
         public IXLConditionalFormat AddConditionalFormat()
         {
-            var cf = new XLConditionalFormat(Worksheet, AsRange());
+            var cf = new XLConditionalFormat(Worksheet, SheetRange.ToAreaList());
             Worksheet.ConditionalFormats.Add(cf);
             return cf;
         }

--- a/ClosedXML/Excel/XLWorksheet.cs
+++ b/ClosedXML/Excel/XLWorksheet.cs
@@ -1234,7 +1234,6 @@ namespace ClosedXML.Excel
                 }
             }
 
-            ShiftConditionalFormattingColumns(range, columnsShifted);
             ShiftPageBreaksColumns(range, columnsShifted);
 
             var sheetListeners = GetSheetListeners();
@@ -1267,53 +1266,7 @@ namespace ClosedXML.Excel
                 }
             }
         }
-
-        private void ShiftConditionalFormattingColumns(XLRange range, int columnsShifted)
-        {
-            if (!ConditionalFormats.Any<XLConditionalFormat>()) return;
-            Int32 firstCol = range.RangeAddress.FirstAddress.ColumnNumber;
-            if (firstCol == 1) return;
-
-            int colNum = columnsShifted > 0 ? firstCol - 1 : firstCol;
-            var model = Column(colNum).AsRange();
-
-            foreach (var cf in ConditionalFormats.ToList<XLConditionalFormat>())
-            {
-                var cfRanges = cf.Ranges.ToList();
-                cf.Ranges.RemoveAll();
-
-                foreach (var cfRange in cfRanges)
-                {
-                    var cfAddress = cfRange.RangeAddress;
-                    IXLRange newRange;
-                    if (cfRange.Intersects(model))
-                    {
-                        newRange = Range(cfAddress.FirstAddress.RowNumber,
-                                         cfAddress.FirstAddress.ColumnNumber,
-                                         cfAddress.LastAddress.RowNumber,
-                                         Math.Min(XLHelper.MaxColumnNumber, cfAddress.LastAddress.ColumnNumber + columnsShifted));
-                    }
-                    else if (cfAddress.FirstAddress.ColumnNumber >= firstCol)
-                    {
-                        newRange = Range(cfAddress.FirstAddress.RowNumber,
-                                         Math.Max(cfAddress.FirstAddress.ColumnNumber + columnsShifted, firstCol),
-                                         cfAddress.LastAddress.RowNumber,
-                                         Math.Min(XLHelper.MaxColumnNumber, cfAddress.LastAddress.ColumnNumber + columnsShifted));
-                    }
-                    else
-                        newRange = cfRange;
-
-                    if (newRange.RangeAddress.IsValid &&
-                        newRange.RangeAddress.FirstAddress.ColumnNumber <=
-                        newRange.RangeAddress.LastAddress.ColumnNumber)
-                        cf.Ranges.Add(newRange);
-                }
-
-                if (!cf.Ranges.Any())
-                    ConditionalFormats.Remove(f => f == cf);
-            }
-        }
-
+        
         internal override void WorksheetRangeShiftedRows(XLRange range, int rowsShifted)
         {
             if (!range.IsEntireRow())
@@ -1332,7 +1285,6 @@ namespace ClosedXML.Excel
                 }
             }
 
-            ShiftConditionalFormattingRows(range, rowsShifted);
             ShiftPageBreaksRows(range, rowsShifted);
 
             var sheetListeners = GetSheetListeners();
@@ -1368,6 +1320,10 @@ namespace ClosedXML.Excel
 
             sheetListeners.AddRange(SparklineGroupsInternal);
 
+            // CF can contain formulas for any worksheet, notify about all changes
+            foreach (var worksheet in Workbook.WorksheetsInternal)
+                sheetListeners.Add(worksheet.ConditionalFormats);
+
             return sheetListeners;
         }
 
@@ -1380,51 +1336,6 @@ namespace ClosedXML.Excel
                 {
                     PageSetup.RowBreaks[i] = br + rowsShifted;
                 }
-            }
-        }
-
-        private void ShiftConditionalFormattingRows(XLRange range, int rowsShifted)
-        {
-            if (!ConditionalFormats.Any<XLConditionalFormat>()) return;
-            Int32 firstRow = range.RangeAddress.FirstAddress.RowNumber;
-            if (firstRow == 1) return;
-
-            int rowNum = rowsShifted > 0 ? firstRow - 1 : firstRow;
-            var model = Row(rowNum).AsRange();
-
-            foreach (var cf in ConditionalFormats.ToList<XLConditionalFormat>())
-            {
-                var cfRanges = cf.Ranges.ToList();
-                cf.Ranges.RemoveAll();
-
-                foreach (var cfRange in cfRanges)
-                {
-                    var cfAddress = cfRange.RangeAddress;
-                    IXLRange newRange;
-                    if (cfRange.Intersects(model))
-                    {
-                        newRange = Range(cfAddress.FirstAddress.RowNumber,
-                                         cfAddress.FirstAddress.ColumnNumber,
-                                         Math.Min(XLHelper.MaxRowNumber, cfAddress.LastAddress.RowNumber + rowsShifted),
-                                         cfAddress.LastAddress.ColumnNumber);
-                    }
-                    else if (cfAddress.FirstAddress.RowNumber >= firstRow)
-                    {
-                        newRange = Range(Math.Max(cfAddress.FirstAddress.RowNumber + rowsShifted, firstRow),
-                                         cfAddress.FirstAddress.ColumnNumber,
-                                         Math.Min(XLHelper.MaxRowNumber, cfAddress.LastAddress.RowNumber + rowsShifted),
-                                         cfAddress.LastAddress.ColumnNumber);
-                    }
-                    else
-                        newRange = cfRange;
-
-                    if (newRange.RangeAddress.IsValid &&
-                        newRange.RangeAddress.FirstAddress.RowNumber <= newRange.RangeAddress.LastAddress.RowNumber)
-                        cf.Ranges.Add(newRange);
-                }
-
-                if (!cf.Ranges.Any())
-                    ConditionalFormats.Remove(f => f == cf);
             }
         }
 

--- a/ClosedXML/XLHelper.cs
+++ b/ClosedXML/XLHelper.cs
@@ -17,6 +17,7 @@ namespace ClosedXML.Excel
         public const int MaxRowNumber = 1048576;
         public const int MaxColumnNumber = 16384;
         public const String MaxColumnLetter = "XFD";
+        public const string LastSheetAddress = "XFD1048576";
         public const Double Epsilon = 1e-10;
 
         internal const string RefError = "#REF!";

--- a/docs/migrations/migrate-to-0.106.rst
+++ b/docs/migrations/migrate-to-0.106.rst
@@ -112,3 +112,12 @@ center (``A1:C3`` without ``B2``).
 
 Reminder: the clearing of a conditional format is done through the Clear method with appropritate
 option, e.g. ``ws.Range("A2:C5").Clear(XLClearOptions.ConditionalFormats)``.
+
+***************************
+IXLConditionalFormat.Ranges
+***************************
+
+The ``IXLConditionalFormat.Ranges`` property had its type changed from ``IXLRanges`` to ``IEnumerable<IXLRange>``.
+If you need to set ranges, use a newly added setter, e.g. ``conditionalFormat.Ranges = ws.Ranges("A1:C5,G1:J5")``.
+
+All conditional formats now must apply to some range. They can't be empty (=with no range).


### PR DESCRIPTION
Refactor and fix the shifting code of conditional formats, so the conditional format updates formula when there is a a structural change. The end result is not great, but it's an improvement. The shifting logic of CFs should now work on area inserts (in most cases) or deletes, not just row or column insert/delete.


* Make conditional formats more self contained (don't expose innards and have logic outside)
* Listen on structural changes through `ISheetListener` and update/delete CF on the changes.

There is a breaking change, the `IXLConditionalFormat.Ranges` has been changes from `IXLRanges` to `IEnumerable<IXLRange>`. It now has a setter if user needs to set multiple ranges to a CF. That is mostly because of always valid model. Each CF should have at least one range and all ranges must be from same worksheet. Exposing `IXLRanges` makes ensuring these invariants nearly impossible.

Related to #686
Related to #2850

# CF formula shifting:

Initial state: Each value in column A looks to corresponing value in column C and if matches, fills the cell red:

<img width="1122" height="403" alt="image" src="https://github.com/user-attachments/assets/8ed74be5-fd44-4bc1-b4bd-ec8967a774c0" />

Now insert 3 rows above row A:

<img width="1274" height="376" alt="image" src="https://github.com/user-attachments/assets/6132912a-f271-4b25-8c91-d8fa3337de50" />


```csharp
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();

ws.Range("A1:A3").AddConditionalFormat().WhenEquals("=C1").Fill.SetBackgroundColor(XLColor.Red);

ws.Cell("A1").Value = 1;
ws.Cell("A2").Value = 2;
ws.Cell("A3").Value = 3;
ws.Cell("C1").Value = 1;
ws.Cell("C2").Value = 2;
ws.Cell("C3").Value = 3;

ws.Row(1).InsertRowsAbove(2);

wb.SaveAs("cf-formula-shift.xlsx");
```

# Conditional formats can be sliced

<img width="1261" height="662" alt="image" src="https://github.com/user-attachments/assets/1ba97673-5391-4097-957e-6ac9fa3e176c" />

```csharp
using var wb = new XLWorkbook();
var ws = wb.AddWorksheet();

ws.Range("A1:D4").AddConditionalFormat().WhenIsBlank().Fill.SetBackgroundColor(XLColor.Red);
ws.Range("B3:C10").Delete(XLShiftDeletedCells.ShiftCellsUp);

wb.SaveAs("cf-slice.xlsx");
```