### PR TITLE
Fix GetHashCode collisions in area/point hashing

### DIFF
--- a/ClosedXML.Tests/Excel/Coordinates/AreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/AreaTests.cs
@@ -352,4 +352,22 @@ public class AreaTests
         Assert.AreEqual(expectedRight, right?.ToString());
         Assert.AreEqual(expectedLeft, left?.ToString());
     }
+
+    [Test]
+    public void Single_cell_areas_hash_codes_have_few_collisions()
+    {
+        // Areas are used in many dictionaries, such as formula dependency tree. Make sure the hash
+        // function doesn't produce too many collision. The hash function originally always
+        // produced hash code 0 for all one-cell areas, which caused a terrible set/dictionary
+        // performance.
+        var hashes = new HashSet<int>();
+        for (var row = 1; row <= 100; ++row)
+        {
+            for (var column = 1; column <= 100; ++column)
+                hashes.Add(new Area(new Point(row, column)).GetHashCode());
+        }
+
+        // Some collisions are inevitable, but the vast majority of areas must be distinguishable.
+        Assert.That(hashes.Count, Is.GreaterThan(9900));
+    }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/AreaTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/AreaTests.cs
@@ -354,6 +354,7 @@ public class AreaTests
     }
 
     [Test]
+    [Issue("2881")]
     public void Single_cell_areas_hash_codes_have_few_collisions()
     {
         // Areas are used in many dictionaries, such as formula dependency tree. Make sure the hash

--- a/ClosedXML.Tests/Excel/Coordinates/PointTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/PointTests.cs
@@ -1,6 +1,7 @@
-﻿using ClosedXML.Excel;
+using ClosedXML.Excel;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 
 namespace ClosedXML.Tests.Excel.Coordinates
 {
@@ -59,6 +60,24 @@ namespace ClosedXML.Tests.Excel.Coordinates
         {
             var r = Point.Parse(cellRef);
             Assert.AreEqual(cellRef, r.ToString());
+        }
+
+        [Test]
+        public void Hash_codes_of_points_in_area_have_few_collisions()
+        {
+            // Points are used in sets or dictionaries. Make sure the hash function doesn't produce
+            // too many collision. The hash function originally produced hash codes only from
+            // a small range of values instead of all possible integer values. That significantly
+            // increased number of collisions and led to a bad performance.
+            var hashes = new HashSet<int>();
+            for (var row = 1; row <= 1000; ++row)
+            {
+                for (var column = 1; column <= 100; ++column)
+                    hashes.Add(new Point(row, column).GetHashCode());
+            }
+
+            // Some collisions are inevitable, but the vast majority of points must be distinguishable.
+            Assert.That(hashes.Count, Is.GreaterThan(99000));
         }
     }
 }

--- a/ClosedXML.Tests/Excel/Coordinates/PointTests.cs
+++ b/ClosedXML.Tests/Excel/Coordinates/PointTests.cs
@@ -63,6 +63,7 @@ namespace ClosedXML.Tests.Excel.Coordinates
         }
 
         [Test]
+        [Issue("2881")]
         public void Hash_codes_of_points_in_area_have_few_collisions()
         {
             // Points are used in sets or dictionaries. Make sure the hash function doesn't produce

--- a/ClosedXML.Tests/IssueAttribute.cs
+++ b/ClosedXML.Tests/IssueAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+using NUnit.Framework;
+
+namespace ClosedXML.Tests;
+
+/// <summary>
+/// Link a test to a GitHub issue for more context about the original problem.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+public class IssueAttribute(string issue) : PropertyAttribute("Issue", issue);

--- a/ClosedXML/Excel/Coordinates/Area.cs
+++ b/ClosedXML/Excel/Coordinates/Area.cs
@@ -92,7 +92,7 @@ internal readonly struct Area : IEquatable<Area>, IEnumerable<Point>
 
     public override int GetHashCode()
     {
-        return FirstPoint.GetHashCode() ^ LastPoint.GetHashCode();
+        return HashCode.Combine(FirstPoint, LastPoint);
     }
 
     public static bool operator ==(Area left, Area right) => left.Equals(right);

--- a/ClosedXML/Excel/Coordinates/Point.cs
+++ b/ClosedXML/Excel/Coordinates/Point.cs
@@ -43,7 +43,7 @@ namespace ClosedXML.Excel
 
         public override int GetHashCode()
         {
-            return (Row * -1) ^ Column;
+            return HashCode.Combine(Row, Column);
         }
 
         public static bool operator ==(Point a, Point b)


### PR DESCRIPTION
Area.GetHashCode() XORed FirstPoint/LastPoint, which is always 0 for single-cell areas (the most common precedent shape). Point.GetHashCode() used (Row * -1) ^ Column, spanning only ~max(rows, columns) values. Both caused severe collisions in the formula dependency tree's dictionaries. Replaced with HashCode.Combine(...).

Recalculate time for 50,000 single-cell-precedent formulas dropped from 30,397 ms to 1,167 ms (~26x faster), same allocations.

Fixes #2881