### PR TITLE
fix: XLColor.ToString() threw on automatic color

### DIFF
--- a/ClosedXML.Tests/Excel/Styles/ColorTests.cs
+++ b/ClosedXML.Tests/Excel/Styles/ColorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
 using ClosedXML.Excel;
@@ -185,6 +186,20 @@ namespace ClosedXML.Tests.Excel
             Thread.CurrentThread.CurrentCulture = culture;
             var color = XLColor.FromHtml("#FF008000");
             Assert.AreEqual(XLColor.Green, color);
+        }
+
+        [TestCaseSource(nameof(ToStringTestCases))]
+        public void ToString_works_for_all_color_types(XLColor colorType, string expectedString)
+        {
+            Assert.AreEqual(expectedString, colorType.ToString());
+        }
+
+        private static IEnumerable<TestCaseData<XLColor, string>> ToStringTestCases()
+        {
+            yield return new TestCaseData<XLColor, string>(XLColor.FromArgb(0xFF804010), "FF804010");
+            yield return new TestCaseData<XLColor, string>(XLColor.FromTheme(XLThemeColor.Text1, 0.25), "Color Theme: Text1, Tint: 0.25");
+            yield return new TestCaseData<XLColor, string>(XLColor.FromIndex(14), "Color Index: 14");
+            yield return new TestCaseData<XLColor, string>(XLColor.Automatic, "Automatic");
         }
     }
 }

--- a/ClosedXML/Excel/Style/Colors/XLColor_Public.cs
+++ b/ClosedXML/Excel/Style/Colors/XLColor_Public.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Globalization;
 
 namespace ClosedXML.Excel
 {
@@ -53,12 +54,9 @@ namespace ClosedXML.Excel
     {
         internal Boolean IsAuto => !HasValue;
 
-        public Boolean HasValue { get; private set; }
+        public Boolean HasValue { get; }
 
-        public XLColorType ColorType
-        {
-            get { return Key.ColorType; }
-        }
+        public XLColorType ColorType => Key.ColorType;
 
         public Color Color
         {
@@ -139,7 +137,10 @@ namespace ClosedXML.Excel
                 return Color.ToHex();
 
             if (ColorType == XLColorType.Theme)
-                return String.Format("Color Theme: {0}, Tint: {1}", ThemeColor.ToString(), ThemeTint.ToString());
+                return $"Color Theme: {ThemeColor}, Tint: {ThemeTint.ToString(CultureInfo.InvariantCulture)}";
+
+            if (ColorType == XLColorType.Automatic)
+                return "Automatic";
 
             return "Color Index: " + Indexed;
         }


### PR DESCRIPTION
0.106 has added automatic color type to better represent styles. But the ToString method wasn't updated and it threw an exception.