### PR TITLE
Structured reference should use cells from table sheet

### DIFF
--- a/ClosedXML.Tests/Excel/CalcEngine/StructuredReferenceTests.cs
+++ b/ClosedXML.Tests/Excel/CalcEngine/StructuredReferenceTests.cs
@@ -162,6 +162,26 @@ namespace ClosedXML.Tests.Excel.CalcEngine
             Assert.AreEqual(XLError.IncompatibleValue, ws.Evaluate(formula, "D11"));
         }
 
+        [Test]
+        public void Structured_reference_uses_cells_from_table_worksheet()
+        {
+            // Structured reference uses cells from the sheet of the table, not sheet where is the formula.
+            // https://github.com/ClosedXML/ClosedXML/issues/2871
+            using var wb = new XLWorkbook();
+            var tableSheet = wb.AddWorksheet("TableSheet");
+            tableSheet.Cell("B3").InsertTable(
+                [
+                    new { Name = "Cake", Price = 7 },
+                    new { Name = "Pie", Price = 9 }
+                ],
+                "Pastries");
+            var formulaSheet = wb.AddWorksheet();
+
+            formulaSheet.Cell("A1").FormulaA1 = "SUM(Pastries[Price])";
+
+            Assert.That(formulaSheet.Cell("A1").Value, Is.EqualTo(16));
+        }
+
         private static IXLTable Add4X3Table(IXLWorksheet ws, string origin)
         {
             var dt = new DataTable("TableName");

--- a/ClosedXML/Excel/CalcEngine/CalculationVisitor.cs
+++ b/ClosedXML/Excel/CalcEngine/CalculationVisitor.cs
@@ -128,7 +128,7 @@ namespace ClosedXML.Excel.CalcEngine
                 return error;
 
             var range = new Area(rowStart, colStart, rowEnd, colEnd);
-            return new Reference(XLRangeAddress.FromSheetRange(context.Worksheet, range));
+            return new Reference(XLRangeAddress.FromSheetRange(table.Worksheet, range));
 
             static bool TryGetTable(CalcContext context, string? tableName, [NotNullWhen(true)] out XLTable? table)
             {


### PR DESCRIPTION
If a formula in a sheet referenced table from different sheet, the function didn't use cells from the sheet with the table, but from the sheet where was the formula.

Fix #2871 