### PR TITLE
fix: keep collection type after Skip/Where/Take on columns and rows

### DIFF
--- a/ClosedXML.Tests/Excel/Columns/XLColumnsFilteringTests.cs
+++ b/ClosedXML.Tests/Excel/Columns/XLColumnsFilteringTests.cs
@@ -1,0 +1,304 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+using System.Linq;
+
+namespace ClosedXML.Tests.Excel.Columns;
+
+/// <summary>
+/// Tests for filtering worksheet columns (<see cref="IXLColumns"/>).
+/// </summary>
+internal class XLColumnsFilteringTests
+{
+    [Test]
+    public void Skip_then_AdjustToContents_does_not_change_skipped_column()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Cool cheesecake stuff");
+        var insertedRange = ws.Cell("A1").InsertData(new[]
+        {
+            new object[] { "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!", 14 },
+            new object[] { "Medovik", 6 },
+            new object[] { "Muffin", 10 }
+        });
+        insertedRange.FirstColumn().Style.Alignment.SetWrapText(true);
+        insertedRange.FirstColumn().WorksheetColumn().Width = 20;
+        ws.Column(2).Width = 1;
+
+        IXLColumns remaining = ws.ColumnsUsed().Skip(1);
+        remaining.AdjustToContents();
+
+        Assert.AreEqual(20, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.Greater(ws.Column(2).Width, 1);
+    }
+
+    [Test]
+    public void Where_and_Take_then_AdjustToContents_filter_as_specified()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").InsertData(new[]
+        {
+            new object[] { "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!", 14 },
+            new object[] { "Medovik", 6 },
+            new object[] { "Muffin", 10 }
+        });
+        ws.Column(1).Width = 20;
+        ws.Column(2).Width = 1;
+
+        IXLColumns remaining = ws.ColumnsUsed().Where(c => c.ColumnNumber() != 1);
+        remaining.AdjustToContents();
+        Assert.AreEqual(20, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.Greater(ws.Column(2).Width, 1);
+
+        ws.Column(1).Width = 1;
+        ws.Column(2).Width = 1;
+        IXLColumns taken = ws.ColumnsUsed().Take(1);
+        taken.AdjustToContents();
+        Assert.Greater(ws.Column(1).Width, 1);
+        Assert.AreEqual(1, ws.Column(2).Width, XLHelper.Epsilon);
+    }
+
+    [Test]
+    public void Skip_Where_Take_enumerate_in_column_number_order()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("C1").Value = "c";
+        ws.Cell("A1").Value = "a";
+        ws.Cell("B1").Value = "b";
+
+        IXLColumns skipped = ws.ColumnsUsed().Skip(1);
+        IXLColumns filtered = ws.ColumnsUsed().Where(c => c.ColumnNumber() != 2);
+        IXLColumns taken = ws.ColumnsUsed().Take(2);
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, skipped.Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 1, 3 }, filtered.Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 1, 2 }, taken.Select(c => c.ColumnNumber()));
+        Assert.AreEqual(0, ws.ColumnsUsed().Skip(10).Count());
+    }
+
+    [Test]
+    public void Filtering_Columns_does_not_treat_result_as_all_columns_of_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A1:C1").Value = "x";
+        var defaultColumnWidth = ws.ColumnWidth;
+
+        ws.Columns().Skip(1).Width = 100;
+        Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+        Assert.AreEqual(defaultColumnWidth, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.AreEqual(100, ws.Column(2).Width, XLHelper.Epsilon);
+        Assert.AreEqual(100, ws.Column(3).Width, XLHelper.Epsilon);
+
+        ws.Columns().Where(c => c.ColumnNumber() != 1).Width = 90;
+        Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+        Assert.AreEqual(defaultColumnWidth, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.AreEqual(90, ws.Column(2).Width, XLHelper.Epsilon);
+
+        ws.Columns().Skip(0).Width = 80;
+        Assert.AreEqual(defaultColumnWidth, ws.ColumnWidth, XLHelper.Epsilon);
+        Assert.AreEqual(80, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.AreEqual(defaultColumnWidth, ws.Column("Z").Width, XLHelper.Epsilon);
+    }
+
+    [Test]
+    public void Skip_on_Columns_Delete_does_not_clear_the_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "keep";
+        ws.Cell("B1").Value = "drop";
+        ws.Cell("C1").Value = "drop";
+
+        IXLColumns skipped = ws.Columns().Skip(1);
+        skipped.Delete();
+
+        Assert.AreEqual("keep", ws.Cell("A1").GetString());
+        Assert.True(ws.Cell("B1").IsEmpty());
+        Assert.True(ws.Cell("C1").IsEmpty());
+    }
+
+    [Test]
+    public void Skip_Where_Take_can_be_chained()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A1:E1").Value = "x";
+
+        IXLColumns subset = ws.ColumnsUsed().Skip(1).Where(c => c.ColumnNumber() != 4).Take(2);
+        IXLColumns skippedTwice = ws.ColumnsUsed().Skip(1).Skip(1);
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, subset.Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 3, 4, 5 }, skippedTwice.Select(c => c.ColumnNumber()));
+    }
+
+    [Test]
+    public void AdjustToContents_overloads_respect_row_bounds_and_min_max()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("B1").Value = "x";
+        ws.Cell("B10").Value = "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!";
+        ws.Column(2).Width = 1;
+
+        IXLColumns columnB = ws.ColumnsUsed().Where(c => c.ColumnNumber() == 2);
+        columnB.AdjustToContents(1, 1);
+        var widthFromFirstRow = ws.Column(2).Width;
+
+        ws.Column(2).AdjustToContents();
+        Assert.Greater(ws.Column(2).Width, widthFromFirstRow);
+
+        ws.Column(2).Width = 1;
+        columnB.AdjustToContents(50.0, 50.0);
+        Assert.AreEqual(50, ws.Column(2).Width, XLHelper.Epsilon);
+    }
+
+    [Test]
+    public void Collection_operations_do_not_affect_skipped_column_or_other_sheets()
+    {
+        using var wb = new XLWorkbook();
+        var ws1 = wb.AddWorksheet("One");
+        var ws2 = wb.AddWorksheet("Two");
+        ws1.Cell("A1").Value = "keep";
+        ws1.Cell("B1").Value = "change";
+        ws1.Cell("C1").Value = "change";
+        ws2.Cells("A1:C1").Value = "y";
+        var ws2Width = ws2.Column(2).Width;
+
+        IXLColumns remaining = ws1.ColumnsUsed().Skip(1);
+        remaining.Style.Font.Bold = true;
+        remaining.Hide();
+        remaining.Clear(XLClearOptions.Contents);
+        remaining.Width = 100;
+
+        Assert.AreEqual("keep", ws1.Cell("A1").GetString());
+        Assert.False(ws1.Column(1).Style.Font.Bold);
+        Assert.False(ws1.Column(1).IsHidden);
+        Assert.True(ws1.Cell("B1").IsEmpty());
+        Assert.True(ws1.Column(2).Style.Font.Bold);
+        Assert.True(ws1.Column(2).IsHidden);
+        Assert.AreEqual(100, ws1.Column(2).Width, XLHelper.Epsilon);
+        Assert.AreEqual(ws2Width, ws2.Column(2).Width, XLHelper.Epsilon);
+    }
+
+    [Test]
+    public void Skip_works_on_materialized_and_inserted_column_collections()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Column(1).Width = 9;
+
+        IXLColumns disjoint = ws.Columns("A,C,E").Skip(1);
+        disjoint.Width = 12;
+        Assert.AreNotEqual(12, ws.Column(1).Width);
+        Assert.AreEqual(12, ws.Column(3).Width, XLHelper.Epsilon);
+        Assert.AreEqual(12, ws.Column(5).Width, XLHelper.Epsilon);
+        Assert.AreNotEqual(12, ws.ColumnWidth);
+
+        IXLColumns inserted = ws.Column(1).InsertColumnsAfter(3);
+        IXLColumns skippedInsert = inserted.Skip(1);
+        skippedInsert.Width = 15;
+        Assert.AreEqual(9, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.AreEqual(9, ws.Column(2).Width, XLHelper.Epsilon);
+        Assert.AreEqual(15, ws.Column(3).Width, XLHelper.Epsilon);
+        Assert.AreEqual(15, ws.Column(4).Width, XLHelper.Epsilon);
+    }
+
+    [Test]
+    public void Foreach_Skip_adjusts_only_remaining_columns()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").InsertData(new[]
+        {
+            new object[] { "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!", 14 },
+            new object[] { "Medovik", 6 },
+            new object[] { "Muffin", 10 }
+        });
+        ws.Column(1).Width = 20;
+        ws.Column(2).Width = 1;
+
+        foreach (var column in ws.ColumnsUsed().Skip(1))
+            column.AdjustToContents();
+
+        Assert.AreEqual(20, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.Greater(ws.Column(2).Width, 1);
+    }
+
+    [Test]
+    public void ColumnsUsed_predicate_filters_columns()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").InsertData(new[]
+        {
+            new object[] { "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!", 14 },
+            new object[] { "Medovik", 6 },
+            new object[] { "Muffin", 10 }
+        });
+        ws.Column(1).Width = 20;
+        ws.Column(2).Width = 1;
+
+        ws.ColumnsUsed(c => c.ColumnNumber() != 1).AdjustToContents();
+
+        Assert.AreEqual(20, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.Greater(ws.Column(2).Width, 1);
+    }
+
+    [Test]
+    public void Skip_follows_column_number_order_not_insertion_order()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("C1").Value = "c";
+        ws.Cell("A1").Value = "a";
+        ws.Cell("B1").Value = "b";
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, ws.ColumnsUsed().Skip(1).Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 3, 5 }, ws.Columns("A,C,E").Skip(1).Select(c => c.ColumnNumber()));
+    }
+
+    [Test]
+    public void Indexed_Where_filters_by_index()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A1:C1").Value = "x";
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, ws.ColumnsUsed().Where((c, i) => i > 0).Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 2, 1 }, ws.ColumnsUsed().OrderByDescending(c => c.ColumnNumber()).Skip(1).Select(c => c.ColumnNumber()));
+    }
+
+    [Test]
+    public void FindColumns_returns_matching_columns()
+    {
+        using var wb = new XLWorkbook();
+        var ws1 = wb.AddWorksheet("One");
+        var ws2 = wb.AddWorksheet("Two");
+        ws1.Cells("A1:C1").Value = "x";
+        ws2.Cells("B1:D1").Value = "y";
+
+        var found = wb.FindColumns(c => c.ColumnNumber() == 2);
+
+        Assert.AreEqual(2, found.Count());
+        CollectionAssert.AreEquivalent(new[] { "One", "Two" }, found.Select(c => c.Worksheet.Name));
+    }
+
+    [Test]
+    public void Columns_Width_and_Delete_affect_whole_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A1:C1").Value = "x";
+
+        ws.Columns().Width = 100;
+        Assert.AreEqual(100, ws.ColumnWidth, XLHelper.Epsilon);
+        Assert.AreEqual(100, ws.Column("G").Width, XLHelper.Epsilon);
+
+        ws.Columns().Delete();
+        Assert.True(ws.Cell("A1").IsEmpty());
+        Assert.True(ws.Cell("B1").IsEmpty());
+        Assert.True(ws.Cell("C1").IsEmpty());
+    }
+}

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeColumnsFilteringTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeColumnsFilteringTests.cs
@@ -1,0 +1,99 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+using System.Linq;
+
+namespace ClosedXML.Tests.Excel.Ranges;
+
+/// <summary>
+/// Tests for filtering range columns (<see cref="IXLRangeColumns"/>).
+/// </summary>
+internal class XLRangeColumnsFilteringTests
+{
+    [Test]
+    public void Skip_then_AdjustToContents_does_not_change_skipped_column()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        var insertedRange = ws.Cell("A1").InsertData(new[]
+        {
+            new object[] { "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!", 14 },
+            new object[] { "Medovik", 6 },
+            new object[] { "Muffin", 10 }
+        });
+        insertedRange.FirstColumn().Style.Alignment.SetWrapText(true);
+        insertedRange.FirstColumn().WorksheetColumn().Width = 20;
+        ws.Column(2).Width = 1;
+
+        IXLRangeColumns remaining = insertedRange.ColumnsUsed().Skip(1);
+        remaining.AdjustToContents();
+
+        Assert.AreEqual(20, ws.Column(1).Width, XLHelper.Epsilon);
+        Assert.Greater(ws.Column(2).Width, 1);
+    }
+
+    [Test]
+    public void AdjustToContents_uses_only_cells_inside_the_range()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("B1").Value = "x";
+        ws.Cell("B20").Value = "Cheesecake sablfdsa daskjfhdsakjdsa and what more tging we have...!";
+        ws.Column(2).Width = 1;
+
+        ws.Range("B1:B1").FirstColumn().AdjustToContents();
+        var widthFromRangeColumn = ws.Column(2).Width;
+
+        ws.Range("A1:B1").ColumnsUsed().Skip(1).AdjustToContents();
+        var widthFromRangeColumns = ws.Column(2).Width;
+
+        ws.Column(2).AdjustToContents();
+        Assert.Greater(ws.Column(2).Width, widthFromRangeColumn);
+        Assert.Greater(ws.Column(2).Width, widthFromRangeColumns);
+    }
+
+    [Test]
+    public void Skip_Where_Take_use_worksheet_column_numbers()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("C1:E1").Value = "x";
+
+        IXLRangeColumns skipped = ws.Range("C1:E1").ColumnsUsed().Skip(1);
+        IXLRangeColumns filtered = ws.Range("C1:E1").ColumnsUsed().Where(c => c.ColumnNumber() != 3);
+        IXLRangeColumns taken = ws.Range("C1:E1").ColumnsUsed().Take(2);
+        IXLRangeColumns chained = ws.Range("C1:E1").ColumnsUsed().Skip(1).Take(1);
+
+        CollectionAssert.AreEqual(new[] { 4, 5 }, skipped.Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 4, 5 }, filtered.Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 3, 4 }, taken.Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 4 }, chained.Select(c => c.ColumnNumber()));
+    }
+
+    [Test]
+    public void Skip_then_Delete_does_not_delete_first_range_column()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "keep";
+        ws.Cell("B1").Value = "drop";
+        ws.Cell("C1").Value = "drop";
+
+        IXLRangeColumns remaining = ws.Range("A1:C1").ColumnsUsed().Skip(1);
+        remaining.Delete();
+
+        Assert.AreEqual("keep", ws.Cell("A1").GetString());
+        Assert.True(ws.Cell("B1").IsEmpty());
+        Assert.True(ws.Cell("C1").IsEmpty());
+    }
+
+    [Test]
+    public void ColumnsUsed_predicate_filters_range_columns()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("C1:E1").Value = "x";
+
+        CollectionAssert.AreEqual(new[] { 4, 5 }, ws.Range("C1:E1").ColumnsUsed().Skip(1).Select(c => c.ColumnNumber()));
+        CollectionAssert.AreEqual(new[] { 4, 5 }, ws.Range("C1:E1").ColumnsUsed(c => c.ColumnNumber() != 3).Select(c => c.ColumnNumber()));
+    }
+}

--- a/ClosedXML.Tests/Excel/Ranges/XLRangeRowsFilteringTests.cs
+++ b/ClosedXML.Tests/Excel/Ranges/XLRangeRowsFilteringTests.cs
@@ -1,0 +1,95 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+using System.Linq;
+
+namespace ClosedXML.Tests.Excel.Ranges;
+
+/// <summary>
+/// Tests for filtering range rows (<see cref="IXLRangeRows"/>).
+/// </summary>
+internal class XLRangeRowsFilteringTests
+{
+    [Test]
+    public void Skip_then_AdjustToContents_does_not_change_skipped_row()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "Keep this height";
+        ws.Cell("A2").Value = "Fit me";
+        ws.Row(1).Height = 40;
+        ws.Row(2).Height = 5;
+
+        IXLRangeRows remaining = ws.Range("A1:A2").RowsUsed().Skip(1);
+        remaining.AdjustToContents();
+
+        Assert.AreEqual(40, ws.Row(1).Height, XLHelper.Epsilon);
+        Assert.AreNotEqual(5, ws.Row(2).Height);
+    }
+
+    [Test]
+    public void AdjustToContents_uses_only_cells_inside_the_range()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A2").Value = "short";
+        ws.Cell("A2").Style.Font.FontSize = 11;
+        ws.Cell("Z2").Value = "tall";
+        ws.Cell("Z2").Style.Font.FontSize = 36;
+        ws.Row(2).Height = 10;
+
+        ws.Range("A2:B2").FirstRow().AdjustToContents();
+        var heightFromRangeRow = ws.Row(2).Height;
+        Assert.Greater(heightFromRangeRow, 10);
+
+        ws.Range("A2:B2").RowsUsed().AdjustToContents();
+        var heightFromRangeRows = ws.Row(2).Height;
+
+        ws.Row(2).AdjustToContents();
+        Assert.Greater(ws.Row(2).Height, heightFromRangeRow);
+        Assert.Greater(ws.Row(2).Height, heightFromRangeRows);
+    }
+
+    [Test]
+    public void Skip_Where_Take_use_worksheet_row_numbers()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A3:A5").Value = "x";
+
+        IXLRangeRows skipped = ws.Range("A3:A5").RowsUsed().Skip(1);
+        IXLRangeRows filtered = ws.Range("A3:A5").RowsUsed().Where(r => r.RowNumber() != 3);
+        IXLRangeRows taken = ws.Range("A3:A5").RowsUsed().Take(2);
+
+        CollectionAssert.AreEqual(new[] { 4, 5 }, skipped.Select(r => r.RowNumber()));
+        CollectionAssert.AreEqual(new[] { 4, 5 }, filtered.Select(r => r.RowNumber()));
+        CollectionAssert.AreEqual(new[] { 3, 4 }, taken.Select(r => r.RowNumber()));
+    }
+
+    [Test]
+    public void Skip_then_Delete_does_not_delete_first_range_row()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "keep";
+        ws.Cell("A2").Value = "drop";
+        ws.Cell("A3").Value = "drop";
+
+        IXLRangeRows remaining = ws.Range("A1:A3").RowsUsed().Skip(1);
+        remaining.Delete();
+
+        Assert.AreEqual("keep", ws.Cell("A1").GetString());
+        Assert.True(ws.Cell("A2").IsEmpty());
+        Assert.True(ws.Cell("A3").IsEmpty());
+    }
+
+    [Test]
+    public void RowsUsed_predicate_filters_range_rows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A3:A5").Value = "y";
+
+        CollectionAssert.AreEqual(new[] { 4, 5 }, ws.Range("A3:A5").RowsUsed().Skip(1).Select(r => r.RowNumber()));
+        CollectionAssert.AreEqual(new[] { 4, 5 }, ws.Range("A3:A5").RowsUsed(r => r.RowNumber() != 3).Select(r => r.RowNumber()));
+    }
+}

--- a/ClosedXML.Tests/Excel/Rows/XLRowsFilteringTests.cs
+++ b/ClosedXML.Tests/Excel/Rows/XLRowsFilteringTests.cs
@@ -1,0 +1,116 @@
+using ClosedXML.Excel;
+using NUnit.Framework;
+using System.Linq;
+
+namespace ClosedXML.Tests.Excel.Rows;
+
+/// <summary>
+/// Tests for filtering worksheet rows (<see cref="IXLRows"/>).
+/// </summary>
+internal class XLRowsFilteringTests
+{
+    [Test]
+    public void Skip_then_AdjustToContents_does_not_change_skipped_row()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "Keep this height";
+        ws.Cell("A2").Value = "Fit me";
+        ws.Row(1).Height = 40;
+        ws.Row(2).Height = 5;
+
+        IXLRows remaining = ws.RowsUsed().Skip(1);
+        remaining.AdjustToContents();
+
+        Assert.AreEqual(40, ws.Row(1).Height, XLHelper.Epsilon);
+        Assert.AreNotEqual(5, ws.Row(2).Height);
+    }
+
+    [Test]
+    public void Filtering_Rows_does_not_treat_result_as_all_rows_of_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "keep";
+        ws.Cell("A2").Value = "drop";
+        ws.Cell("A3").Value = "drop";
+        var defaultRowHeight = ws.RowHeight;
+
+        ws.Rows().Skip(1).Height = 30;
+        Assert.AreEqual(defaultRowHeight, ws.RowHeight, XLHelper.Epsilon);
+        Assert.AreEqual(defaultRowHeight, ws.Row(1).Height, XLHelper.Epsilon);
+        Assert.AreEqual(30, ws.Row(2).Height, XLHelper.Epsilon);
+        Assert.AreEqual(30, ws.Row(3).Height, XLHelper.Epsilon);
+        Assert.AreEqual(defaultRowHeight, ws.Row(11).Height, XLHelper.Epsilon);
+
+        ws.Rows().Skip(0).Height = 25;
+        Assert.AreEqual(defaultRowHeight, ws.RowHeight, XLHelper.Epsilon);
+
+        ws.Rows().Skip(1).Delete();
+        Assert.AreEqual("keep", ws.Cell("A1").GetString());
+        Assert.True(ws.Cell("A2").IsEmpty());
+        Assert.True(ws.Cell("A3").IsEmpty());
+    }
+
+    [Test]
+    public void Skip_Where_Take_can_be_chained()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A1:A5").Value = "x";
+
+        IXLRows subset = ws.RowsUsed().Skip(1).Where(r => r.RowNumber() != 4).Take(2);
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, subset.Select(r => r.RowNumber()));
+    }
+
+    [Test]
+    public void Foreach_Skip_adjusts_only_remaining_rows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "Keep this height";
+        ws.Cell("A2").Value = "Fit me";
+        ws.Row(1).Height = 40;
+        ws.Row(2).Height = 5;
+
+        foreach (var row in ws.RowsUsed().Skip(1))
+            row.AdjustToContents();
+
+        Assert.AreEqual(40, ws.Row(1).Height, XLHelper.Epsilon);
+        Assert.AreNotEqual(5, ws.Row(2).Height);
+    }
+
+    [Test]
+    public void RowsUsed_predicate_filters_rows()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cell("A1").Value = "Keep this height";
+        ws.Cell("A2").Value = "Fit me";
+        ws.Row(1).Height = 40;
+        ws.Row(2).Height = 5;
+
+        ws.RowsUsed(r => r.RowNumber() != 1).AdjustToContents();
+
+        Assert.AreEqual(40, ws.Row(1).Height, XLHelper.Epsilon);
+        Assert.AreNotEqual(5, ws.Row(2).Height);
+    }
+
+    [Test]
+    public void Rows_Height_and_Delete_affect_whole_sheet()
+    {
+        using var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet();
+        ws.Cells("A1:A3").Value = "x";
+
+        ws.Rows().Height = 30;
+        Assert.AreEqual(30, ws.RowHeight, XLHelper.Epsilon);
+        Assert.AreEqual(30, ws.Row(11).Height, XLHelper.Epsilon);
+
+        ws.Rows().Delete();
+        Assert.True(ws.Cell("A1").IsEmpty());
+        Assert.True(ws.Cell("A2").IsEmpty());
+        Assert.True(ws.Cell("A3").IsEmpty());
+    }
+}

--- a/ClosedXML/Excel/Columns/IXLColumns.cs
+++ b/ClosedXML/Excel/Columns/IXLColumns.cs
@@ -45,6 +45,23 @@ namespace ClosedXML.Excel
         IXLColumns AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth);
 
         /// <summary>
+        /// Returns a collection of the same type containing the columns that match the predicate.
+        /// </summary>
+        IXLColumns Where(Func<IXLColumn, Boolean> predicate);
+
+        /// <summary>
+        /// Returns a collection of the same type containing all columns after the first
+        /// <paramref name="count"/> columns, in column-number order.
+        /// </summary>
+        IXLColumns Skip(Int32 count);
+
+        /// <summary>
+        /// Returns a collection of the same type containing the first <paramref name="count"/>
+        /// columns, in column-number order.
+        /// </summary>
+        IXLColumns Take(Int32 count);
+
+        /// <summary>
         /// Hides all columns.
         /// </summary>
         void Hide();

--- a/ClosedXML/Excel/Columns/XLColumns.cs
+++ b/ClosedXML/Excel/Columns/XLColumns.cs
@@ -132,6 +132,24 @@ namespace ClosedXML.Excel
             return this;
         }
 
+        public IXLColumns Where(Func<IXLColumn, Boolean> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return FromOrdered(OrderedColumns.Where(c => predicate(c)));
+        }
+
+        public IXLColumns Skip(Int32 count)
+        {
+            return FromOrdered(OrderedColumns.Skip(count));
+        }
+
+        public IXLColumns Take(Int32 count)
+        {
+            return FromOrdered(OrderedColumns.Take(count));
+        }
+
         public void Hide()
         {
             Columns.ForEach(c => c.Hide());
@@ -265,6 +283,16 @@ namespace ClosedXML.Excel
         {
             foreach (var range in this)
                 range.Select();
+        }
+
+        private IEnumerable<XLColumn> OrderedColumns => Columns.OrderBy(c => c.ColumnNumber());
+
+        private XLColumns FromOrdered(IEnumerable<XLColumn> columns)
+        {
+            var result = new XLColumns(_workbook, worksheet: null, defaultStyleSheet: _defaultStyleSheet);
+            foreach (var column in columns)
+                result.Add(column);
+            return result;
         }
 
         private void Materialize()

--- a/ClosedXML/Excel/Ranges/IXLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeColumn.cs
@@ -107,6 +107,21 @@ namespace ClosedXML.Excel
 
         IXLColumn WorksheetColumn();
 
+        /// <summary>
+        /// Adjusts the width of the worksheet column based on the contents of cells in this range column.
+        /// </summary>
+        IXLRangeColumn AdjustToContents();
+
+        IXLRangeColumn AdjustToContents(Int32 startRow);
+
+        IXLRangeColumn AdjustToContents(Int32 startRow, Int32 endRow);
+
+        IXLRangeColumn AdjustToContents(Double minWidth, Double maxWidth);
+
+        IXLRangeColumn AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth);
+
+        IXLRangeColumn AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth);
+
         IXLTable AsTable();
 
         IXLTable AsTable(String name);

--- a/ClosedXML/Excel/Ranges/IXLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeColumns.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 
 namespace ClosedXML.Excel
@@ -32,6 +33,38 @@ namespace ClosedXML.Excel
         /// Deletes all columns and shifts the columns at the right of them accordingly.
         /// </summary>
         void Delete();
+
+        /// <summary>
+        /// Adjusts the width of all columns based on the contents of cells in these range columns.
+        /// </summary>
+        IXLRangeColumns AdjustToContents();
+
+        IXLRangeColumns AdjustToContents(Int32 startRow);
+
+        IXLRangeColumns AdjustToContents(Int32 startRow, Int32 endRow);
+
+        IXLRangeColumns AdjustToContents(Double minWidth, Double maxWidth);
+
+        IXLRangeColumns AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth);
+
+        IXLRangeColumns AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth);
+
+        /// <summary>
+        /// Returns a collection of the same type containing the columns that match the predicate.
+        /// </summary>
+        IXLRangeColumns Where(Func<IXLRangeColumn, Boolean> predicate);
+
+        /// <summary>
+        /// Returns a collection of the same type containing all columns after the first
+        /// <paramref name="count"/> columns, in column-number order.
+        /// </summary>
+        IXLRangeColumns Skip(Int32 count);
+
+        /// <summary>
+        /// Returns a collection of the same type containing the first <paramref name="count"/>
+        /// columns, in column-number order.
+        /// </summary>
+        IXLRangeColumns Take(Int32 count);
 
         IXLStyle Style { get; set; }
 

--- a/ClosedXML/Excel/Ranges/IXLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeRow.cs
@@ -118,6 +118,21 @@ namespace ClosedXML.Excel
         IXLRow WorksheetRow();
 
         /// <summary>
+        /// Adjusts the height of the worksheet row based on the contents of cells in this range row.
+        /// </summary>
+        IXLRangeRow AdjustToContents();
+
+        IXLRangeRow AdjustToContents(Int32 startColumn);
+
+        IXLRangeRow AdjustToContents(Int32 startColumn, Int32 endColumn);
+
+        IXLRangeRow AdjustToContents(Double minHeight, Double maxHeight);
+
+        IXLRangeRow AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight);
+
+        IXLRangeRow AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight);
+
+        /// <summary>
         /// Clears the contents of this row.
         /// </summary>
         /// <param name="clearOptions">Specify what you want to clear.</param>

--- a/ClosedXML/Excel/Ranges/IXLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/IXLRangeRows.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 
 namespace ClosedXML.Excel
@@ -33,6 +34,38 @@ namespace ClosedXML.Excel
         /// Deletes all rows and shifts the rows below them accordingly.
         /// </summary>
         void Delete();
+
+        /// <summary>
+        /// Adjusts the height of all rows based on the contents of cells in these range rows.
+        /// </summary>
+        IXLRangeRows AdjustToContents();
+
+        IXLRangeRows AdjustToContents(Int32 startColumn);
+
+        IXLRangeRows AdjustToContents(Int32 startColumn, Int32 endColumn);
+
+        IXLRangeRows AdjustToContents(Double minHeight, Double maxHeight);
+
+        IXLRangeRows AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight);
+
+        IXLRangeRows AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight);
+
+        /// <summary>
+        /// Returns a collection of the same type containing the rows that match the predicate.
+        /// </summary>
+        IXLRangeRows Where(Func<IXLRangeRow, Boolean> predicate);
+
+        /// <summary>
+        /// Returns a collection of the same type containing all rows after the first
+        /// <paramref name="count"/> rows, in row-number order.
+        /// </summary>
+        IXLRangeRows Skip(Int32 count);
+
+        /// <summary>
+        /// Returns a collection of the same type containing the first <paramref name="count"/>
+        /// rows, in row-number order.
+        /// </summary>
+        IXLRangeRows Take(Int32 count);
 
         IXLStyle Style { get; set; }
 

--- a/ClosedXML/Excel/Ranges/XLRangeColumn.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumn.cs
@@ -174,6 +174,38 @@ namespace ClosedXML.Excel
             return Worksheet.Column(RangeAddress.FirstAddress.ColumnNumber);
         }
 
+        public IXLRangeColumn AdjustToContents()
+        {
+            return AdjustToContents(RangeAddress.FirstAddress.RowNumber, RangeAddress.LastAddress.RowNumber);
+        }
+
+        public IXLRangeColumn AdjustToContents(Int32 startRow)
+        {
+            return AdjustToContents(startRow, RangeAddress.LastAddress.RowNumber);
+        }
+
+        public IXLRangeColumn AdjustToContents(Int32 startRow, Int32 endRow)
+        {
+            WorksheetColumn().AdjustToContents(startRow, endRow);
+            return this;
+        }
+
+        public IXLRangeColumn AdjustToContents(Double minWidth, Double maxWidth)
+        {
+            return AdjustToContents(RangeAddress.FirstAddress.RowNumber, RangeAddress.LastAddress.RowNumber, minWidth, maxWidth);
+        }
+
+        public IXLRangeColumn AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth)
+        {
+            return AdjustToContents(startRow, RangeAddress.LastAddress.RowNumber, minWidth, maxWidth);
+        }
+
+        public IXLRangeColumn AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth)
+        {
+            WorksheetColumn().AdjustToContents(startRow, endRow, minWidth, maxWidth);
+            return this;
+        }
+
         #endregion IXLRangeColumn Members
 
         public override XLRangeType RangeType

--- a/ClosedXML/Excel/Ranges/XLRangeColumns.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeColumns.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,6 +44,60 @@ namespace ClosedXML.Excel
         {
             _ranges.OrderByDescending(c => c.ColumnNumber()).ForEach(r => r.Delete());
             _ranges.Clear();
+        }
+
+        public IXLRangeColumns AdjustToContents()
+        {
+            OrderedColumns.ForEach(c => c.AdjustToContents());
+            return this;
+        }
+
+        public IXLRangeColumns AdjustToContents(Int32 startRow)
+        {
+            OrderedColumns.ForEach(c => c.AdjustToContents(startRow));
+            return this;
+        }
+
+        public IXLRangeColumns AdjustToContents(Int32 startRow, Int32 endRow)
+        {
+            OrderedColumns.ForEach(c => c.AdjustToContents(startRow, endRow));
+            return this;
+        }
+
+        public IXLRangeColumns AdjustToContents(Double minWidth, Double maxWidth)
+        {
+            OrderedColumns.ForEach(c => c.AdjustToContents(minWidth, maxWidth));
+            return this;
+        }
+
+        public IXLRangeColumns AdjustToContents(Int32 startRow, Double minWidth, Double maxWidth)
+        {
+            OrderedColumns.ForEach(c => c.AdjustToContents(startRow, minWidth, maxWidth));
+            return this;
+        }
+
+        public IXLRangeColumns AdjustToContents(Int32 startRow, Int32 endRow, Double minWidth, Double maxWidth)
+        {
+            OrderedColumns.ForEach(c => c.AdjustToContents(startRow, endRow, minWidth, maxWidth));
+            return this;
+        }
+
+        public IXLRangeColumns Where(Func<IXLRangeColumn, Boolean> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return FromOrdered(OrderedColumns.Where(c => predicate(c)));
+        }
+
+        public IXLRangeColumns Skip(Int32 count)
+        {
+            return FromOrdered(OrderedColumns.Skip(count));
+        }
+
+        public IXLRangeColumns Take(Int32 count)
+        {
+            return FromOrdered(OrderedColumns.Take(count));
         }
 
         public void Add(IXLRangeColumn range)
@@ -95,5 +150,16 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLRangeColumns Members
+
+        private IEnumerable<XLRangeColumn> OrderedColumns =>
+            _ranges.OrderBy(c => c.Worksheet.Position).ThenBy(c => c.ColumnNumber());
+
+        private IXLRangeColumns FromOrdered(IEnumerable<XLRangeColumn> columns)
+        {
+            var result = new XLRangeColumns(_worksheet);
+            foreach (var column in columns)
+                result.Add(column);
+            return result;
+        }
     }
 }

--- a/ClosedXML/Excel/Ranges/XLRangeRow.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRow.cs
@@ -175,6 +175,38 @@ namespace ClosedXML.Excel
             return Worksheet.Row(RangeAddress.FirstAddress.RowNumber);
         }
 
+        public IXLRangeRow AdjustToContents()
+        {
+            return AdjustToContents(RangeAddress.FirstAddress.ColumnNumber, RangeAddress.LastAddress.ColumnNumber);
+        }
+
+        public IXLRangeRow AdjustToContents(Int32 startColumn)
+        {
+            return AdjustToContents(startColumn, RangeAddress.LastAddress.ColumnNumber);
+        }
+
+        public IXLRangeRow AdjustToContents(Int32 startColumn, Int32 endColumn)
+        {
+            WorksheetRow().AdjustToContents(startColumn, endColumn);
+            return this;
+        }
+
+        public IXLRangeRow AdjustToContents(Double minHeight, Double maxHeight)
+        {
+            return AdjustToContents(RangeAddress.FirstAddress.ColumnNumber, RangeAddress.LastAddress.ColumnNumber, minHeight, maxHeight);
+        }
+
+        public IXLRangeRow AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight)
+        {
+            return AdjustToContents(startColumn, RangeAddress.LastAddress.ColumnNumber, minHeight, maxHeight);
+        }
+
+        public IXLRangeRow AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight)
+        {
+            WorksheetRow().AdjustToContents(startColumn, endColumn, minHeight, maxHeight);
+            return this;
+        }
+
         #endregion IXLRangeRow Members
         public override XLRangeType RangeType
         {

--- a/ClosedXML/Excel/Ranges/XLRangeRows.cs
+++ b/ClosedXML/Excel/Ranges/XLRangeRows.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,6 +44,60 @@ namespace ClosedXML.Excel
         {
             _ranges.OrderByDescending(r => r.RowNumber()).ForEach(r => r.Delete());
             _ranges.Clear();
+        }
+
+        public IXLRangeRows AdjustToContents()
+        {
+            OrderedRows.ForEach(r => r.AdjustToContents());
+            return this;
+        }
+
+        public IXLRangeRows AdjustToContents(Int32 startColumn)
+        {
+            OrderedRows.ForEach(r => r.AdjustToContents(startColumn));
+            return this;
+        }
+
+        public IXLRangeRows AdjustToContents(Int32 startColumn, Int32 endColumn)
+        {
+            OrderedRows.ForEach(r => r.AdjustToContents(startColumn, endColumn));
+            return this;
+        }
+
+        public IXLRangeRows AdjustToContents(Double minHeight, Double maxHeight)
+        {
+            OrderedRows.ForEach(r => r.AdjustToContents(minHeight, maxHeight));
+            return this;
+        }
+
+        public IXLRangeRows AdjustToContents(Int32 startColumn, Double minHeight, Double maxHeight)
+        {
+            OrderedRows.ForEach(r => r.AdjustToContents(startColumn, minHeight, maxHeight));
+            return this;
+        }
+
+        public IXLRangeRows AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight)
+        {
+            OrderedRows.ForEach(r => r.AdjustToContents(startColumn, endColumn, minHeight, maxHeight));
+            return this;
+        }
+
+        public IXLRangeRows Where(Func<IXLRangeRow, Boolean> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return FromOrdered(OrderedRows.Where(r => predicate(r)));
+        }
+
+        public IXLRangeRows Skip(Int32 count)
+        {
+            return FromOrdered(OrderedRows.Skip(count));
+        }
+
+        public IXLRangeRows Take(Int32 count)
+        {
+            return FromOrdered(OrderedRows.Take(count));
         }
 
         public void Add(IXLRangeRow range)
@@ -95,5 +150,16 @@ namespace ClosedXML.Excel
         }
 
         #endregion IXLRangeRows Members
+
+        private IEnumerable<XLRangeRow> OrderedRows =>
+            _ranges.OrderBy(r => r.Worksheet.Position).ThenBy(r => r.RowNumber());
+
+        private IXLRangeRows FromOrdered(IEnumerable<XLRangeRow> rows)
+        {
+            var result = new XLRangeRows(_worksheet);
+            foreach (var row in rows)
+                result.Add(row);
+            return result;
+        }
     }
 }

--- a/ClosedXML/Excel/Rows/IXLRows.cs
+++ b/ClosedXML/Excel/Rows/IXLRows.cs
@@ -45,6 +45,23 @@ namespace ClosedXML.Excel
         IXLRows AdjustToContents(Int32 startColumn, Int32 endColumn, Double minHeight, Double maxHeight);
 
         /// <summary>
+        /// Returns a collection of the same type containing the rows that match the predicate.
+        /// </summary>
+        IXLRows Where(Func<IXLRow, Boolean> predicate);
+
+        /// <summary>
+        /// Returns a collection of the same type containing all rows after the first
+        /// <paramref name="count"/> rows, in row-number order.
+        /// </summary>
+        IXLRows Skip(Int32 count);
+
+        /// <summary>
+        /// Returns a collection of the same type containing the first <paramref name="count"/>
+        /// rows, in row-number order.
+        /// </summary>
+        IXLRows Take(Int32 count);
+
+        /// <summary>
         /// Hides all rows.
         /// </summary>
         void Hide();

--- a/ClosedXML/Excel/Rows/XLRows.cs
+++ b/ClosedXML/Excel/Rows/XLRows.cs
@@ -130,6 +130,24 @@ namespace ClosedXML.Excel
             return this;
         }
 
+        public IXLRows Where(Func<IXLRow, Boolean> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            return FromOrdered(OrderedRows.Where(r => predicate(r)));
+        }
+
+        public IXLRows Skip(Int32 count)
+        {
+            return FromOrdered(OrderedRows.Skip(count));
+        }
+
+        public IXLRows Take(Int32 count)
+        {
+            return FromOrdered(OrderedRows.Take(count));
+        }
+
         public void Hide()
         {
             Rows.ForEach(r => r.Hide());
@@ -249,6 +267,16 @@ namespace ClosedXML.Excel
         {
             foreach (var range in this)
                 range.Select();
+        }
+
+        private IEnumerable<XLRow> OrderedRows => Rows.OrderBy(r => r.RowNumber());
+
+        private XLRows FromOrdered(IEnumerable<XLRow> rows)
+        {
+            var result = new XLRows(_workbook, worksheet: null, defaultStyleSheet: _defaultStyleSheet);
+            foreach (var row in rows)
+                result.Add(row);
+            return result;
         }
 
         private void Materialize()


### PR DESCRIPTION
LINQ Skip/Where/Take on IXLColumns and IXLRows returned IEnumerable<T>, so collection methods such as AdjustToContents could not be chained (issue #2867). The foreach workaround also looked broken because ColumnsUsed() only yields used columns, so Skip(1) correctly runs once when two columns are used.

Add instance Skip, Where, and Take on IXLColumns, IXLRows, IXLRangeColumns, and IXLRangeRows that return the same collection type. Instance methods win overload resolution over LINQ, so

    ws.ColumnsUsed().Skip(1).AdjustToContents();

compiles and auto-fits only the remaining columns. Indexed LINQ (Where((c, i) => ...), OrderByDescending().Skip()) still binds to LINQ.

Filtered collections are never treated as all columns/rows of the sheet (worksheet is not passed through). Width, Height, and Delete therefore affect only the remaining items, not the worksheet default or the whole grid. Skip/Take enumerate in column/row number order so they match existing GetEnumerator ordering rather than insertion order.

Also add AdjustToContents on IXLRangeColumn, IXLRangeColumns, IXLRangeRow, and IXLRangeRows. Range auto-fit uses only cells inside the range (via the worksheet column/row with the range's bounds), which is the natural API for InsertData.

Fixes #2867
