### PR TITLE
fix: bound SixLabors.Fonts to version range [1.0.0,3.0.0)

### DIFF
--- a/ClosedXML/ClosedXML.csproj
+++ b/ClosedXML/ClosedXML.csproj
@@ -45,7 +45,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="RBush.Signed" Version="4.0.0" />
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
+    <PackageReference Include="SixLabors.Fonts" Version="[1.0.0,2.0.0)" />
     <PackageReference Include="ClosedXML.Parser" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Prevents NuGet from resolving SixLabors.Fonts ≥ 2.0.0 as a dependency of ClosedXML, which protects .NET Framework consumers from runtime crashes.

## Problem

SixLabors.Fonts 2.0.0+ introduced commercial license requirements, and 3.0.0 targets `net8.0` only — dropping `netstandard` entirely. Because ClosedXML specifies `Version="1.0.0"` (≥ 1.0.0, no ceiling), NuGet can resolve 3.0.0 on any project that updates its packages broadly, causing:

```
System.TypeLoadException: Could not load type 'SixLabors.Fonts.GlyphMetrics'
from assembly 'ClosedXML' due to value type mismatch.
```

This is tracked in:
- #2844 — TypeLoadException with SixLabors.Fonts 3.0.0
- #2168 — SixLabors.Fonts v2.0.0 incompatible with netstandard
- #2171 — SixLabors.Fonts v2.0.0 changed to Commercial License

## Fix

Changes `Version="1.0.0"` to `Version="[1.0.0,2.0.0)"` — matching the established pattern already used for `DocumentFormat.OpenXml` in the same file.

## Compatibility

| Target | Before | After |
|---|---|---|
| .NET Framework 4.6.1+ | Could resolve 3.x → crash | Resolves ≤ 1.x → works |
| .NET Core / .NET 5+ | Could resolve 3.x → crash | Resolves ≤ 1.x → works |
| License enforcement | Hits v2/v3 license wall | Stays on Apache-licensed v1 |

## Notes

This is a minimal fix targeting the `release-candidate` branch (0.105.0). The maintainer has indicated (#2844 comment) that SixLabors.Fonts will eventually be replaced by SkiaSharp — this bound serves as a safety net until that migration is complete.

Closes #2844