### PR TITLE
Don't mistake text as as formula

### DIFF
--- a/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
+++ b/ClosedXML.Tests/Excel/ConditionalFormats/ConditionalFormatTests.cs
@@ -192,5 +192,42 @@ namespace ClosedXML.Tests.Excel.ConditionalFormats
 
             Assert.That(() => cf.Ranges = emptyRanges, Throws.TypeOf<ArgumentException>().With.Message.Contains("empty"));
         }
+
+        [Test]
+        public void Text_formats_are_loaded_as_value()
+        {
+            // Issue #2690: Ensure that CF for text are loaded as a value and not as a formula.
+            TestHelper.CreateSaveLoadAssert(
+                (_, ws) =>
+                {
+                    ws.AddConditionalFormat().WhenContains("Contains")
+                        .Fill.SetBackgroundColor(XLColor.Red);
+
+                    ws.AddConditionalFormat().WhenNotContains("Not Contains")
+                        .Fill.SetBackgroundColor(XLColor.Green);
+
+                    ws.AddConditionalFormat().WhenStartsWith("Starts With")
+                        .Fill.SetBackgroundColor(XLColor.Blue);
+
+                    ws.AddConditionalFormat().WhenEndsWith("Ends With")
+                        .Fill.SetBackgroundColor(XLColor.Black);
+                },
+                (_, ws) =>
+                {
+                    AssertTextCfValue(ws, XLConditionalFormatType.ContainsText, "Contains");
+                    AssertTextCfValue(ws, XLConditionalFormatType.NotContainsText, "Not Contains");
+                    AssertTextCfValue(ws, XLConditionalFormatType.StartsWith, "Starts With");
+                    AssertTextCfValue(ws, XLConditionalFormatType.EndsWith, "Ends With");
+                });
+            return;
+
+            static void AssertTextCfValue(IXLWorksheet ws, XLConditionalFormatType type, string text)
+            {
+                var cf = ws.ConditionalFormats.Single(x => x.ConditionalFormatType == type);
+                Assert.AreEqual(1, cf.Values.Count);
+                Assert.AreEqual(text, cf.Values[1].Value);
+                Assert.IsFalse(cf.Values[1].IsFormula);
+            }
+        }
     }
 }

--- a/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
+++ b/ClosedXML/Excel/ConditionalFormats/XLConditionalFormat.cs
@@ -96,19 +96,6 @@ namespace ClosedXML.Excel
             }
         }
 
-        private void AdjustFormulas(XLCell baseCell, XLCell targetCell)
-        {
-            var keys = Values.Keys.ToList();
-            foreach (var key in keys)
-            {
-                if (Values[key] == null || !Values[key].IsFormula)
-                    continue;
-
-                var r1c1 = baseCell.GetFormulaR1C1(Values[key].Value);
-                Values[key] = new XLFormula { _value = targetCell.GetFormulaA1(r1c1), IsFormula = true };
-            }
-        }
-
         internal static IEqualityComparer<XLConditionalFormat> NoRangeComparer { get; } = new NoRangeCfComparer();
 
         #region Constructors
@@ -127,14 +114,35 @@ namespace ClosedXML.Excel
             IconSetOperators = new XLDictionary<XLCFIconSetOperator>();
         }
 
-        internal XLConditionalFormat(XLWorksheet worksheet, XLConditionalFormat conditionalFormat, XLAreaList areaList)
+        /// <summary>
+        /// Copy ctor.
+        /// </summary>
+        internal XLConditionalFormat(XLWorksheet worksheet, XLConditionalFormat other, XLAreaList areaList)
             : this(worksheet, areaList)
         {
-            CopyFrom(conditionalFormat);
+            var otherDxf = other.FormatValue;
+            FormatValue = otherDxf is not null
+                ? _worksheet.Workbook.Styles.GetRegisteredDxFormat(otherDxf, static x => x)
+                : null;
+            ConditionalFormatType = other.ConditionalFormatType;
+            TimePeriod = other.TimePeriod;
+            IconSetStyle = other.IconSetStyle;
+            Operator = other.Operator;
+            Bottom = other.Bottom;
+            Percent = other.Percent;
+            ReverseIconOrder = other.ReverseIconOrder;
+            ShowIconOnly = other.ShowIconOnly;
+            ShowBarOnly = other.ShowBarOnly;
+            StopIfTrue = other.StopIfTrue;
 
-            var sourceAnchor = _worksheet.Cell(conditionalFormat.Areas[0].FirstPoint);
-            var targetAnchor = _worksheet.Cell(areaList[0].FirstPoint);
-            AdjustFormulas(sourceAnchor, targetAnchor);
+            var sourceAnchor = other.Areas[0].FirstPoint;
+            var targetAnchor = Areas[0].FirstPoint;
+            foreach (var (key, originalValue) in other.Values)
+                Values.Add(key, originalValue.GetAdjustedCopy(sourceAnchor, targetAnchor));
+
+            Colors = other.Colors.CopyDictionary();
+            ContentTypes = other.ContentTypes.CopyDictionary();
+            IconSetOperators = other.IconSetOperators.CopyDictionary();
         }
 
         #endregion Constructors
@@ -157,13 +165,13 @@ namespace ClosedXML.Excel
             set => Format.SetValue(value);
         }
 
-        public XLDictionary<XLFormula> Values { get; private set; }
+        public XLDictionary<XLFormula> Values { get; }
 
-        public XLDictionary<XLColor> Colors { get; private set; }
+        public XLDictionary<XLColor> Colors { get; }
 
-        public XLDictionary<XLCFContentType> ContentTypes { get; private set; }
+        public XLDictionary<XLCFContentType> ContentTypes { get; }
 
-        public XLDictionary<XLCFIconSetOperator> IconSetOperators { get; private set; }
+        public XLDictionary<XLCFIconSetOperator> IconSetOperators { get; }
 
         public IXLRange Range
         {
@@ -224,41 +232,6 @@ namespace ClosedXML.Excel
             var newCf = new XLConditionalFormat((XLWorksheet)targetSheet, this, Areas);
             targetSheet.ConditionalFormats.Add(newCf);
             return newCf;
-        }
-
-        public void CopyFrom(IXLConditionalFormat other)
-        {
-#if STYLES_REWORK
-            var otherDxf = ((XLConditionalFormat)other).FormatValue;
-            FormatValue = otherDxf is not null
-                ? _worksheet.Workbook.Styles.GetRegisteredDxFormat(otherDxf, static x => x)
-                : null;
-#else
-            InnerStyle = other.Style;
-#endif
-            ConditionalFormatType = other.ConditionalFormatType;
-            TimePeriod = other.TimePeriod;
-            IconSetStyle = other.IconSetStyle;
-            Operator = other.Operator;
-            Bottom = other.Bottom;
-            Percent = other.Percent;
-            ReverseIconOrder = other.ReverseIconOrder;
-            ShowIconOnly = other.ShowIconOnly;
-            ShowBarOnly = other.ShowBarOnly;
-            StopIfTrue = other.StopIfTrue;
-
-            Values.Clear();
-            other.Values.ForEach(kp => Values.Add(kp.Key, new XLFormula(kp.Value)));
-            //CopyDictionary(Values, other.Values);
-            CopyDictionary(Colors, other.Colors);
-            CopyDictionary(ContentTypes, other.ContentTypes);
-            CopyDictionary(IconSetOperators, other.IconSetOperators);
-        }
-
-        private void CopyDictionary<T>(XLDictionary<T> target, XLDictionary<T> source)
-        {
-            target.Clear();
-            source.ForEach(kp => target.Add(kp.Key, kp.Value));
         }
 
         public IXLStyle WhenIsBlank()

--- a/ClosedXML/Excel/IO/WorksheetPartReader.cs
+++ b/ClosedXML/Excel/IO/WorksheetPartReader.cs
@@ -867,11 +867,15 @@ internal class WorksheetPartReader
 
                 conditionalFormat.Values.Add(GetFormula(formula.Text));
             }
-
-            if (!String.IsNullOrWhiteSpace(fr.Text))
-                conditionalFormat.Values.Add(GetFormula(fr.Text.Value));
-
-            if (conditionalFormat.ConditionalFormatType == XLConditionalFormatType.Top10)
+            else if (conditionalFormat.ConditionalFormatType is
+                     XLConditionalFormatType.ContainsText or
+                     XLConditionalFormatType.NotContainsText or
+                     XLConditionalFormatType.StartsWith or
+                     XLConditionalFormatType.EndsWith)
+            {
+                conditionalFormat.Values.Add(new XLFormula(fr.Text?.Value ?? string.Empty) { IsFormula = false });
+            }
+            else if (conditionalFormat.ConditionalFormatType == XLConditionalFormatType.Top10)
             {
                 if (fr.Percent != null)
                     conditionalFormat.Percent = fr.Percent.Value;

--- a/ClosedXML/Excel/Misc/XLDictionary.cs
+++ b/ClosedXML/Excel/Misc/XLDictionary.cs
@@ -28,5 +28,14 @@ namespace ClosedXML.Excel
         {
             Add(Count + 1, value);
         }
+
+        internal XLDictionary<T> CopyDictionary()
+        {
+            var copy = new XLDictionary<T>();
+            foreach (var (key, value) in this)
+                copy.Add(key, value);
+
+            return copy;
+        }
     }
 }

--- a/ClosedXML/Excel/Misc/XLFormula.cs
+++ b/ClosedXML/Excel/Misc/XLFormula.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using ClosedXML.Parser;
 using System;
 
 namespace ClosedXML.Excel
@@ -53,5 +54,15 @@ namespace ClosedXML.Excel
         }
 
         public Boolean IsFormula { get; internal set; }
+
+        internal XLFormula GetAdjustedCopy(Point sourceAnchor, Point targetAnchor)
+        {
+            if (!IsFormula)
+                return new XLFormula(this);
+
+            var formulaR1C1 = FormulaConverter.ToR1C1(Value, sourceAnchor.Row, sourceAnchor.Column);
+            var formulaA1 = FormulaConverter.ToA1(formulaR1C1, targetAnchor.Row, targetAnchor.Column);
+            return new XLFormula { _value = formulaA1, IsFormula = true };
+        }
     }
 }


### PR DESCRIPTION
The loading code of CF was loading text operand of CF (ContainsText, NotContainsText, StartsWith, EndsWith) as a formula. It is never formula, but a text. Fix loading code so it always recognizes it as a text. That later failed, because (by default `SaveOptions.ConsolidateConditionalFormatRanges`) CFs are consolidated during saving. So the code tried to parse the text as a formula to convert it to R1C1 for relocation and failed. Operands in CFs deserve some TLC, but that is true for most of the API.

Fixes #2695 
Fixes #2690