### PR TITLE
Make a fast path for deletion of rows

### DIFF
--- a/ClosedXML.Tests/Excel/Cells/SliceTests.cs
+++ b/ClosedXML.Tests/Excel/Cells/SliceTests.cs
@@ -1,4 +1,4 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 
 namespace ClosedXML.Tests.Excel.Cells
@@ -231,6 +231,48 @@ namespace ClosedXML.Tests.Excel.Cells
             Assert.AreEqual(1, slice[leftAddress]);
             Assert.AreEqual(4, slice[belowAddress]);
             Assert.AreEqual(6, slice[aboveAddress]);
+        }
+
+        [Test]
+        public void DeleteAreaAndShiftUp_for_full_row_deletion_deletes_the_row_and_updates_column_usage()
+        {
+            // Test that a fast path for deletion of a area with full sheet width works the same
+            // way as deletion of any area.
+            var slice = new Slice<int>();
+
+            slice.Set(new XLSheetPoint(1, 3), 1);
+            slice.Set(new XLSheetPoint(1, 7), 1);
+            slice.Set(new XLSheetPoint(2, 4), 1);
+            slice.Set(new XLSheetPoint(3, 6), 1);
+            slice.Set(new XLSheetPoint(5, 4), 1);
+
+            Assert.That(slice.MaxColumn, Is.EqualTo(7));
+            Assert.That(slice.UsedColumns, Is.EquivalentTo([3, 4, 6, 7]));
+
+            // Delete row with values at [3, 7]
+            DeleteTopRow(6, [4, 6]);
+
+            // Delete row with values at [4], but that is also used in the last row, so no change
+            DeleteTopRow(6, [4, 6]);
+
+            // Delete row with values at [6]
+            DeleteTopRow(4, [4]);
+
+            // Delete blank row, no change
+            DeleteTopRow(4, [4]);
+
+            // Delete last row [4], leaving the slice empty
+            DeleteTopRow(0, []);
+            return;
+
+            void DeleteTopRow(int maxColumn, int[] columnUsage)
+            {
+                var fullFirstRow = XLSheetRange.Full.SliceFromTop(1);
+                slice.DeleteAreaAndShiftUp(fullFirstRow);
+
+                Assert.That(slice.MaxColumn, Is.EqualTo(maxColumn));
+                Assert.That(slice.UsedColumns, Is.EquivalentTo(columnUsage));
+            }
         }
     }
 }

--- a/ClosedXML/Excel/Cells/Slice.Lut.cs
+++ b/ClosedXML/Excel/Cells/Slice.Lut.cs
@@ -1,4 +1,4 @@
-﻿#nullable disable
+#nullable disable
 
 using System;
 using System.Collections.Generic;
@@ -228,13 +228,14 @@ namespace ClosedXML.Excel
                 /// <param name="endIdx">Last desired index, included.</param>
                 internal LutEnumerator(Lut<T> lut, int startIdx, int endIdx)
                 {
+                    Debug.Assert(lut is not null);
                     Debug.Assert(startIdx <= endIdx);
                     _lut = lut;
                     _idx = startIdx - 1;
                     _endIdx = endIdx;
                 }
 
-                public ref T Current => ref _lut._buckets[_idx >> BottomLutBits].Nodes[_idx & BottomLutMask];
+                public readonly ref T Current => ref _lut._buckets[_idx >> BottomLutBits].Nodes[_idx & BottomLutMask];
 
                 /// <summary>
                 /// Index of current element in the LUT. Only valid, if enumerator is valid.

--- a/ClosedXML/Excel/Cells/Slice.cs
+++ b/ClosedXML/Excel/Cells/Slice.cs
@@ -127,6 +127,25 @@ namespace ClosedXML.Excel
 
             var shiftDistance = rangeToDelete.Height;
             var shiftRange = rangeToDelete.BelowRange();
+
+            // Fast path for deleting full rows
+            if (rangeToDelete.HasFullRowWidth)
+            {
+                // Shifting full rows up to an empty space doesn't change column usage or max column and
+                // is thus safe to only move row lookup tables to the new position. Start from top to not
+                // overwrite not-yet moved rows.
+                var rowEnumerator = new Lut<Lut<TElement>>.LutEnumerator(_data, shiftRange.TopRow - 1, shiftRange.BottomRow - 1);
+                while (rowEnumerator.MoveNext())
+                {
+                    // Enumerator is essentially a wrapped index and MoveNext() looks for the next
+                    // used index from current state of LUT, so it's fine to set the values like this.
+                    _data.Set(rowEnumerator.Index - shiftDistance, rowEnumerator.Current);
+                    _data.Set(rowEnumerator.Index, null);
+                }
+
+                return;
+            }
+
             var cellEnumerator = new Enumerator(this, shiftRange);
             while (cellEnumerator.MoveNext())
             {


### PR DESCRIPTION
Deleting and inserting rows is one of most common cases and is thus worth a special path in a slice (most of time is now spent elsewhere).  Speedup was significant. An example: 3000 rows with 21 cells each, delete top 200 rows: 1900ms original vs 530ms after.

I have made several executions of code from #1210, either supplied code that contains `IXLRange`s that are also being updates on background or one without them. The other dimension was whether the code had the new special path for deleting full row areas or not. The fastest version was of course the one with special path and no `IXLRange`s (the last column). It's clear that just by using ranges (the second column) double the execution time. That is not very transparent to the user and is one of reasons why `IXLRange` is being removed from internals.

So with sparse array representation (added in 0.102), special path and no ranges, it is possible to achieve 20x speedup of deletion (or 10x if there are ranges, hopefully not for long). That is sufficient speed up. It could be significantly improved, but not worth the time, until ranges bottleneck is removed.

| Info |  |  |  |  |
| ------------------ | ------ | ------ | ------ | ----- |
| Uses ranges        | Yes    |  Yes    |  No | No    |
| Has special path   | No     |  Yes   |  No    | Yes   |
| ------------------ | ------ | ------ | ------ | ----- |
| 3000 rows created. | 7159.5 | 6392.6 |  105.5 | 102.9 |
| 1 200row deleted.  | 6059.5 | 1086.8 | 1931.7 | 532.4 |
| 2 200row deleted.  | 5660.0 | 1002.2 | 1758.2 | 286.4 |
| 3 200row deleted.  | 4111.7 |  990.6 | 1549.0 | 247.0 |
| 4 200row deleted.  | 3703.2 |  943.6 | 1311.8 | 223.4 |
| 5 200row deleted.  | 2771.5 |  968.2 | 1225.2 | 424.9 |
| 6 200row deleted.  | 2387.8 |  841.3 | 1152.0 | 394.1 |
| 7 200row deleted.  | 2147.7 |  683.6 | 1074.3 | 266.9 |
| 8 200row deleted.  | 1887.7 |  669.0 |  963.4 | 268.0 |
| 9 200row deleted.  | 1539.3 |  519.5 |  795.4 | 198.2 |
| 10 200row deleted. | 1290.3 |  492.6 |  612.0 | 138.2 |
| 11 200row deleted. |  999.5 |  402.3 |  487.8 | 115.5 |
| 12 200row deleted. |  740.1 |  239.4 |  372.5 |  91.4 |
| 13 200row deleted. |  478.1 |  158.1 |  270.5 |  67.6 |
| 14 200row deleted. |  254.9 |  104.5 |  152.0 |  39.3 |
| 15 200row deleted. |   35.2 |   31.9 |   18.1 |  15.1 |

Rangeless version (`ws._rangeRepository` is empty):

```csharp
var wb = new XLWorkbook();
var ws = wb.Worksheets.Add("1");
DateTime start;
Random random = new Random();
// headers
for (int i = 1; i <= 20; i++)
	ws.Cell(1, i).Value = i;

start = DateTime.Now;
// main data
for (int i = 2; i <= 3000; i++)
{
	for (int j = 1; j < 21; j++)
		ws.Cell(i, j).Value = random.NextDouble() * 99999999;
}
Console.WriteLine("3000 rows created. Tooked time (ms): " + (DateTime.Now - start).TotalMilliseconds);

for (int i = 1; i <= 15; i++)
{
	start = DateTime.Now;
	ws.Rows(2, 202).Delete();
	Console.WriteLine(i + " 200row deleted. Tooked time (ms): " + (DateTime.Now - start).TotalMilliseconds);
}
```

Related to #1210